### PR TITLE
build: add ruff linter, prek pre-commit hooks, and PR submission skill

### DIFF
--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: submit-pr
+description: Prepare and submit a pull request for the APME project. Syncs with upstream, creates a feature branch, runs pre-commit checks (prek/ruff), updates documentation and ADRs as needed, commits with conventional commits, then creates the PR via gh. Use when the user asks to submit, create, or open a pull request, or says "submit PR", "open PR", "create PR".
+---
+
+# Submit PR
+
+## Workflow
+
+### Step 1: Sync with upstream and create a feature branch
+
+Always start from the latest upstream main:
+
+```bash
+git fetch upstream
+git checkout -b <branch-name> upstream/master
+```
+
+Use a descriptive branch name (e.g., `feat/add-ruff-prek`, `fix/parser-context-manager`).
+
+If changes already exist on the current branch (e.g., from an in-progress session), cherry-pick or rebase them onto the new branch.
+
+### Step 2: Run pre-commit checks
+
+```bash
+prek run --all-files
+```
+
+If `prek` is not installed, fall back to:
+
+```bash
+ruff check src/ tests/ && ruff format --check src/ tests/
+```
+
+If violations are found:
+1. Run `ruff check --fix src/ tests/` and `ruff format src/ tests/` to auto-fix
+2. Manually fix any remaining violations
+3. Re-run until clean
+
+### Step 3: Update documentation
+
+Check whether your changes affect areas covered by existing docs. Update any that apply:
+
+| Doc | When to update |
+|-----|----------------|
+| `docs/DEVELOPMENT.md` | New dev workflows, setup changes, new rule patterns |
+| `docs/ARCHITECTURE.md` | Container topology, gRPC contract changes, new services |
+| `docs/DATA_FLOW.md` | Request lifecycle, serialization, payload shape changes |
+| `docs/DEPLOYMENT.md` | Podman pod spec, container config, env vars |
+| `docs/LINT_RULE_MAPPING.md` | New or renamed rule IDs |
+| `docs/DESIGN_VALIDATORS.md` | Validator abstraction changes |
+| `docs/DESIGN_REMEDIATION.md` | Remediation engine changes |
+
+If a new rule was added, regenerate the catalog:
+
+```bash
+python scripts/generate_rule_catalog.py
+```
+
+### Step 4: Update ADR (if applicable)
+
+If the change involves an architectural decision (new service, new protocol, new deployment strategy, new tooling adoption), add an entry to `docs/ADR.md`.
+
+Follow the existing format:
+
+```markdown
+## ADR-NNN: Title
+
+**Status:** Accepted
+**Date:** YYYY-MM
+
+### Context
+Why this decision was needed.
+
+### Options considered
+| Option | Pros | Cons |
+|--------|------|------|
+| Option A | ... | ... |
+| Option B | ... | ... |
+
+### Decision
+What was decided and why.
+
+### Rationale
+- Bullet points explaining the reasoning
+```
+
+Update the **Changelog** table at the bottom of `docs/ADR.md` with the new entry.
+
+### Step 5: Commit with conventional commits
+
+Use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types for this project:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature (rule, validator, CLI subcommand, service) |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `style` | Code style/formatting (no logic change) |
+| `refactor` | Code restructuring (no feature or fix) |
+| `test` | Adding or updating tests |
+| `build` | Build system, dependencies, containers |
+| `ci` | CI/CD configuration |
+| `chore` | Maintenance tasks |
+
+Scopes reflect project areas: `engine`, `native`, `opa`, `ansible`, `gitleaks`, `daemon`, `cli`, `formatter`, `remediation`, `cache`, `proto`.
+
+Examples:
+- `feat(native): add L060 jinja2-spacing rule`
+- `fix(engine): use context manager for file reads in parser`
+- `build: add ruff linter and prek pre-commit hooks`
+- `docs: add prek section to DEVELOPMENT.md`
+
+### Step 6: Push and create the pull request
+
+```bash
+git push -u origin HEAD
+
+gh pr create --repo upstream-owner/repo --title "conventional commit style title" --body "$(cat <<'EOF'
+## Summary
+- Concise description of what changed and why
+
+## Changes
+- List of notable changes
+
+## Test plan
+- [ ] prek run --all-files passes
+- [ ] pytest passes
+- [ ] Docs updated (if applicable)
+- [ ] ADR added (if applicable)
+EOF
+)"
+```
+
+The PR targets upstream's `main` branch from the fork. Return the PR URL to the user.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -440,6 +440,43 @@ Diagnostics are **always collected** by every validator and the engine. Display 
 
 ---
 
+## ADR-014: Ruff linter and prek pre-commit hooks
+
+**Status:** Accepted  
+**Date:** 2026-03  
+
+### Context
+
+The project had no linter, code formatter, or pre-commit hooks. Code style inconsistencies and latent issues (unused imports, bare raises, missing context managers, ambiguous variable names) accumulated across the codebase. There was no automated gate to prevent these from entering the repository.
+
+### Options considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| ruff | Extremely fast (Rust), replaces flake8+isort+pyupgrade+pycodestyle, minimal config, auto-fix | Newer tool, not all plugins ported |
+| flake8 + isort + black | Mature ecosystem, widely adopted | Multiple tools to configure and run, slower |
+| pylint | Deep analysis, type inference | Very slow, high noise, heavy configuration |
+
+| Option | Pros | Cons |
+|--------|------|------|
+| prek (pre-commit) | Single Rust binary, no Python dependency, drop-in `.pre-commit-config.yaml` compatibility, faster than pre-commit | Newer tool |
+| pre-commit (Python) | Mature, large hook ecosystem | Requires Python, slower hook execution |
+| Custom shell script | No external tool | Not standard, no hook management, no caching |
+
+### Decision
+
+Use **ruff** for linting and formatting, managed via **prek** pre-commit hooks. Configuration lives in `pyproject.toml` under `[tool.ruff]`. The `.pre-commit-config.yaml` uses `astral-sh/ruff-pre-commit` with `ruff` (lint + auto-fix) and `ruff-format` hooks.
+
+### Rationale
+
+- ruff is a single tool that replaces flake8, isort, pyupgrade, and pycodestyle — one config, one dependency
+- ruff runs in milliseconds on the full codebase, making it practical as a pre-commit hook
+- prek is a faster, dependency-free drop-in for pre-commit — no Python runtime required to run hooks
+- `.pre-commit-config.yaml` is the standard format understood by both prek and pre-commit
+- All existing violations were remediated at adoption time, so the codebase starts clean
+
+---
+
 ## Changelog
 
 | ADR | Date | Summary |
@@ -457,3 +494,4 @@ Diagnostics are **always collected** by every validator and the engine. Display 
 | 011 | 2026-03 | YAML formatter as Phase 1 pre-pass |
 | 012 | 2026-02 | Scale pods, not services |
 | 013 | 2026-03 | Structured diagnostics in gRPC contract |
+| 014 | 2026-03 | Ruff linter and prek pre-commit hooks |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,6 +8,49 @@ pip install -r requirements.txt
 pip install -e ".[dev]"
 ```
 
+## Pre-commit hooks (prek)
+
+The project uses [prek](https://github.com/j178/prek) to run [ruff](https://docs.astral.sh/ruff/) lint and format checks as pre-commit hooks.
+
+### Install prek
+
+```bash
+uv tool install prek   # recommended
+# or: pip install prek
+```
+
+### Install git hooks
+
+```bash
+prek install
+```
+
+This installs a Git pre-commit hook so checks run automatically on `git commit`.
+
+### Run manually
+
+```bash
+prek run --all-files
+```
+
+### What runs
+
+| Hook | What it does |
+|------|--------------|
+| `ruff` | Lint check (rules: E, F, W, I, UP, B, SIM) with `--fix` |
+| `ruff-format` | Code formatting |
+
+Configuration is in `pyproject.toml` under `[tool.ruff]`. Generated gRPC stubs (`src/apme/v1/*_pb2*.py`) are excluded.
+
+### Running ruff directly
+
+```bash
+ruff check src/ tests/          # lint
+ruff check --fix src/ tests/    # lint + auto-fix
+ruff format src/ tests/         # format
+ruff format --check src/ tests/ # format check (CI mode)
+```
+
 ## Code organization
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "pytest-mock", "pytest-asyncio>=0.24"]
+dev = ["pytest", "pytest-cov", "pytest-mock", "pytest-asyncio>=0.24", "ruff"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src/apme_engine/validators/native/rules"]
@@ -59,6 +59,17 @@ apme-ansible-validator = "apme_engine.daemon.ansible_validator_main:main"
 apme-native-validator = "apme_engine.daemon.native_validator_main:main"
 apme-opa-validator = "apme_engine.daemon.opa_validator_main:main"
 apme-gitleaks-validator = "apme_engine.daemon.gitleaks_validator_main:main"
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+exclude = ["src/apme/v1/*_pb2*.py"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM"]
+
+[tool.ruff.lint.per-file-ignores]
+"src/apme_engine/engine/annotators/ansible.builtin/*.py" = ["E501"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/apme_engine/cli.py
+++ b/src/apme_engine/cli.py
@@ -7,12 +7,8 @@ import sys
 from pathlib import Path
 
 import grpc
+
 from apme.v1 import primary_pb2, primary_pb2_grpc
-from apme_engine.daemon.chunked_fs import build_scan_request
-from apme_engine.daemon.violation_convert import violation_proto_to_dict
-from apme_engine.runner import run_scan
-from apme_engine.validators.opa import OpaValidator
-from apme_engine.validators.native import NativeValidator
 from apme_engine.collection_cache import (
     get_cache_root,
     pull_galaxy_collection,
@@ -20,20 +16,27 @@ from apme_engine.collection_cache import (
     pull_github_org,
     pull_github_repos,
 )
+from apme_engine.daemon.chunked_fs import build_scan_request
 from apme_engine.daemon.health_check import run_health_checks
-from apme_engine.formatter import format_file, format_directory, check_idempotent
+from apme_engine.daemon.violation_convert import violation_proto_to_dict
+from apme_engine.formatter import format_directory, format_file
 from apme_engine.remediation.engine import RemediationEngine
 from apme_engine.remediation.transforms import build_default_registry
+from apme_engine.runner import run_scan
+from apme_engine.validators.native import NativeValidator
+from apme_engine.validators.opa import OpaValidator
 
 
 def _sort_violations(violations: list[dict]) -> list[dict]:
     """Sort by file, then line for stable output."""
+
     def key(v):
         f = v.get("file") or ""
         line = v.get("line")
         if isinstance(line, (list, tuple)) and line:
             line = line[0] if line else 0
         return (f, line if isinstance(line, int) else (line or 0))
+
     return sorted(violations, key=key)
 
 
@@ -87,7 +90,10 @@ def _print_diagnostics_v(diag: "primary_pb2.ScanDiagnostics"):
             if k not in ("opa_response_size", "files_written"):
                 meta_parts.append(f"{k}={v}")
         meta_str = f" | {', '.join(meta_parts)}" if meta_parts else ""
-        w(f"  {connector} {vd.validator_name.title():10s} {_fmt_ms(vd.total_ms):>8s} | {vd.violations_found:3d} violation(s){meta_str}\n")
+        w(
+            f"  {connector} {vd.validator_name.title():10s} {_fmt_ms(vd.total_ms):>8s} | "
+            f"{vd.violations_found:3d} violation(s){meta_str}\n"
+        )
 
     w(f"  Total:        {_fmt_ms(diag.total_ms)}\n")
 
@@ -144,17 +150,19 @@ def _diag_to_dict(diag: "primary_pb2.ScanDiagnostics") -> dict:
     """Convert ScanDiagnostics proto to a JSON-serializable dict."""
     validators = []
     for vd in diag.validators:
-        validators.append({
-            "validator_name": vd.validator_name,
-            "total_ms": round(vd.total_ms, 1),
-            "files_received": vd.files_received,
-            "violations_found": vd.violations_found,
-            "rule_timings": [
-                {"rule_id": rt.rule_id, "elapsed_ms": round(rt.elapsed_ms, 1), "violations": rt.violations}
-                for rt in vd.rule_timings
-            ],
-            "metadata": dict(vd.metadata),
-        })
+        validators.append(
+            {
+                "validator_name": vd.validator_name,
+                "total_ms": round(vd.total_ms, 1),
+                "files_received": vd.files_received,
+                "violations_found": vd.violations_found,
+                "rule_timings": [
+                    {"rule_id": rt.rule_id, "elapsed_ms": round(rt.elapsed_ms, 1), "violations": rt.violations}
+                    for rt in vd.rule_timings
+                ],
+                "metadata": dict(vd.metadata),
+            }
+        )
     return {
         "engine_parse_ms": round(diag.engine_parse_ms, 1),
         "engine_annotate_ms": round(diag.engine_annotate_ms, 1),
@@ -398,10 +406,7 @@ def _run_fix(args):
 
     # Phase 1: Format
     sys.stderr.write("Phase 1: Formatting...\n")
-    if target.is_file():
-        results = [format_file(target)]
-    else:
-        results = format_directory(target, exclude_patterns=exclude)
+    results = [format_file(target)] if target.is_file() else format_directory(target, exclude_patterns=exclude)
 
     changed = [r for r in results if r.changed]
 
@@ -426,10 +431,7 @@ def _run_fix(args):
 
     # Phase 2: Idempotency gate
     sys.stderr.write("Phase 2: Idempotency check...\n")
-    if target.is_file():
-        recheck = [format_file(target)]
-    else:
-        recheck = format_directory(target, exclude_patterns=exclude)
+    recheck = [format_file(target)] if target.is_file() else format_directory(target, exclude_patterns=exclude)
 
     still_changed = [r for r in recheck if r.changed]
     if still_changed:
@@ -447,7 +449,8 @@ def _run_fix(args):
         yaml_files = [str(target)]
     else:
         yaml_files = [
-            str(p) for p in target.rglob("*")
+            str(p)
+            for p in target.rglob("*")
             if p.suffix in (".yml", ".yaml") and not any(part.startswith(".") for part in p.parts)
         ]
 
@@ -537,7 +540,10 @@ def main():
     scan_parser.add_argument(
         "--primary-addr",
         default=None,
-        help="Primary daemon gRPC address (e.g. localhost:50051). If set, scan runs on daemon; else in-process. Env: APME_PRIMARY_ADDRESS",
+        help=(
+            "Primary daemon gRPC address (e.g. localhost:50051). If set, scan runs on daemon; "
+            "else in-process. Env: APME_PRIMARY_ADDRESS"
+        ),
     )
     scan_parser.add_argument(
         "--opa-bundle",
@@ -559,7 +565,8 @@ def main():
         help="Collection specs to make available (e.g. community.general:9.0.0 amazon.aws)",
     )
     scan_parser.add_argument(
-        "-v", "--verbose",
+        "-v",
+        "--verbose",
         action="count",
         default=0,
         help="Diagnostics verbosity: -v for summary + top 10, -vv for full per-rule breakdown",
@@ -573,7 +580,9 @@ def main():
     )
     cache_sub = cache_parser.add_subparsers(dest="cache_command", required=True)
 
-    pull_galaxy = cache_sub.add_parser("pull-galaxy", help="Install a Galaxy collection (e.g. namespace.collection or ns.coll:1.2.3)")
+    pull_galaxy = cache_sub.add_parser(
+        "pull-galaxy", help="Install a Galaxy collection (e.g. namespace.collection or ns.coll:1.2.3)"
+    )
     pull_galaxy.add_argument("spec", help="Collection spec: namespace.collection or namespace.collection:version")
     pull_galaxy.add_argument("--galaxy-server", default=None, help="Galaxy server URL")
 
@@ -583,7 +592,9 @@ def main():
 
     clone_org = cache_sub.add_parser("clone-org", help="Clone GitHub org repos that are Ansible collections")
     clone_org.add_argument("org", help="GitHub organization name")
-    clone_org.add_argument("--repos", nargs="*", default=None, help="Optional list of repo names to clone (default: all from org)")
+    clone_org.add_argument(
+        "--repos", nargs="*", default=None, help="Optional list of repo names to clone (default: all from org)"
+    )
     clone_org.add_argument("--depth", type=int, default=1, help="Git clone depth (default: 1)")
     clone_org.add_argument("--token", default=None, help="GitHub token for API (for listing org repos)")
 
@@ -611,16 +622,26 @@ def main():
     fix_parser.add_argument("--opa-bundle", default=None, help="Path to OPA bundle directory")
 
     # ── health-check ──
-    health_parser = subparsers.add_parser("health-check", help="Check health of all services (Primary, Native, OPA, Ansible, Cache maintainer) via gRPC")
+    health_parser = subparsers.add_parser(
+        "health-check", help="Check health of all services (Primary, Native, OPA, Ansible, Cache maintainer) via gRPC"
+    )
     health_parser.add_argument(
         "--primary-addr",
         default=None,
         help="Primary daemon gRPC address (e.g. localhost:50051). Env: APME_PRIMARY_ADDRESS",
     )
-    health_parser.add_argument("--native-addr", default=None, help="Native validator gRPC address (default: derived or NATIVE_GRPC_ADDRESS)")
-    health_parser.add_argument("--opa-addr", default=None, help="OPA validator gRPC address (default: derived or OPA_GRPC_ADDRESS)")
-    health_parser.add_argument("--ansible-addr", default=None, help="Ansible validator gRPC address (default: derived or ANSIBLE_GRPC_ADDRESS)")
-    health_parser.add_argument("--cache-addr", default=None, help="Cache maintainer gRPC address (default: derived or APME_CACHE_GRPC_ADDRESS)")
+    health_parser.add_argument(
+        "--native-addr", default=None, help="Native validator gRPC address (default: derived or NATIVE_GRPC_ADDRESS)"
+    )
+    health_parser.add_argument(
+        "--opa-addr", default=None, help="OPA validator gRPC address (default: derived or OPA_GRPC_ADDRESS)"
+    )
+    health_parser.add_argument(
+        "--ansible-addr", default=None, help="Ansible validator gRPC address (default: derived or ANSIBLE_GRPC_ADDRESS)"
+    )
+    health_parser.add_argument(
+        "--cache-addr", default=None, help="Cache maintainer gRPC address (default: derived or APME_CACHE_GRPC_ADDRESS)"
+    )
     health_parser.add_argument("--timeout", type=float, default=5.0, help="Timeout per check in seconds (default: 5)")
     health_parser.add_argument("--json", action="store_true", help="Output results as JSON")
 

--- a/src/apme_engine/collection_cache/__init__.py
+++ b/src/apme_engine/collection_cache/__init__.py
@@ -3,11 +3,11 @@
 
 from apme_engine.collection_cache.config import get_cache_root
 from apme_engine.collection_cache.manager import (
+    collection_path_in_cache,
     pull_galaxy_collection,
     pull_galaxy_requirements,
     pull_github_org,
     pull_github_repos,
-    collection_path_in_cache,
 )
 from apme_engine.collection_cache.venv_builder import build_venv, get_venv_python
 

--- a/src/apme_engine/collection_cache/_fqcn_resolve.py
+++ b/src/apme_engine/collection_cache/_fqcn_resolve.py
@@ -30,15 +30,11 @@ def main() -> None:
         sys.exit(1)
 
     # PluginResolutionContext: resolved_fqcn (ansible-core 2.14+)
-    fqcn = getattr(ctx, "resolved_fqcn", None) or getattr(
-        ctx, "plugin_resolved_name", None
-    )
+    fqcn = getattr(ctx, "resolved_fqcn", None) or getattr(ctx, "plugin_resolved_name", None)
     if not fqcn and hasattr(ctx, "plugin"):
         plugin = ctx.plugin
         if plugin is not None:
-            fqcn = getattr(plugin, "resolved_fqcn", None) or getattr(
-                plugin, "_load_name", None
-            )
+            fqcn = getattr(plugin, "resolved_fqcn", None) or getattr(plugin, "_load_name", None)
     if not fqcn:
         fqcn = name
     print(fqcn)

--- a/src/apme_engine/collection_cache/manager.py
+++ b/src/apme_engine/collection_cache/manager.py
@@ -1,12 +1,11 @@
 """Populate and query the collection cache (Galaxy + GitHub)."""
 
-import re
 import subprocess
 from pathlib import Path
 
 from apme_engine.collection_cache.config import (
-    get_cache_root,
     galaxy_cache_dir,
+    get_cache_root,
     github_cache_dir,
 )
 
@@ -35,8 +34,12 @@ def pull_galaxy_collection(
     target = galaxy_cache_dir(root)
     target.mkdir(parents=True, exist_ok=True)
     cmd = [
-        "ansible-galaxy", "collection", "install", spec,
-        "-p", str(target),
+        "ansible-galaxy",
+        "collection",
+        "install",
+        spec,
+        "-p",
+        str(target),
         "--force",
     ]
     if galaxy_server:
@@ -70,9 +73,13 @@ def pull_galaxy_requirements(
     if not req_path.is_file():
         raise FileNotFoundError(f"Requirements file not found: {requirements_path}")
     cmd = [
-        "ansible-galaxy", "collection", "install",
-        "-r", str(req_path),
-        "-p", str(target),
+        "ansible-galaxy",
+        "collection",
+        "install",
+        "-r",
+        str(req_path),
+        "-p",
+        str(target),
         "--force",
     ]
     if galaxy_server:
@@ -189,6 +196,7 @@ def _list_org_repos(org: str, token: str) -> list[str]:
     try:
         import json
         import urllib.request
+
         url = f"https://api.github.com/orgs/{org}/repos?per_page=100"
         req = urllib.request.Request(url)
         if token:
@@ -237,11 +245,16 @@ def collection_path_in_cache(
                 if galaxy_yml.is_file():
                     try:
                         import yaml
+
                         with open(galaxy_yml) as f:
                             meta = yaml.safe_load(f)
                         if meta:
                             n = meta.get("namespace") or meta.get("name", "").split(".")[0]
-                            c = meta.get("name", "").split(".")[-1] if "." in meta.get("name", "") else meta.get("name", "")
+                            c = (
+                                meta.get("name", "").split(".")[-1]
+                                if "." in meta.get("name", "")
+                                else meta.get("name", "")
+                            )
                             if n == namespace and c == collection:
                                 return repo_dir
                     except Exception:
@@ -250,6 +263,7 @@ def collection_path_in_cache(
                 if runtime.is_file():
                     try:
                         import yaml
+
                         with open(runtime) as f:
                             meta = yaml.safe_load(f)
                         if meta:

--- a/src/apme_engine/collection_cache/venv_builder.py
+++ b/src/apme_engine/collection_cache/venv_builder.py
@@ -9,8 +9,8 @@ from pathlib import Path
 
 from apme_engine.collection_cache.config import get_cache_root
 from apme_engine.collection_cache.manager import (
-    collection_path_in_cache,
     _parse_collection_spec,
+    collection_path_in_cache,
 )
 
 
@@ -43,14 +43,10 @@ def _resolve_collection_path(
 ) -> Path | None:
     """Resolve a collection spec to its path in the cache (galaxy first, then github)."""
     namespace, collection = _parse_collection_spec(spec)
-    path = collection_path_in_cache(
-        namespace, collection, cache_root=cache_root, source="galaxy"
-    )
+    path = collection_path_in_cache(namespace, collection, cache_root=cache_root, source="galaxy")
     if path is not None:
         return path
-    return collection_path_in_cache(
-        namespace, collection, cache_root=cache_root, source="github"
-    )
+    return collection_path_in_cache(namespace, collection, cache_root=cache_root, source="github")
 
 
 def build_venv(
@@ -167,10 +163,7 @@ def build_venv(
 
 def get_venv_python(venv_root: Path) -> Path:
     """Return the python executable inside the venv."""
-    if os.name == "nt":
-        exe = venv_root / "Scripts" / "python.exe"
-    else:
-        exe = venv_root / "bin" / "python"
+    exe = venv_root / "Scripts" / "python.exe" if os.name == "nt" else venv_root / "bin" / "python"
     if not exe.is_file():
         raise FileNotFoundError(f"venv has no python: {venv_root}")
     return exe

--- a/src/apme_engine/daemon/ansible_validator_server.py
+++ b/src/apme_engine/daemon/ansible_validator_server.py
@@ -1,6 +1,7 @@
 """Ansible validator daemon: async gRPC adapter with ephemeral per-request venvs."""
 
 import asyncio
+import contextlib
 import json
 import os
 import shutil
@@ -13,12 +14,12 @@ from pathlib import Path
 
 import grpc
 import grpc.aio
-from apme.v1 import validate_pb2, validate_pb2_grpc, common_pb2
 
+from apme.v1 import common_pb2, validate_pb2, validate_pb2_grpc
 from apme_engine.collection_cache.config import get_cache_root
-from apme_engine.collection_cache.venv_builder import build_venv, get_venv_python
+from apme_engine.collection_cache.venv_builder import build_venv
 from apme_engine.daemon.violation_convert import violation_dict_to_proto
-from apme_engine.validators.ansible import AnsibleValidator, AnsibleRunResult
+from apme_engine.validators.ansible import AnsibleRunResult, AnsibleValidator
 from apme_engine.validators.ansible._venv import (
     DEFAULT_VERSION,
     setup_collections_env,
@@ -107,10 +108,8 @@ def _run_ansible_validate(
 
         env_extra = None
         if collection_specs:
-            try:
+            with contextlib.suppress(Exception):
                 env_extra = setup_collections_env(collection_specs, cache)
-            except Exception:
-                pass
 
         scan_context = ScanContext(
             hierarchy_payload=hierarchy_payload,
@@ -125,6 +124,7 @@ def _run_ansible_validate(
         )
     except Exception as e:
         import traceback
+
         sys.stderr.write(f"[req={req_id}] Ansible error: {e}\n")
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
@@ -143,15 +143,11 @@ def _run_ansible_validate(
         )
     finally:
         if temp_dir is not None and temp_dir.is_dir():
-            try:
+            with contextlib.suppress(OSError):
                 shutil.rmtree(temp_dir)
-            except OSError:
-                pass
         if venv_root is not None and venv_root.is_dir():
-            try:
+            with contextlib.suppress(OSError):
                 shutil.rmtree(venv_root.parent)
-            except OSError:
-                pass
 
 
 class AnsibleValidatorServicer(validate_pb2_grpc.ValidatorServicer):
@@ -198,7 +194,9 @@ class AnsibleValidatorServicer(validate_pb2_grpc.ValidatorServicer):
 
             rule_timings = [
                 common_pb2.RuleTiming(
-                    rule_id=rt.rule_id, elapsed_ms=rt.elapsed_ms, violations=rt.violations,
+                    rule_id=rt.rule_id,
+                    elapsed_ms=rt.elapsed_ms,
+                    violations=rt.violations,
                 )
                 for rt in result.run_result.rule_timings
             ]
@@ -222,6 +220,7 @@ class AnsibleValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             )
         except Exception as e:
             import traceback
+
             sys.stderr.write(f"[req={req_id}] Ansible error: {e}\n")
             traceback.print_exc(file=sys.stderr)
             sys.stderr.flush()

--- a/src/apme_engine/daemon/cache_maintainer_server.py
+++ b/src/apme_engine/daemon/cache_maintainer_server.py
@@ -1,12 +1,12 @@
 """Cache maintainer daemon: gRPC server that populates the collection cache (Galaxy + GitHub)."""
 
 import os
+from concurrent import futures
 from pathlib import Path
 
 import grpc
-from apme.v1 import cache_pb2, cache_pb2_grpc, common_pb2
-from concurrent import futures
 
+from apme.v1 import cache_pb2, cache_pb2_grpc, common_pb2
 from apme_engine.collection_cache.config import get_cache_root
 from apme_engine.collection_cache.manager import (
     pull_galaxy_collection,
@@ -42,29 +42,21 @@ class CacheMaintainerServicer(cache_pb2_grpc.CacheMaintainerServicer):
         try:
             req_path = (request.requirements_path or "").strip()
             if not req_path:
-                return cache_pb2.PullRequirementsResponse(
-                    success=False, error_message="requirements_path is required"
-                )
+                return cache_pb2.PullRequirementsResponse(success=False, error_message="requirements_path is required")
             paths = pull_galaxy_requirements(
                 requirements_path=req_path,
                 cache_root=_cache_root(),
                 galaxy_server=request.galaxy_server or None,
             )
-            return cache_pb2.PullRequirementsResponse(
-                success=True, paths=[str(p) for p in paths]
-            )
+            return cache_pb2.PullRequirementsResponse(success=True, paths=[str(p) for p in paths])
         except Exception as e:
-            return cache_pb2.PullRequirementsResponse(
-                success=False, error_message=str(e)
-            )
+            return cache_pb2.PullRequirementsResponse(success=False, error_message=str(e))
 
     def CloneOrg(self, request, context):
         try:
             org = (request.org or "").strip()
             if not org:
-                return cache_pb2.CloneOrgResponse(
-                    success=False, error_message="org is required"
-                )
+                return cache_pb2.CloneOrgResponse(success=False, error_message="org is required")
             depth = request.depth if request.depth > 0 else 1
             token = (request.token or "").strip() or None
             cache = _cache_root()
@@ -89,9 +81,7 @@ class CacheMaintainerServicer(cache_pb2_grpc.CacheMaintainerServicer):
                 finally:
                     if token and "GITHUB_TOKEN" in os.environ:
                         del os.environ["GITHUB_TOKEN"]
-            return cache_pb2.CloneOrgResponse(
-                success=True, paths=[str(p) for p in paths]
-            )
+            return cache_pb2.CloneOrgResponse(success=True, paths=[str(p) for p in paths])
         except Exception as e:
             return cache_pb2.CloneOrgResponse(success=False, error_message=str(e))
 
@@ -102,9 +92,7 @@ class CacheMaintainerServicer(cache_pb2_grpc.CacheMaintainerServicer):
 def serve(listen: str = "0.0.0.0:50052"):
     """Create and return a gRPC server with CacheMaintainer servicer (caller must start it)."""
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
-    cache_pb2_grpc.add_CacheMaintainerServicer_to_server(
-        CacheMaintainerServicer(), server
-    )
+    cache_pb2_grpc.add_CacheMaintainerServicer_to_server(CacheMaintainerServicer(), server)
     if ":" in listen:
         _, _, port = listen.rpartition(":")
         server.add_insecure_port(f"[::]:{port}")

--- a/src/apme_engine/daemon/chunked_fs.py
+++ b/src/apme_engine/daemon/chunked_fs.py
@@ -3,7 +3,7 @@
 import os
 from pathlib import Path
 
-from apme.v1 import primary_pb2, common_pb2
+from apme.v1 import common_pb2, primary_pb2
 
 # Skip these dirs when walking (same kind of ignores as many linters)
 SKIP_DIRS = {".git", "__pycache__", ".venv", "venv", "node_modules", ".tox", "htmlcov"}
@@ -13,8 +13,21 @@ MAX_FILE_SIZE = 2 * 1024 * 1024  # 2 MiB
 
 # Extensions we care about for Ansible (include these; exclude or skip binary)
 TEXT_EXTENSIONS = {
-    ".yml", ".yaml", ".json", ".j2", ".jinja2", ".md", ".py", ".sh", ".cfg", ".ini",
-    ".toml", ".yml.sample", ".yaml.sample", ".tf", ".tfvars",
+    ".yml",
+    ".yaml",
+    ".json",
+    ".j2",
+    ".jinja2",
+    ".md",
+    ".py",
+    ".sh",
+    ".cfg",
+    ".ini",
+    ".toml",
+    ".yml.sample",
+    ".yaml.sample",
+    ".tf",
+    ".tfvars",
 }
 
 
@@ -40,9 +53,7 @@ def _should_include(path: Path, root: Path) -> bool:
     if path.name in ("playbook", "main", "meta", "handlers", "tasks", "vars", "defaults"):
         return True
     # Include small text files under roles/ and playbooks/
-    if "roles" in parts or "playbooks" in parts or suffix in (".yml", ".yaml", ".j2"):
-        return True
-    return False
+    return bool("roles" in parts or "playbooks" in parts or suffix in (".yml", ".yaml", ".j2"))
 
 
 def build_scan_request(
@@ -87,9 +98,7 @@ def build_scan_request(
         # Skip if looks binary
         if b"\x00" in content[:8192]:
             continue
-        files.append(
-            common_pb2.File(path=str(rel), content=content)
-        )
+        files.append(common_pb2.File(path=str(rel), content=content))
 
     options = primary_pb2.ScanOptions()
     if ansible_core_version:

--- a/src/apme_engine/daemon/gitleaks_validator_server.py
+++ b/src/apme_engine/daemon/gitleaks_validator_server.py
@@ -2,6 +2,7 @@
 runs gitleaks detect, and returns violations."""
 
 import asyncio
+import contextlib
 import os
 import shutil
 import sys
@@ -11,15 +12,23 @@ from pathlib import Path
 
 import grpc
 import grpc.aio
-from apme.v1 import validate_pb2, validate_pb2_grpc, common_pb2
 
+from apme.v1 import common_pb2, validate_pb2, validate_pb2_grpc
 from apme_engine.daemon.violation_convert import violation_dict_to_proto
-from apme_engine.validators.gitleaks.scanner import run_gitleaks, GITLEAKS_BIN
+from apme_engine.validators.gitleaks.scanner import GITLEAKS_BIN, run_gitleaks
 
 _MAX_CONCURRENT_RPCS = int(os.environ.get("APME_GITLEAKS_MAX_RPCS", "16"))
 
 _SCANNABLE_EXTENSIONS = (
-    ".yml", ".yaml", ".cfg", ".ini", ".conf", ".env", ".py", ".sh", ".json",
+    ".yml",
+    ".yaml",
+    ".cfg",
+    ".ini",
+    ".conf",
+    ".env",
+    ".py",
+    ".sh",
+    ".json",
 )
 
 
@@ -38,15 +47,14 @@ def _run_scan(files: list) -> tuple[list[dict], int]:
 
         return run_gitleaks(temp_dir), file_count
     finally:
-        try:
+        with contextlib.suppress(OSError):
             shutil.rmtree(temp_dir)
-        except OSError:
-            pass
 
 
 def _get_gitleaks_version() -> str:
     """Attempt to get gitleaks version string (best-effort)."""
     import subprocess as _sp
+
     try:
         r = _sp.run([GITLEAKS_BIN, "version"], capture_output=True, text=True, timeout=5)
         return r.stdout.strip() if r.returncode == 0 else "unknown"
@@ -68,13 +76,13 @@ class GitleaksValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             sys.stderr.flush()
 
             violations, files_written = await asyncio.get_event_loop().run_in_executor(
-                None, _run_scan, list(request.files),
+                None,
+                _run_scan,
+                list(request.files),
             )
 
             total_ms = (time.monotonic() - t0) * 1000
-            sys.stderr.write(
-                f"[req={req_id}] Gitleaks: {len(violations)} finding(s) in {total_ms:.1f}ms\n"
-            )
+            sys.stderr.write(f"[req={req_id}] Gitleaks: {len(violations)} finding(s) in {total_ms:.1f}ms\n")
             sys.stderr.flush()
 
             diag = common_pb2.ValidatorDiagnostics(
@@ -103,16 +111,17 @@ class GitleaksValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             )
         except Exception as e:
             import traceback
+
             sys.stderr.write(f"[req={req_id}] Gitleaks error: {e}\n")
             traceback.print_exc(file=sys.stderr)
             sys.stderr.flush()
             return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
 
     async def Health(self, request, context):
-        import subprocess
         try:
             proc = await asyncio.create_subprocess_exec(
-                GITLEAKS_BIN, "version",
+                GITLEAKS_BIN,
+                "version",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/src/apme_engine/daemon/health_check.py
+++ b/src/apme_engine/daemon/health_check.py
@@ -5,7 +5,8 @@ import time
 from typing import Any
 
 import grpc
-from apme.v1 import common_pb2, primary_pb2_grpc, validate_pb2_grpc, cache_pb2_grpc
+
+from apme.v1 import cache_pb2_grpc, common_pb2, primary_pb2_grpc, validate_pb2_grpc
 
 
 def _derive_addresses(primary_addr: str) -> dict[str, str]:

--- a/src/apme_engine/daemon/native_validator_server.py
+++ b/src/apme_engine/daemon/native_validator_server.py
@@ -9,11 +9,11 @@ import time
 import grpc
 import grpc.aio
 import jsonpickle
-from apme.v1 import validate_pb2, validate_pb2_grpc, common_pb2
 
+from apme.v1 import common_pb2, validate_pb2, validate_pb2_grpc
 from apme_engine.daemon.violation_convert import violation_dict_to_proto
 from apme_engine.validators.base import ScanContext
-from apme_engine.validators.native import NativeValidator, NativeRunResult
+from apme_engine.validators.native import NativeRunResult, NativeValidator
 
 _MAX_CONCURRENT_RPCS = int(os.environ.get("APME_NATIVE_MAX_RPCS", "32"))
 
@@ -51,17 +51,20 @@ class NativeValidatorServicer(validate_pb2_grpc.ValidatorServicer):
                     return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
 
             result = await asyncio.get_event_loop().run_in_executor(
-                None, _run_native, hierarchy_payload, scandata,
+                None,
+                _run_native,
+                hierarchy_payload,
+                scandata,
             )
             total_ms = (time.monotonic() - t0) * 1000
-            sys.stderr.write(
-                f"[req={req_id}] Native: {len(result.violations)} violation(s) in {total_ms:.1f}ms\n"
-            )
+            sys.stderr.write(f"[req={req_id}] Native: {len(result.violations)} violation(s) in {total_ms:.1f}ms\n")
             sys.stderr.flush()
 
             rule_timings = [
                 common_pb2.RuleTiming(
-                    rule_id=rt.rule_id, elapsed_ms=rt.elapsed_ms, violations=rt.violations,
+                    rule_id=rt.rule_id,
+                    elapsed_ms=rt.elapsed_ms,
+                    violations=rt.violations,
                 )
                 for rt in result.rule_timings
             ]
@@ -81,6 +84,7 @@ class NativeValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             )
         except Exception as e:
             import traceback
+
             sys.stderr.write(f"[req={req_id}] Native error: {e}\n")
             traceback.print_exc(file=sys.stderr)
             sys.stderr.flush()

--- a/src/apme_engine/daemon/opa_validator_server.py
+++ b/src/apme_engine/daemon/opa_validator_server.py
@@ -8,8 +8,8 @@ import time
 import grpc
 import grpc.aio
 import httpx
-from apme.v1 import validate_pb2, validate_pb2_grpc, common_pb2
 
+from apme.v1 import common_pb2, validate_pb2, validate_pb2_grpc
 from apme_engine.daemon.violation_convert import violation_dict_to_proto
 
 OPA_REST_URL = os.environ.get("APME_OPA_REST_URL", "http://localhost:8181")
@@ -54,9 +54,7 @@ class OpaValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             result = data.get("result", [])
             violations = result if isinstance(result, list) else []
             total_ms = (time.monotonic() - t0) * 1000
-            sys.stderr.write(
-                f"[req={req_id}] OPA: {len(violations)} violation(s) in {total_ms:.1f}ms\n"
-            )
+            sys.stderr.write(f"[req={req_id}] OPA: {len(violations)} violation(s) in {total_ms:.1f}ms\n")
             sys.stderr.flush()
         except Exception as e:
             sys.stderr.write(f"[req={req_id}] OPA error: {e}\n")
@@ -66,6 +64,7 @@ class OpaValidatorServicer(validate_pb2_grpc.ValidatorServicer):
         total_ms = (time.monotonic() - t0) * 1000
 
         from collections import Counter
+
         rule_counts = Counter(v.get("rule_id", "unknown") for v in violations)
         rule_timings = [
             common_pb2.RuleTiming(rule_id="opa_query", elapsed_ms=opa_query_ms, violations=len(violations)),

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -1,10 +1,11 @@
 """Primary daemon: async gRPC server that runs engine then fans out to all validators."""
 
 import asyncio
+import contextlib
 import json
 import os
-import sys
 import shutil
+import sys
 import tempfile
 import time
 import uuid
@@ -14,10 +15,10 @@ from pathlib import Path
 import grpc
 import grpc.aio
 import jsonpickle
-from apme.v1 import primary_pb2, primary_pb2_grpc, validate_pb2, validate_pb2_grpc, common_pb2
 
-from apme_engine.runner import run_scan
+from apme.v1 import common_pb2, primary_pb2, primary_pb2_grpc, validate_pb2, validate_pb2_grpc
 from apme_engine.daemon.violation_convert import violation_proto_to_dict
+from apme_engine.runner import run_scan
 
 _MAX_CONCURRENT_RPCS = int(os.environ.get("APME_PRIMARY_MAX_RPCS", "16"))
 
@@ -37,6 +38,7 @@ def _sort_violations(violations: list[dict]) -> list[dict]:
         if not isinstance(line, (int, float)):
             line = 0
         return (f, line)
+
     return sorted(violations, key=key)
 
 
@@ -111,16 +113,23 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                 return primary_pb2.ScanResponse(scan_id=scan_id, violations=[])
 
             temp_dir = await asyncio.get_event_loop().run_in_executor(
-                None, _write_chunked_fs, request.project_root or "project", list(request.files),
+                None,
+                _write_chunked_fs,
+                request.project_root or "project",
+                list(request.files),
             )
             target = str(temp_dir)
             project_root = target
 
             engine_t0 = time.monotonic()
             context_obj = await asyncio.get_event_loop().run_in_executor(
-                None, run_scan, target, project_root, True,
+                None,
+                run_scan,
+                target,
+                project_root,
+                True,
             )
-            engine_wall_ms = (time.monotonic() - engine_t0) * 1000
+            (time.monotonic() - engine_t0) * 1000
 
             if not context_obj.hierarchy_payload:
                 sys.stderr.write(f"[req={scan_id}] Scan: no hierarchy payload produced\n")
@@ -154,7 +163,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                 fan_out_ms = (time.monotonic() - fan_t0) * 1000
 
                 counts: dict[str, int] = {}
-                for name, result in zip(tasks.keys(), results):
+                for name, result in zip(tasks.keys(), results, strict=False):
                     if isinstance(result, Exception):
                         sys.stderr.write(f"[req={scan_id}] {name} raised: {result}\n")
                         sys.stderr.flush()
@@ -171,6 +180,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
 
             violations = _deduplicate_violations(_sort_violations(violations))
             from apme_engine.daemon.violation_convert import violation_dict_to_proto
+
             proto_violations = [violation_dict_to_proto(v) for v in violations]
 
             total_ms = (time.monotonic() - scan_t0) * 1000
@@ -194,16 +204,15 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             )
         except Exception as e:
             import traceback
+
             sys.stderr.write(f"[req={scan_id}] Scan failed: {e}\n")
             traceback.print_exc(file=sys.stderr)
             sys.stderr.flush()
             raise
         finally:
             if temp_dir is not None and temp_dir.is_dir():
-                try:
+                with contextlib.suppress(OSError):
                     shutil.rmtree(temp_dir)
-                except OSError:
-                    pass
 
     async def Format(self, request, context):
         from apme_engine.formatter import format_content
@@ -222,16 +231,20 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                     continue
                 result = format_content(text, filename=f.path)
                 if result.changed:
-                    diffs.append(primary_pb2.FileDiff(
-                        path=f.path,
-                        original=f.content,
-                        formatted=result.formatted.encode("utf-8"),
-                        diff=result.diff,
-                    ))
+                    diffs.append(
+                        primary_pb2.FileDiff(
+                            path=f.path,
+                            original=f.content,
+                            formatted=result.formatted.encode("utf-8"),
+                            diff=result.diff,
+                        )
+                    )
             return diffs
 
         diffs = await asyncio.get_event_loop().run_in_executor(
-            None, _do_format, list(request.files),
+            None,
+            _do_format,
+            list(request.files),
         )
 
         sys.stderr.write(f"Format: {len(diffs)} file(s) changed\n")

--- a/src/apme_engine/daemon/violation_convert.py
+++ b/src/apme_engine/daemon/violation_convert.py
@@ -14,9 +14,7 @@ def violation_dict_to_proto(v: dict) -> common_pb2.Violation:
     )
     line = v.get("line")
     if isinstance(line, (list, tuple)) and len(line) >= 2:
-        out.line_range.CopyFrom(
-            common_pb2.LineRange(start=int(line[0]), end=int(line[1]))
-        )
+        out.line_range.CopyFrom(common_pb2.LineRange(start=int(line[0]), end=int(line[1])))
     elif isinstance(line, int):
         out.line = line
     return out

--- a/src/apme_engine/engine/__init__.py
+++ b/src/apme_engine/engine/__init__.py
@@ -1,4 +1,5 @@
 import sys
+
 from .scanner import ARIScanner, Config
 
 # ARI CLI (ARICLI, RAMCLI) not imported by default to avoid pulling in heavy deps on scanner import.
@@ -13,7 +14,6 @@ all_actions = ari_actions + ram_actions
 
 def main():
     if len(sys.argv) == 1:
-
         print("Please specify one of the following operations of ari.")
         print("[operations]")
         print("   playbook     scan a playbook (e.g. `ari playbook path/to/playbook.yml` )")

--- a/src/apme_engine/engine/analyzer.py
+++ b/src/apme_engine/engine/analyzer.py
@@ -1,11 +1,11 @@
 import argparse
 import json
-from typing import List
-from apme_engine.engine.annotators.risk_annotator_base import RiskAnnotator
-import apme_engine.engine.logger as logger
-from .models import TaskCallsInTree, AnsibleRunContext
-from .utils import load_classes_in_dir
 
+import apme_engine.engine.logger as logger
+from apme_engine.engine.annotators.risk_annotator_base import RiskAnnotator
+
+from .models import AnsibleRunContext, TaskCallsInTree
+from .utils import load_classes_in_dir
 
 annotator_cache = []
 
@@ -22,30 +22,30 @@ def load_annotators(ctx: AnsibleRunContext = None):
         try:
             _annotator = a(context=ctx)
             _annotators.append(_annotator)
-        except Exception:
-            raise ValueError(f"failed to load an annotator: {a}")
+        except Exception as err:
+            raise ValueError(f"failed to load an annotator: {a}") from err
     annotator_cache = _annotators
     return _annotators
 
 
-def load_taskcalls_in_trees(path: str) -> List[TaskCallsInTree]:
+def load_taskcalls_in_trees(path: str) -> list[TaskCallsInTree]:
     taskcalls_in_trees = []
     try:
-        with open(path, "r") as file:
+        with open(path) as file:
             for line in file:
                 taskcalls_in_tree = TaskCallsInTree.from_json(line)
                 taskcalls_in_trees.append(taskcalls_in_tree)
     except Exception as e:
-        raise ValueError("failed to load the json file {} {}".format(path, e))
+        raise ValueError(f"failed to load the json file {path} {e}") from e
     return taskcalls_in_trees
 
 
-def analyze(contexts: List[AnsibleRunContext]):
+def analyze(contexts: list[AnsibleRunContext]):
     num = len(contexts)
     for i, ctx in enumerate(contexts):
         if not isinstance(ctx, AnsibleRunContext):
             continue
-        for j, t in enumerate(ctx.tasks):
+        for _j, t in enumerate(ctx.tasks):
             annotator = None
             _annotators = load_annotators(ctx)
             for ax in _annotators:
@@ -61,7 +61,7 @@ def analyze(contexts: List[AnsibleRunContext]):
                 continue
             if result.annotations:
                 t.annotations.extend(result.annotations)
-        logger.debug("analyze() {}/{} done".format(i + 1, num))
+        logger.debug(f"analyze() {i + 1}/{num} done")
     return contexts
 
 
@@ -88,7 +88,7 @@ def main():
 
     if args.output != "":
         lines = [json.dumps(single_tree_data) for single_tree_data in taskcalls_in_trees]
-        with open(args.output, mode="wt") as file:
+        with open(args.output, mode="w") as file:
             file.write("\n".join(lines))
 
 

--- a/src/apme_engine/engine/annotators/annotator_base.py
+++ b/src/apme_engine/engine/annotators/annotator_base.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
-from typing import List
-from apme_engine.engine.models import TaskCall, AnsibleRunContext, Annotation
+
+from apme_engine.engine.models import Annotation, AnsibleRunContext, TaskCall
 
 
-class Annotator(object):
+class Annotator:
     type: str = ""
     context: AnsibleRunContext = None
 
@@ -16,8 +16,8 @@ class Annotator(object):
 
 
 @dataclass
-class AnnotatorResult(object):
-    annotations: List[Annotation] = None
+class AnnotatorResult:
+    annotations: list[Annotation] = None
     data: any = None
 
     def print(self):

--- a/src/apme_engine/engine/annotators/ansible.builtin/apt.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/apt.py
@@ -1,18 +1,19 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, PackageInstallDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
 
 
 class AptAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.apt"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         pkg = task.args.get("name")
         if pkg is None:
             pkg = task.args.get("pkg")
         if pkg is None:
             pkg = task.args.get("deb")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.PACKAGE_INSTALL, detail=PackageInstallDetail(_pkg_arg=pkg))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.PACKAGE_INSTALL, detail=PackageInstallDetail(_pkg_arg=pkg)
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/apt_key.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/apt_key.py
@@ -1,13 +1,12 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, KeyConfigChangeDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, KeyConfigChangeDetail, RiskAnnotation, TaskCall
 
 
 class AptKeyAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.apt_key"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         # id = task.args.get("id")
         key = None
         if key is None:
@@ -19,6 +18,7 @@ class AptKeyAnnotator(ModuleAnnotator):
 
         state = task.args.get("state")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.CONFIG_CHANGE,
-                                         detail=KeyConfigChangeDetail(_key_arg=key, _state_arg=state))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.CONFIG_CHANGE, detail=KeyConfigChangeDetail(_key_arg=key, _state_arg=state)
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/assemble.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/assemble.py
@@ -1,17 +1,18 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, FileChangeDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class AssembleAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.assemble"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         path = task.args.get("dest")
         src = task.args.get("src")
         unsafe_writes = task.args.get("unsafe_writes")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.FILE_CHANGE,
-                                         detail=FileChangeDetail(_path_arg=path, _src_arg=src, _unsafe_write_arg=unsafe_writes))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.FILE_CHANGE,
+            detail=FileChangeDetail(_path_arg=path, _src_arg=src, _unsafe_write_arg=unsafe_writes),
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/blockinfile.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/blockinfile.py
@@ -1,17 +1,18 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, FileChangeDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class BlockinfileAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.blockinfile"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         path = task.args.get("path")
         unsafe_writes = task.args.get("unsafe_writes")
         state = task.args.get("state")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.FILE_CHANGE,
-                                         detail=FileChangeDetail(_path_arg=path, _state_arg=state, _unsafe_write_arg=unsafe_writes))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.FILE_CHANGE,
+            detail=FileChangeDetail(_path_arg=path, _state_arg=state, _unsafe_write_arg=unsafe_writes),
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/command.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/command.py
@@ -1,5 +1,5 @@
-from apme_engine.engine.models import RiskAnnotation, TaskCall, DefaultRiskType, CommandExecDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import CommandExecDetail, DefaultRiskType, RiskAnnotation, TaskCall
 
 
 class CommandAnnotator(ModuleAnnotator):

--- a/src/apme_engine/engine/annotators/ansible.builtin/dnf.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/dnf.py
@@ -1,17 +1,20 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, PackageInstallDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
 
 
 class DnfAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.dnf"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         pkg = task.args.get("name")
         allow_downgrade = task.args.get("allow_downgrade")
         validate_certs = task.args.get("validate_certs")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.PACKAGE_INSTALL, detail=PackageInstallDetail(_pkg_arg=pkg,
-                                         _validate_certs_arg=validate_certs, _allow_downgrade_arg=allow_downgrade))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.PACKAGE_INSTALL,
+            detail=PackageInstallDetail(
+                _pkg_arg=pkg, _validate_certs_arg=validate_certs, _allow_downgrade_arg=allow_downgrade
+            ),
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/expect.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/expect.py
@@ -1,5 +1,5 @@
-from apme_engine.engine.models import RiskAnnotation, TaskCall, DefaultRiskType, CommandExecDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import CommandExecDetail, DefaultRiskType, RiskAnnotation, TaskCall
 
 
 class RawAnnotator(ModuleAnnotator):

--- a/src/apme_engine/engine/annotators/ansible.builtin/file.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/file.py
@@ -1,18 +1,19 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, FileChangeDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class FileAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.file"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         path = task.args.get("path")
         mode = task.args.get("mode")
         unsafe_writes = task.args.get("unsafe_writes")
         state = task.args.get("state")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.FILE_CHANGE,
-                                         detail=FileChangeDetail(_path_arg=path, _state_arg=state, _mode_arg=mode, _unsafe_write_arg=unsafe_writes))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.FILE_CHANGE,
+            detail=FileChangeDetail(_path_arg=path, _state_arg=state, _mode_arg=mode, _unsafe_write_arg=unsafe_writes),
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/get_url.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/get_url.py
@@ -1,15 +1,16 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, InboundTransferDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
 
 
 class GetURLAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.get_url"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         src = task.args.get("url")
         dest = task.args.get("dest")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.INBOUND, detail=InboundTransferDetail(_src_arg=src, _dest_arg=dest))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.INBOUND, detail=InboundTransferDetail(_src_arg=src, _dest_arg=dest)
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/git.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/git.py
@@ -1,15 +1,16 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, InboundTransferDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
 
 
 class GetURLAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.git"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         src = task.args.get("repo")
         dest = task.args.get("dest")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.INBOUND, detail=InboundTransferDetail(_src_arg=src, _dest_arg=dest))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.INBOUND, detail=InboundTransferDetail(_src_arg=src, _dest_arg=dest)
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/lineinfile.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/lineinfile.py
@@ -1,18 +1,19 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, FileChangeDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class LineInFileAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.lineinfile"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         path = task.args.get("path")
         mode = task.args.get("mode")
         unsafe_writes = task.args.get("unsafe_writes")
         state = task.args.get("state")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.FILE_CHANGE,
-                                         detail=FileChangeDetail(_path_arg=path, _state_arg=state, _mode_arg=mode, _unsafe_write_arg=unsafe_writes))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.FILE_CHANGE,
+            detail=FileChangeDetail(_path_arg=path, _state_arg=state, _mode_arg=mode, _unsafe_write_arg=unsafe_writes),
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/pip.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/pip.py
@@ -1,16 +1,17 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, PackageInstallDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
 
 
 class PipAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.pip"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         pkg = task.args.get("name")
         if pkg is None:
             pkg = task.args.get("requirements")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.PACKAGE_INSTALL, detail=PackageInstallDetail(_pkg_arg=pkg))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.PACKAGE_INSTALL, detail=PackageInstallDetail(_pkg_arg=pkg)
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/raw.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/raw.py
@@ -1,5 +1,5 @@
-from apme_engine.engine.models import RiskAnnotation, TaskCall, DefaultRiskType, CommandExecDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import CommandExecDetail, DefaultRiskType, RiskAnnotation, TaskCall
 
 
 class RawAnnotator(ModuleAnnotator):

--- a/src/apme_engine/engine/annotators/ansible.builtin/replace.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/replace.py
@@ -1,17 +1,18 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, FileChangeDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class ReplaceAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.replace"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         path = task.args.get("path")
         mode = task.args.get("mode")
         unsafe_writes = task.args.get("unsafe_writes")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.FILE_CHANGE,
-                                         detail=FileChangeDetail(_path_arg=path, _mode_arg=mode, _unsafe_write_arg=unsafe_writes))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.FILE_CHANGE,
+            detail=FileChangeDetail(_path_arg=path, _mode_arg=mode, _unsafe_write_arg=unsafe_writes),
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/rpm_key.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/rpm_key.py
@@ -1,16 +1,16 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, KeyConfigChangeDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, KeyConfigChangeDetail, RiskAnnotation, TaskCall
 
 
 class RpmKeyAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.rpm_key"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         key = task.args.get("key")
         state = task.args.get("state")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.CONFIG_CHANGE,
-                                         detail=KeyConfigChangeDetail(_key_arg=key, _state_arg=state))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.CONFIG_CHANGE, detail=KeyConfigChangeDetail(_key_arg=key, _state_arg=state)
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/script.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/script.py
@@ -1,5 +1,5 @@
-from apme_engine.engine.models import RiskAnnotation, TaskCall, DefaultRiskType, CommandExecDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import CommandExecDetail, DefaultRiskType, RiskAnnotation, TaskCall
 
 
 class ScriptAnnotator(ModuleAnnotator):

--- a/src/apme_engine/engine/annotators/ansible.builtin/shell.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/shell.py
@@ -1,5 +1,5 @@
-from apme_engine.engine.models import RiskAnnotation, TaskCall, DefaultRiskType, CommandExecDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import CommandExecDetail, DefaultRiskType, RiskAnnotation, TaskCall
 
 
 class ShellAnnotator(ModuleAnnotator):

--- a/src/apme_engine/engine/annotators/ansible.builtin/subversion.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/subversion.py
@@ -1,14 +1,15 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, InboundTransferDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
 
 
 class SubversionAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.subversion"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         src = task.args.get("repo")
         dest = task.args.get("dest")
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.INBOUND, detail=InboundTransferDetail(_src_arg=src, _dest_arg=dest))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.INBOUND, detail=InboundTransferDetail(_src_arg=src, _dest_arg=dest)
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/template.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/template.py
@@ -1,18 +1,19 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, FileChangeDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class TemplateAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.template"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         path = task.args.get("dest")
         src = task.args.get("src")
         mode = task.args.get("mode")
         unsafe_writes = task.args.get("unsafe_writes")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.FILE_CHANGE,
-                                         detail=FileChangeDetail(_path_arg=path, _src_arg=src, _mode_arg=mode, _unsafe_write_arg=unsafe_writes))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.FILE_CHANGE,
+            detail=FileChangeDetail(_path_arg=path, _src_arg=src, _mode_arg=mode, _unsafe_write_arg=unsafe_writes),
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/unarchive.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/unarchive.py
@@ -1,31 +1,27 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, InboundTransferDetail
-from apme_engine.engine.utils import parse_bool
+import contextlib
+
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.utils import parse_bool
 
 
 class UnarchiveAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.unarchive"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         src = task.args.get("src")  # required
         dest = task.args.get("dest")  # required
         remote_src = task.args.get("remote_src")
 
         is_remote_src = False
         if remote_src:
-
-            if isinstance(remote_src.raw, str) or isinstance(remote_src.raw, bool):
-                try:
+            if isinstance(remote_src.raw, (str, bool)):
+                with contextlib.suppress(Exception):
                     is_remote_src = parse_bool(remote_src.raw)
-                except Exception:
-                    pass
-            if not is_remote_src and (isinstance(remote_src.templated, str) or isinstance(remote_src.templated, bool)):
-                try:
+            if not is_remote_src and (isinstance(remote_src.templated, (str, bool))):
+                with contextlib.suppress(Exception):
                     is_remote_src = parse_bool(remote_src.templated)
-                except Exception:
-                    pass
 
         url_sep = "://"
         is_download = False
@@ -35,5 +31,7 @@ class UnarchiveAnnotator(ModuleAnnotator):
         if not is_download:
             return None
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.INBOUND, detail=InboundTransferDetail(_src_arg=src, _dest_arg=dest))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.INBOUND, detail=InboundTransferDetail(_src_arg=src, _dest_arg=dest)
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible.builtin/uri.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/uri.py
@@ -1,5 +1,5 @@
-from apme_engine.engine.models import RiskAnnotation, TaskCall, DefaultRiskType, OutboundTransferDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import DefaultRiskType, OutboundTransferDetail, RiskAnnotation, TaskCall
 
 
 class URIAnnotator(ModuleAnnotator):

--- a/src/apme_engine/engine/annotators/ansible.builtin/yum.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/yum.py
@@ -1,17 +1,20 @@
-from typing import List
-from apme_engine.engine.models import Annotation, RiskAnnotation, TaskCall, DefaultRiskType, PackageInstallDetail
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import Annotation, DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
 
 
 class YumAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.yum"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         pkg = task.args.get("name")
         allow_downgrade = task.args.get("allow_downgrade")
         validate_certs = task.args.get("validate_certs")
 
-        annotation = RiskAnnotation.init(risk_type=DefaultRiskType.PACKAGE_INSTALL, detail=PackageInstallDetail(_pkg_arg=pkg,
-                                         _validate_certs_arg=validate_certs, _allow_downgrade_arg=allow_downgrade))
+        annotation = RiskAnnotation.init(
+            risk_type=DefaultRiskType.PACKAGE_INSTALL,
+            detail=PackageInstallDetail(
+                _pkg_arg=pkg, _validate_certs_arg=validate_certs, _allow_downgrade_arg=allow_downgrade
+            ),
+        )
         return ModuleAnnotatorResult(annotations=[annotation])

--- a/src/apme_engine/engine/annotators/ansible_builtin.py
+++ b/src/apme_engine/engine/annotators/ansible_builtin.py
@@ -1,5 +1,5 @@
-from apme_engine.engine.models import TaskCall
 from apme_engine.engine.annotators.risk_annotator_base import RiskAnnotator
+from apme_engine.engine.models import TaskCall
 
 
 class AnsibleBuiltinRiskAnnotator(RiskAnnotator):

--- a/src/apme_engine/engine/annotators/module_annotator_base.py
+++ b/src/apme_engine/engine/annotators/module_annotator_base.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
-from apme_engine.engine.models import TaskCall
+
 from apme_engine.engine.annotators.annotator_base import Annotator, AnnotatorResult
+from apme_engine.engine.models import TaskCall
 
 
 class ModuleAnnotator(Annotator):

--- a/src/apme_engine/engine/annotators/risk_annotator_base.py
+++ b/src/apme_engine/engine/annotators/risk_annotator_base.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-from apme_engine.engine.models import TaskCall, RiskAnnotation
-from apme_engine.engine.utils import load_classes_in_dir
+
 from apme_engine.engine.annotators.annotator_base import Annotator, AnnotatorResult
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
+from apme_engine.engine.models import RiskAnnotation, TaskCall
+from apme_engine.engine.utils import load_classes_in_dir
 
 
 class RiskAnnotator(Annotator):

--- a/src/apme_engine/engine/annotators/sample_custom_annotator.py
+++ b/src/apme_engine/engine/annotators/sample_custom_annotator.py
@@ -1,7 +1,6 @@
-from typing import List
-from apme_engine.engine.models import TaskCall, Annotation, RiskAnnotation, DefaultRiskType
-from apme_engine.engine.annotators.variable_resolver import VariableAnnotation
 from apme_engine.engine.annotators.risk_annotator_base import RiskAnnotator
+from apme_engine.engine.annotators.variable_resolver import VariableAnnotation
+from apme_engine.engine.models import Annotation, DefaultRiskType, RiskAnnotation, TaskCall
 
 
 class SampleCustomAnnotator(RiskAnnotator):
@@ -15,7 +14,7 @@ class SampleCustomAnnotator(RiskAnnotator):
         return False
 
     # extract analyzed_data from task and embed it
-    def run(self, task: TaskCall) -> List[Annotation]:
+    def run(self, task: TaskCall) -> list[Annotation]:
         resolved_name = task.spec.resolved_name
         options = task.spec.module_options
         var_annos = task.get_annotation_by_type(VariableAnnotation.type)

--- a/src/apme_engine/engine/annotators/variable_resolver.py
+++ b/src/apme_engine/engine/annotators/variable_resolver.py
@@ -1,20 +1,20 @@
 from dataclasses import dataclass
-from typing import List
+
+from apme_engine.engine.annotators.annotator_base import Annotator, AnnotatorResult
+from apme_engine.engine.context import Context, resolve_module_options
 from apme_engine.engine.keyutil import detect_type
 from apme_engine.engine.models import (
-    ObjectList,
-    Repository,
-    Playbook,
-    Role,
-    TaskCall,
-    VariableAnnotation,
     Arguments,
     ArgumentsType,
+    ObjectList,
+    Playbook,
+    Repository,
+    Role,
+    TaskCall,
     Variable,
+    VariableAnnotation,
     VariableType,
 )
-from apme_engine.engine.context import Context, resolve_module_options
-from apme_engine.engine.annotators.annotator_base import Annotator, AnnotatorResult
 
 
 class VariableAnnotator(Annotator):
@@ -112,9 +112,7 @@ def tree_to_task_list(tree, node_objects):
         node_type = detect_type(node.key)
 
         children_tasks = []
-        if node_type == "module":
-            resolved_name = no.fqcn
-        elif node_type == "role":
+        if node_type == "module" or node_type == "role":
             resolved_name = no.fqcn
         elif node_type == "taskfile":
             resolved_name = no.key
@@ -130,34 +128,33 @@ def tree_to_task_list(tree, node_objects):
         # obj["children_types"] = list(children_per_type.keys())
         if "playbook" in children_per_type:
             tasks_per_children = [getSubTree(c) for c in children_per_type["playbook"]]
-            for (_tasks, _) in tasks_per_children:
+            for _tasks, _ in tasks_per_children:
                 children_tasks.extend(_tasks)
         if "play" in children_per_type:
             tasks_per_children = [getSubTree(c) for c in children_per_type["play"]]
-            for (_tasks, _) in tasks_per_children:
+            for _tasks, _ in tasks_per_children:
                 children_tasks.extend(_tasks)
         if "role" in children_per_type:
             tasks_per_children = [getSubTree(c) for c in children_per_type["role"]]
-            for (_tasks, _) in tasks_per_children:
+            for _tasks, _ in tasks_per_children:
                 children_tasks.extend(_tasks)
             if node_type == "task":
                 fqcns = [fqcn for (_, fqcn) in tasks_per_children]
                 resolved_name = fqcns[0] if len(fqcns) > 0 else ""
         if "taskfile" in children_per_type:
             tasks_per_children = [getSubTree(c) for c in children_per_type["taskfile"]]
-            for (_tasks, _) in tasks_per_children:
+            for _tasks, _ in tasks_per_children:
                 children_tasks.extend(_tasks)
             if node_type == "task":
                 _tf_path_list = [_tf_path for (_, _tf_path) in tasks_per_children]
                 resolved_name = _tf_path_list[0] if len(_tf_path_list) > 0 else ""
         if "task" in children_per_type:
             tasks_per_children = [getSubTree(c) for c in children_per_type["task"]]
-            for (_tasks, _) in tasks_per_children:
+            for _tasks, _ in tasks_per_children:
                 children_tasks.extend(_tasks)
-        if "module" in children_per_type:
-            if node_type == "task":
-                fqcns = [getSubTree(c)[1] for c in children_per_type["module"]]
-                resolved_name = fqcns[0] if len(fqcns) > 0 else ""
+        if "module" in children_per_type and node_type == "task":
+            fqcns = [getSubTree(c)[1] for c in children_per_type["module"]]
+            resolved_name = fqcns[0] if len(fqcns) > 0 else ""
 
         if node_type == "task":
             no.resolved_name = resolved_name
@@ -169,7 +166,7 @@ def tree_to_task_list(tree, node_objects):
     return tasks
 
 
-def resolve_variables(tree: ObjectList, additional: ObjectList) -> List[TaskCall]:
+def resolve_variables(tree: ObjectList, additional: ObjectList) -> list[TaskCall]:
     tree_root_key = tree.items[0].spec.key if len(tree.items) > 0 else ""
     inventories = get_inventories(tree_root_key, additional)
     context = Context(inventories=inventories)
@@ -209,10 +206,9 @@ def get_inventories(tree_root_key, additional):
                     if playbook == tree_root_key:
                         inventories = p.inventories
                         found = True
-                elif isinstance(playbook, Playbook):
-                    if playbook.key == tree_root_key:
-                        inventories = p.inventories
-                        found = True
+                elif isinstance(playbook, Playbook) and playbook.key == tree_root_key:
+                    inventories = p.inventories
+                    found = True
                 if found:
                     break
         elif tree_root_type == "role":
@@ -221,10 +217,9 @@ def get_inventories(tree_root_key, additional):
                     if role == tree_root_key:
                         inventories = p.inventories
                         found = True
-                elif isinstance(role, Role):
-                    if role.key == tree_root_key:
-                        inventories = p.inventories
-                        found = True
+                elif isinstance(role, Role) and role.key == tree_root_key:
+                    inventories = p.inventories
+                    found = True
                 if found:
                     break
         if found:

--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -2,7 +2,6 @@ import codecs
 import os
 import re
 
-
 valid_playbook_re = re.compile(r"^\s*?-?\s*?(?:hosts|include|import_playbook):\s*?.*?$")
 
 
@@ -19,15 +18,10 @@ def could_be_playbook(fpath):
     try:
         with codecs.open(fpath, "r", encoding="utf-8", errors="ignore") as f:
             for n, line in enumerate(f):
-                if valid_playbook_re.match(line):
+                if valid_playbook_re.match(line) or n == 0 and line.startswith("$ANSIBLE_VAULT;"):
                     matched = True
                     break
-                # Any YAML file can also be encrypted with vault;
-                # allow these to be used as the main playbook.
-                elif n == 0 and line.startswith("$ANSIBLE_VAULT;"):
-                    matched = True
-                    break
-    except IOError:
+    except OSError:
         return False
     return matched
 
@@ -37,7 +31,7 @@ def could_be_playbook(fpath):
 def search_playbooks(root_path):
     results = []
     if root_path and os.path.exists(root_path):
-        for dirpath, dirnames, filenames in os.walk(root_path, followlinks=False):
+        for dirpath, _dirnames, filenames in os.walk(root_path, followlinks=False):
             if skip_directory(dirpath):
                 continue
             for filename in filenames:
@@ -68,6 +62,4 @@ def skip_directory(relative_directory_path):
         if element.startswith("."):
             return True
     # Exclude anything inside of group or host vars directories
-    if "group_vars" in path_elements or "host_vars" in path_elements:
-        return True
-    return False
+    return bool("group_vars" in path_elements or "host_vars" in path_elements)

--- a/src/apme_engine/engine/cli/__init__.py
+++ b/src/apme_engine/engine/cli/__init__.py
@@ -1,16 +1,16 @@
-import os
-import json
 import argparse
+import json
+import os
 
+from ..finder import get_yml_list, list_scan_target, update_the_yaml_target
 from ..scanner import ARIScanner, config
 from ..utils import (
-    is_url,
-    is_local_path,
     get_collection_metadata,
     get_role_metadata,
+    is_local_path,
+    is_url,
     split_name_and_version,
 )
-from ..finder import list_scan_target, update_the_yaml_target, get_yml_list
 from . import logger
 
 
@@ -25,30 +25,64 @@ class ARICLI:
             action="store_true",
             help="enable file save under ARI_DATA_DIR (default=/tmp/ari-data)",
         )
-        parser.add_argument("target_type", help="Content type", choices={"project", "role", "collection", "playbook", "taskfile"})
-        parser.add_argument("target_name", help="Name")
-        parser.add_argument("--playbook-only", action="store_true", help="if true, don't load playbooks/roles arround the specified playbook")
-        parser.add_argument("--taskfile-only", action="store_true", help="if true, don't load playbooks/roles arround the specified taskfile")
         parser.add_argument(
-            "--skip-isolated-taskfiles", action="store_true", help="if true, skip isolated (not imported/included) taskfiles from roles"
+            "target_type", help="Content type", choices={"project", "role", "collection", "playbook", "taskfile"}
         )
-        parser.add_argument("--skip-install", action="store_true", help="if true, skip install for the specified target")
-        parser.add_argument("--dependency-dir", nargs="?", help="path to a directory that have dependencies for the target")
+        parser.add_argument("target_name", help="Name")
+        parser.add_argument(
+            "--playbook-only",
+            action="store_true",
+            help="if true, don't load playbooks/roles arround the specified playbook",
+        )
+        parser.add_argument(
+            "--taskfile-only",
+            action="store_true",
+            help="if true, don't load playbooks/roles arround the specified taskfile",
+        )
+        parser.add_argument(
+            "--skip-isolated-taskfiles",
+            action="store_true",
+            help="if true, skip isolated (not imported/included) taskfiles from roles",
+        )
+        parser.add_argument(
+            "--skip-install", action="store_true", help="if true, skip install for the specified target"
+        )
+        parser.add_argument(
+            "--dependency-dir", nargs="?", help="path to a directory that have dependencies for the target"
+        )
         parser.add_argument("--collection-name", nargs="?", help="if provided, use it as a collection name")
         parser.add_argument("--role-name", nargs="?", help="if provided, use it as a role name")
-        parser.add_argument("--source", help="source server name in ansible config file (if empty, use public ansible galaxy)")
-        parser.add_argument("--without-ram", action="store_true", help="if true, RAM data is not used and not even updated")
+        parser.add_argument(
+            "--source", help="source server name in ansible config file (if empty, use public ansible galaxy)"
+        )
+        parser.add_argument(
+            "--without-ram", action="store_true", help="if true, RAM data is not used and not even updated"
+        )
         parser.add_argument("--read-only-ram", action="store_true", help="if true, RAM data is used but not updated")
-        parser.add_argument("--read-ram-for-dependency", action="store_true", help="if true, RAM data is used only for dependency")
-        parser.add_argument("--update-ram", action="store_true", help="if true, RAM data is not used for scan but updated with the scan result")
-        parser.add_argument("--include-tests", action="store_true", help='if true, load test contents in "tests/integration/targets"')
+        parser.add_argument(
+            "--read-ram-for-dependency", action="store_true", help="if true, RAM data is used only for dependency"
+        )
+        parser.add_argument(
+            "--update-ram",
+            action="store_true",
+            help="if true, RAM data is not used for scan but updated with the scan result",
+        )
+        parser.add_argument(
+            "--include-tests", action="store_true", help='if true, load test contents in "tests/integration/targets"'
+        )
         parser.add_argument("--silent", action="store_true", help='if true, do not print anything"')
-        parser.add_argument("--objects", action="store_true", help="if true, output objects.json to the output directory")
-        parser.add_argument("--show-all", action="store_true", help="if true, show findings even if missing dependencies are found")
+        parser.add_argument(
+            "--objects", action="store_true", help="if true, output objects.json to the output directory"
+        )
+        parser.add_argument(
+            "--show-all", action="store_true", help="if true, show findings even if missing dependencies are found"
+        )
         parser.add_argument("--json", help="if specified, show findings in json format")
         parser.add_argument("--yaml", help="if specified, show findings in yaml format")
         parser.add_argument(
-            "--save-only-rule-result", action="store_true", help="if true, save only rule results and remove node details to reduce result file size"
+            "--save-only-rule-result",
+            action="store_true",
+            help="if true, save only rule results and remove node details to reduce result file size",
         )
         parser.add_argument(
             "--scan-per-target",
@@ -56,18 +90,26 @@ class ARICLI:
             help="if true, do scanning per playbook, role or taskfile (this reduces memory usage while scanning)",
         )
         parser.add_argument(
-            "--fix", action="store_true", help="if true, fix the scanned playbook after performing the inpline replace with ARI suggestions"
+            "--fix",
+            action="store_true",
+            help="if true, fix the scanned playbook after performing the inpline replace with ARI suggestions",
         )
         parser.add_argument(
             "--task-num-threshold",
             default="100",
-            help="A threshold number to give up scanning a file where the number of tasks exceeds this (default to 100)",
+            help=(
+                "A threshold number to give up scanning a file where the number of tasks exceeds this (default to 100)"
+            ),
         )
         parser.add_argument("-o", "--out-dir", help="output directory for the rule evaluation result")
         parser.add_argument(
-            "-r", "--rules-dir", help=f"specify custom rule directories. use `-R` instead to ignore default rules in {config.rules_dir}"
+            "-r",
+            "--rules-dir",
+            help=f"specify custom rule directories. use `-R` instead to ignore default rules in {config.rules_dir}",
         )
-        parser.add_argument("-R", "--rules-dir-without-default", help="specify custom rule directories and ignore default rules")
+        parser.add_argument(
+            "-R", "--rules-dir-without-default", help="specify custom rule directories and ignore default rules"
+        )
         args = parser.parse_args()
         self.args = args
 
@@ -133,11 +175,7 @@ class ARICLI:
         elif args.update_ram:
             read_ram = False
             write_ram = True
-        elif args.read_ram_for_dependency:
-            read_ram_for_dependency = True
-            read_ram = False
-            write_ram = False
-        elif args.include_tests:
+        elif args.read_ram_for_dependency or args.include_tests:
             read_ram_for_dependency = True
             read_ram = False
             write_ram = False
@@ -174,7 +212,7 @@ class ARICLI:
                 fpath_from_root = target_info["path_from_root"]
                 scan_type = target_info["scan_type"]
                 count_in_type = len(file_list[scan_type])
-                print(f"\r[{i+1}/{total}] {scan_type} {fpath_from_root}                 ", end="")
+                print(f"\r[{i + 1}/{total}] {scan_type} {fpath_from_root}                 ", end="")
                 out_dir = os.path.join(args.out_dir, f"{scan_type}s", str(count_in_type))
                 c.evaluate(
                     type=scan_type,
@@ -207,8 +245,10 @@ class ARICLI:
                 with open(list_file_path, "w") as file:
                     json.dump(index_data, file)
                 if args.fix:
-                    for each in index_data.keys():
-                        ari_suggestion_file_path = os.path.join(args.out_dir, f"{scan_type}s", str(each), "rule_result.json")
+                    for each in index_data:
+                        ari_suggestion_file_path = os.path.join(
+                            args.out_dir, f"{scan_type}s", str(each), "rule_result.json"
+                        )
                         logger.debug("ARI suggestion file path: %s", ari_suggestion_file_path)
                         with open(ari_suggestion_file_path) as f:
                             ari_suggestion_data = json.load(f)
@@ -222,7 +262,9 @@ class ARICLI:
                                 temp_file_path = ""
                                 for j in range(1, len(nodes)):
                                     node_rules = nodes[j]["rules"]
-                                    for k in reversed(range(len(node_rules))):  # loop through from rule 11, as that has the mutation
+                                    for k in reversed(
+                                        range(len(node_rules))
+                                    ):  # loop through from rule 11, as that has the mutation
                                         w007_rule = node_rules[k]
                                         if (w007_rule["rule"]["rule_id"]).lower() == "w007":
                                             if not w007_rule.get("verdict") and w007_rule:
@@ -232,9 +274,13 @@ class ARICLI:
                                                 break
                                             temp_data = index_data[each]
                                             if w007_rule["file"][0] not in temp_data:
-                                                target_file_path = os.path.join(args.target_name, temp_data, w007_rule["file"][0])
+                                                target_file_path = os.path.join(
+                                                    args.target_name, temp_data, w007_rule["file"][0]
+                                                )
                                                 if temp_file_path != "" and target_file_path != temp_file_path:
-                                                    update_the_yaml_target(target_file_path, line_number_list, mutated_yaml_list)
+                                                    update_the_yaml_target(
+                                                        target_file_path, line_number_list, mutated_yaml_list
+                                                    )
                                                     line_number_list = []
                                                     mutated_yaml_list = []
                                                 mutated_yaml_list.append(mutated_yaml)
@@ -242,7 +288,9 @@ class ARICLI:
                                             else:
                                                 target_file_path = os.path.join(args.target_name, temp_data)
                                                 if temp_file_path != "" and target_file_path != temp_file_path:
-                                                    update_the_yaml_target(target_file_path, line_number_list, mutated_yaml_list)
+                                                    update_the_yaml_target(
+                                                        target_file_path, line_number_list, mutated_yaml_list
+                                                    )
                                                     line_number_list = []
                                                     mutated_yaml_list = []
                                                 mutated_yaml_list.append(mutated_yaml)

--- a/src/apme_engine/engine/cli/ram/__init__.py
+++ b/src/apme_engine/engine/cli/ram/__init__.py
@@ -1,12 +1,11 @@
 import sys
 
-from .search import RAMSearchCLI
-from .list import RAMListCLI
 from .diff import RAMDiffCLI
 from .generate import RAMGenerateCLI
-from .update import RAMUpdateCLI
+from .list import RAMListCLI
 from .release import RAMReleaseCLI
-
+from .search import RAMSearchCLI
+from .update import RAMUpdateCLI
 
 ram_actions = ["search", "list", "diff", "generate", "update", "release"]
 

--- a/src/apme_engine/engine/cli/ram/diff.py
+++ b/src/apme_engine/engine/cli/ram/diff.py
@@ -1,7 +1,7 @@
 import argparse
 
-from ...scanner import config
 from ...risk_assessment_model import RAMClient
+from ...scanner import config
 from ...utils import show_diffs
 
 

--- a/src/apme_engine/engine/cli/ram/generate.py
+++ b/src/apme_engine/engine/cli/ram/generate.py
@@ -15,7 +15,9 @@ class RAMGenerateCLI:
         parser.add_argument("--serial", action="store_true", help="if True, do not parallelize ram generation")
         parser.add_argument("--no-module-spec", action="store_true", help="if True, ansible-doc is not used")
         parser.add_argument("--download-only", action="store_true", help="if True, just download the content")
-        parser.add_argument("--include-tests", action="store_true", help='if true, load test contents in "tests/integration/targets"')
+        parser.add_argument(
+            "--include-tests", action="store_true", help='if true, load test contents in "tests/integration/targets"'
+        )
         parser.add_argument("--no-retry", action="store_true", help="if True, not retry failed items.")
         parser.add_argument("-o", "--out-dir", help="output directory for the rule evaluation result")
         args = parser.parse_args()
@@ -28,11 +30,13 @@ class RAMGenerateCLI:
             raise ValueError('RAMGenerateCLI cannot be executed without "generate" action')
 
         target_list = []
-        with open(args.file, "r") as file:
+        with open(args.file) as file:
             for line in file:
                 parts = line.replace("\n", "").split(" ")
                 if len(parts) != 2:
-                    raise ValueError('target list file must be lines of "<type> <name>" such as "collection community.general"')
+                    raise ValueError(
+                        'target list file must be lines of "<type> <name>" such as "collection community.general"'
+                    )
                 target_list.append((parts[0], parts[1]))
 
         resume = -1

--- a/src/apme_engine/engine/cli/ram/list.py
+++ b/src/apme_engine/engine/cli/ram/list.py
@@ -1,7 +1,7 @@
 import argparse
 
-from ...scanner import config
 from ...risk_assessment_model import RAMClient
+from ...scanner import config
 from ...utils import show_all_ram_metadata
 
 

--- a/src/apme_engine/engine/cli/ram/release.py
+++ b/src/apme_engine/engine/cli/ram/release.py
@@ -1,7 +1,7 @@
 import argparse
 
-from ...scanner import config
 from ...risk_assessment_model import RAMClient
+from ...scanner import config
 
 
 class RAMReleaseCLI:
@@ -22,7 +22,10 @@ class RAMReleaseCLI:
             raise ValueError('RAMReleaseCLI cannot be executed without "release" action')
 
         if not args.outfile:
-            raise ValueError(' "release" action cannot be executed without `--outfile` option. Please set "tar.gz" file name to export KB files.')
+            raise ValueError(
+                '"release" action cannot be executed without `--outfile` option. '
+                'Please set "tar.gz" file name to export KB files.'
+            )
 
         ram_client = RAMClient(root_dir=config.data_dir)
         ram_client.release(args.outfile)

--- a/src/apme_engine/engine/cli/ram/search.py
+++ b/src/apme_engine/engine/cli/ram/search.py
@@ -1,7 +1,7 @@
 import argparse
 
-from ...scanner import config
 from ...risk_assessment_model import RAMClient
+from ...scanner import config
 from ...utils import split_name_and_version
 
 

--- a/src/apme_engine/engine/cli/ram/update.py
+++ b/src/apme_engine/engine/cli/ram/update.py
@@ -22,11 +22,13 @@ class RAMUpdateCLI:
             raise ValueError('RAMUpdateCLI cannot be executed without "update" action')
 
         target_list = []
-        with open(args.file, "r") as file:
+        with open(args.file) as file:
             for line in file:
                 parts = line.replace("\n", "").split(" ")
                 if len(parts) != 2:
-                    raise ValueError('target list file must be lines of "<type> <name>" such as "collection community.general"')
+                    raise ValueError(
+                        'target list file must be lines of "<type> <name>" such as "collection community.general"'
+                    )
                 target_list.append((parts[0], parts[1]))
 
         resume = -1

--- a/src/apme_engine/engine/context.py
+++ b/src/apme_engine/engine/context.py
@@ -1,47 +1,50 @@
+import copy
 import os
 import re
-import copy
 from dataclasses import dataclass, field
 from pathlib import Path
+
 from .models import (
-    Playbook,
-    Play,
-    Role,
+    BecomeInfo,
+    CallObject,
     Collection,
-    TaskFile,
-    Task,
-    TaskCall,
     InventoryType,
     Object,
-    CallObject,
+    Play,
+    Playbook,
+    Role,
+    Task,
+    TaskCall,
+    TaskFile,
     Variable,
     VariableType,
-    BecomeInfo,
     immutable_var_types,
 )
 
 p = Path(__file__).resolve().parent
-ansible_special_variables = [line.replace("\n", "") for line in open(p / "ansible_variables.txt", "r").read().splitlines()]
+ansible_special_variables = [line.replace("\n", "") for line in (p / "ansible_variables.txt").read_text().splitlines()]
 _special_var_value = "__ansible_special_variable__"
 variable_block_re = re.compile(r"{{[^}]+}}")
 
 
-def get_object(json_path, type, name, cache={}):
+def get_object(json_path, type, name, cache=None):
+    if cache is None:
+        cache = {}
     json_type = ""
     json_str = ""
-    cached = cache.get(json_path, None)
+    cached = cache.get(json_path)
     if cached is None:
         if not os.path.exists(json_path):
-            raise ValueError('the json path "{}" not found'.format(json_path))
+            raise ValueError(f'the json path "{json_path}" not found')
         basename = os.path.basename(json_path)
 
         if basename.startswith("role-"):
             json_type = "role"
-            with open(json_path, "r") as file:
+            with open(json_path) as file:
                 json_str = file.read()
         elif basename.startswith("collection-"):
             json_type = "collection"
-            with open(json_path, "r") as file:
+            with open(json_path) as file:
                 json_str = file.read()
         if json_str == "":
             raise ValueError("json data is empty")
@@ -113,7 +116,10 @@ def get_object(json_path, type, name, cache={}):
     return None
 
 
-def recursive_find_variable(var_name, var_dict={}):
+def recursive_find_variable(var_name, var_dict=None):
+    if var_dict is None:
+        var_dict = {}
+
     def _visitor(vname, nname, node):
         if nname == vname:
             return node
@@ -121,8 +127,8 @@ def recursive_find_variable(var_name, var_dict={}):
             if nname in node:
                 return node[nname]
             for k, v in node.items():
-                nname2 = "{}.{}".format(nname, k) if nname != "" else k
-                if vname.startswith("{}.".format(nname2)):
+                nname2 = f"{nname}.{k}" if nname != "" else k
+                if vname.startswith(f"{nname2}."):
                     vname2 = vname[len(nname) + 1 :]
                     return _visitor(vname2, nname2, v)
             return None
@@ -132,7 +138,9 @@ def recursive_find_variable(var_name, var_dict={}):
     return _visitor(var_name, "", var_dict)
 
 
-def flatten(var_dict: dict = {}, _prefix: str = ""):
+def flatten(var_dict: dict = None, _prefix: str = ""):
+    if var_dict is None:
+        var_dict = {}
     flat_vars = {}
     for k, v in var_dict.items():
         if isinstance(v, dict):
@@ -211,10 +219,7 @@ class Context:
                 current = self.var_set_history.get(key, [])
                 current.append(Variable(name=key, value=val, type=VariableType.RoleVars, setter=_spec.key))
                 self.var_set_history[key] = current
-        elif isinstance(_spec, Collection):
-            self.variables.update(_spec.variables)
-            self.update_flat_vars(_spec.variables)
-        elif isinstance(_spec, TaskFile):
+        elif isinstance(_spec, (Collection, TaskFile)):
             self.variables.update(_spec.variables)
             self.update_flat_vars(_spec.variables)
         elif isinstance(_spec, Task):
@@ -253,7 +258,9 @@ class Context:
             chain_node["obj"] = _obj
         self.chain.append(chain_node)
 
-    def resolve_variable(self, var_name, resolve_history={}):
+    def resolve_variable(self, var_name, resolve_history=None):
+        if resolve_history is None:
+            resolve_history = {}
         if var_name in resolve_history:
             val = resolve_history[var_name].get("value", None)
             v_type = resolve_history[var_name].get("type", VariableType.Unknown)
@@ -310,7 +317,9 @@ class Context:
                 return val, v_type, _resolve_history
 
         # TODO: consider group
-        inventory_for_all = [iv for iv in self.inventories if iv.inventory_type == InventoryType.GROUP_VARS_TYPE and iv.name == "all"]
+        inventory_for_all = [
+            iv for iv in self.inventories if iv.inventory_type == InventoryType.GROUP_VARS_TYPE and iv.name == "all"
+        ]
         for iv in inventory_for_all:
             iv_var_dict = flatten(iv.variables)
             val = iv_var_dict.get(var_name, None)
@@ -334,7 +343,9 @@ class Context:
 
         return None, VariableType.Unknown, _resolve_history
 
-    def resolve_single_variable(self, txt, resolve_history=[]):
+    def resolve_single_variable(self, txt, resolve_history=None):
+        if resolve_history is None:
+            resolve_history = []
         new_history = resolve_history.copy()
         if not isinstance(txt, str):
             return txt, new_history
@@ -379,10 +390,10 @@ class Context:
             indent = "  " * depth
             obj_type = type(obj).__name__
             obj_name = obj.name
-            line = "{}{}: {}\n".format(indent, obj_type, obj_name)
+            line = f"{indent}{obj_type}: {obj_name}\n"
             if obj_type == "Task":
                 module_name = obj.module
-                line = "{}{}: {} (module: {})\n".format(indent, obj_type, obj_name, module_name)
+                line = f"{indent}{obj_type}: {obj_name} (module: {module_name})\n"
             lines.append(line)
         return "".join(lines)
 
@@ -514,7 +525,7 @@ def resolve_module_options(context: Context, taskcall: TaskCall):
                     if isinstance(v, dict):
                         tmp_variables = {}
                         for k2, v2 in v.items():
-                            key = "{}.{}".format(loop_key, k2)
+                            key = f"{loop_key}.{k2}"
                             tmp_variables.update({key: v2})
                         variables_in_loop.append(tmp_variables)
                     else:
@@ -522,12 +533,12 @@ def resolve_module_options(context: Context, taskcall: TaskCall):
         elif isinstance(loop_values, dict):
             tmp_variables = {}
             for k, v in loop_values.items():
-                key = "{}.{}".format(loop_key, k)
+                key = f"{loop_key}.{k}"
                 tmp_variables.update({key: v})
             variables_in_loop.append(tmp_variables)
         else:
             if loop_values:
-                raise ValueError("loop_values of type {} is not supported yet".format(type(loop_values).__name__))
+                raise ValueError(f"loop_values of type {type(loop_values).__name__} is not supported yet")
 
     resolved_opts_in_loop = []
     mutable_vars_per_mo = {}
@@ -691,7 +702,11 @@ def extract_variable_names(txt):
             else:
                 if "default(" in p and ")" in p:
                     default_var = p.replace("}}", "").replace("default(", "").replace(")", "").replace(" ", "")
-                    if not default_var.startswith('"') and not default_var.startswith("'") and not re.compile(r"[0-9].*").match(default_var):
+                    if (
+                        not default_var.startswith('"')
+                        and not default_var.startswith("'")
+                        and not re.compile(r"[0-9].*").match(default_var)
+                    ):
                         default_var_name = default_var
         tmp_b = {
             "original": b,

--- a/src/apme_engine/engine/dependency_dir_preparator.py
+++ b/src/apme_engine/engine/dependency_dir_preparator.py
@@ -1,36 +1,38 @@
-import os
-import json
-import yaml
-import subprocess
-import tempfile
-import glob
-import re
-import sys
+import contextlib
 import datetime
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
 import tarfile
+import tempfile
 from copy import deepcopy
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
+
+import yaml
 
 from . import logger
-from .models import (
-    LoadType,
-)
 from .dependency_finder import find_dependency
-from .utils import (
-    escape_url,
-    install_galaxy_target,
-    install_github_target,
-    get_installed_metadata,
-    get_hash_of_url,
-    is_url,
-    is_local_path,
-)
 from .loader import (
     get_target_name,
     remove_subdirectories,
     trim_suffix,
 )
+from .models import (
+    LoadType,
+)
 from .safe_glob import safe_glob
+from .utils import (
+    escape_url,
+    get_hash_of_url,
+    get_installed_metadata,
+    install_galaxy_target,
+    install_github_target,
+    is_local_path,
+    is_url,
+)
 
 collection_manifest_json = "MANIFEST.json"
 collection_files_json = "FILES.json"
@@ -49,7 +51,7 @@ download_metadata_file = "download_meta.json"
 
 
 @dataclass
-class DownloadMetadata(object):
+class DownloadMetadata:
     name: str = ""
     type: str = ""
     version: str = ""
@@ -67,7 +69,7 @@ class DownloadMetadata(object):
 
 
 @dataclass
-class Dependency(object):
+class Dependency:
     dir: str = ""
     name: str = ""
     metadata: DownloadMetadata = field(default_factory=DownloadMetadata)
@@ -75,7 +77,7 @@ class Dependency(object):
 
 
 @dataclass
-class DependencyDirPreparator(object):
+class DependencyDirPreparator:
     root_dir: str = ""
     source_repository: str = ""
     target_type: str = ""
@@ -97,7 +99,9 @@ class DependencyDirPreparator(object):
     # -- out --
     dependency_dirs: list = field(default_factory=list)
 
-    def prepare_dir(self, root_install=True, use_ansible_path=False, is_src_installed=False, cache_enabled=False, cache_dir=""):
+    def prepare_dir(
+        self, root_install=True, use_ansible_path=False, is_src_installed=False, cache_enabled=False, cache_dir=""
+    ):
         logger.debug("setup base dirs")
         self.setup_dirs(cache_enabled, cache_dir)
         logger.debug("prepare target dir")
@@ -105,14 +109,18 @@ class DependencyDirPreparator(object):
 
         prepare_dependency = False
         # if a project target is a local path, check dependency
-        if self.target_type in [LoadType.PROJECT, LoadType.PLAYBOOK, LoadType.TASKFILE] and not is_url(self.target_name):
+        if self.target_type in [LoadType.PROJECT, LoadType.PLAYBOOK, LoadType.TASKFILE] and not is_url(
+            self.target_name
+        ):
             prepare_dependency = True
         # if a collection/role is a local path, check dependency
         if self.target_type in [LoadType.COLLECTION, LoadType.ROLE] and is_local_path(self.target_name):
             prepare_dependency = True
         if prepare_dependency:
             logger.debug("search dependencies")
-            dependencies = find_dependency(self.target_type, self.target_path, self.target_dependency_dir, use_ansible_path)
+            dependencies = find_dependency(
+                self.target_type, self.target_path, self.target_dependency_dir, use_ansible_path
+            )
             logger.debug("prepare dir for dependencies")
             self.prepare_dependency_dir(dependencies, cache_enabled, cache_dir)
         return self.dependency_dirs
@@ -137,10 +145,13 @@ class DependencyDirPreparator(object):
             pass
         else:
             # if a project target is a local path, then skip install
-            if self.target_type in [LoadType.PROJECT, LoadType.PLAYBOOK, LoadType.TASKFILE] and not is_url(self.target_name):
+            if self.target_type in [LoadType.PROJECT, LoadType.PLAYBOOK, LoadType.TASKFILE] and not is_url(
+                self.target_name
+            ):
                 root_install = False
 
-            # if a collection/role is a local path, then skip install (require MANIFEST.json or meta/main.yml to get the actual name)
+            # if a collection/role is a local path, then skip install
+            # (require MANIFEST.json or meta/main.yml to get the actual name)
             if self.target_type in [LoadType.COLLECTION, LoadType.ROLE] and is_local_path(self.target_name):
                 root_install = False
 
@@ -165,7 +176,9 @@ class DependencyDirPreparator(object):
                     download_url = ""
                     version = ""
                     hash = ""
-                    download_url, version = get_installed_metadata(self.target_type, self.target_name, self.target_path, self.target_dependency_dir)
+                    download_url, version = get_installed_metadata(
+                        self.target_type, self.target_name, self.target_path, self.target_dependency_dir
+                    )
                     if download_url != "":
                         hash = get_hash_of_url(download_url)
                     self.metadata.download_url = download_url
@@ -193,7 +206,7 @@ class DependencyDirPreparator(object):
                     if col_name == "":
                         col_name = cdep.get("source", "")
 
-                logger.debug("prepare dir for {}:{}".format(col_name, col_version))
+                logger.debug(f"prepare dir for {col_name}:{col_version}")
                 downloaded_dep = Dependency(
                     name=col_name,
                 )
@@ -214,7 +227,7 @@ class DependencyDirPreparator(object):
                     is_exist, targz_file = self.is_download_file_exist(LoadType.COLLECTION, col_name, cache_dir)
                     # check cache data
                     if is_exist:
-                        logger.debug("found cache data {}".format(targz_file))
+                        logger.debug(f"found cache data {targz_file}")
                         metadata_file = os.path.join(targz_file.rsplit("/", 1)[0], download_metadata_file)
                         md = self.find_target_metadata(LoadType.COLLECTION, metadata_file, col_name)
                         downloaded_dep.metadata = md
@@ -222,7 +235,9 @@ class DependencyDirPreparator(object):
                         # if no cache data, download
                         logger.debug("cache data not found")
                         cache_location = os.path.join(cache_dir, "collection", col_name)
-                        install_msg = self.download_galaxy_collection(col_name, cache_location, col_version, self.source_repository)
+                        install_msg = self.download_galaxy_collection(
+                            col_name, cache_location, col_version, self.source_repository
+                        )
                         metadata = self.extract_collections_metadata(install_msg, cache_location)
                         metadata_file = self.export_data(metadata, cache_location, download_metadata_file)
                         md = self.find_target_metadata(LoadType.COLLECTION, metadata_file, col_name)
@@ -251,12 +266,14 @@ class DependencyDirPreparator(object):
                         downloaded_dep.metadata.version = version
                         downloaded_dep.dir = sub_dependency_dir_path
                 else:
-                    logger.debug("download dependency {}".format(col_name))
+                    logger.debug(f"download dependency {col_name}")
                     is_exist, targz = self.is_download_file_exist(
                         LoadType.COLLECTION, col_name, os.path.join(self.download_location, "collection", col_name)
                     )
                     if is_exist:
-                        metadata_file = os.path.join(self.download_location, "collection", col_name, download_metadata_file)
+                        metadata_file = os.path.join(
+                            self.download_location, "collection", col_name, download_metadata_file
+                        )
                         self.install_galaxy_collection_from_targz(targz, sub_dependency_dir_path)
                         md = self.find_target_metadata(LoadType.COLLECTION, metadata_file, col_name)
                     else:
@@ -264,7 +281,9 @@ class DependencyDirPreparator(object):
                         sub_download_location = os.path.join(self.download_location, "collection", col_name)
                         if not os.path.exists(sub_download_location):
                             os.makedirs(sub_download_location)
-                        install_msg = self.download_galaxy_collection(col_name, sub_download_location, col_version, self.source_repository)
+                        install_msg = self.download_galaxy_collection(
+                            col_name, sub_download_location, col_version, self.source_repository
+                        )
                         metadata = self.extract_collections_metadata(install_msg, sub_download_location)
                         metadata_file = self.export_data(metadata, sub_download_location, download_metadata_file)
                         md = self.find_target_metadata(LoadType.COLLECTION, metadata_file, col_name)
@@ -295,7 +314,7 @@ class DependencyDirPreparator(object):
                     name = rdep.get("name", "")
                     if name == "":
                         name = rdep.get("src", "")
-                logger.debug("prepare dir for {}".format(name))
+                logger.debug(f"prepare dir for {name}")
                 downloaded_dep = Dependency(
                     name=name,
                     is_local_dir=is_local_dir,
@@ -338,12 +357,14 @@ class DependencyDirPreparator(object):
                         install_dir = sub_dependency_dir_path
                         if os.path.exists(install_dir):
                             install_dir = os.path.dirname(install_dir)
-                        install_msg, install_err = install_galaxy_target(name, LoadType.ROLE, install_dir, self.source_repository, target_version)
-                        logger.debug("role install msg: {}".format(install_msg))
-                        logger.debug("role install msg err: {}".format(install_err))
+                        install_msg, install_err = install_galaxy_target(
+                            name, LoadType.ROLE, install_dir, self.source_repository, target_version
+                        )
+                        logger.debug(f"role install msg: {install_msg}")
+                        logger.debug(f"role install msg err: {install_err}")
                         metadata = self.extract_roles_metadata(install_msg)
                         if not metadata:
-                            raise ValueError("failed to install {} {}".format(LoadType.ROLE, name))
+                            raise ValueError(f"failed to install {LoadType.ROLE} {name}")
                         metadata_file = self.export_data(metadata, download_meta_dir_path, download_metadata_file)
                         md = self.find_target_metadata(LoadType.ROLE, metadata_file, name)
                         # save cache
@@ -371,12 +392,14 @@ class DependencyDirPreparator(object):
                         downloaded_dep.metadata.version = version
                         downloaded_dep.dir = sub_dependency_dir_path
                 else:
-                    install_msg, install_err = install_galaxy_target(name, LoadType.ROLE, sub_dependency_dir_path, self.source_repository)
-                    logger.debug("role install msg: {}".format(install_msg))
-                    logger.debug("role install msg err: {}".format(install_err))
+                    install_msg, install_err = install_galaxy_target(
+                        name, LoadType.ROLE, sub_dependency_dir_path, self.source_repository
+                    )
+                    logger.debug(f"role install msg: {install_msg}")
+                    logger.debug(f"role install msg err: {install_err}")
                     metadata = self.extract_roles_metadata(install_msg)
                     if not metadata:
-                        raise ValueError("failed to install {} {}".format(LoadType.ROLE, name))
+                        raise ValueError(f"failed to install {LoadType.ROLE} {name}")
                     sub_download_location = os.path.join(self.download_location, "role", name)
                     metadata_file = self.export_data(metadata, sub_download_location, download_metadata_file)
                     md = self.find_target_metadata(LoadType.ROLE, metadata_file, name)
@@ -399,15 +422,15 @@ class DependencyDirPreparator(object):
         if not os.path.exists(tmp_src_dir):
             os.makedirs(tmp_src_dir)
 
-        logger.debug("root type is {}".format(self.target_type))
+        logger.debug(f"root type is {self.target_type}")
         if self.target_type == LoadType.PROJECT:
             # install_type = "github"
             # ansible-galaxy install
             if not self.silent:
-                print("cloning {} from github".format(self.target_name))
+                print(f"cloning {self.target_name} from github")
             install_msg = install_github_target(self.target_name, tmp_src_dir)
             if not self.silent:
-                logger.debug("STDOUT: {}".format(install_msg))
+                logger.debug(f"STDOUT: {install_msg}")
             # if self.target_dependency_dir == "":
             #     raise ValueError("dependency dir is required for project type")
             dependency_dir = self.target_dependency_dir
@@ -416,12 +439,16 @@ class DependencyDirPreparator(object):
         elif self.target_type == LoadType.COLLECTION:
             install_msg = ""
             sub_download_location = os.path.join(self.download_location, "collection", self.target_name)
-            is_exist, targz_file = self.is_download_file_exist(LoadType.COLLECTION, self.target_name, self.download_location)
+            is_exist, targz_file = self.is_download_file_exist(
+                LoadType.COLLECTION, self.target_name, self.download_location
+            )
             if is_exist:
                 metadata_file = os.path.join(targz_file.rsplit("/", 1)[0], download_metadata_file)
                 md = self.find_target_metadata(LoadType.COLLECTION, metadata_file, self.target_name)
             else:
-                install_msg = self.download_galaxy_collection(self.target_name, sub_download_location, version=self.target_version)
+                install_msg = self.download_galaxy_collection(
+                    self.target_name, sub_download_location, version=self.target_version
+                )
                 metadata = self.extract_collections_metadata(install_msg, sub_download_location)
                 metadata_file = self.export_data(metadata, sub_download_location, download_metadata_file)
                 md = self.find_target_metadata(LoadType.COLLECTION, metadata_file, self.target_name)
@@ -435,7 +462,7 @@ class DependencyDirPreparator(object):
             sub_download_location = os.path.join(self.download_location, "roles", self.target_name)
             metafile_location = os.path.join(self.download_location, "roles_download_meta", self.target_name)
             if os.path.exists(sub_download_location) and len(os.listdir(sub_download_location)) != 0:
-                logger.debug("found cache data {}".format(sub_download_location))
+                logger.debug(f"found cache data {sub_download_location}")
                 metadata_file = os.path.join(metafile_location, download_metadata_file)
                 md = self.find_target_metadata(LoadType.ROLE, metadata_file, self.target_name)
                 tmp_target_dir = os.path.join(tmp_src_dir, self.target_name)
@@ -444,13 +471,17 @@ class DependencyDirPreparator(object):
                 self.move_src(sub_download_location, tmp_target_dir)
             else:
                 install_msg, install_err = install_galaxy_target(
-                    self.target_name, self.target_type, tmp_src_dir, self.source_repository, target_version=self.target_version
+                    self.target_name,
+                    self.target_type,
+                    tmp_src_dir,
+                    self.source_repository,
+                    target_version=self.target_version,
                 )
-                logger.debug("role install msg: {}".format(install_msg))
-                logger.debug("role install msg err: {}".format(install_err))
+                logger.debug(f"role install msg: {install_msg}")
+                logger.debug(f"role install msg err: {install_err}")
                 metadata = self.extract_roles_metadata(install_msg)
                 if not metadata:
-                    raise ValueError("failed to install {} {}".format(self.target_type, self.target_name))
+                    raise ValueError(f"failed to install {self.target_type} {self.target_name}")
                 metadata_file = self.export_data(metadata, metafile_location, download_metadata_file)
                 md = self.find_target_metadata(LoadType.ROLE, metadata_file, self.target_name)
                 # save cache
@@ -458,10 +489,10 @@ class DependencyDirPreparator(object):
                     os.makedirs(sub_download_location)
                 self.move_src(tmp_src_dir, sub_download_location)
             if not md:
-                raise ValueError("failed to install {} {}".format(self.target_type, self.target_name))
+                raise ValueError(f"failed to install {self.target_type} {self.target_name}")
             dependency_dir = tmp_src_dir
             dst_src_dir = self.target_path_mappings["src"]
-            self.metadata.download_src_path = "{}.{}".format(dst_src_dir, self.target_name)
+            self.metadata.download_src_path = f"{dst_src_dir}.{self.target_name}"
             self.metadata = md
         else:
             raise ValueError("unsupported container type")
@@ -474,13 +505,13 @@ class DependencyDirPreparator(object):
 
         if not self.silent:
             print("moving index")
-            logger.debug("index: {}".format(json.dumps(self.index)))
+            logger.debug(f"index: {json.dumps(self.index)}")
         if self.do_save:
             self.__save_index()
         if not os.path.exists(dst_src_dir):
             os.makedirs(dst_src_dir)
         self.move_src(tmp_src_dir, dst_src_dir)
-        root_dst_src_path = "{}/{}".format(dst_src_dir, self.target_name)
+        root_dst_src_path = f"{dst_src_dir}/{self.target_name}"
         if self.target_type == LoadType.ROLE:
             self.update_role_download_src(metadata_file, dst_src_dir)
             self.metadata.download_src_path = root_dst_src_path
@@ -492,7 +523,7 @@ class DependencyDirPreparator(object):
             if not os.path.exists(dst_dependency_dir):
                 os.makedirs(dst_dependency_dir)
             self.move_src(dependency_dir, dst_dependency_dir)
-            logger.debug("root metadata: {}".format(json.dumps(asdict(self.metadata))))
+            logger.debug(f"root metadata: {json.dumps(asdict(self.metadata))}")
 
         # prepare dependency data
         self.dependency_dirs = self.dependnecy_dirs(metadata_file, self.target_type, self.target_name)
@@ -517,7 +548,7 @@ class DependencyDirPreparator(object):
             dep_type, target_path_list = find_ext_dependencies(path)
 
         if not self.silent:
-            logger.info('the detected target type: "{}", found targets: {}'.format(self.target_type, len(target_path_list)))
+            logger.info(f'the detected target type: "{self.target_type}", found targets: {len(target_path_list)}')
 
         if self.target_type not in supported_target_types:
             logger.error("this target type is not supported")
@@ -543,51 +574,52 @@ class DependencyDirPreparator(object):
     def download_galaxy_collection(self, target, output_dir, version="", source_repository=""):
         server_option = ""
         if source_repository:
-            server_option = "--server {}".format(source_repository)
+            server_option = f"--server {source_repository}"
         target_version = target
         if version:
-            target_version = "{}:{}".format(target, version)
-        logger.debug("downloading: {}".format("ansible-galaxy collection download '{}' {} -p {}".format(target_version, server_option, output_dir)))
+            target_version = f"{target}:{version}"
+        logger.debug(
+            "downloading: {}".format(
+                f"ansible-galaxy collection download '{target_version}' {server_option} -p {output_dir}"
+            )
+        )
         proc = subprocess.run(
-            "ansible-galaxy collection download '{}' {} -p {}".format(target_version, server_option, output_dir),
+            f"ansible-galaxy collection download '{target_version}' {server_option} -p {output_dir}",
             shell=True,
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
         install_msg = proc.stdout
-        logger.debug("STDOUT: {}".format(install_msg))
+        logger.debug(f"STDOUT: {install_msg}")
         return install_msg
 
     def download_galaxy_collection_from_reqfile(self, requirements, output_dir, source_repository=""):
         server_option = ""
         if source_repository:
-            server_option = "--server {}".format(source_repository)
+            server_option = f"--server {source_repository}"
         proc = subprocess.run(
-            "ansible-galaxy collection download -r {} {} -p {}".format(requirements, server_option, output_dir),
+            f"ansible-galaxy collection download -r {requirements} {server_option} -p {output_dir}",
             shell=True,
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
         install_msg = proc.stdout
-        logger.debug("STDOUT: {}".format(install_msg))
+        logger.debug(f"STDOUT: {install_msg}")
         # return proc.stdout
 
     def install_galaxy_collection_from_targz(self, tarfile, output_dir):
-        logger.debug("install collection from {}".format(tarfile))
+        logger.debug(f"install collection from {tarfile}")
         proc = subprocess.run(
-            "ansible-galaxy collection install {} -p {}".format(tarfile, output_dir),
+            f"ansible-galaxy collection install {tarfile} -p {output_dir}",
             shell=True,
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
         install_msg = proc.stdout
-        logger.debug("STDOUT: {}".format(install_msg))
+        logger.debug(f"STDOUT: {install_msg}")
         # return proc.stdout
 
     def install_galaxy_collection_from_reqfile(self, requirements, output_dir):
@@ -596,16 +628,15 @@ class DependencyDirPreparator(object):
             child_dir_path = requirements.split("archives")[-1]
             requirements = f"{self.download_location}{child_dir_path}"
             if not os.path.isfile(requirements):
-                logger.warning("requirements file not found: {}".format(requirements))
+                logger.warning(f"requirements file not found: {requirements}")
                 return
-        logger.debug("install collection from {}".format(requirements))
+        logger.debug(f"install collection from {requirements}")
         src_dir = requirements.replace(requirements_yml, "")
         proc = subprocess.run(
-            "cd {} && ansible-galaxy collection install -r {} -p {} --force".format(src_dir, requirements_yml, output_dir),
+            f"cd {src_dir} && ansible-galaxy collection install -r {requirements_yml} -p {output_dir} --force",
             shell=True,
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
         try:
@@ -613,7 +644,7 @@ class DependencyDirPreparator(object):
         except Exception as exc:
             raise ValueError("failed to install collection: " + proc.stderr) from exc
         install_msg = proc.stdout
-        logger.debug("STDOUT: {}".format(install_msg))
+        logger.debug(f"STDOUT: {install_msg}")
         # return proc.stdout
 
     def is_download_file_exist(self, type, target, dir):
@@ -638,15 +669,14 @@ class DependencyDirPreparator(object):
 
     def install_galaxy_role_from_reqfile(self, file, output_dir):
         proc = subprocess.run(
-            "ansible-galaxy role install -r {} -p {}".format(file, output_dir),
+            f"ansible-galaxy role install -r {file} -p {output_dir}",
             shell=True,
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
         install_msg = proc.stdout
-        logger.debug("STDOUT: {}".format(install_msg))
+        logger.debug(f"STDOUT: {install_msg}")
 
     def extract_collections_metadata(self, log_message, download_location):
         # -- log message
@@ -663,7 +693,7 @@ class DependencyDirPreparator(object):
             metadata = DownloadMetadata()
             metadata.type = LoadType.COLLECTION
             if m.endswith("tar.gz"):
-                logger.debug("extracted url from download log message: {}".format(m))
+                logger.debug(f"extracted url from download log message: {m}")
                 url = m
                 version = url.split("-")[-1].replace(".tar.gz", "")
                 name = "{}.{}".format(url.split("-")[0].split("/")[-1], url.split("-")[1])
@@ -671,9 +701,9 @@ class DependencyDirPreparator(object):
                 metadata.version = version
                 metadata.name = name
                 filename = url.split("/")[-1]
-                fullpath = "{}/{}".format(download_location, filename)
+                fullpath = f"{download_location}/{filename}"
                 if not os.path.exists(fullpath):
-                    logger.warning("failed to get metadata for {}".format(url))
+                    logger.warning(f"failed to get metadata for {url}")
                     pass
                 m_time = os.path.getmtime(fullpath)
                 dt_m = datetime.datetime.utcfromtimestamp(m_time).isoformat()
@@ -683,12 +713,12 @@ class DependencyDirPreparator(object):
                 metadata.metafile_path = metafile_path.replace(download_location, download_path_from_root_dir)
                 metadata.files_json_path = files_json_path.replace(download_location, download_path_from_root_dir)
                 metadata.author = self.get_author(LoadType.COLLECTION, metadata.metafile_path)
-                metadata.requirements_file = "{}/{}".format(download_path_from_root_dir, requirements_yml)
+                metadata.requirements_file = f"{download_path_from_root_dir}/{requirements_yml}"
 
                 if url != "":
                     hash = get_hash_of_url(url)
                     metadata.hash = hash
-                logger.debug("metadata: {}".format(json.dumps(asdict(metadata))))
+                logger.debug(f"metadata: {json.dumps(asdict(metadata))}")
 
                 metadata_list.append(asdict(metadata))
         result = {"collections": metadata_list}
@@ -707,7 +737,7 @@ class DependencyDirPreparator(object):
                 metadata = DownloadMetadata()
                 metadata.type = LoadType.ROLE
                 url = line.split(" ")[-1]
-                logger.debug("extracted url from download log message: {}".format(url))
+                logger.debug(f"extracted url from download log message: {url}")
                 version = url.split("/")[-1].replace(".tar.gz", "")
                 if len(messages) > i:
                     name = messages[i + 1].split("/")[-1]
@@ -722,7 +752,7 @@ class DependencyDirPreparator(object):
                     if url != "":
                         hash = get_hash_of_url(url)
                         metadata.hash = hash
-                    logger.debug("metadata: {}".format(json.dumps(asdict(metadata))))
+                    logger.debug(f"metadata: {json.dumps(asdict(metadata))}")
                     metadata_list.append(asdict(metadata))
         if len(metadata_list) == 0:
             logger.warning(f"failed to extract download metadata from install log: {log_message}")
@@ -736,23 +766,23 @@ class DependencyDirPreparator(object):
             child_dir_path = metadata_file.split("archives")[-1]
             metadata_file = f"{self.download_location}{child_dir_path}"
             if not os.path.isfile(metadata_file):
-                logger.warning("metadata file not found: {}".format(target))
+                logger.warning(f"metadata file not found: {target}")
                 return None
-        with open(metadata_file, "r") as f:
+        with open(metadata_file) as f:
             metadata = json.load(f)
         if type == LoadType.COLLECTION:
             metadata_list = metadata.get("collections", [])
         elif type == LoadType.ROLE:
             metadata_list = metadata.get("roles", [])
         else:
-            logger.warning("metadata not found: unsupported type {} {}".format(type, target))
+            logger.warning(f"metadata not found: unsupported type {type} {target}")
             return None
         for data in metadata_list:
             dm = DownloadMetadata(**data)
             if dm.name == target:
-                logger.debug("found metadata: {}".format(target))
+                logger.debug(f"found metadata: {target}")
                 return dm
-        logger.warning("metadata not found: {}".format(target))
+        logger.warning(f"metadata not found: {target}")
         return None
 
     def existing_dependency_dir_loader(self, dependency_type, dependency_dir_path):
@@ -763,7 +793,10 @@ class DependencyDirPreparator(object):
                 base_dir = os.path.join(dependency_dir_path, "ansible_collections")
             namespaces = [ns for ns in os.listdir(base_dir) if not ns.endswith(".info")]
             for ns in namespaces:
-                colls = [{"name": f"{ns}.{name}", "path": os.path.join(base_dir, ns, name)} for name in os.listdir(os.path.join(base_dir, ns))]
+                colls = [
+                    {"name": f"{ns}.{name}", "path": os.path.join(base_dir, ns, name)}
+                    for name in os.listdir(os.path.join(base_dir, ns))
+                ]
                 search_dirs.extend(colls)
 
         dependency_dirs = []
@@ -792,9 +825,9 @@ class DependencyDirPreparator(object):
 
     def move_src(self, src, dst):
         if src == "" or not os.path.exists(src) or not os.path.isdir(src):
-            raise ValueError("src {} is not directory".format(src))
+            raise ValueError(f"src {src} is not directory")
         if dst == "" or ".." in dst:
-            raise ValueError("dst {} is invalid".format(dst))
+            raise ValueError(f"dst {dst} is invalid")
         if src and src[-1] == "/":
             src = src[:-1]
         if dst and dst[-1] == "/":
@@ -807,8 +840,7 @@ class DependencyDirPreparator(object):
             f"cp -r {src}/* {dst}/",
             shell=True,
             stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
         # raise if copy failed
@@ -829,10 +861,8 @@ class DependencyDirPreparator(object):
             if self.periodical_cleanup:
                 if len(self.cleanup_queue) > self.cleanup_threshold:
                     for tmp_dir in self.cleanup_queue:
-                        try:
+                        with contextlib.suppress(Exception):
                             tmp_dir.cleanup()
-                        except Exception:
-                            pass
                     self.cleanup_queue = []
             else:
                 self.tmp_install_dir.cleanup()
@@ -842,7 +872,7 @@ class DependencyDirPreparator(object):
         if not os.path.exists(dir):
             os.makedirs(dir)
         file = os.path.join(dir, filename)
-        logger.debug("export data {} to {}".format(data, file))
+        logger.debug(f"export data {data} to {file}")
         with open(file, "w") as f:
             json.dump(data, f)
         return file
@@ -856,12 +886,12 @@ class DependencyDirPreparator(object):
                 for info in tar.getmembers():
                     if info.name.endswith(collection_manifest_json):
                         f = tar.extractfile(info)
-                        metafile_path = filepath.replace(".tar.gz", "-{}".format(collection_manifest_json))
+                        metafile_path = filepath.replace(".tar.gz", f"-{collection_manifest_json}")
                         with open(metafile_path, "wb") as c:
                             c.write(f.read())
                     if info.name.endswith(collection_files_json):
                         f = tar.extractfile(info)
-                        files_path = filepath.replace(".tar.gz", "-{}".format(collection_files_json))
+                        files_path = filepath.replace(".tar.gz", f"-{collection_files_json}")
                         with open(files_path, "wb") as c:
                             c.write(f.read())
         elif type == LoadType.ROLE:
@@ -878,14 +908,14 @@ class DependencyDirPreparator(object):
         return metafile_path, files_path
 
     def update_metadata(self, type, metadata_file, target, key, value):
-        with open(metadata_file, "r") as f:
+        with open(metadata_file) as f:
             metadata = json.load(f)
         if type == LoadType.COLLECTION:
             metadata_list = metadata.get("collections", [])
         elif type == LoadType.ROLE:
             metadata_list = metadata.get("roles", [])
         else:
-            logger.warning("metadata not found: unsupported type {}".format(target))
+            logger.warning(f"metadata not found: unsupported type {target}")
             return None
         for i, data in enumerate(metadata_list):
             dm = DownloadMetadata(**data)
@@ -893,7 +923,7 @@ class DependencyDirPreparator(object):
                 if hasattr(dm, key):
                     setattr(dm, key, value)
                 metadata_list[i] = asdict(dm)
-                logger.debug("update {} in metadata: {}".format(key, dm))
+                logger.debug(f"update {key} in metadata: {dm}")
                 if type == LoadType.COLLECTION:
                     metadata["collections"] = metadata_list
                 elif type == LoadType.ROLE:
@@ -903,12 +933,12 @@ class DependencyDirPreparator(object):
         return
 
     def update_role_download_src(self, metadata_file, dst_src_dir):
-        with open(metadata_file, "r") as f:
+        with open(metadata_file) as f:
             metadata = json.load(f)
         metadata_list = metadata.get("roles", [])
         for i, data in enumerate(metadata_list):
             dm = DownloadMetadata(**data)
-            full_path = "{}/{}".format(dst_src_dir, dm.name)
+            full_path = f"{dst_src_dir}/{dm.name}"
             path_from_root = full_path.replace(f"{self.root_dir}/", "")
             key = "download_src_path"
             if hasattr(dm, key):
@@ -917,7 +947,7 @@ class DependencyDirPreparator(object):
             dm.metafile_path = metafile_path.replace(f"{self.root_dir}/", "")
             dm.author = self.get_author(LoadType.ROLE, metafile_path)
             metadata_list[i] = asdict(dm)
-            logger.debug("update {} in metadata: {}".format(key, dm))
+            logger.debug(f"update {key} in metadata: {dm}")
         metadata["roles"] = metadata_list
         with open(metadata_file, "w") as f:
             json.dump(metadata, f)
@@ -927,15 +957,15 @@ class DependencyDirPreparator(object):
         if not os.path.exists(metafile_path):
             metafile_path = f"{self.root_dir}/{metafile_path}"
             if not os.path.exists(metafile_path):
-                logger.warning("invalid file path: {}".format(metafile_path))
+                logger.warning(f"invalid file path: {metafile_path}")
                 return ""
         if type == LoadType.COLLECTION:
-            with open(metafile_path, "r") as f:
+            with open(metafile_path) as f:
                 metadata = json.load(f)
             authors = metadata.get("collection_info", {}).get("authors", [])
             return ",".join(authors)
         elif type == LoadType.ROLE:
-            with open(metafile_path, "r") as f:
+            with open(metafile_path) as f:
                 metadata = yaml.safe_load(f)
             author = metadata.get("galaxy_info", {}).get("author", "")
             return author
@@ -947,9 +977,9 @@ class DependencyDirPreparator(object):
             child_dir_path = metadata_file.split("archives")[-1]
             metadata_file = f"{self.download_location}{child_dir_path}"
             if not os.path.isfile(metadata_file):
-                logger.warning("metadata file not found: {}".format(target_name))
+                logger.warning(f"metadata file not found: {target_name}")
                 return dependency_dirs
-        with open(metadata_file, "r") as f:
+        with open(metadata_file) as f:
             metadata = json.load(f)
         metadata_list = metadata.get("roles", [])
         for _, data in enumerate(metadata_list):
@@ -993,7 +1023,9 @@ def find_ext_dependencies(path):
         recursive=True,
     )
     if len(role_meta_files) > 0:
-        role_path_list = [trim_suffix(f, ["/" + role_meta_main_yml, "/" + role_meta_main_yaml]) for f in role_meta_files]
+        role_path_list = [
+            trim_suffix(f, ["/" + role_meta_main_yml, "/" + role_meta_main_yaml]) for f in role_meta_files
+        ]
         role_path_list = remove_subdirectories(role_path_list)
         return LoadType.ROLE, role_path_list
     return LoadType.UNKNOWN, []

--- a/src/apme_engine/engine/dependency_finder.py
+++ b/src/apme_engine/engine/dependency_finder.py
@@ -1,15 +1,15 @@
-import os
-import yaml
 import json
+import os
 import subprocess
 from pathlib import Path
 
-from . import logger
-from .safe_glob import safe_glob
+import yaml
 
+from . import logger
 from .models import (
     LoadType,
 )
+from .safe_glob import safe_glob
 
 collection_manifest_json = "MANIFEST.json"
 role_meta_main_yml = "meta/main.yml"
@@ -101,7 +101,7 @@ def search_ansible_dir(dependencies: dict, ansible_dir: str):
                 if d_name.startswith(f"{coll_name}-") and d_name.endswith(".info"):
                     galaxy_yml_path = os.path.join(collection_dir, d_name, GALAXY_yml)
                     try:
-                        with open(galaxy_yml_path, "r") as galaxy_yml_file:
+                        with open(galaxy_yml_path) as galaxy_yml_file:
                             galaxy_data = yaml.safe_load(galaxy_yml_file)
                     except Exception:
                         pass
@@ -131,7 +131,7 @@ def search_ansible_dir(dependencies: dict, ansible_dir: str):
 def find_role_dependency(target):
     requirements = {}
     if not os.path.exists(target):
-        raise ValueError("Invalid target dir: {}".format(target))
+        raise ValueError(f"Invalid target dir: {target}")
     role_meta_files = safe_glob(
         [
             os.path.join(target, "**", role_meta_main_yml),
@@ -145,11 +145,11 @@ def find_role_dependency(target):
         for rf in role_meta_files:
             if os.path.exists(rf):
                 main_yaml = rf
-                with open(rf, "r") as file:
+                with open(rf) as file:
                     try:
                         metadata = yaml.safe_load(file)
                     except Exception as e:
-                        logger.debug("failed to load this yaml file to read metadata; {}".format(e.args[0]))
+                        logger.debug(f"failed to load this yaml file to read metadata; {e.args[0]}")
 
                     if metadata is not None and isinstance(metadata, dict):
                         requirements["roles"] = metadata.get("dependencies", [])
@@ -192,14 +192,14 @@ def find_collection_dependency(target):
     # collection dir installed by ansible-galaxy command
     manifest_json_files = safe_glob(os.path.join(target, "**", collection_manifest_json), recursive=True)
     manifest_json_files = [fpath for fpath in manifest_json_files if github_workflows_dir not in fpath]
-    logger.debug("found meta files {}".format(manifest_json_files))
+    logger.debug(f"found meta files {manifest_json_files}")
     manifest_json = ""
     if len(manifest_json_files) > 0:
         for cmf in manifest_json_files:
             if os.path.exists(cmf):
                 manifest_json = cmf
                 metadata = {}
-                with open(cmf, "r") as file:
+                with open(cmf) as file:
                     metadata = json.load(file)
                     dependencies = metadata.get("collection_info", {}).get("dependencies", [])
                     requirements["collections"] = format_dependency_info(dependencies)
@@ -220,10 +220,10 @@ def find_project_dependency(target):
         elif os.path.exists(role_req1) or os.path.exists(role_req2):
             return find_role_dependency(target)
         # local dir
-        logger.debug("load requirements from dir {}".format(target))
+        logger.debug(f"load requirements from dir {target}")
         return load_requirements(target)
     else:
-        raise ValueError("Invalid target dir: {}".format(target))
+        raise ValueError(f"Invalid target dir: {target}")
 
 
 def load_requirements(path):
@@ -233,11 +233,11 @@ def load_requirements(path):
     requirements_yml_path = os.path.join(path, requirements_yml)
     if os.path.exists(requirements_yml_path):
         yaml_path = requirements_yml_path
-        with open(requirements_yml_path, "r") as file:
+        with open(requirements_yml_path) as file:
             try:
                 requirements = yaml.safe_load(file)
             except Exception as e:
-                logger.debug("failed to load requirements.yml; {}".format(e.args[0]))
+                logger.debug(f"failed to load requirements.yml; {e.args[0]}")
     else:
         requirements, yaml_path = load_dependency_from_galaxy(path)
 
@@ -269,7 +269,7 @@ def is_galaxy_yml(path):
 
     metadata = None
     try:
-        with open(path, "r") as file:
+        with open(path) as file:
             metadata = yaml.safe_load(file)
     except Exception:
         pass
@@ -277,10 +277,7 @@ def is_galaxy_yml(path):
     if not isinstance(metadata, dict):
         return False
 
-    if "name" in metadata and "namespace" in metadata:
-        return True
-
-    return False
+    return bool("name" in metadata and "namespace" in metadata)
 
 
 def load_dependency_from_galaxy(path):
@@ -289,13 +286,13 @@ def load_dependency_from_galaxy(path):
     galaxy_yml_files = safe_glob(os.path.join(path, "**", galaxy_yml), recursive=True)
     galaxy_yml_files.extend(safe_glob(os.path.join(path, "**", GALAXY_yml), recursive=True))
     galaxy_yml_files = [fpath for fpath in galaxy_yml_files if github_workflows_dir not in fpath]
-    logger.debug("found meta files {}".format(galaxy_yml_files))
+    logger.debug(f"found meta files {galaxy_yml_files}")
     if len(galaxy_yml_files) > 0:
         for g in galaxy_yml_files:
             if is_galaxy_yml(g):
                 yaml_path = g
                 metadata = {}
-                with open(g, "r") as file:
+                with open(g) as file:
                     metadata = yaml.safe_load(file)
                     dependencies = metadata.get("dependencies", {})
                     if dependencies:
@@ -342,7 +339,7 @@ def load_existing_dependency_dir(dependency_dir):
             if dir_name.startswith(collection_name) and dir_name.endswith(".info"):
                 galaxy_yml_path = os.path.join(collection_base_path, dir_name, galaxy_yml)
                 try:
-                    with open(galaxy_yml_path, "r") as galaxy_yml_file:
+                    with open(galaxy_yml_path) as galaxy_yml_file:
                         galaxy_data = yaml.safe_load(galaxy_yml_file)
                 except Exception:
                     pass
@@ -356,15 +353,14 @@ def load_existing_dependency_dir(dependency_dir):
 
 def install_github_target(target, output_dir):
     proc = subprocess.run(
-        "git clone {} {}".format(target, output_dir),
+        f"git clone {target} {output_dir}",
         shell=True,
         stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     install_msg = proc.stdout
-    logger.debug("STDOUT: {}".format(install_msg))
+    logger.debug(f"STDOUT: {install_msg}")
     return proc.stdout
 
 

--- a/src/apme_engine/engine/finder.py
+++ b/src/apme_engine/engine/finder.py
@@ -1,10 +1,12 @@
+import json
+import os
+import re
+import traceback
 from dataclasses import dataclass
 from pathlib import Path
-import re
-import os
-import json
+
 import yaml
-import traceback
+
 from .yaml_utils import FormattedYAML
 
 try:
@@ -14,10 +16,11 @@ try:
 except Exception:
     # otherwise, use Python based loader
     from yaml import SafeLoader as Loader
-from . import logger
-from .safe_glob import safe_glob
-from .awx_utils import could_be_playbook, search_playbooks
+import contextlib
 
+from . import logger
+from .awx_utils import could_be_playbook, search_playbooks
+from .safe_glob import safe_glob
 
 fqcn_module_name_re = re.compile(r"^[a-z0-9_]+\.[a-z0-9_]+\.[a-z0-9_]+$")
 module_name_re = re.compile(r"^[a-z0-9_.]+$")
@@ -54,10 +57,10 @@ class BuiltinModuleSet(metaclass=Singleton):
 
 
 p = Path(__file__).resolve().parent
-with open(p / "task_keywords.txt", "r") as f:
+with open(p / "task_keywords.txt") as f:
     TaskKeywordSet(set(f.read().splitlines()))
 
-with open(p / "builtin-modules.txt", "r") as f:
+with open(p / "builtin-modules.txt") as f:
     BuiltinModuleSet(set(f.read().splitlines()))
 
 
@@ -66,7 +69,7 @@ def get_builtin_module_names():
 
 
 def find_module_name(data_block):
-    keys = [k for k in data_block.keys()]
+    keys = [k for k in data_block]
     task_keywords = TaskKeywordSet().task_keywords
     builtin_modules = BuiltinModuleSet().builtin_modules
     for k in keys:
@@ -112,17 +115,17 @@ def get_task_blocks(
             d = yaml.load(yaml_str, Loader=Loader)
             yaml_lines = yaml_str
         except Exception as e:
-            logger.debug("failed to load this yaml string to get task blocks; {}".format(e.args[0]))
+            logger.debug(f"failed to load this yaml string to get task blocks; {e.args[0]}")
             return None, None
     elif fpath:
         if not os.path.exists(fpath):
             return None, None
-        with open(fpath, "r") as file:
+        with open(fpath) as file:
             try:
                 yaml_lines = file.read()
                 d = yaml.load(yaml_lines, Loader=Loader)
             except Exception as e:
-                logger.debug("failed to load this yaml file to get task blocks; {}".format(e.args[0]))
+                logger.debug(f"failed to load this yaml file to get task blocks; {e.args[0]}")
                 return None, None
     elif task_dict_list is not None:
         d = task_dict_list
@@ -150,7 +153,9 @@ def get_task_blocks(
 #         - some_module2
 #         - some_module3
 #
-def flatten_block_tasks(task_dict, jsonpath_prefix="", module_defaults={}):
+def flatten_block_tasks(task_dict, jsonpath_prefix="", module_defaults=None):
+    if module_defaults is None:
+        module_defaults = {}
     if task_dict is None:
         return []
     tasks = []
@@ -203,7 +208,9 @@ def flatten_block_tasks(task_dict, jsonpath_prefix="", module_defaults={}):
     return tasks
 
 
-def identify_lines_with_jsonpath(fpath: str = "", yaml_str: str = "", jsonpath: str = "") -> tuple[str, tuple[int, int]]:
+def identify_lines_with_jsonpath(
+    fpath: str = "", yaml_str: str = "", jsonpath: str = ""
+) -> tuple[str, tuple[int, int]]:
     if not jsonpath:
         return None, None
 
@@ -214,17 +221,17 @@ def identify_lines_with_jsonpath(fpath: str = "", yaml_str: str = "", jsonpath: 
             d = yaml.load(yaml_str, Loader=Loader)
             yaml_lines = yaml_str
         except Exception as e:
-            logger.debug("failed to load this yaml string to identify lines; {}".format(e.args[0]))
+            logger.debug(f"failed to load this yaml string to identify lines; {e.args[0]}")
             return None, None
     elif fpath:
         if not os.path.exists(fpath):
             return None, None
-        with open(fpath, "r") as file:
+        with open(fpath) as file:
             try:
                 yaml_lines = file.read()
                 d = yaml.load(yaml_lines, Loader=Loader)
             except Exception as e:
-                logger.debug("failed to load this yaml file to identify lines; {}".format(e.args[0]))
+                logger.debug(f"failed to load this yaml file to identify lines; {e.args[0]}")
                 return None, None
     if not d:
         return None, None
@@ -369,14 +376,16 @@ def find_child_yaml_block(yaml_str: str, key: str = "", line_num_offset: int = -
     return blocks
 
 
-def search_module_files(path, module_dir_paths=[]):
+def search_module_files(path, module_dir_paths=None):
+    if module_dir_paths is None:
+        module_dir_paths = []
     file_list = []
     # must copy the input here; otherwise, the added items are kept forever
     search_targets = [p for p in module_dir_paths]
     for module_dir_pattern in module_dir_patterns:
         search_targets.append(os.path.join(path, module_dir_pattern))
     for search_target in search_targets:
-        for dirpath, folders, files in os.walk(search_target):
+        for dirpath, _folders, files in os.walk(search_target):
             for file in files:
                 basename, ext = os.path.splitext(file)
                 if basename == "__init__":
@@ -386,7 +395,7 @@ def search_module_files(path, module_dir_paths=[]):
 
                     # check if "DOCUMENTATION" is found in the file
                     skip = False
-                    with open(fpath, "r") as f:
+                    with open(fpath) as f:
                         body = f.read()
                         if "DOCUMENTATION" not in body:
                             # if not, it is not a module file, so skip it
@@ -408,8 +417,10 @@ def find_module_dirs(role_root_dir):
     return module_dirs
 
 
-def search_taskfiles_for_playbooks(path, taskfile_dir_paths: list = []):
+def search_taskfiles_for_playbooks(path, taskfile_dir_paths: list = None):
     # must copy the input here; otherwise, the added items are kept forever
+    if taskfile_dir_paths is None:
+        taskfile_dir_paths = []
     search_targets = [p for p in taskfile_dir_paths]
     for playbook_taskfile_dir_pattern in playbook_taskfile_dir_patterns:
         search_targets.append(os.path.join(path, playbook_taskfile_dir_pattern))
@@ -425,11 +436,11 @@ def search_taskfiles_for_playbooks(path, taskfile_dir_paths: list = []):
             if could_be_playbook(f):
                 continue
             d = None
-            with open(f, "r") as file:
+            with open(f) as file:
                 try:
                     d = yaml.load(file, Loader=Loader)
                 except Exception as e:
-                    logger.debug("failed to load this yaml file to search task" " files; {}".format(e.args[0]))
+                    logger.debug(f"failed to load this yaml file to search task files; {e.args[0]}")
             # if d cannot be loaded as tasks yaml file, skip it
             if d is None or not isinstance(d, list):
                 continue
@@ -478,7 +489,7 @@ def find_best_repo_root_path(path):
     # ignore tests directory
     playbooks = [p for p in playbooks if "/tests/" not in p]
     if len(playbooks) == 0:
-        raise ValueError("no playbook files found under {}".format(path))
+        raise ValueError(f"no playbook files found under {path}")
     top_playbook_path = playbooks[0]
     top_playbook_relative_path = top_playbook_path[len(base_path) :]
     root_path = ""
@@ -525,22 +536,22 @@ def find_collection_name_of_repo(path):
         metadata_file = found_metadata_files[0]
         my_collection_info = None
         if metadata_file.endswith(".yml"):
-            with open(metadata_file, "r") as file:
+            with open(metadata_file) as file:
                 try:
                     my_collection_info = yaml.load(file, Loader=Loader)
                 except Exception as e:
-                    logger.debug("failed to load this yaml file to read galaxy.yml; {}".format(e.args[0]))
+                    logger.debug(f"failed to load this yaml file to read galaxy.yml; {e.args[0]}")
         elif metadata_file.endswith(".json"):
-            with open(metadata_file, "r") as file:
+            with open(metadata_file) as file:
                 try:
                     my_collection_info = json.load(file).get("collection_info", {})
                 except Exception as e:
-                    logger.debug("failed to load this json file to read MANIFEST.json; {}".format(e.args[0]))
+                    logger.debug(f"failed to load this json file to read MANIFEST.json; {e.args[0]}")
         if my_collection_info is None:
             return ""
         namespace = my_collection_info.get("namespace", "")
         name = my_collection_info.get("name", "")
-        my_collection_name = "{}.{}".format(namespace, name)
+        my_collection_name = f"{namespace}.{name}"
     return my_collection_name
 
 
@@ -559,16 +570,14 @@ def find_all_files(root_dir: str):
 def _get_body_data(body: str = "", data: list = None, fpath: str = ""):
     if fpath and not body and not data:
         try:
-            with open(fpath, "r") as file:
+            with open(fpath) as file:
                 body = file.read()
                 data = yaml.safe_load(body)
         except Exception:
             pass
     elif body and not data:
-        try:
+        with contextlib.suppress(Exception):
             data = yaml.safe_load(body)
-        except Exception:
-            pass
     return body, data, fpath
 
 
@@ -593,10 +602,7 @@ def could_be_playbook_detail(body: str = "", data: list = None, fpath: str = "")
     if "hosts" in data[0]:
         return True
 
-    if "import_playbook" in data[0] or "ansible.builtin.import_playbook" in data[0]:
-        return True
-
-    return False
+    return bool("import_playbook" in data[0] or "ansible.builtin.import_playbook" in data[0])
 
 
 def could_be_taskfile(body: str = "", data: list = None, fpath: str = ""):
@@ -620,11 +626,8 @@ def could_be_taskfile(body: str = "", data: list = None, fpath: str = ""):
     module_name = find_module_name(data[0])
     if module_name:
         short_module_name = module_name.split(".")[-1] if "." in module_name else module_name
-        if short_module_name == "import_playbook":
-            # if the found module name is import_playbook, the file is a playbook
-            return False
-        else:
-            return True
+        # if the found module name is import_playbook, the file is a playbook
+        return short_module_name != "import_playbook"
 
     return False
 
@@ -713,16 +716,12 @@ def get_project_info_for_file(fpath, root_dir):
 
 def is_meta_yml(yml_path):
     parts = yml_path.split("/")
-    if len(parts) > 2 and parts[-2] == "meta":
-        return True
-    return False
+    return bool(len(parts) > 2 and parts[-2] == "meta")
 
 
 def is_vars_yml(yml_path):
     parts = yml_path.split("/")
-    if len(parts) > 2 and parts[-2] in ["vars", "defaults"]:
-        return True
-    return False
+    return bool(len(parts) > 2 and parts[-2] in ["vars", "defaults"])
 
 
 def count_top_level_element(yml_body: str = ""):
@@ -731,9 +730,7 @@ def count_top_level_element(yml_body: str = ""):
         if not line.strip():
             return True
         # skip comment line
-        if line.strip()[0] == "#":
-            return True
-        return False
+        return line.strip()[0] == "#"
 
     lines = yml_body.splitlines()
     top_level_indent = 1024
@@ -774,7 +771,7 @@ def label_yml_file(yml_path: str = "", yml_body: str = "", task_num_thresh: int 
         body = yml_body
     elif not yml_body and yml_path:
         try:
-            with open(yml_path, "r") as file:
+            with open(yml_path) as file:
                 body = file.read()
         except Exception:
             error = {"type": "FileReadError", "detail": traceback.format_exc()}
@@ -785,18 +782,16 @@ def label_yml_file(yml_path: str = "", yml_body: str = "", task_num_thresh: int 
     # roughly count tasks
     name_count = len([line for line in lines if line.lstrip().startswith("- name:")])
 
-    if task_num_thresh > 0:
-        if name_count > task_num_thresh:
-            error_detail = f"The number of task names found in yml exceeds the threshold ({task_num_thresh})"
-            error = {"type": "TooManyTasksError", "detail": error_detail}
-            return "others", name_count, error
+    if task_num_thresh > 0 and name_count > task_num_thresh:
+        error_detail = f"The number of task names found in yml exceeds the threshold ({task_num_thresh})"
+        error = {"type": "TooManyTasksError", "detail": error_detail}
+        return "others", name_count, error
 
     top_level_element_count = count_top_level_element(body)
-    if task_num_thresh > 0:
-        if top_level_element_count > task_num_thresh:
-            error_detail = f"The number of top-level elements found in yml exceeds the threshold ({task_num_thresh})"
-            error = {"type": "TooManyTasksError", "detail": error_detail}
-            return "others", name_count, error
+    if task_num_thresh > 0 and top_level_element_count > task_num_thresh:
+        error_detail = f"The number of top-level elements found in yml exceeds the threshold ({task_num_thresh})"
+        error = {"type": "TooManyTasksError", "detail": error_detail}
+        return "others", name_count, error
 
     try:
         data = yaml.safe_load(body)
@@ -857,9 +852,9 @@ def get_yml_list(root_dir: str, task_num_threshold: int = -1):
         if role_info:
             if role_info["path"] and not role_info["path"].startswith(root_dir):
                 role_info["path"] = os.path.join(root_dir, role_info["path"])
-            role_info["is_external_dependency"] = True if "." in role_info["name"] else False
-        in_role = True if role_info else False
-        in_project = True if project_info else False
+            role_info["is_external_dependency"] = "." in role_info["name"]
+        in_role = bool(role_info)
+        in_project = bool(project_info)
         all_files.append(
             {
                 "filepath": yml_path,
@@ -973,7 +968,7 @@ def update_and_append_new_line(new_line, old_line, leading_spaces, data_copy):
 def update_the_yaml_target(file_path, line_number_list, new_content_list):
     try:
         # Read the original YAML file
-        with open(file_path, "r") as file:
+        with open(file_path) as file:
             data = file.read()
         yaml = FormattedYAML(
             # Ansible only uses YAML 1.1, but others files should use newer 1.2 (ruamel.yaml defaults to 1.2)
@@ -1044,18 +1039,21 @@ def update_the_yaml_target(file_path, line_number_list, new_content_list):
                                                 lines.pop(i)
                                             else:
                                                 break
-                                    new_line_content = update_and_append_new_line(new_line_content, lines[k], leading_spaces, data_copy)
+                                    new_line_content = update_and_append_new_line(
+                                        new_line_content, lines[k], leading_spaces, data_copy
+                                    )
                                     break
-                                elif old_key == new_key:
-                                    new_line_content = update_and_append_new_line(new_line_content, lines[k], 0, data_copy)
+                                elif (
+                                    old_key == new_key
+                                    or old_key.rstrip("\n") == new_key
+                                    or old_key.rstrip("\n") in new_key.split(".")
+                                ):
+                                    new_line_content = update_and_append_new_line(
+                                        new_line_content, lines[k], 0, data_copy
+                                    )
                                     break
-                                elif old_key.rstrip("\n") == new_key:
-                                    new_line_content = update_and_append_new_line(new_line_content, lines[k], 0, data_copy)
-                                    break
-                                elif old_key.rstrip("\n") in new_key.split("."):
-                                    new_line_content = update_and_append_new_line(new_line_content, lines[k], 0, data_copy)
-                                    break
-                        if new_line_content:  # if there wasn't a match with old line, so this seems updated by ARI and added to w/o any change
+                        # if there wasn't a match with old line, updated by ARI and added w/o change
+                        if new_line_content:
                             data_copy.append(new_line_content)
                 else:
                     return IndexError("Line number out of range.")
@@ -1071,4 +1069,6 @@ def update_the_yaml_target(file_path, line_number_list, new_content_list):
             with open(file_path, "w") as file:
                 yaml.dump(updated_parsed_data, file)
     except Exception as ex:
-        logger.warning("YAML LINES: ARI fix update yaml by lines failed for file: '%s', with error: '%s'", file_path, ex)
+        logger.warning(
+            "YAML LINES: ARI fix update yaml by lines failed for file: '%s', with error: '%s'", file_path, ex
+        )

--- a/src/apme_engine/engine/findings.py
+++ b/src/apme_engine/engine/findings.py
@@ -1,11 +1,13 @@
 import os
 from copy import deepcopy
 from dataclasses import dataclass, field
+
 import jsonpickle
+
 from .utils import (
     lock_file,
-    unlock_file,
     remove_lock_file,
+    unlock_file,
 )
 
 
@@ -61,7 +63,7 @@ class Findings:
     @staticmethod
     def load(fpath="", json_str=""):
         if fpath:
-            with open(fpath, "r") as file:
+            with open(fpath) as file:
                 json_str = file.read()
         findings = jsonpickle.decode(json_str)
         return findings

--- a/src/apme_engine/engine/key_test.py
+++ b/src/apme_engine/engine/key_test.py
@@ -1,6 +1,6 @@
 import json
-from keyutil import get_obj_info_by_key
 
+from keyutil import get_obj_info_by_key
 
 if __name__ == "__main__":
     keys = [
@@ -8,7 +8,7 @@ if __name__ == "__main__":
         "taskfile role:geerlingguy.gitlab#taskfile:tasks/main.yml",
         "role role:geerlingguy.gitlab",
         "play collection:debops.debops#playbook:playbooks/virt/dnsmasq-persistent_paths.yml#play:[0]",
-        "playbook" " collection:debops.debops#playbook:playbooks/sys/cryptsetup-plain.yml",
+        "playbook collection:debops.debops#playbook:playbooks/sys/cryptsetup-plain.yml",
         "module collection:debops.debops#module:debops.debops.apache2_module",
     ]
     for k in keys:

--- a/src/apme_engine/engine/keyutil.py
+++ b/src/apme_engine/engine/keyutil.py
@@ -23,9 +23,9 @@ class Key:
 def make_global_key_prefix(collection, role):
     key_prefix = ""
     if collection != "":
-        key_prefix = "collection{}{}{}".format(key_delimiter, collection, object_delimiter)
+        key_prefix = f"collection{key_delimiter}{collection}{object_delimiter}"
     elif role != "":
-        key_prefix = "role{}{}{}".format(key_delimiter, role, object_delimiter)
+        key_prefix = f"role{key_delimiter}{role}{object_delimiter}"
     return key_prefix
 
 
@@ -35,47 +35,33 @@ def detect_type(key=""):
 
 def set_play_key(obj, parent_key="", parent_local_key=""):
     type_str = obj.type
-    index_info = "[{}]".format(obj.index)
+    index_info = f"[{obj.index}]"
     _parent_key = parent_key.split(" ")[-1]
     _parent_local_key = parent_local_key.split(" ")[-1]
-    global_key = "{} {}{}{}{}{}".format(
-        type_str,
-        _parent_key,
-        object_delimiter,
-        type_str,
-        key_delimiter,
-        index_info,
-    )
-    local_key = "{} {}{}{}{}{}".format(
-        type_str,
-        _parent_local_key,
-        object_delimiter,
-        type_str,
-        key_delimiter,
-        index_info,
-    )
+    global_key = f"{type_str} {_parent_key}{object_delimiter}{type_str}{key_delimiter}{index_info}"
+    local_key = f"{type_str} {_parent_local_key}{object_delimiter}{type_str}{key_delimiter}{index_info}"
     obj.key = global_key
     obj.local_key = local_key
 
 
 def set_role_key(obj):
     global_key_prefix = make_global_key_prefix(obj.collection, "")
-    global_key = "{} {}{}{}{}".format(obj.type, global_key_prefix, obj.type, key_delimiter, obj.fqcn)
-    local_key = "{} {}{}{}".format(obj.type, obj.type, key_delimiter, obj.defined_in)
+    global_key = f"{obj.type} {global_key_prefix}{obj.type}{key_delimiter}{obj.fqcn}"
+    local_key = f"{obj.type} {obj.type}{key_delimiter}{obj.defined_in}"
     obj.key = global_key
     obj.local_key = local_key
 
 
 def set_module_key(obj):
     global_key_prefix = make_global_key_prefix(obj.collection, obj.role)
-    global_key = "{} {}{}{}{}".format(obj.type, global_key_prefix, obj.type, key_delimiter, obj.fqcn)
-    local_key = "{} {}{}{}".format(obj.type, obj.type, key_delimiter, obj.defined_in)
+    global_key = f"{obj.type} {global_key_prefix}{obj.type}{key_delimiter}{obj.fqcn}"
+    local_key = f"{obj.type} {obj.type}{key_delimiter}{obj.defined_in}"
     obj.key = global_key
     obj.local_key = local_key
 
 
 def set_collection_key(obj):
-    global_key = "{} {}{}{}".format(obj.type, obj.type, key_delimiter, obj.name)
+    global_key = f"{obj.type} {obj.type}{key_delimiter}{obj.name}"
     local_key = global_key
     obj.key = global_key
     obj.local_key = local_key
@@ -178,59 +164,33 @@ def get_obj_info_by_key(key):
 
 
 def set_task_key(obj, parent_key="", parent_local_key=""):
-    index_info = "[{}]".format(obj.index)
+    index_info = f"[{obj.index}]"
     _parent_key = parent_key.split(" ")[-1]
     _parent_local_key = parent_local_key.split(" ")[-1]
-    global_key = "{} {}{}{}{}{}".format(
-        obj.type,
-        _parent_key,
-        object_delimiter,
-        obj.type,
-        key_delimiter,
-        index_info,
-    )
-    local_key = "{} {}{}{}{}{}".format(
-        obj.type,
-        _parent_local_key,
-        object_delimiter,
-        obj.type,
-        key_delimiter,
-        index_info,
-    )
+    global_key = f"{obj.type} {_parent_key}{object_delimiter}{obj.type}{key_delimiter}{index_info}"
+    local_key = f"{obj.type} {_parent_local_key}{object_delimiter}{obj.type}{key_delimiter}{index_info}"
     obj.key = global_key
     obj.local_key = local_key
 
 
 def set_taskfile_key(obj):
     global_key_prefix = make_global_key_prefix(obj.collection, obj.role)
-    global_key = "{} {}{}{}{}".format(
-        obj.type,
-        global_key_prefix,
-        obj.type,
-        key_delimiter,
-        obj.defined_in,
-    )
-    local_key = "{} {}{}{}".format(obj.type, obj.type, key_delimiter, obj.defined_in)
+    global_key = f"{obj.type} {global_key_prefix}{obj.type}{key_delimiter}{obj.defined_in}"
+    local_key = f"{obj.type} {obj.type}{key_delimiter}{obj.defined_in}"
     obj.key = global_key
     obj.local_key = local_key
 
 
 def set_playbook_key(obj):
     global_key_prefix = make_global_key_prefix(obj.collection, obj.role)
-    global_key = "{} {}{}{}{}".format(
-        obj.type,
-        global_key_prefix,
-        obj.type,
-        key_delimiter,
-        obj.defined_in,
-    )
-    local_key = "{} {}{}{}".format(obj.type, obj.type, key_delimiter, obj.defined_in)
+    global_key = f"{obj.type} {global_key_prefix}{obj.type}{key_delimiter}{obj.defined_in}"
+    local_key = f"{obj.type} {obj.type}{key_delimiter}{obj.defined_in}"
     obj.key = global_key
     obj.local_key = local_key
 
 
 def set_repository_key(obj):
-    global_key = "{} {}{}{}".format(obj.type, obj.type, key_delimiter, obj.name)
+    global_key = f"{obj.type} {obj.type}{key_delimiter}{obj.name}"
     local_key = global_key
     obj.key = global_key
     obj.local_key = local_key
@@ -239,7 +199,7 @@ def set_repository_key(obj):
 def set_call_object_key(cls_name: str, spec_key: str, caller_key: str):
     parts = spec_key.split(" ", 1)
     caller_only = caller_key.split(" FROM ")[0]
-    return "{} {} FROM {}".format(cls_name, parts[1], caller_only)
+    return f"{cls_name} {parts[1]} FROM {caller_only}"
 
 
 def make_imported_taskfile_key(caller_key, path):
@@ -255,7 +215,7 @@ def make_imported_taskfile_key(caller_key, path):
 
 def set_file_key(obj):
     global_key_prefix = make_global_key_prefix(obj.collection, obj.role)
-    global_key = "{} {}{}{}{}".format(obj.type, global_key_prefix, obj.type, key_delimiter, obj.defined_in)
-    local_key = "{} {}{}{}".format(obj.type, obj.type, key_delimiter, obj.defined_in)
+    global_key = f"{obj.type} {global_key_prefix}{obj.type}{key_delimiter}{obj.defined_in}"
+    local_key = f"{obj.type} {obj.type}{key_delimiter}{obj.defined_in}"
     obj.key = global_key
     obj.local_key = local_key

--- a/src/apme_engine/engine/loader.py
+++ b/src/apme_engine/engine/loader.py
@@ -1,7 +1,9 @@
+import contextlib
+import json
 import os
 import pathlib
-import json
 from importlib.metadata import version as _pkg_version
+
 from .models import LoadType
 
 collection_manifest_json = "MANIFEST.json"
@@ -20,7 +22,9 @@ def remove_subdirectories(dir_list):
     return new_dir_list
 
 
-def trim_suffix(txt, suffix_patterns=[]):
+def trim_suffix(txt, suffix_patterns=None):
+    if suffix_patterns is None:
+        suffix_patterns = []
     if isinstance(suffix_patterns, str):
         suffix_patterns = [suffix_patterns]
     if not isinstance(suffix_patterns, list):
@@ -33,20 +37,16 @@ def trim_suffix(txt, suffix_patterns=[]):
 
 def get_loader_version():
     version = ""
-    try:
+    with contextlib.suppress(Exception):
         version = _pkg_version("apme-engine")
-    except Exception:
-        pass
     if version != "":
         return version
     # try to get version from commit ID in source code repository
-    try:
+    with contextlib.suppress(Exception):
         # TODO: consider how to get git version if it is needed
         _ = pathlib.Path(__file__).parent.resolve()
         # repo = pygit2.Repository(script_dir)
         # version = repo.head.target
-    except Exception:
-        pass
     return version
 
 
@@ -58,11 +58,11 @@ def get_target_name(target_type, target_path):
     elif target_type == LoadType.COLLECTION:
         meta_file = os.path.join(target_path, collection_manifest_json)
         metadata = {}
-        with open(meta_file, "r") as file:
+        with open(meta_file) as file:
             metadata = json.load(file)
         collection_namespace = metadata.get("collection_info", {}).get("namespace", "")
         collection_name = metadata.get("collection_info", {}).get("name", "")
-        target_name = "{}.{}".format(collection_namespace, collection_name)
+        target_name = f"{collection_namespace}.{collection_name}"
     elif target_type == LoadType.ROLE:
         # any better approach?
         target_name = target_path.split("/")[-1]

--- a/src/apme_engine/engine/logger.py
+++ b/src/apme_engine/engine/logger.py
@@ -1,6 +1,5 @@
-import sys
 import logging
-
+import sys
 
 _logger = None
 
@@ -24,7 +23,7 @@ def set_logger_channel(channel: str = ""):
 
 def set_log_level(level_str: str = "info"):
     global _logger
-    level = log_level_map.get(level_str.lower(), None)
+    level = log_level_map.get(level_str.lower())
     _logger.setLevel(level)
 
 

--- a/src/apme_engine/engine/model_loader.py
+++ b/src/apme_engine/engine/model_loader.py
@@ -2,8 +2,9 @@ import datetime
 import json
 import os
 import re
-import yaml
 import traceback
+
+import yaml
 
 try:
     # if `libyaml` is available, use C based loader for performance
@@ -13,53 +14,54 @@ except Exception:
     # otherwise, use Python based loader
     from yaml import SafeLoader as Loader
 
+import contextlib
+
 from . import logger
-from .utils import parse_bool
-from .safe_glob import safe_glob
+from .awx_utils import could_be_playbook
+from .finder import (
+    could_be_playbook_detail,
+    could_be_taskfile,
+    find_best_repo_root_path,
+    find_collection_name_of_repo,
+    find_module_dirs,
+    find_module_name,
+    get_task_blocks,
+    module_dir_patterns,
+    search_inventory_files,
+    search_module_files,
+    search_taskfiles_for_playbooks,
+)
 from .models import (
+    BecomeInfo,
+    Collection,
     ExecutableType,
+    File,
     Inventory,
     InventoryType,
-    File,
     LoadType,
+    Module,
+    ModuleArgument,
+    ObjectList,
     Play,
     Playbook,
     PlaybookFormatError,
     Repository,
     Role,
-    Module,
-    ModuleArgument,
     RoleInPlay,
     Task,
     TaskFile,
     TaskFormatError,
-    Collection,
-    BecomeInfo,
-    ObjectList,
 )
-from .finder import (
-    find_best_repo_root_path,
-    find_collection_name_of_repo,
-    find_module_name,
-    get_task_blocks,
-    search_inventory_files,
-    find_module_dirs,
-    search_module_files,
-    search_taskfiles_for_playbooks,
-    could_be_playbook_detail,
-    module_dir_patterns,
-)
+from .safe_glob import safe_glob
 from .utils import (
+    get_class_by_arg_type,
+    get_documentation_in_module_file,
+    get_module_specs_by_ansible_doc,
+    is_test_object,
+    parse_bool,
     split_target_playbook_fullpath,
     split_target_taskfile_fullpath,
-    get_module_specs_by_ansible_doc,
-    get_documentation_in_module_file,
-    get_class_by_arg_type,
-    is_test_object,
 )
-from .awx_utils import could_be_playbook
-from .finder import could_be_taskfile
-
 
 # collection info direcotry can be something like
 #   "brightcomputing.bcm-9.1.11+41615.gitfab9053.info"
@@ -123,7 +125,10 @@ def load_repository(
 
     # if `path` and `repo_path` are different, update yaml_label_list
     if repo_to_root and yaml_label_list:
-        yaml_label_list = [(os.path.normpath(os.path.join(repo_to_root, fpath)), label, role_info) for (fpath, label, role_info) in yaml_label_list]
+        yaml_label_list = [
+            (os.path.normpath(os.path.join(repo_to_root, fpath)), label, role_info)
+            for (fpath, label, role_info) in yaml_label_list
+        ]
 
     if repo_path != "":
         if my_collection_name == "":
@@ -134,12 +139,16 @@ def load_repository(
     if basedir == "":
         basedir = path
 
-    logger.debug("start loading the repo {}".format(repo_path))
+    logger.debug(f"start loading the repo {repo_path}")
     logger.debug("start loading playbooks")
     repoObj.playbooks = load_playbooks(
-        repo_path, basedir=basedir, include_test_contents=include_test_contents, yaml_label_list=yaml_label_list, load_children=load_children
+        repo_path,
+        basedir=basedir,
+        include_test_contents=include_test_contents,
+        yaml_label_list=yaml_label_list,
+        load_children=load_children,
     )
-    logger.debug("done ... {} playbooks loaded".format(len(repoObj.playbooks)))
+    logger.debug(f"done ... {len(repoObj.playbooks)} playbooks loaded")
     logger.debug("start loading roles")
     repoObj.roles = load_roles(
         repo_path,
@@ -166,7 +175,7 @@ def load_repository(
                 repoObj.roles.append(role)
             else:
                 repoObj.roles.append(role.defined_in)
-    logger.debug("done ... {} roles loaded".format(len(repoObj.roles)))
+    logger.debug(f"done ... {len(repoObj.roles)} roles loaded")
     logger.debug("start loading modules (that are defined in this repository)")
     repoObj.modules = load_modules(
         repo_path,
@@ -175,22 +184,26 @@ def load_repository(
         use_ansible_doc=use_ansible_doc,
         load_children=load_children,
     )
-    logger.debug("done ... {} modules loaded".format(len(repoObj.modules)))
-    logger.debug("start loading taskfiles (that are defined for playbooks in this" " repository)")
-    repoObj.taskfiles = load_taskfiles(repo_path, basedir=basedir, yaml_label_list=yaml_label_list, load_children=load_children)
-    logger.debug("done ... {} task files loaded".format(len(repoObj.taskfiles)))
+    logger.debug(f"done ... {len(repoObj.modules)} modules loaded")
+    logger.debug("start loading taskfiles (that are defined for playbooks in this repository)")
+    repoObj.taskfiles = load_taskfiles(
+        repo_path, basedir=basedir, yaml_label_list=yaml_label_list, load_children=load_children
+    )
+    logger.debug(f"done ... {len(repoObj.taskfiles)} task files loaded")
     logger.debug("start loading inventory files")
     repoObj.inventories = load_inventories(repo_path, basedir=basedir)
-    logger.debug("done ... {} inventory files loaded".format(len(repoObj.inventories)))
-    repoObj.files = load_files(path=repo_path, basedir=basedir, yaml_label_list=yaml_label_list, load_children=load_children)
-    logger.debug("done ... {} other files loaded".format(len(repoObj.files)))
+    logger.debug(f"done ... {len(repoObj.inventories)} inventory files loaded")
+    repoObj.files = load_files(
+        path=repo_path, basedir=basedir, yaml_label_list=yaml_label_list, load_children=load_children
+    )
+    logger.debug(f"done ... {len(repoObj.files)} other files loaded")
     logger.debug("start loading installed collections")
     repoObj.installed_collections = load_installed_collections(installed_collections_path)
 
-    logger.debug("done ... {} collections loaded".format(len(repoObj.installed_collections)))
+    logger.debug(f"done ... {len(repoObj.installed_collections)} collections loaded")
     logger.debug("start loading installed roles")
     repoObj.installed_roles = load_installed_roles(installed_roles_path)
-    logger.debug("done ... {} roles loaded".format(len(repoObj.installed_roles)))
+    logger.debug(f"done ... {len(repoObj.installed_roles)} roles loaded")
     repoObj.requirements = load_requirements(path=repo_path)
     name = os.path.basename(path)
     repoObj.name = name
@@ -229,7 +242,7 @@ def load_installed_collections(installed_collections_path):
                 c = load_collection(collection_dir=collection_path, basedir=basedir)
                 collections.append(c)
             except Exception:
-                logger.exception("error while loading the collection at {}".format(collection_path))
+                logger.exception(f"error while loading the collection at {collection_path}")
     return collections
 
 
@@ -243,11 +256,10 @@ def load_inventory(path, basedir=""):
     if fullpath == "":
         raise ValueError("file not found")
     defined_in = fullpath
-    if basedir != "":
-        if defined_in.startswith(basedir):
-            defined_in = defined_in[len(basedir) :]
-            if defined_in.startswith("/"):
-                defined_in = defined_in[1:]
+    if basedir != "" and defined_in.startswith(basedir):
+        defined_in = defined_in[len(basedir) :]
+        if defined_in.startswith("/"):
+            defined_in = defined_in[1:]
     invObj.defined_in = defined_in
     base_parts = os.path.splitext(os.path.basename(fullpath))
     invObj.name = base_parts[0]
@@ -270,17 +282,17 @@ def load_inventory(path, basedir=""):
         # TODO: parse it as INI file
         pass
     elif file_ext == ".yml" or file_ext == ".yaml":
-        with open(fullpath, "r") as file:
+        with open(fullpath) as file:
             try:
                 data = yaml.load(file, Loader=Loader)
             except Exception as e:
-                logger.debug("failed to load this yaml file (inventory); {}".format(e.args[0]))
+                logger.debug(f"failed to load this yaml file (inventory); {e.args[0]}")
     elif file_ext == ".json":
-        with open(fullpath, "r") as file:
+        with open(fullpath) as file:
             try:
                 data = json.load(file)
             except Exception as e:
-                logger.debug("failed to load this json file (inventory); {}".format(e.args[0]))
+                logger.debug(f"failed to load this json file (inventory); {e.args[0]}")
     invObj.variables = data
     return invObj
 
@@ -297,7 +309,7 @@ def load_inventories(path, basedir=""):
                 iv = load_inventory(inventory_path, basedir=basedir)
                 inventories.append(iv)
             except Exception:
-                logger.exception("error while loading the inventory file at {}".format(inventory_path))
+                logger.exception(f"error while loading the inventory file at {inventory_path}")
     return inventories
 
 
@@ -313,9 +325,8 @@ def load_file(
     collection_name="",
 ):
     fullpath = os.path.join(basedir, path)
-    if not os.path.exists(fullpath):
-        if path and os.path.exists(path):
-            fullpath = path
+    if not os.path.exists(fullpath) and path and os.path.exists(path):
+        fullpath = path
 
     # use passed body/error when provided or when read=False
     if body or error or not read:
@@ -324,7 +335,7 @@ def load_file(
         # otherwise, try reading the file
         if os.path.exists(fullpath):
             try:
-                with open(fullpath, "r") as file:
+                with open(fullpath) as file:
                     body = file.read()
             except Exception:
                 error = traceback.format_exc()
@@ -347,11 +358,10 @@ def load_file(
             pass
 
     defined_in = fullpath
-    if basedir != "":
-        if defined_in.startswith(basedir):
-            defined_in = defined_in[len(basedir) :]
-            if defined_in.startswith("/"):
-                defined_in = defined_in[1:]
+    if basedir != "" and defined_in.startswith(basedir):
+        defined_in = defined_in[len(basedir) :]
+        if defined_in.startswith("/"):
+            defined_in = defined_in[1:]
 
     fObj = File()
     fObj.name = defined_in
@@ -378,7 +388,7 @@ def load_files(path, basedir="", yaml_label_list=None, role_name="", collection_
         return []
 
     files = []
-    for fpath, label, role_info in yaml_label_list:
+    for fpath, label, _role_info in yaml_label_list:
         if not fpath:
             continue
         if not label:
@@ -410,7 +420,7 @@ def load_play(
     if play_block_dict is None:
         raise ValueError("play block dict is required to load Play")
     if not isinstance(play_block_dict, dict):
-        raise PlaybookFormatError("this play block is not loaded as dict; maybe this is not a" " playbook")
+        raise PlaybookFormatError("this play block is not loaded as dict; maybe this is not a playbook")
     data_block = play_block_dict
     play_keywords = [
         "hosts",
@@ -422,7 +432,9 @@ def load_play(
     ]
     could_be_play = any([k in data_block for k in play_keywords])
     if not could_be_play:
-        raise PlaybookFormatError(f"this play block does not have any of the following keywords {play_keywords}; maybe this is not a playbook")
+        raise PlaybookFormatError(
+            f"this play block does not have any of the following keywords {play_keywords}; maybe this is not a playbook"
+        )
 
     jsonpath = f"$.{index}"
     pbObj.index = index
@@ -458,9 +470,7 @@ def load_play(
         if k not in data_block:
             continue
         v = data_block[k]
-        if k == "name":
-            pass
-        elif k == "collections":
+        if k == "name" or k == "collections":
             pass
         elif k == "pre_tasks":
             if not isinstance(v, list):
@@ -498,12 +508,14 @@ def load_play(
                 except TaskFormatError as exc:
                     error = exc
                     if skip_task_format_error:
-                        logger.debug("this task is wrong format; skip the task in {}," " index: {}; skip this".format(path, i))
+                        logger.debug(f"this task is wrong format; skip the task in {path}, index: {i}; skip this")
                     else:
-                        raise TaskFormatError(f"this task is wrong format; skip the task in {path}," " index: {i}")
+                        raise TaskFormatError(
+                            f"this task is wrong format; skip the task in {path}, index: {{i}}"
+                        ) from exc
                 except Exception as exc:
                     error = exc
-                    logger.exception("error while loading the task at {} (index={})".format(path, i))
+                    logger.exception(f"error while loading the task at {path} (index={i})")
                 finally:
                     task_count += 1
                     if error:
@@ -545,12 +557,14 @@ def load_play(
                 except TaskFormatError as exc:
                     error = exc
                     if skip_task_format_error:
-                        logger.debug("this task is wrong format; skip the task in {}," " index: {}; skip this".format(path, i))
+                        logger.debug(f"this task is wrong format; skip the task in {path}, index: {i}; skip this")
                     else:
-                        raise TaskFormatError(f"this task is wrong format; skip the task in {path}," " index: {i}")
+                        raise TaskFormatError(
+                            f"this task is wrong format; skip the task in {path}, index: {{i}}"
+                        ) from exc
                 except Exception as exc:
                     error = exc
-                    logger.exception("error while loading the task at {} (index={})".format(path, i))
+                    logger.exception(f"error while loading the task at {path} (index={i})")
                 finally:
                     task_count += 1
                     if error:
@@ -592,12 +606,14 @@ def load_play(
                 except TaskFormatError as exc:
                     error = exc
                     if skip_task_format_error:
-                        logger.debug("this task is wrong format; skip the task in {}," " index: {}; skip this".format(path, i))
+                        logger.debug(f"this task is wrong format; skip the task in {path}, index: {i}; skip this")
                     else:
-                        raise TaskFormatError(f"this task is wrong format; skip the task in {path}," " index: {i}")
+                        raise TaskFormatError(
+                            f"this task is wrong format; skip the task in {path}, index: {{i}}"
+                        ) from exc
                 except Exception as exc:
                     error = exc
-                    logger.exception("error while loading the task at {} (index={})".format(path, i))
+                    logger.exception(f"error while loading the task at {path} (index={i})")
                 finally:
                     task_count += 1
                     if error:
@@ -639,12 +655,14 @@ def load_play(
                 except TaskFormatError as exc:
                     error = exc
                     if skip_task_format_error:
-                        logger.debug("this task is wrong format; skip the task in {}," " index: {}; skip this".format(path, i))
+                        logger.debug(f"this task is wrong format; skip the task in {path}, index: {i}; skip this")
                     else:
-                        raise TaskFormatError(f"this task is wrong format; skip the task in {path}," " index: {i}")
+                        raise TaskFormatError(
+                            f"this task is wrong format; skip the task in {path}, index: {{i}}"
+                        ) from exc
                 except Exception as exc:
                     error = exc
-                    logger.exception("error while loading the task at {} (index={})".format(path, i))
+                    logger.exception(f"error while loading the task at {path} (index={i})")
                 finally:
                     task_count += 1
                     if error:
@@ -677,7 +695,9 @@ def load_play(
                     )
                     roles.append(rip)
                 except Exception:
-                    logger.exception("error while loading the role in playbook at {}" " (play_index={}, role_index={})".format(path, pbObj.index, i))
+                    logger.exception(
+                        f"error while loading the role in playbook at {path} (play_index={pbObj.index}, role_index={i})"
+                    )
         elif k == "vars":
             if not isinstance(v, dict):
                 continue
@@ -690,12 +710,7 @@ def load_play(
             if not isinstance(v, dict):
                 continue
             module_defaults = v
-        elif k == "import_playbook":
-            if not isinstance(v, str):
-                continue
-            import_module = k
-            import_playbook = v
-        elif k == "include":
+        elif k == "import_playbook" or k == "include":
             if not isinstance(v, str):
                 continue
             import_module = k
@@ -731,22 +746,22 @@ def load_roleinplay(
     play_index,
     role_name="",
     collection_name="",
-    collections_in_play=[],
+    collections_in_play=None,
     playbook_yaml="",
     basedir="",
 ):
+    if collections_in_play is None:
+        collections_in_play = []
     ripObj = RoleInPlay()
-    if name == "":
-        if "name" in options:
-            name = options["name"]
-            options.pop("name", None)
+    if name == "" and "name" in options:
+        name = options["name"]
+        options.pop("name", None)
     ripObj.name = name
     ripObj.options = options
-    if basedir != "":
-        if defined_in.startswith(basedir):
-            defined_in = defined_in[len(basedir) :]
-            if defined_in.startswith("/"):
-                defined_in = defined_in[1:]
+    if basedir != "" and defined_in.startswith(basedir):
+        defined_in = defined_in[len(basedir) :]
+        if defined_in.startswith("/"):
+            defined_in = defined_in[1:]
     ripObj.defined_in = defined_in
     ripObj.role = role_name
     ripObj.collection = collection_name
@@ -757,7 +772,15 @@ def load_roleinplay(
     return ripObj
 
 
-def load_playbook(path="", yaml_str="", role_name="", collection_name="", basedir="", skip_playbook_format_error=True, skip_task_format_error=True):
+def load_playbook(
+    path="",
+    yaml_str="",
+    role_name="",
+    collection_name="",
+    basedir="",
+    skip_playbook_format_error=True,
+    skip_task_format_error=True,
+):
     pbObj = Playbook()
     fullpath = ""
     if yaml_str:
@@ -770,11 +793,10 @@ def load_playbook(path="", yaml_str="", role_name="", collection_name="", basedi
         if fullpath == "":
             raise ValueError("file not found")
     defined_in = fullpath
-    if basedir:
-        if defined_in.startswith(basedir):
-            defined_in = defined_in[len(basedir) :]
-            if defined_in.startswith("/"):
-                defined_in = defined_in[1:]
+    if basedir and defined_in.startswith(basedir):
+        defined_in = defined_in[len(basedir) :]
+        if defined_in.startswith("/"):
+            defined_in = defined_in[1:]
     pbObj.defined_in = defined_in
     pbObj.name = os.path.basename(fullpath)
     pbObj.role = role_name
@@ -790,9 +812,9 @@ def load_playbook(path="", yaml_str="", role_name="", collection_name="", basedi
             if skip_playbook_format_error:
                 logger.debug(f"failed to load this yaml string to load playbook, skip this yaml; {e}")
             else:
-                raise PlaybookFormatError(f"failed to load this yaml string to load playbook; {e}")
+                raise PlaybookFormatError(f"failed to load this yaml string to load playbook; {e}") from e
     elif fullpath != "":
-        with open(fullpath, "r") as file:
+        with open(fullpath) as file:
             try:
                 yaml_lines = file.read()
                 data = yaml.load(yaml_lines, Loader=Loader)
@@ -800,11 +822,11 @@ def load_playbook(path="", yaml_str="", role_name="", collection_name="", basedi
                 if skip_playbook_format_error:
                     logger.debug(f"failed to load this yaml file to load playbook, skip this yaml; {e}")
                 else:
-                    raise PlaybookFormatError(f"failed to load this yaml file to load playbook; {e}")
+                    raise PlaybookFormatError(f"failed to load this yaml file to load playbook; {e}") from e
     if data is None:
         return pbObj
     if not isinstance(data, list):
-        raise PlaybookFormatError("playbook must be loaded as a list, but got {}".format(type(data).__name__))
+        raise PlaybookFormatError(f"playbook must be loaded as a list, but got {type(data).__name__}")
 
     if yaml_lines:
         pbObj.yaml_lines = yaml_lines
@@ -825,13 +847,15 @@ def load_playbook(path="", yaml_str="", role_name="", collection_name="", basedi
                 skip_task_format_error=skip_task_format_error,
             )
             plays.append(play)
-        except PlaybookFormatError:
+        except PlaybookFormatError as err:
             if skip_playbook_format_error:
-                logger.debug("this play is wrong format; skip the play in {}, index: {}, skip this play".format(fullpath, i))
+                logger.debug(f"this play is wrong format; skip the play in {fullpath}, index: {i}, skip this play")
             else:
-                raise PlaybookFormatError(f"this play is wrong format; skip the play in {fullpath}, index: {i}")
+                raise PlaybookFormatError(
+                    f"this play is wrong format; skip the play in {fullpath}, index: {i}"
+                ) from err
         except Exception:
-            logger.exception("error while loading the play at {} (index={})".format(fullpath, i))
+            logger.exception(f"error while loading the play at {fullpath} (index={i})")
     pbObj.plays = plays
 
     return pbObj
@@ -896,12 +920,16 @@ def load_playbooks(
                 )
             except PlaybookFormatError as e:
                 if skip_playbook_format_error:
-                    logger.debug("this file is not in a playbook format, maybe not a playbook file, skip this: {}".format(e.args[0]))
+                    logger.debug(
+                        f"this file is not in a playbook format, maybe not a playbook file, skip this: {e.args[0]}"
+                    )
                     continue
                 else:
-                    raise PlaybookFormatError(f"this file is not in a playbook format, maybe not a playbook file: {e.args[0]}")
+                    raise PlaybookFormatError(
+                        f"this file is not in a playbook format, maybe not a playbook file: {e.args[0]}"
+                    ) from e
             except Exception:
-                logger.exception("error while loading the playbook at {}".format(fpath))
+                logger.exception(f"error while loading the playbook at {fpath}")
             if p:
                 if load_children:
                     playbooks.append(p)
@@ -919,7 +947,7 @@ def load_role(
     path,
     name="",
     collection_name="",
-    module_dir_paths=[],
+    module_dir_paths=None,
     basedir="",
     use_ansible_doc=True,
     skip_playbook_format_error=True,
@@ -927,6 +955,8 @@ def load_role(
     include_test_contents=False,
     load_children=True,
 ):
+    if module_dir_paths is None:
+        module_dir_paths = []
     roleObj = Role()
     fullpath = ""
     if os.path.exists(path) and path != "" and path != ".":
@@ -958,11 +988,11 @@ def load_role(
         handlers_dir_path = os.path.join(fullpath, "handlers")
         includes_dir_path = os.path.join(fullpath, "includes")
     if os.path.exists(meta_file_path):
-        with open(meta_file_path, "r") as file:
+        with open(meta_file_path) as file:
             try:
                 roleObj.metadata = yaml.load(file, Loader=Loader)
             except Exception as e:
-                logger.debug("failed to load this yaml file to raed metadata; {}".format(e.args[0]))
+                logger.debug(f"failed to load this yaml file to raed metadata; {e.args[0]}")
 
             if roleObj.metadata is not None and isinstance(roleObj.metadata, dict):
                 roleObj.dependency["roles"] = roleObj.metadata.get("dependencies", [])
@@ -970,11 +1000,11 @@ def load_role(
 
     requirements_yml_path = os.path.join(fullpath, "requirements.yml")
     if os.path.exists(requirements_yml_path):
-        with open(requirements_yml_path, "r") as file:
+        with open(requirements_yml_path) as file:
             try:
                 roleObj.requirements = yaml.load(file, Loader=Loader)
             except Exception as e:
-                logger.debug("failed to load requirements.yml; {}".format(e.args[0]))
+                logger.debug(f"failed to load requirements.yml; {e.args[0]}")
 
     parts = tasks_dir_path.split("/")
     if len(parts) < 2:
@@ -982,11 +1012,10 @@ def load_role(
     role_name = parts[-2] if name == "" else name
     roleObj.name = role_name
     defined_in = fullpath
-    if basedir != "":
-        if defined_in.startswith(basedir):
-            defined_in = defined_in[len(basedir) :]
-            if defined_in.startswith("/"):
-                defined_in = defined_in[1:]
+    if basedir != "" and defined_in.startswith(basedir):
+        defined_in = defined_in[len(basedir) :]
+        if defined_in.startswith("/"):
+            defined_in = defined_in[1:]
     roleObj.defined_in = defined_in
     is_test = is_test_object(defined_in)
 
@@ -994,7 +1023,7 @@ def load_role(
     fqcn = role_name
     if collection_name != "" and not is_test:
         collection = collection_name
-        fqcn = "{}.{}".format(collection_name, role_name)
+        fqcn = f"{collection_name}.{role_name}"
     roleObj.collection = collection
     roleObj.fqcn = fqcn
     roleObj.set_key()
@@ -1016,7 +1045,7 @@ def load_role(
         defaults_yaml_files = safe_glob(patterns, recursive=True)
         default_variables = {}
         for fpath in defaults_yaml_files:
-            with open(fpath, "r") as file:
+            with open(fpath) as file:
                 try:
                     vars_in_yaml = yaml.load(file, Loader=Loader)
                     if vars_in_yaml is None:
@@ -1025,7 +1054,7 @@ def load_role(
                         continue
                     default_variables.update(vars_in_yaml)
                 except Exception as e:
-                    logger.debug("failed to load this yaml file to read default" " variables; {}".format(e.args[0]))
+                    logger.debug(f"failed to load this yaml file to read default variables; {e.args[0]}")
         roleObj.default_variables = default_variables
 
     if os.path.exists(vars_dir_path):
@@ -1033,7 +1062,7 @@ def load_role(
         vars_yaml_files = safe_glob(patterns, recursive=True)
         variables = {}
         for fpath in vars_yaml_files:
-            with open(fpath, "r") as file:
+            with open(fpath) as file:
                 try:
                     vars_in_yaml = yaml.load(file, Loader=Loader)
                     if vars_in_yaml is None:
@@ -1042,7 +1071,7 @@ def load_role(
                         continue
                     variables.update(vars_in_yaml)
                 except Exception as e:
-                    logger.debug("failed to load this yaml file to read variables; {}".format(e.args[0]))
+                    logger.debug(f"failed to load this yaml file to read variables; {e.args[0]}")
         roleObj.variables = variables
 
     modules = []
@@ -1071,7 +1100,7 @@ def load_role(
                 module_specs=module_specs,
             )
         except Exception:
-            logger.exception("error while loading the module at {}".format(module_file_path))
+            logger.exception(f"error while loading the module at {module_file_path}")
         if load_children:
             modules.append(m)
         else:
@@ -1107,9 +1136,9 @@ def load_role(
             if skip_task_format_error:
                 logger.debug(f"Task format error found; skip this taskfile {task_yaml_path}")
             else:
-                raise TaskFormatError(f"Task format error found: {e.args[0]}")
+                raise TaskFormatError(f"Task format error found: {e.args[0]}") from e
         except Exception:
-            logger.exception("error while loading the task file at {}".format(task_yaml_path))
+            logger.exception(f"error while loading the task file at {task_yaml_path}")
         if not tf:
             continue
         if load_children:
@@ -1139,9 +1168,9 @@ def load_role(
                 if skip_task_format_error:
                     logger.debug(f"Task format error found; skip this taskfile {task_yaml_path}")
                 else:
-                    raise TaskFormatError(f"Task format error found: {e.args[0]}")
+                    raise TaskFormatError(f"Task format error found: {e.args[0]}") from e
             except Exception:
-                logger.exception("error while loading the task file at {}".format(task_yaml_path))
+                logger.exception(f"error while loading the task file at {task_yaml_path}")
             if not tf:
                 continue
             if load_children:
@@ -1228,7 +1257,7 @@ def load_roles(
 
     # add role dirs if yaml_label_list is given
     if yaml_label_list:
-        for fpath, label, role_info in yaml_label_list:
+        for _fpath, _label, role_info in yaml_label_list:
             if role_info and isinstance(role_info, dict):
                 role_path = role_info.get("path", "")
                 _role_path = role_path
@@ -1252,7 +1281,7 @@ def load_roles(
                 include_test_contents=include_test_contents,
             )
         except Exception:
-            logger.exception("error while loading the role at {}".format(role_dir))
+            logger.exception(f"error while loading the role at {role_dir}")
         if load_children:
             roles.append(r)
         else:
@@ -1266,11 +1295,11 @@ def load_requirements(path):
     requirements = {}
     requirements_yml_path = os.path.join(path, "requirements.yml")
     if os.path.exists(requirements_yml_path):
-        with open(requirements_yml_path, "r") as file:
+        with open(requirements_yml_path) as file:
             try:
                 requirements = yaml.load(file, Loader=Loader)
             except Exception as e:
-                logger.debug("failed to load requirements.yml; {}".format(e.args[0]))
+                logger.debug(f"failed to load requirements.yml; {e.args[0]}")
     return requirements
 
 
@@ -1304,11 +1333,15 @@ def load_installed_roles(installed_roles_path):
                 )
                 roles.append(r)
             except Exception:
-                logger.exception("error while loading the role at {}".format(role_dir_path))
+                logger.exception(f"error while loading the role at {role_dir_path}")
     return roles
 
 
-def load_module(module_file_path, collection_name="", role_name="", basedir="", use_ansible_doc=True, module_specs={}):
+def load_module(
+    module_file_path, collection_name="", role_name="", basedir="", use_ansible_doc=True, module_specs=None
+):
+    if module_specs is None:
+        module_specs = {}
     moduleObj = Module()
     if module_file_path == "":
         raise ValueError("require module file path to load a Module")
@@ -1334,17 +1367,16 @@ def load_module(module_file_path, collection_name="", role_name="", basedir="", 
     moduleObj.name = module_name
     if collection_name != "":
         moduleObj.collection = collection_name
-        moduleObj.fqcn = "{}.{}".format(collection_name, module_name)
+        moduleObj.fqcn = f"{collection_name}.{module_name}"
     elif role_name != "":
         # if module is defined in a role, it does not have real fqcn
         moduleObj.role = role_name
         moduleObj.fqcn = module_name
     defined_in = module_file_path
-    if basedir != "":
-        if defined_in.startswith(basedir):
-            defined_in = defined_in[len(basedir) :]
-            if defined_in.startswith("/"):
-                defined_in = defined_in[1:]
+    if basedir != "" and defined_in.startswith(basedir):
+        defined_in = defined_in[len(basedir) :]
+        if defined_in.startswith("/"):
+            defined_in = defined_in[1:]
     moduleObj.defined_in = defined_in
 
     arguments = []
@@ -1383,10 +1415,8 @@ def load_module(module_file_path, collection_name="", role_name="", basedir="", 
                 if arg_elements_type:
                     arg_elements_type_str = arg_elements_type.__name__
                 required = None
-                try:
+                with contextlib.suppress(Exception):
                     required = parse_bool(arg_spec.get("required", "false"))
-                except Exception:
-                    pass
                 arg = ModuleArgument(
                     name=arg_name,
                     type=arg_value_type_str,
@@ -1426,7 +1456,9 @@ def load_builtin_modules():
 # https://docs.ansible.com/ansible/2.8/user_guide/playbooks_best_practices.html
 # however, it is often defined in `plugins/modules` directory,
 # so we search both the directories
-def load_modules(path, basedir="", collection_name="", module_dir_paths=[], use_ansible_doc=True, load_children=True):
+def load_modules(path, basedir="", collection_name="", module_dir_paths=None, use_ansible_doc=True, load_children=True):
+    if module_dir_paths is None:
+        module_dir_paths = []
     if path == "":
         return []
     if not os.path.exists(path):
@@ -1459,7 +1491,7 @@ def load_modules(path, basedir="", collection_name="", module_dir_paths=[], use_
                 module_specs=module_specs,
             )
         except Exception:
-            logger.exception("error while loading the module at {}".format(module_file_path))
+            logger.exception(f"error while loading the module at {module_file_path}")
         if load_children:
             modules.append(m)
         else:
@@ -1476,7 +1508,7 @@ def load_task(
     task_jsonpath="",
     role_name="",
     collection_name="",
-    collections_in_play=[],
+    collections_in_play=None,
     play_index=-1,
     parent_key="",
     parent_local_key="",
@@ -1485,6 +1517,8 @@ def load_task(
     basedir="",
 ):
 
+    if collections_in_play is None:
+        collections_in_play = []
     taskObj = Task()
     fullpath = ""
     if yaml_lines:
@@ -1501,7 +1535,9 @@ def load_task(
     if task_block_dict is None:
         raise ValueError("task block dict is required to load Task")
     if not isinstance(task_block_dict, dict):
-        raise TaskFormatError(f"this task block is not a dict, but {type(task_block_dict).__name__}; maybe this is not a task")
+        raise TaskFormatError(
+            f"this task block is not a dict, but {type(task_block_dict).__name__}; maybe this is not a task"
+        )
     data_block = task_block_dict
     task_name = ""
     module_name = find_module_name(task_block_dict)
@@ -1545,30 +1581,29 @@ def load_task(
     #   with_items:
     #   - 5222
     #   - 5269
-    if isinstance(module_options, str):
-        if string_module_options_re.match(module_options):
-            new_module_options = {}
-            unknown_key = "__unknown_option_name__"
-            if module_short_name in ["import_role", "include_role"]:
-                unknown_key = "name"
-            elif module_short_name in [
-                "import_tasks",
-                "include_tasks",
-                "include",
-            ]:
-                unknown_key = "file"
-            matched_options = string_module_option_parts_re.findall(module_options)
-            if len(matched_options) == 0:
-                new_module_options[unknown_key] = module_options
-            else:
-                unknown_key_val = module_options.split(matched_options[0])[0]
-                if unknown_key_val != "":
-                    new_module_options[unknown_key] = unknown_key_val.strip()
-                for p in matched_options:
-                    key = p.split("=")[0]
-                    val = "=".join(p.split("=")[1:]).rstrip()
-                    new_module_options[key] = val
-            module_options = new_module_options
+    if isinstance(module_options, str) and string_module_options_re.match(module_options):
+        new_module_options = {}
+        unknown_key = "__unknown_option_name__"
+        if module_short_name in ["import_role", "include_role"]:
+            unknown_key = "name"
+        elif module_short_name in [
+            "import_tasks",
+            "include_tasks",
+            "include",
+        ]:
+            unknown_key = "file"
+        matched_options = string_module_option_parts_re.findall(module_options)
+        if len(matched_options) == 0:
+            new_module_options[unknown_key] = module_options
+        else:
+            unknown_key_val = module_options.split(matched_options[0])[0]
+            if unknown_key_val != "":
+                new_module_options[unknown_key] = unknown_key_val.strip()
+            for p in matched_options:
+                key = p.split("=")[0]
+                val = "=".join(p.split("=")[1:]).rstrip()
+                new_module_options[key] = val
+        module_options = new_module_options
     executable = module_name
     executable_type = ExecutableType.MODULE_TYPE
     if module_short_name in ["import_role", "include_role"]:
@@ -1592,11 +1627,10 @@ def load_task(
     taskObj.role = role_name
     taskObj.collection = collection_name
     defined_in = fullpath
-    if basedir:
-        if defined_in.startswith(basedir):
-            defined_in = defined_in[len(basedir) :]
-            if defined_in.startswith("/"):
-                defined_in = defined_in[1:]
+    if basedir and defined_in.startswith(basedir):
+        defined_in = defined_in[len(basedir) :]
+        if defined_in.startswith("/"):
+            defined_in = defined_in[1:]
     taskObj.defined_in = defined_in
     taskObj.index = index
     taskObj.play_index = play_index
@@ -1623,9 +1657,8 @@ def load_task(
 
     set_facts = {}
     # if the Task is set_fact, set variables too
-    if module_short_name == "set_fact":
-        if isinstance(module_options, dict):
-            set_facts.update(module_options)
+    if module_short_name == "set_fact" and isinstance(module_options, dict):
+        set_facts.update(module_options)
 
     registered_variables = {}
     # set variables if this task register a new var
@@ -1670,11 +1703,10 @@ def load_taskfile(path, yaml_str="", role_name="", collection_name="", basedir="
             raise ValueError('task yaml file must be ".yml" or ".yaml"')
     tfObj.name = os.path.basename(fullpath)
     defined_in = fullpath
-    if basedir != "":
-        if defined_in.startswith(basedir):
-            defined_in = defined_in[len(basedir) :]
-            if defined_in.startswith("/"):
-                defined_in = defined_in[1:]
+    if basedir != "" and defined_in.startswith(basedir):
+        defined_in = defined_in[len(basedir) :]
+        if defined_in.startswith("/"):
+            defined_in = defined_in[1:]
     tfObj.defined_in = defined_in
     if role_name != "":
         tfObj.role = role_name
@@ -1723,13 +1755,13 @@ def load_taskfile(path, yaml_str="", role_name="", collection_name="", basedir="
         except TaskFormatError as exc:
             error = exc
             if skip_task_format_error:
-                logger.debug("this task is wrong format; skip the task in {}, index: {}; skip this".format(fullpath, i))
+                logger.debug(f"this task is wrong format; skip the task in {fullpath}, index: {i}; skip this")
                 continue
             else:
-                raise TaskFormatError(f"Task format error found; {fullpath}, index: {i}")
+                raise TaskFormatError(f"Task format error found; {fullpath}, index: {i}") from exc
         except Exception as exc:
             error = exc
-            logger.exception("error while loading the task at {}, index: {}".format(fullpath, i))
+            logger.exception(f"error while loading the task at {fullpath}, index: {i}")
         finally:
             if error:
                 task_loading["failure"] += 1
@@ -1770,7 +1802,7 @@ def load_taskfiles(path, basedir="", yaml_label_list=None, load_children=True):
         try:
             tf = load_taskfile(taskfile_path, basedir=basedir)
         except Exception:
-            logger.exception("error while loading the task file at {}".format(taskfile_path))
+            logger.exception(f"error while loading the task file at {taskfile_path}")
         if load_children:
             taskfiles.append(tf)
         else:
@@ -1801,11 +1833,11 @@ def load_collection(
     parts = fullpath.split("/")
     if len(parts) < 2:
         raise ValueError("collection directory path is wrong")
-    collection_name = "{}.{}".format(parts[-2], parts[-1])
+    collection_name = f"{parts[-2]}.{parts[-1]}"
 
     manifest_file_path = os.path.join(fullpath, "MANIFEST.json")
     if os.path.exists(manifest_file_path):
-        with open(manifest_file_path, "r") as file:
+        with open(manifest_file_path) as file:
             colObj.metadata = json.load(file)
 
         if colObj.metadata is not None and isinstance(colObj.metadata, dict):
@@ -1813,31 +1845,31 @@ def load_collection(
 
     files_file_path = os.path.join(fullpath, "FILES.json")
     if os.path.exists(files_file_path):
-        with open(files_file_path, "r") as file:
+        with open(files_file_path) as file:
             colObj.files = json.load(file)
 
     meta_runtime_file_path = os.path.join(fullpath, "meta", "runtime.yml")
     if os.path.exists(meta_runtime_file_path):
-        with open(meta_runtime_file_path, "r") as file:
+        with open(meta_runtime_file_path) as file:
             try:
                 colObj.meta_runtime = yaml.load(file, Loader=Loader)
             except Exception as e:
-                logger.debug("failed to load meta/runtime.yml; {}".format(e.args[0]))
+                logger.debug(f"failed to load meta/runtime.yml; {e.args[0]}")
 
     requirements_yml_path = os.path.join(fullpath, "requirements.yml")
     if os.path.exists(requirements_yml_path):
-        with open(requirements_yml_path, "r") as file:
+        with open(requirements_yml_path) as file:
             try:
                 colObj.requirements = yaml.load(file, Loader=Loader)
             except Exception as e:
-                logger.debug("failed to load requirements.yml; {}".format(e.args[0]))
+                logger.debug(f"failed to load requirements.yml; {e.args[0]}")
 
     if isinstance(colObj.metadata, dict):
         license_filename = colObj.metadata.get("collection_info", {}).get("license_file", None)
         if license_filename:
             license_filepath = os.path.join(fullpath, license_filename)
             if os.path.exists(license_filepath):
-                with open(license_filepath, "r") as file:
+                with open(license_filepath) as file:
                     contents = file.read()
                     lines = contents.splitlines()
                     if len(lines) > 10:
@@ -1862,7 +1894,7 @@ def load_collection(
             try:
                 tf = load_taskfile(taskfile_path, basedir=basedir)
             except Exception:
-                logger.exception("error while loading the task file at {}".format(taskfile_path))
+                logger.exception(f"error while loading the task file at {taskfile_path}")
                 continue
             if load_children:
                 taskfiles.append(tf)
@@ -1897,9 +1929,15 @@ def load_collection(
     for f in module_files:
         m = None
         try:
-            m = load_module(f, collection_name=collection_name, basedir=basedir, use_ansible_doc=use_ansible_doc, module_specs=module_specs)
+            m = load_module(
+                f,
+                collection_name=collection_name,
+                basedir=basedir,
+                use_ansible_doc=use_ansible_doc,
+                module_specs=module_specs,
+            )
         except Exception:
-            logger.exception("error while loading the module at {}".format(f))
+            logger.exception(f"error while loading the module at {f}")
             continue
         if load_children:
             modules.append(m)
@@ -1909,9 +1947,8 @@ def load_collection(
         modules = sorted(modules)
     colObj.name = collection_name
     path = collection_dir
-    if basedir != "":
-        if path.startswith(basedir):
-            path = path[len(basedir) :]
+    if basedir != "" and path.startswith(basedir):
+        path = path[len(basedir) :]
     colObj.path = path
     colObj.playbooks = playbooks
     colObj.roles = roles
@@ -1925,9 +1962,13 @@ def load_object(loadObj):
     path = loadObj.path
     obj = None
     if target_type == LoadType.COLLECTION:
-        obj = load_collection(collection_dir=path, basedir=path, include_test_contents=loadObj.include_test_contents, load_children=False)
+        obj = load_collection(
+            collection_dir=path, basedir=path, include_test_contents=loadObj.include_test_contents, load_children=False
+        )
     elif target_type == LoadType.ROLE:
-        obj = load_role(path=path, basedir=path, include_test_contents=loadObj.include_test_contents, load_children=False)
+        obj = load_role(
+            path=path, basedir=path, include_test_contents=loadObj.include_test_contents, load_children=False
+        )
     elif target_type == LoadType.PLAYBOOK:
         basedir = ""
         target_playbook_path = ""
@@ -1944,7 +1985,9 @@ def load_object(loadObj):
         if loadObj.playbook_only:
             obj = load_playbook(path=target_playbook_path, yaml_str=loadObj.playbook_yaml, basedir=basedir)
         else:
-            obj = load_repository(path=basedir, basedir=basedir, target_playbook_path=target_playbook_path, load_children=False)
+            obj = load_repository(
+                path=basedir, basedir=basedir, target_playbook_path=target_playbook_path, load_children=False
+            )
     elif target_type == LoadType.TASKFILE:
         basedir = ""
         target_taskfile_path = ""
@@ -1961,10 +2004,16 @@ def load_object(loadObj):
         if loadObj.taskfile_only:
             obj = load_taskfile(path=target_taskfile_path, yaml_str=loadObj.taskfile_yaml, basedir=basedir)
         else:
-            obj = load_repository(path=basedir, basedir=basedir, target_taskfile_path=target_taskfile_path, load_children=False)
+            obj = load_repository(
+                path=basedir, basedir=basedir, target_taskfile_path=target_taskfile_path, load_children=False
+            )
     elif target_type == LoadType.PROJECT:
         obj = load_repository(
-            path=path, basedir=path, include_test_contents=loadObj.include_test_contents, yaml_label_list=loadObj.yaml_label_list, load_children=False
+            path=path,
+            basedir=path,
+            include_test_contents=loadObj.include_test_contents,
+            yaml_label_list=loadObj.yaml_label_list,
+            load_children=False,
         )
 
     if hasattr(obj, "roles"):
@@ -1990,16 +2039,14 @@ def load_object(loadObj):
     elif target_type == LoadType.TASKFILE and loadObj.taskfile_only:
         loadObj.taskfiles = [obj.defined_in]
 
-    loadObj.timestamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')
+    loadObj.timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")
 
 
 def find_playbook_role_module(path, use_ansible_doc=True):
     playbooks = load_playbooks(path, basedir=path, load_children=False)
     root_role = None
-    try:
+    with contextlib.suppress(Exception):
         root_role = load_role(path, basedir=path, use_ansible_doc=use_ansible_doc, load_children=False)
-    except Exception:
-        pass
     sub_roles = load_roles(path, basedir=path, use_ansible_doc=use_ansible_doc, load_children=False)
     roles = []
     if root_role and root_role.metadata:

--- a/src/apme_engine/engine/models.py
+++ b/src/apme_engine/engine/models.py
@@ -1,18 +1,25 @@
-import os
-from dataclasses import dataclass, field
-from typing import List, Union
-from collections.abc import Callable
-from tabulate import tabulate
-from ruamel.yaml.scalarstring import DoubleQuotedScalarString
-
-from copy import deepcopy
+import contextlib
 import json
+import os
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+
 import jsonpickle
 from rapidfuzz.distance import Levenshtein
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
+from tabulate import tabulate
+
 from . import yaml as ariyaml
-from .utils import parse_bool
+from .finder import (
+    identify_lines_with_jsonpath,
+)
 from .keyutil import (
+    get_obj_info_by_key,
+    set_call_object_key,
     set_collection_key,
+    set_file_key,
     set_module_key,
     set_play_key,
     set_playbook_key,
@@ -20,16 +27,11 @@ from .keyutil import (
     set_role_key,
     set_task_key,
     set_taskfile_key,
-    set_file_key,
-    set_call_object_key,
-    get_obj_info_by_key,
 )
 from .utils import (
     equal,
+    parse_bool,
     recursive_copy_dict,
-)
-from .finder import (
-    identify_lines_with_jsonpath,
 )
 
 
@@ -45,7 +47,7 @@ class FatalRuleResultError(Exception):
     pass
 
 
-class JSONSerializable(object):
+class JSONSerializable:
     def dump(self):
         return self.to_json()
 
@@ -60,7 +62,7 @@ class JSONSerializable(object):
         return instance
 
 
-class Resolvable(object):
+class Resolvable:
     def resolve(self, resolver):
         if not hasattr(resolver, "apply"):
             raise ValueError("this resolver does not have apply() method")
@@ -139,7 +141,7 @@ class ObjectList(JSONSerializable):
         lines = [jsonpickle.encode(obj, make_refs=False) for obj in self.items]
         json_str = "\n".join(lines)
         if fpath != "":
-            open(fpath, "w").write(json_str)
+            Path(fpath).write_text(json_str)
         return json_str
 
     def to_one_line_json(self):
@@ -149,7 +151,7 @@ class ObjectList(JSONSerializable):
     def from_json(cls, json_str="", fpath=""):
         instance = cls()
         if fpath != "":
-            json_str = open(fpath, "r").read()
+            json_str = Path(fpath).read_text()
         lines = json_str.splitlines()
         items = [jsonpickle.decode(obj_str) for obj_str in lines]
         instance.items = items
@@ -164,7 +166,7 @@ class ObjectList(JSONSerializable):
 
     def merge(self, obj_list):
         if not isinstance(obj_list, ObjectList):
-            raise ValueError("obj_list must be an instance of ObjectList, but got {}".format(type(obj_list).__name__))
+            raise ValueError(f"obj_list must be an instance of ObjectList, but got {type(obj_list).__name__}")
         self.items.extend(obj_list.items)
         self._update_dict()
         return
@@ -239,7 +241,7 @@ class RunTargetType:
 
 
 @dataclass
-class RunTarget(object):
+class RunTarget:
     type: str = ""
 
     def file_info(self):
@@ -249,8 +251,8 @@ class RunTarget(object):
 
 
 @dataclass
-class RunTargetList(object):
-    items: List[RunTarget] = field(default_factory=list)
+class RunTargetList:
+    items: list[RunTarget] = field(default_factory=list)
 
     _i: int = 0
 
@@ -273,7 +275,7 @@ class RunTargetList(object):
 
 
 @dataclass
-class File(object):
+class File:
     type: str = "file"
     name: str = ""
     key: str = ""
@@ -302,7 +304,7 @@ class File(object):
 
 
 @dataclass
-class ModuleArgument(object):
+class ModuleArgument:
     name: str = ""
     type: str = None
     elements: str = None
@@ -409,7 +411,7 @@ class TaskCallsInTree(JSONSerializable):
 
 
 @dataclass
-class VariablePrecedence(object):
+class VariablePrecedence:
     name: str = ""
     order: int = -1
 
@@ -438,7 +440,7 @@ class VariablePrecedence(object):
         return not self.__lt__(__o)
 
 
-class VariableType(object):
+class VariableType:
     # When resolving variables, sometimes find unknown variables (e.g. undefined variable)
     # so we consider it as one type of variable
     Unknown = VariablePrecedence("unknown", -100)
@@ -479,7 +481,7 @@ immutable_var_types = [VariableType.LoopVars]
 
 
 @dataclass
-class Variable(object):
+class Variable:
     name: str = ""
     value: any = None
     type: VariableType = None
@@ -493,7 +495,7 @@ class Variable(object):
 
 
 @dataclass
-class VariableDict(object):
+class VariableDict:
     _dict: dict = field(default_factory=dict)
 
     @staticmethod
@@ -527,17 +529,17 @@ class VariableDict(object):
         return tabulate(table, headers="keys")
 
 
-class ArgumentsType(object):
+class ArgumentsType:
     SIMPLE = "simple"
     LIST = "list"
     DICT = "dict"
 
 
 @dataclass
-class Arguments(object):
+class Arguments:
     type: ArgumentsType = ""
     raw: any = None
-    vars: List[Variable] = field(default_factory=list)
+    vars: list[Variable] = field(default_factory=list)
     resolved: bool = False
     templated: any = None
     is_mutable: bool = False
@@ -592,10 +594,10 @@ class LocationType:
 
 
 @dataclass
-class Location(object):
+class Location:
     type: str = ""
     value: str = ""
-    vars: List[Variable] = field(default_factory=list)
+    vars: list[Variable] = field(default_factory=list)
 
     _args: Arguments = None
 
@@ -632,27 +634,20 @@ class Location(object):
 
         my_path = self.value
         target_path = target.value
-        if target_path.startswith(my_path):
-            return True
-        return False
+        return bool(target_path.startswith(my_path))
 
     def contains_any(self, target_list):
-        for target in target_list:
-            if self.contains(target):
-                return True
-        return False
+        return any(self.contains(target) for target in target_list)
 
     def contains_all(self, target_list):
         count = 0
         for target in target_list:
             if self.contains(target):
                 count += 1
-        if count == len(target_list):
-            return True
-        return False
+        return count == len(target_list)
 
 
-class AnnotationDetail(object):
+class AnnotationDetail:
     pass
 
 
@@ -710,12 +705,10 @@ class PackageInstallDetail(AnnotationDetail):
                 self.is_mutable_pkg = True
         if self._version_arg:
             self.version = self._version_arg.vars
-        if self._allow_downgrade_arg:
-            if _convert_to_bool(self._allow_downgrade_arg.raw):
-                self.allow_downgrade = True
-        if self._validate_certs_arg:
-            if not _convert_to_bool(self._validate_certs_arg.raw):
-                self.disable_validate_certs = True
+        if self._allow_downgrade_arg and _convert_to_bool(self._allow_downgrade_arg.raw):
+            self.allow_downgrade = True
+        if self._validate_certs_arg and not _convert_to_bool(self._validate_certs_arg.raw):
+            self.disable_validate_certs = True
 
 
 @dataclass
@@ -765,9 +758,8 @@ class FileChangeDetail(AnnotationDetail):
             self.src = Location(_args=self._src_arg)
             if self._src_arg.is_mutable:
                 self.is_mutable_src = True
-        if self._unsafe_write_arg:
-            if _convert_to_bool(self._unsafe_write_arg.raw):
-                self.is_unsafe_write = True
+        if self._unsafe_write_arg and _convert_to_bool(self._unsafe_write_arg.raw):
+            self.is_unsafe_write = True
 
 
 execution_programs: list = ["sh", "bash", "zsh", "fish", "ash", "python*", "java*", "node*"]
@@ -777,7 +769,7 @@ non_execution_programs: list = ["tar", "gunzip", "unzip", "mv", "cp"]
 @dataclass
 class CommandExecDetail(AnnotationDetail):
     command: Arguments = None
-    exec_files: List[Location] = field(default_factory=list)
+    exec_files: list[Location] = field(default_factory=list)
 
     def __post_init__(self):
         self.exec_files = self.extract_exec_files()
@@ -818,9 +810,8 @@ class CommandExecDetail(AnnotationDetail):
                         continue
                     # for the case that the program name is like "python-3.6"
                     for exec_p in execution_programs:
-                        if exec_p[-1] == "*":
-                            if program.startswith(exec_p[:-1]):
-                                continue
+                        if exec_p[-1] == "*" and program.startswith(exec_p[:-1]):
+                            continue
                 if p.startswith("-"):
                     continue
                 if found_program is None:
@@ -843,10 +834,7 @@ def _convert_to_bool(a: any):
     if type(a) is bool:
         return bool(a)
     if type(a) is str:
-        if a == "true" or a == "True" or a == "yes":
-            return True
-        else:
-            return False
+        return bool(a == "true" or a == "True" or a == "yes")
     return None
 
 
@@ -911,19 +899,17 @@ class RiskAnnotation(Annotation, NetworkTransferDetail, CommandExecDetail):
             return False
         self_dict = self.__dict__
         anno_dict = anno.__dict__
-        if not equal(self_dict, anno_dict):
-            return False
-        return True
+        return equal(self_dict, anno_dict)
 
 
 @dataclass
-class FindCondition(object):
+class FindCondition:
     def check(self, anno: RiskAnnotation):
         raise NotImplementedError
 
 
 @dataclass
-class AnnotationCondition(object):
+class AnnotationCondition:
     type: RiskType = ""
     attr_conditions: list = field(default_factory=list)
 
@@ -942,35 +928,32 @@ class AttributeCondition(FindCondition):
     result: any = None
 
     def check(self, anno: RiskAnnotation):
-        if self.attr:
-            if hasattr(anno.detail, self.attr):
-                anno_value = getattr(anno.detail, self.attr)
-                if anno_value == self.result:
-                    return True
-                if self.result is None:
-                    if isinstance(anno_value, bool) and anno_value:
-                        return True
+        if self.attr and hasattr(anno.detail, self.attr):
+            anno_value = getattr(anno.detail, self.attr)
+            if anno_value == self.result:
+                return True
+            if self.result is None and isinstance(anno_value, bool) and anno_value:
+                return True
         return False
 
 
 @dataclass
 class FunctionCondition(FindCondition):
     func: Callable = None
-    args: List[any] = None
+    args: list[any] = None
     result: any = None
 
     def check(self, anno: RiskAnnotation):
-        if self.func:
-            if callable(self.func):
-                result = self.func(anno, **self.args)
-                if result == self.result:
-                    return True
+        if self.func and callable(self.func):
+            result = self.func(anno, **self.args)
+            if result == self.result:
+                return True
         return False
 
 
 @dataclass
-class RiskAnnotationList(object):
-    items: List[RiskAnnotation] = field(default_factory=list)
+class RiskAnnotationList:
+    items: list[RiskAnnotation] = field(default_factory=list)
 
     _i: int = 0
 
@@ -994,7 +977,7 @@ class RiskAnnotationList(object):
             current = filter_annotations_by_type(current, risk_type)
         return current
 
-    def find(self, risk_type: RiskType = "", condition: Union[FindCondition, List[FindCondition]] = None):
+    def find(self, risk_type: RiskType = "", condition: FindCondition | list[FindCondition] = None):
         return search_risk_annotations(self, risk_type, condition)
 
 
@@ -1019,14 +1002,15 @@ def filter_annotations_by_type(anno_list: RiskAnnotationList, risk_type: RiskTyp
     return sub_list
 
 
-def search_risk_annotations(anno_list: RiskAnnotationList, risk_type: RiskType = "", condition: Union[FindCondition, List[FindCondition]] = None):
+def search_risk_annotations(
+    anno_list: RiskAnnotationList, risk_type: RiskType = "", condition: FindCondition | list[FindCondition] = None
+):
     matched = []
     for risk_anno in anno_list:
         if not isinstance(risk_anno, RiskAnnotation):
             continue
-        if risk_type:
-            if risk_anno.risk_type != risk_type:
-                continue
+        if risk_type and risk_anno.risk_type != risk_type:
+            continue
         if condition:
             if isinstance(condition, FindCondition):
                 condition = [condition]
@@ -1044,7 +1028,7 @@ class ExecutableType:
 
 
 @dataclass
-class BecomeInfo(object):
+class BecomeInfo:
     enabled: bool = False
     become: str = ""
     user: str = ""
@@ -1056,10 +1040,8 @@ class BecomeInfo(object):
         if "become" in options:
             become = options.get("become", "")
             enabled = False
-            try:
+            with contextlib.suppress(Exception):
                 enabled = parse_bool(become)
-            except Exception:
-                pass
             user = options.get("become_user", "")
             method = options.get("become_method", "")
             flags = options.get("become_flags", "")
@@ -1119,10 +1101,7 @@ class Task(Object, Resolvable):
             return
 
         lines = []
-        if yaml_lines:
-            lines = yaml_lines.splitlines()
-        else:
-            lines = open(fullpath, "r").read().splitlines()
+        lines = yaml_lines.splitlines() if yaml_lines else Path(fullpath).read_text().splitlines()
 
         if jsonpath:
             found_yaml, line_num = identify_lines_with_jsonpath(fpath=fullpath, yaml_str=yaml_lines, jsonpath=jsonpath)
@@ -1138,23 +1117,21 @@ class Task(Object, Resolvable):
         #       - if module option is dict, at least one key is included
         candidate_line_nums = []
         for i, line in enumerate(lines):
-
             # skip lines until `previous_task_line` if provided
-            if previous_task_line > 0:
-                if i <= previous_task_line - 1:
-                    continue
+            if previous_task_line > 0 and i <= previous_task_line - 1:
+                continue
 
             if task_name:
                 if task_name in line:
                     candidate_line_nums.append(i)
-            elif "{}:".format(module_name) in line:
+            elif f"{module_name}:" in line:
                 if isinstance(module_options, str):
                     if module_options in line:
                         candidate_line_nums.append(i)
                 elif isinstance(module_options, dict):
                     option_matched = False
                     for key in module_options:
-                        if i + 1 < len(lines) and "{}:".format(key) in lines[i + 1]:
+                        if i + 1 < len(lines) and f"{key}:" in lines[i + 1]:
                             option_matched = True
                             break
                     if option_matched:
@@ -1190,10 +1167,8 @@ class Task(Object, Resolvable):
                     if key not in reconstructed_data[0]:
                         reconstructed_data[0][key] = val
 
-            try:
+            with contextlib.suppress(Exception):
                 reconstructed_yaml = ariyaml.dump(reconstructed_data)
-            except Exception:
-                pass
 
             # find best match by edit distance
             if reconstructed_yaml:
@@ -1250,7 +1225,7 @@ class Task(Object, Resolvable):
                 if p != "":
                     break
                 _indent_of_block = i + 1
-            for i in range(len(lines)):
+            for _ in range(len(lines)):
                 index = begin_line_num
                 _line = lines[index]
                 is_top_of_block = _line.replace(" ", "").startswith("-")
@@ -1269,7 +1244,7 @@ class Task(Object, Resolvable):
         index = begin_line_num + 1
         end_found = False
         end_line_num = -1
-        for i in range(len(lines)):
+        for _ in range(len(lines)):
             if index >= len(lines):
                 break
             _line = lines[index]
@@ -1459,7 +1434,7 @@ class Task(Object, Resolvable):
 
 
 @dataclass
-class MutableContent(object):
+class MutableContent:
     _yaml: str = ""
     _task_spec: Task = None
 
@@ -1521,7 +1496,7 @@ class MutableContent(object):
         self._yaml = self._task_spec.yaml()
         self._task_spec.yaml_lines = self._yaml
         if need_restore:
-            for k, v in self._task_spec.options.items():
+            for k, _ in self._task_spec.options.items():
                 if k in keys_to_be_restored:
                     self._task_spec.options[k] = original_new_value
         return self
@@ -1627,7 +1602,7 @@ class TaskCall(CallObject, RunTarget):
     type: str = "taskcall"
     # annotations are used for storing generic analysis data
     # any Annotators in "annotators" dir can add them to this object
-    annotations: List[Annotation] = field(default_factory=list)
+    annotations: list[Annotation] = field(default_factory=list)
     args: Arguments = field(default_factory=Arguments)
     variable_set: dict = field(default_factory=dict)
     variable_use: dict = field(default_factory=dict)
@@ -1642,7 +1617,11 @@ class TaskCall(CallObject, RunTarget):
         return matched
 
     def get_annotation_by_type_and_attr(self, type_str="", key="", val=None):
-        matched = [an for an in self.annotations if hasattr(an, "type") and an.type == type_str and getattr(an, key, None) == val]
+        matched = [
+            an
+            for an in self.annotations
+            if hasattr(an, "type") and an.type == type_str and getattr(an, key, None) == val
+        ]
         return matched
 
     def set_annotation(self, key: str, value: any, rule_id: str):
@@ -1650,8 +1629,8 @@ class TaskCall(CallObject, RunTarget):
         for an in self.annotations:
             if not hasattr(an, "key"):
                 continue
-            if getattr(an, "key") == key:
-                setattr(an, "value", value)
+            if an.key == key:
+                an.value = value
                 end_to_set = True
                 break
         if not end_to_set:
@@ -1663,20 +1642,16 @@ class TaskCall(CallObject, RunTarget):
         for an in self.annotations:
             if not hasattr(an, "key"):
                 continue
-            if rule_id:
-                if hasattr(an, "rule_id"):
-                    if an.rule_id != rule_id:
-                        continue
-            if getattr(an, "key") == key:
+            if rule_id and hasattr(an, "rule_id") and an.rule_id != rule_id:
+                continue
+            if an.key == key:
                 value = getattr(an, "value", __default)
                 break
         return value
 
     def has_annotation_by_condition(self, cond: AnnotationCondition):
         anno = self.get_annotation_by_condition(cond)
-        if anno:
-            return True
-        return False
+        return bool(anno)
 
     def get_annotation_by_condition(self, cond: AnnotationCondition):
         _annotations = self.annotations
@@ -1711,7 +1686,7 @@ class TaskCall(CallObject, RunTarget):
 
 
 @dataclass
-class AnsibleRunContext(object):
+class AnsibleRunContext:
     sequence: RunTargetList = field(default_factory=RunTargetList)
     root_key: str = ""
     parent: Object = None
@@ -1749,7 +1724,9 @@ class AnsibleRunContext(object):
         return self.sequence[i]
 
     @staticmethod
-    def from_tree(tree: ObjectList, parent: Object = None, last_item: bool = False, ram_client=None, scan_metadata=None):
+    def from_tree(
+        tree: ObjectList, parent: Object = None, last_item: bool = False, ram_client=None, scan_metadata=None
+    ):
         if not tree:
             return AnsibleRunContext(parent=parent, last_item=last_item)
         if len(tree.items) == 0:
@@ -1763,19 +1740,33 @@ class AnsibleRunContext(object):
             sequence_items.append(item)
         tl = RunTargetList(items=sequence_items)
         return AnsibleRunContext(
-            sequence=tl, root_key=root_key, parent=parent, last_item=last_item, ram_client=ram_client, scan_metadata=scan_metadata
+            sequence=tl,
+            root_key=root_key,
+            parent=parent,
+            last_item=last_item,
+            ram_client=ram_client,
+            scan_metadata=scan_metadata,
         )
 
     @staticmethod
     def from_targets(
-        targets: List[RunTarget], root_key: str = "", parent: Object = None, last_item: bool = False, ram_client=None, scan_metadata=None
+        targets: list[RunTarget],
+        root_key: str = "",
+        parent: Object = None,
+        last_item: bool = False,
+        ram_client=None,
+        scan_metadata=None,
     ):
-        if not root_key:
-            if len(targets) > 0:
-                root_key = targets[0].spec.key
+        if not root_key and len(targets) > 0:
+            root_key = targets[0].spec.key
         tl = RunTargetList(items=targets)
         return AnsibleRunContext(
-            sequence=tl, root_key=root_key, parent=parent, last_item=last_item, ram_client=ram_client, scan_metadata=scan_metadata
+            sequence=tl,
+            root_key=root_key,
+            parent=parent,
+            last_item=last_item,
+            ram_client=ram_client,
+            scan_metadata=scan_metadata,
         )
 
     def find(self, target: RunTarget):
@@ -2217,7 +2208,7 @@ class GalaxyArtifact(Repository):
 
 
 @dataclass
-class ModuleMetadata(object):
+class ModuleMetadata:
     fqcn: str = ""
     # arguments: list = field(default_factory=list)
     type: str = ""
@@ -2264,11 +2255,17 @@ class ModuleMetadata(object):
     def __eq__(self, mm):
         if not isinstance(mm, ModuleMetadata):
             return False
-        return self.fqcn == mm.fqcn and self.name == mm.name and self.type == mm.type and self.version == mm.version and self.hash == mm.hash
+        return (
+            self.fqcn == mm.fqcn
+            and self.name == mm.name
+            and self.type == mm.type
+            and self.version == mm.version
+            and self.hash == mm.hash
+        )
 
 
 @dataclass
-class RoleMetadata(object):
+class RoleMetadata:
     fqcn: str = ""
     type: str = ""
     name: str = ""
@@ -2302,11 +2299,17 @@ class RoleMetadata(object):
     def __eq__(self, rm):
         if not isinstance(rm, ModuleMetadata):
             return False
-        return self.fqcn == rm.fqcn and self.name == rm.name and self.type == rm.type and self.version == rm.version and self.hash == rm.hash
+        return (
+            self.fqcn == rm.fqcn
+            and self.name == rm.name
+            and self.type == rm.type
+            and self.version == rm.version
+            and self.hash == rm.hash
+        )
 
 
 @dataclass
-class TaskFileMetadata(object):
+class TaskFileMetadata:
     key: str = ""
     type: str = ""
     name: str = ""
@@ -2340,11 +2343,17 @@ class TaskFileMetadata(object):
     def __eq__(self, tfm):
         if not isinstance(tfm, TaskFileMetadata):
             return False
-        return self.key == tfm.key and self.name == tfm.name and self.type == tfm.type and self.version == tfm.version and self.hash == tfm.hash
+        return (
+            self.key == tfm.key
+            and self.name == tfm.name
+            and self.type == tfm.type
+            and self.version == tfm.version
+            and self.hash == tfm.hash
+        )
 
 
 @dataclass
-class ActionGroupMetadata(object):
+class ActionGroupMetadata:
     group_name: str = ""
     group_modules: list = field(default_factory=list)
     type: str = ""
@@ -2425,7 +2434,7 @@ class RuleTag:
 
 
 @dataclass
-class RuleMetadata(object):
+class RuleMetadata:
     rule_id: str = ""
     description: str = ""
     name: str = ""
@@ -2437,7 +2446,7 @@ class RuleMetadata(object):
 
 
 @dataclass
-class SpecMutation(object):
+class SpecMutation:
     key: str = None
     changes: list = field(default_factory=list)
     object: Object = field(default_factory=Object)
@@ -2445,7 +2454,7 @@ class SpecMutation(object):
 
 
 @dataclass
-class RuleResult(object):
+class RuleResult:
     rule: RuleMetadata = None
 
     verdict: bool = False
@@ -2501,7 +2510,9 @@ class Rule(RuleMetadata):
         raise ValueError("this is a base class method")
 
     def print(self, result: RuleResult):
-        output = f"ruleID={self.rule_id}, severity={self.severity}, description={self.description}, result={result.verdict}"
+        output = (
+            f"ruleID={self.rule_id}, severity={self.severity}, description={self.description}, result={result.verdict}"
+        )
 
         if result.file:
             output += f", file={result.file}"
@@ -2532,7 +2543,7 @@ class Rule(RuleMetadata):
 @dataclass
 class NodeResult(JSONSerializable):
     node: RunTarget = None
-    rules: List[RuleResult] = field(default_factory=list)
+    rules: list[RuleResult] = field(default_factory=list)
 
     def results(self):
         return self.rules
@@ -2545,8 +2556,8 @@ class NodeResult(JSONSerializable):
 
     def search_results(
         self,
-        rule_id: Union[str, list] = None,
-        tag: Union[str, list] = None,
+        rule_id: str | list = None,
+        tag: str | list = None,
         matched: bool = None,
         verdict: bool = None,
     ):
@@ -2583,7 +2594,7 @@ class NodeResult(JSONSerializable):
 class TargetResult(JSONSerializable):
     target_type: str = ""  # playbook, role or taskfile
     target_name: str = ""
-    nodes: List[NodeResult] = field(default_factory=list)
+    nodes: list[NodeResult] = field(default_factory=list)
 
     def applied_rules(self):
         results = []
@@ -2650,7 +2661,7 @@ class TargetResult(JSONSerializable):
 
 @dataclass
 class ARIResult(JSONSerializable):
-    targets: List[TargetResult] = field(default_factory=list)
+    targets: list[TargetResult] = field(default_factory=list)
 
     def playbooks(self):
         return self._filter("playbook")
@@ -2725,7 +2736,9 @@ class ARIResult(JSONSerializable):
         filtered_targets = [
             tr
             for tr in type_only_result.targets
-            if tr.nodes and hasattr(tr.nodes[0].node.spec, "yaml_lines") and tr.nodes[0].node.spec.yaml_lines == yaml_str
+            if tr.nodes
+            and hasattr(tr.nodes[0].node.spec, "yaml_lines")
+            and tr.nodes[0].node.spec.yaml_lines == yaml_str
         ]
         if not filtered_targets:
             return None

--- a/src/apme_engine/engine/parser.py
+++ b/src/apme_engine/engine/parser.py
@@ -1,6 +1,17 @@
-import os
 import copy
+import os
+from pathlib import Path
+
 from . import logger
+from .model_loader import (
+    load_collection,
+    load_file,
+    load_module,
+    load_playbook,
+    load_repository,
+    load_role,
+    load_taskfile,
+)
 from .models import (
     Collection,
     Load,
@@ -8,31 +19,24 @@ from .models import (
     Module,
     Play,
     Playbook,
+    PlaybookFormatError,
     Repository,
     Role,
     Task,
     TaskFile,
-    PlaybookFormatError,
     TaskFormatError,
 )
-from .model_loader import (
-    load_collection,
-    load_module,
-    load_playbook,
-    load_repository,
-    load_role,
-    load_taskfile,
-    load_file,
-)
 from .utils import (
+    get_module_specs_by_ansible_doc,
     split_target_playbook_fullpath,
     split_target_taskfile_fullpath,
-    get_module_specs_by_ansible_doc,
 )
 
 
 class Parser:
-    def __init__(self, do_save=False, use_ansible_doc=True, skip_playbook_format_error=True, skip_task_format_error=True):
+    def __init__(
+        self, do_save=False, use_ansible_doc=True, skip_playbook_format_error=True, skip_task_format_error=True
+    ):
         self.do_save = do_save
         self.use_ansible_doc = use_ansible_doc
         self.skip_playbook_format_error = skip_playbook_format_error
@@ -44,8 +48,8 @@ class Parser:
             ld = load_data
         elif load_json_path != "":
             if not os.path.exists(load_json_path):
-                raise ValueError("file not found: {}".format(load_json_path))
-            ld = Load.from_json(open(load_json_path, "r").read())
+                raise ValueError(f"file not found: {load_json_path}")
+            ld = Load.from_json(Path(load_json_path).read_text())
 
         collection_name = ""
         role_name = ""
@@ -69,7 +73,7 @@ class Parser:
                 if not self.skip_task_format_error:
                     raise
             except Exception:
-                logger.exception("failed to load the collection {}".format(collection_name))
+                logger.exception(f"failed to load the collection {collection_name}")
                 return
         elif ld.target_type == LoadType.ROLE:
             role_name = ld.target_name
@@ -93,7 +97,7 @@ class Parser:
                 if not self.skip_task_format_error:
                     raise
             except Exception:
-                logger.exception("failed to load the role {}".format(role_name))
+                logger.exception(f"failed to load the role {role_name}")
                 return
         elif ld.target_type == LoadType.PROJECT:
             repo_name = ld.target_name
@@ -114,7 +118,7 @@ class Parser:
                 if not self.skip_task_format_error:
                     raise
             except Exception:
-                logger.exception("failed to load the project {}".format(repo_name))
+                logger.exception(f"failed to load the project {repo_name}")
                 return
             if obj.my_collection_name:
                 collection_name = obj.my_collection_name
@@ -160,7 +164,7 @@ class Parser:
                 if not self.skip_task_format_error:
                     raise
             except Exception:
-                logger.exception("failed to load the playbook {}".format(playbook_name))
+                logger.exception(f"failed to load the playbook {playbook_name}")
                 return
         elif ld.target_type == LoadType.TASKFILE:
             basedir = ""
@@ -198,10 +202,10 @@ class Parser:
                 if not self.skip_task_format_error:
                     raise
             except Exception:
-                logger.exception("failed to load the taskfile {}".format(taskfile_name))
+                logger.exception(f"failed to load the taskfile {taskfile_name}")
                 return
         else:
-            raise ValueError("unsupported type: {}".format(ld.target_type))
+            raise ValueError(f"unsupported type: {ld.target_type}")
 
         mappings = {
             "roles": [],
@@ -360,23 +364,23 @@ class Parser:
             files.append(f)
             mappings["files"].append([file_path, f.key])
 
-        logger.debug("roles: {}".format(len(roles)))
-        logger.debug("taskfiles: {}".format(len(taskfiles)))
-        logger.debug("modules: {}".format(len(modules)))
-        logger.debug("playbooks: {}".format(len(playbooks)))
-        logger.debug("plays: {}".format(len(plays)))
-        logger.debug("tasks: {}".format(len(tasks)))
-        logger.debug("files: {}".format(len(files)))
+        logger.debug(f"roles: {len(roles)}")
+        logger.debug(f"taskfiles: {len(taskfiles)}")
+        logger.debug(f"modules: {len(modules)}")
+        logger.debug(f"playbooks: {len(playbooks)}")
+        logger.debug(f"plays: {len(plays)}")
+        logger.debug(f"tasks: {len(tasks)}")
+        logger.debug(f"files: {len(files)}")
 
         collections = []
         projects = []
         if ld.target_type == LoadType.COLLECTION:
             collections = [obj]
-        elif ld.target_type == LoadType.ROLE:
-            pass
-        elif ld.target_type == LoadType.PLAYBOOK:
-            pass
-        elif ld.target_type == LoadType.TASKFILE:
+        elif (
+            ld.target_type == LoadType.ROLE
+            or ld.target_type == LoadType.PLAYBOOK
+            or ld.target_type == LoadType.TASKFILE
+        ):
             pass
         elif ld.target_type == LoadType.PROJECT:
             projects = [obj]
@@ -455,8 +459,8 @@ class Parser:
         ld = Load()
         mapping_path = os.path.join(input_dir, "mappings.json")
         if not os.path.exists(mapping_path):
-            raise ValueError("file not found: {}".format(mapping_path))
-        ld = Load.from_json(open(mapping_path, "r").read())
+            raise ValueError(f"file not found: {mapping_path}")
+        ld = Load.from_json(Path(mapping_path).read_text())
         return definitions, ld
 
     @classmethod
@@ -494,7 +498,7 @@ class Parser:
             _dump_object_list(tasks, os.path.join(output_dir, "tasks.json"))
 
         mapping_path = os.path.join(output_dir, "mappings.json")
-        open(mapping_path, "w").write(ld.dump())
+        Path(mapping_path).write_text(ld.dump())
 
 
 def _dump_object_list(obj_list, output_path):
@@ -502,14 +506,14 @@ def _dump_object_list(obj_list, output_path):
     lines = []
     for i in range(len(tmp_obj_list)):
         lines.append(tmp_obj_list[i].dump())
-    open(output_path, "w").write("\n".join(lines))
+    Path(output_path).write_text("\n".join(lines))
     return
 
 
 def _load_object_list(cls, input_path):
     obj_list = []
     if os.path.exists(input_path):
-        with open(input_path, "r") as f:
+        with open(input_path) as f:
             for line in f:
                 obj = cls.from_json(line)
                 obj_list.append(obj)

--- a/src/apme_engine/engine/ram_generator.py
+++ b/src/apme_engine/engine/ram_generator.py
@@ -1,15 +1,16 @@
-import traceback
-import joblib
-import os
-import json
-import time
 import datetime
+import json
+import os
 import threading
+import time
+import traceback
+
+import joblib
 
 from .scanner import ARIScanner, config
 
 
-class RiskAssessmentModelGenerator(object):
+class RiskAssessmentModelGenerator:
     _queue: list = []
     _resume: int = -1
     _update: bool = False
@@ -18,7 +19,7 @@ class RiskAssessmentModelGenerator(object):
 
     def __init__(
         self,
-        target_list=[],
+        target_list=None,
         resume=-1,
         update=False,
         parallel=True,
@@ -28,6 +29,8 @@ class RiskAssessmentModelGenerator(object):
         no_module_spec=False,
         no_retry=False,
     ):
+        if target_list is None:
+            target_list = []
         self._queue = target_list
         self._resume = resume
         self._update = update
@@ -67,9 +70,13 @@ class RiskAssessmentModelGenerator(object):
             if i + 1 < self._resume:
                 continue
             if not isinstance(target_info, tuple):
-                raise ValueError(f"target list must be a list of tuple(target_type, target_name), but got a {type(target_info)}")
+                raise ValueError(
+                    f"target list must be a list of tuple(target_type, target_name), but got a {type(target_info)}"
+                )
             if len(target_info) != 2:
-                raise ValueError(f"target list must be a list of tuple(target_type, target_name), but got this; {target_info}")
+                raise ValueError(
+                    f"target list must be a list of tuple(target_type, target_name), but got this; {target_info}"
+                )
 
             _type, _name = target_info
             input_list.append((i, num, _type, _name))
@@ -77,7 +84,9 @@ class RiskAssessmentModelGenerator(object):
         self.start = time.time()
 
         if self._parallel:
-            joblib.Parallel(n_jobs=-1)(joblib.delayed(self.scan)(i, num, _type, _name) for (i, num, _type, _name) in input_list)
+            joblib.Parallel(n_jobs=-1)(
+                joblib.delayed(self.scan)(i, num, _type, _name) for (i, num, _type, _name) in input_list
+            )
         else:
             for i, num, _type, _name in input_list:
                 self.scan(i, num, _type, _name)
@@ -86,7 +95,7 @@ class RiskAssessmentModelGenerator(object):
         elapsed = round(time.time() - self.start, 2)
         start_of_this_scan = time.time()
         thread_id = threading.get_native_id()
-        print(f"[{i+1}/{num}] start {type} {name} ({elapsed} sec. elapsed) (thread: {thread_id})")
+        print(f"[{i + 1}/{num}] start {type} {name} ({elapsed} sec. elapsed) (thread: {thread_id})")
         use_src_cache = True
 
         if self.skip_scan(type, name):
@@ -117,18 +126,18 @@ class RiskAssessmentModelGenerator(object):
 
         elapsed_for_this_scan = round(time.time() - start_of_this_scan, 2)
         if elapsed_for_this_scan > 60:
-            print(f"WARNING: It took {elapsed_for_this_scan} sec. to process [{i+1}/{num}] {type} {name}")
+            print(f"WARNING: It took {elapsed_for_this_scan} sec. to process [{i + 1}/{num}] {type} {name}")
 
     def save_ram_log(self, type, name, fail):
         out_dir = os.path.join(self._scanner.root_dir, "log", type, name)
         path = os.path.join(out_dir, "ram_log.json")
 
-        scan_time = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')
+        scan_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")
         new_record = {"type": type, "name": name, "succeed": not fail, "time": scan_time}
 
         logs = []
         if os.path.exists(path):
-            with open(path, "r") as file:
+            with open(path) as file:
                 data = file.read()
                 d = json.loads(data)
                 logs.extend(d)
@@ -146,16 +155,13 @@ class RiskAssessmentModelGenerator(object):
         if not os.path.exists(path):
             return skip
         logs = []
-        with open(path, "r") as file:
+        with open(path) as file:
             data = file.read()
             d = json.loads(data)
             logs.extend(d)
         if logs:
             latest = logs[-1]
-            if latest.get("succeed", False):
-                skip = True
-                return skip
-            elif self._no_retry:
+            if latest.get("succeed", False) or self._no_retry:
                 skip = True
                 return skip
         return skip

--- a/src/apme_engine/engine/risk_assessment_model.py
+++ b/src/apme_engine/engine/risk_assessment_model.py
@@ -1,36 +1,36 @@
-import os
 import json
-import jsonpickle
-from dataclasses import dataclass, field
+import os
 import tarfile
+from dataclasses import dataclass, field
 
+import jsonpickle
+
+from .findings import Findings
+from .keyutil import get_obj_info_by_key, make_imported_taskfile_key
+from .model_loader import load_builtin_modules
 from .models import (
-    LoadType,
-    ObjectList,
-    ExecutableType,
+    ActionGroupMetadata,
     Collection,
+    ExecutableType,
+    LoadType,
     Module,
     ModuleMetadata,
+    ObjectList,
     Role,
     RoleMetadata,
     TaskFile,
     TaskFileMetadata,
-    ActionGroupMetadata,
-)
-from .findings import Findings
-from .utils import (
-    escape_url,
-    version_to_num,
-    diff_files_data,
-    is_test_object,
-    lock_file,
-    unlock_file,
-    remove_lock_file,
 )
 from .safe_glob import safe_glob
-from .keyutil import get_obj_info_by_key, make_imported_taskfile_key
-from .model_loader import load_builtin_modules
-
+from .utils import (
+    diff_files_data,
+    escape_url,
+    is_test_object,
+    lock_file,
+    remove_lock_file,
+    unlock_file,
+    version_to_num,
+)
 
 module_index_name = "module_index.json"
 role_index_name = "role_index.json"
@@ -39,7 +39,7 @@ action_group_index_name = "action_group_index.json"
 
 
 @dataclass
-class RAMClient(object):
+class RAMClient:
     root_dir: str = ""
 
     findings_json_list_cache: list = field(default_factory=list)
@@ -66,22 +66,22 @@ class RAMClient(object):
     def __post_init__(self):
         module_index_path = os.path.join(self.root_dir, "indices", module_index_name)
         if os.path.exists(module_index_path):
-            with open(module_index_path, "r") as file:
+            with open(module_index_path) as file:
                 self.module_index = json.load(file)
 
         role_index_path = os.path.join(self.root_dir, "indices", role_index_name)
         if os.path.exists(role_index_path):
-            with open(role_index_path, "r") as file:
+            with open(role_index_path) as file:
                 self.role_index = json.load(file)
 
         taskfile_index_path = os.path.join(self.root_dir, "indices", taskfile_index_name)
         if os.path.exists(taskfile_index_path):
-            with open(taskfile_index_path, "r") as file:
+            with open(taskfile_index_path) as file:
                 self.taskfile_index = json.load(file)
 
         action_group_index_path = os.path.join(self.root_dir, "indices", action_group_index_name)
         if os.path.exists(action_group_index_path):
-            with open(action_group_index_path, "r") as file:
+            with open(action_group_index_path) as file:
                 self.action_group_index = json.load(file)
 
     def clear_old_cache(self):
@@ -386,7 +386,9 @@ class RAMClient(object):
         }
         return m_wrapper
 
-    def search_module(self, name, exact_match=False, max_match=-1, collection_name="", collection_version="", used_in=""):
+    def search_module(
+        self, name, exact_match=False, max_match=-1, collection_name="", collection_version="", used_in=""
+    ):
         if max_match == 0:
             return []
         args_str = json.dumps([name, exact_match, max_match, collection_name, collection_version])
@@ -422,10 +424,7 @@ class RAMClient(object):
             # if any candidates don't match with FQCN, use the first index
             if not found_index:
                 non_deprecated_cands = [idx for idx in self.module_index[short_name] if not idx["deprecated"]]
-                if non_deprecated_cands:
-                    found_index = non_deprecated_cands[0]
-                else:
-                    found_index = self.module_index[short_name][0]
+                found_index = non_deprecated_cands[0] if non_deprecated_cands else self.module_index[short_name][0]
 
         modules_json_list = []
         if from_indices:
@@ -433,7 +432,9 @@ class RAMClient(object):
             _name = found_index.get("name", "")
             _version = found_index.get("version", "")
             _hash = found_index.get("hash", "")
-            findings_path = os.path.join(self.root_dir, _type + "s", "findings", _name, _version, _hash, "findings.json")
+            findings_path = os.path.join(
+                self.root_dir, _type + "s", "findings", _name, _version, _hash, "findings.json"
+            )
             if os.path.exists(findings_path):
                 modules_json_list.append(findings_path)
             search_name = found_index.get("fqcn", "")
@@ -480,10 +481,9 @@ class RAMClient(object):
                             "used_in": used_in,
                         }
                     )
-                if max_match > 0:
-                    if len(matched_modules) >= max_match:
-                        search_end = True
-                        break
+                if max_match > 0 and len(matched_modules) >= max_match:
+                    search_end = True
+                    break
             if search_end:
                 break
         self.module_search_cache[args_str] = matched_modules
@@ -508,7 +508,9 @@ class RAMClient(object):
             _name = found_index.get("name", "")
             _version = found_index.get("version", "")
             _hash = found_index.get("hash", "")
-            findings_path = os.path.join(self.root_dir, _type + "s", "findings", _name, _version, _hash, "findings.json")
+            findings_path = os.path.join(
+                self.root_dir, _type + "s", "findings", _name, _version, _hash, "findings.json"
+            )
             if os.path.exists(findings_path):
                 roles_json_list.append(findings_path)
         else:
@@ -572,10 +574,9 @@ class RAMClient(object):
                             "used_in": used_in,
                         }
                     )
-                if max_match > 0:
-                    if len(matched_roles) >= max_match:
-                        search_end = True
-                        break
+                if max_match > 0 and len(matched_roles) >= max_match:
+                    search_end = True
+                    break
             if search_end:
                 break
         self.role_search_cache[args_str] = matched_roles
@@ -613,10 +614,7 @@ class RAMClient(object):
         found_index = None
         found_key = ""
         taskfile_key_candidates = []
-        if is_key:
-            taskfile_key_candidates = [name]
-        else:
-            taskfile_key_candidates = self.make_taskfile_key_candidates(name, from_path, from_key)
+        taskfile_key_candidates = [name] if is_key else self.make_taskfile_key_candidates(name, from_path, from_key)
         for taskfile_key in taskfile_key_candidates:
             if taskfile_key in self.taskfile_index and self.taskfile_index[taskfile_key]:
                 from_indices = True
@@ -632,7 +630,9 @@ class RAMClient(object):
             _version = found_index.get("version", "")
             _hash = found_index.get("hash", "")
             content_info = found_index
-            findings_path = os.path.join(self.root_dir, _type + "s", "findings", _name, _version, _hash, "findings.json")
+            findings_path = os.path.join(
+                self.root_dir, _type + "s", "findings", _name, _version, _hash, "findings.json"
+            )
             if os.path.exists(findings_path):
                 taskfiles_json_list.append(findings_path)
         else:
@@ -664,7 +664,9 @@ class RAMClient(object):
                     parts = findings_json.split("/")
                     offspring_objects = []
                     for task_key in tf.tasks:
-                        _tmp_offspring_objects = self.search_task(task_key, is_key=True, content_info=content_info, used_in=used_in)
+                        _tmp_offspring_objects = self.search_task(
+                            task_key, is_key=True, content_info=content_info, used_in=used_in
+                        )
                         if len(_tmp_offspring_objects) > 0:
                             t = _tmp_offspring_objects[0]
                             if t:
@@ -695,10 +697,9 @@ class RAMClient(object):
                             "used_in": used_in,
                         }
                     )
-                if max_match > 0:
-                    if len(matched_taskfiles) >= max_match:
-                        search_end = True
-                        break
+                if max_match > 0 and len(matched_taskfiles) >= max_match:
+                    search_end = True
+                    break
             if search_end:
                 break
         return matched_taskfiles
@@ -759,7 +760,9 @@ class RAMClient(object):
                     elif t.executable_type == ExecutableType.ROLE_TYPE:
                         _tmp_offspring_objects = self.search_role(t.executable, used_in=t.defined_in)
                     elif t.executable_type == ExecutableType.TASKFILE_TYPE:
-                        _tmp_offspring_objects = self.search_taskfile(t.executable, from_path=t.defined_in, from_key=t.key, used_in=t.defined_in)
+                        _tmp_offspring_objects = self.search_taskfile(
+                            t.executable, from_path=t.defined_in, from_key=t.key, used_in=t.defined_in
+                        )
                     if len(_tmp_offspring_objects) > 0:
                         child = _tmp_offspring_objects[0]
                         if child:
@@ -790,10 +793,9 @@ class RAMClient(object):
                             "used_in": used_in,
                         }
                     )
-                if max_match > 0:
-                    if len(matched_tasks) >= max_match:
-                        search_end = True
-                        break
+                if max_match > 0 and len(matched_tasks) >= max_match:
+                    search_end = True
+                    break
             if search_end:
                 break
         self.task_search_cache[args_str] = matched_tasks
@@ -817,10 +819,14 @@ class RAMClient(object):
         parent_name = obj_info.get("parent_name", "")
         type_str = obj_type + "s"
 
-        search_patterns = os.path.join(self.root_dir, "collections", "findings", parent_name, "*", "*", "root", f"{type_str}.json")
+        search_patterns = os.path.join(
+            self.root_dir, "collections", "findings", parent_name, "*", "*", "root", f"{type_str}.json"
+        )
         obj_json_list_coll = safe_glob(search_patterns)
         obj_json_list_coll = sort_by_version(obj_json_list_coll)
-        search_patterns = os.path.join(self.root_dir, "roles", "findings", parent_name, "*", "*", "root", f"{type_str}.json")
+        search_patterns = os.path.join(
+            self.root_dir, "roles", "findings", parent_name, "*", "*", "root", f"{type_str}.json"
+        )
         obj_json_list_role = safe_glob(search_patterns)
         obj_json_list_role = sort_by_version(obj_json_list_role)
         obj_json_list = obj_json_list_coll + obj_json_list_role
@@ -891,12 +897,10 @@ class RAMClient(object):
             _version = parts[-3]
             if _name != target_name:
                 continue
-            if target_version and target_version != "*":
-                if _version != target_name:
-                    continue
-            if target_type and target_type != "*":
-                if _type != target_type:
-                    continue
+            if target_version and target_version != "*" and _version != target_name:
+                continue
+            if target_type and target_type != "*" and _type != target_type:
+                continue
             found_path_list.append(findings_path)
 
         latest_findings_path = ""
@@ -953,7 +957,7 @@ class RAMClient(object):
         path = os.path.join(self.root_dir, "indices", filename)
         index_objects = {}
         if os.path.exists(path):
-            with open(path, "r") as file:
+            with open(path) as file:
                 index_objects = json.load(file)
         return index_objects
 

--- a/src/apme_engine/engine/risk_detector.py
+++ b/src/apme_engine/engine/risk_detector.py
@@ -1,27 +1,26 @@
 import argparse
-import os
+import contextlib
 import json
-import traceback
-from typing import List
+import os
 import time
+import traceback
 
 from . import logger
+from .analyzer import load_taskcalls_in_trees
+from .keyutil import detect_type, key_delimiter
 from .models import (
     AnsibleRunContext,
     ARIResult,
-    TargetResult,
-    NodeResult,
-    RuleResult,
-    Rule,
-    SpecMutation,
     FatalRuleResultError,
+    NodeResult,
+    Rule,
+    RuleResult,
     RunTarget,
+    SpecMutation,
+    TargetResult,
     TaskCall,
 )
-from .keyutil import detect_type, key_delimiter
-from .analyzer import load_taskcalls_in_trees
 from .utils import load_classes_in_dir
-
 
 rule_versions_filename = "rule_versions.json"
 
@@ -35,13 +34,11 @@ def load_rule_versions_file(filepath: str):
         return {}
 
     version_dict = {}
-    with open(filepath, "r") as file:
+    with open(filepath) as file:
         for line in file:
             d = None
-            try:
+            with contextlib.suppress(Exception):
                 d = json.loads(line)
-            except Exception:
-                pass
             if not d or not isinstance(d, dict):
                 continue
             rule_id = d.get("rule_id")
@@ -52,7 +49,11 @@ def load_rule_versions_file(filepath: str):
     return version_dict
 
 
-def load_rules(rules_dir: str = "", rule_id_list: list = [], fail_on_error: bool = False, exclude_rule_ids: list = None):
+def load_rules(
+    rules_dir: str = "", rule_id_list: list = None, fail_on_error: bool = False, exclude_rule_ids: list = None
+):
+    if rule_id_list is None:
+        rule_id_list = []
     if not rules_dir:
         return []
     if exclude_rule_ids is None:
@@ -74,20 +75,18 @@ def load_rules(rules_dir: str = "", rule_id_list: list = [], fail_on_error: bool
             try:
                 _rule = r()
                 # if `rule_id_list` is provided, filter out rules that are not in the list
-                if rule_id_list:
-                    if _rule.rule_id not in rule_id_list:
-                        continue
+                if rule_id_list and _rule.rule_id not in rule_id_list:
+                    continue
                 if _rule.rule_id in exclude_rule_ids:
                     continue
-                if versions_dict:
-                    if _rule.rule_id in versions_dict:
-                        _rule.commit_id = versions_dict[_rule.rule_id]
+                if versions_dict and _rule.rule_id in versions_dict:
+                    _rule.commit_id = versions_dict[_rule.rule_id]
                 _rules.append(_rule)
-            except Exception:
+            except Exception as err:
                 exc = traceback.format_exc()
                 msg = f"failed to load a rule `{r}`: {exc}"
                 if fail_on_error:
-                    raise ValueError(msg)
+                    raise ValueError(msg) from err
                 else:
                     logger.warning(f"The rule {r} was skipped: {msg}")
 
@@ -122,12 +121,20 @@ def make_subject_str(playbook_num: int, role_num: int):
     return subject
 
 
-def detect(contexts: List[AnsibleRunContext], rules_dir: str = "", rules: list = [], rules_cache: list = [], save_only_rule_result: bool = False, exclude_rule_ids: list = None):
+def detect(
+    contexts: list[AnsibleRunContext],
+    rules_dir: str = "",
+    rules: list = None,
+    rules_cache: list = None,
+    save_only_rule_result: bool = False,
+    exclude_rule_ids: list = None,
+):
+    if rules_cache is None:
+        rules_cache = []
+    if rules is None:
+        rules = []
     loaded_rules = []
-    if rules_cache:
-        loaded_rules = rules_cache
-    else:
-        loaded_rules = load_rules(rules_dir, rules, False, exclude_rule_ids=exclude_rule_ids or [])
+    loaded_rules = rules_cache or load_rules(rules_dir, rules, False, exclude_rule_ids=exclude_rule_ids or [])
 
     playbook_count = {"total": 0, "risk_found": 0}
     role_count = {"total": 0, "risk_found": 0}
@@ -171,7 +178,7 @@ def detect(contexts: List[AnsibleRunContext], rules_dir: str = "", rules: list =
             for rule in loaded_rules:
                 if not rule.enabled:
                     continue
-                rule_id = getattr(rule, "rule_id")
+                rule_id = rule.rule_id
                 start_time = time.time()
                 r_result = RuleResult(file=t.file_info(), rule=rule.get_metadata())
                 detail = {}
@@ -189,13 +196,12 @@ def detect(contexts: List[AnsibleRunContext], rules_dir: str = "", rules: list =
                         error = r_result.error or "unknown error"
                         error = f"ARI rule evaluation threw fatal exception: RuleID={rule_id}, error={error}"
                         raise FatalRuleResultError(error)
-                    if rule.spec_mutation:
-                        if isinstance(detail, dict):
-                            s_mutations = detail.get("spec_mutations", [])
-                            for s_mutation in s_mutations:
-                                if not isinstance(s_mutation, SpecMutation):
-                                    continue
-                                spec_mutations[s_mutation.key] = s_mutation
+                    if rule.spec_mutation and isinstance(detail, dict):
+                        s_mutations = detail.get("spec_mutations", [])
+                        for s_mutation in s_mutations:
+                            if not isinstance(s_mutation, SpecMutation):
+                                continue
+                            spec_mutations[s_mutation.key] = s_mutation
                 except FatalRuleResultError:
                     raise
                 except Exception:
@@ -216,14 +222,14 @@ def detect(contexts: List[AnsibleRunContext], rules_dir: str = "", rules: list =
 
 def omit_node_details(node: RunTarget):
     spec = None
-    if getattr(node, "spec"):
+    if node.spec:
         spec = {
-            "type": getattr(node.spec, "type"),
-            "name": getattr(node.spec, "name"),
-            "defined_in": getattr(node.spec, "defined_in"),
+            "type": node.spec.type,
+            "name": node.spec.name,
+            "defined_in": node.spec.defined_in,
         }
         if isinstance(node, TaskCall):
-            spec["line_num_in_file"] = (getattr(node.spec, "line_num_in_file"),)
+            spec["line_num_in_file"] = (node.spec.line_num_in_file,)
     summary = {
         "type": node.type,
         "spec": spec,

--- a/src/apme_engine/engine/safe_glob.py
+++ b/src/apme_engine/engine/safe_glob.py
@@ -1,11 +1,13 @@
 import os
-import sys
 import re
+import sys
 
 
 # glob.glob() may cause infinite loop when there is symlink loop
 # safe_glob() support the case by `followlink=False` option as default
-def safe_glob(patterns, root_dir="", recursive=True, type=["file", "dir"], followlinks=False):
+def safe_glob(patterns, root_dir="", recursive=True, type=None, followlinks=False):
+    if type is None:
+        type = ["file", "dir"]
     pattern_list = []
     if isinstance(patterns, list):
         pattern_list = [p for p in patterns]
@@ -22,11 +24,9 @@ def safe_glob(patterns, root_dir="", recursive=True, type=["file", "dir"], follo
         root_dir_for_this_pattern = ""
         if root_dir == "":
             root_cand = pattern.split("*")[0]
-            if root_cand.endswith("/"):
-                root_cand = root_cand[:-1]  # trim "/" suffix
-            else:
-                root_cand = "/".join(root_cand.split("/")[:-1])  # testdir1/testdir2/file-*.txt --> testdir1/testdir2
-            root_dir_for_this_pattern = root_cand
+            root_dir_for_this_pattern = (
+                root_cand[:-1] if root_cand.endswith("/") else "/".join(root_cand.split("/")[:-1])
+            )
         else:
             root_dir_for_this_pattern = root_dir
 
@@ -79,7 +79,7 @@ def pattern_match(pattern, fpath):
     pattern = pattern.replace("**/", "<ANY>")
     pattern = pattern.replace("*", "[^/]*")
     pattern = pattern.replace("<ANY>", ".*")
-    regex_pattern = r"^{}$".format(pattern)
+    regex_pattern = rf"^{pattern}$"
     return re.match(regex_pattern, fpath)
 
 

--- a/src/apme_engine/engine/scanner.py
+++ b/src/apme_engine/engine/scanner.py
@@ -1,55 +1,53 @@
+import contextlib
+import datetime
+import json
 import os
 import sys
-import json
-import yaml
 import tempfile
-import jsonpickle
-import datetime
 from dataclasses import dataclass, field
+from pathlib import Path
 
-from .models import (
-    Object,
-    Load,
-    LoadType,
-    ObjectList,
-    TaskCall,
-    TaskCallsInTree,
-    AnsibleRunContext,
-    ARIResult,
-)
-from .loader import (
-    get_loader_version,
-)
-from .parser import Parser
-from .model_loader import load_object
-from .tree import TreeLoader
-from .annotators.variable_resolver import resolve_variables
+import jsonpickle
+import yaml
+
+from . import logger
 from .analyzer import analyze
-from .risk_detector import detect
+from .annotators.variable_resolver import resolve_variables
 from .dependency_dir_preparator import (
     DependencyDirPreparator,
 )
 from .findings import Findings
-from .risk_assessment_model import RAMClient
 from .keyutil import detect_type as key_detect_type
-from . import logger
+from .loader import (
+    get_loader_version,
+)
+from .model_loader import load_object
+from .models import (
+    AnsibleRunContext,
+    ARIResult,
+    Load,
+    LoadType,
+    Object,
+    ObjectList,
+    TaskCall,
+    TaskCallsInTree,
+)
+from .parser import Parser
+from .risk_assessment_model import RAMClient
+from .tree import TreeLoader
 from .utils import (
-    is_url,
-    is_local_path,
-    escape_url,
+    equal,
     escape_local_path,
-    summarize_findings,
-    summarize_findings_data,
+    escape_url,
+    is_local_path,
+    is_url,
     split_target_playbook_fullpath,
     split_target_taskfile_fullpath,
-    equal,
+    summarize_findings,
 )
 
 ARI_CONFIG_PATH = os.getenv("ARI_CONFIG_PATH")
-if ARI_CONFIG_PATH:
-    default_config_path = ARI_CONFIG_PATH
-else:
-    default_config_path = os.path.expanduser("~/.ari/config")
+default_config_path = ARI_CONFIG_PATH or os.path.expanduser("~/.ari/config")
 default_data_dir = os.path.join("/tmp", "ari-data")
 default_rules_dir = os.path.join(os.path.dirname(__file__), "rules")
 default_log_level = "info"
@@ -76,18 +74,20 @@ class Config:
             self.path = default_config_path
         config_data = {}
         if os.path.exists(self.path):
-            with open(self.path, "r") as file:
+            with open(self.path) as file:
                 try:
                     config_data = yaml.safe_load(file)
                 except Exception as e:
-                    raise ValueError(f"failed to load the config file: {e}")
+                    raise ValueError(f"failed to load the config file: {e}") from e
         if config_data:
             self._data = config_data
 
         if not self.data_dir:
             self.data_dir = self._get_single_config("ARI_DATA_DIR", "data_dir", default_data_dir)
         if not self.disable_default_rules:
-            self.disable_default_rules = self._get_single_config("ARI_DISABLE_DEFAULT_RULES", "disable_default_rules", default_disable_default_rules)
+            self.disable_default_rules = self._get_single_config(
+                "ARI_DISABLE_DEFAULT_RULES", "disable_default_rules", default_disable_default_rules
+            )
         if not self.rules_dir:
             if self.disable_default_rules:
                 self.rules_dir = self._get_single_config("ARI_RULES_DIR", "rules_dir", "")
@@ -103,12 +103,13 @@ class Config:
         if not self.rules:
             self.rules = self._get_single_config("ARI_RULES", "rules", default_rules, "list", ",")
 
-    def _get_single_config(self, env_key: str = "", yaml_key: str = "", __default: any = None, __type=None, separator=""):
+    def _get_single_config(
+        self, env_key: str = "", yaml_key: str = "", __default: any = None, __type=None, separator=""
+    ):
         if env_key in os.environ:
             _from_env = os.environ.get(env_key, None)
-            if _from_env and __type:
-                if __type == "list":
-                    _from_env = _from_env.split(separator)
+            if _from_env and __type and __type == "list":
+                _from_env = _from_env.split(separator)
             return _from_env
         elif yaml_key in self._data:
             _from_file = self._data.get(yaml_key, None)
@@ -136,7 +137,7 @@ logger.set_log_level(config.log_level)
 
 
 @dataclass
-class SingleScan(object):
+class SingleScan:
     type: str = ""
     name: str = ""
     collection_name: str = ""
@@ -241,12 +242,12 @@ class SingleScan(object):
                 "index": os.path.join(
                     self.root_dir,
                     type_root,
-                    "{}-{}-index-ext.json".format(self.type, target_name),
+                    f"{self.type}-{target_name}-index-ext.json",
                 ),
                 "install_log": os.path.join(
                     self.root_dir,
                     type_root,
-                    "{}-{}-install.log".format(self.type, target_name),
+                    f"{self.type}-{target_name}-install.log",
                 ),
             }
 
@@ -299,13 +300,13 @@ class SingleScan(object):
                     self.root_dir,
                     type_root,
                     proj_name,
-                    "{}-{}-install.log".format(self.type, proj_name),
+                    f"{self.type}-{proj_name}-install.log",
                 ),
                 "dependencies": os.path.join(self.root_dir, type_root, proj_name, "dependencies"),
             }
 
         else:
-            raise ValueError("Unsupported type: {}".format(self.type))
+            raise ValueError(f"Unsupported type: {self.type}")
 
         if self.playbook_yaml:
             self.playbook_only = True
@@ -349,17 +350,7 @@ class SingleScan(object):
                 target_path = target_name
             else:
                 target_path = os.path.join(self.root_dir, typ + "s", "src", target_name)
-        elif typ == LoadType.PROJECT:
-            if is_url(target_name):
-                target_path = os.path.join(self.get_src_root(), escape_url(target_name))
-            else:
-                target_path = target_name
-        elif typ == LoadType.PLAYBOOK:
-            if is_url(target_name):
-                target_path = os.path.join(self.get_src_root(), escape_url(target_name))
-            else:
-                target_path = target_name
-        elif typ == LoadType.TASKFILE:
+        elif typ == LoadType.PROJECT or typ == LoadType.PLAYBOOK or typ == LoadType.TASKFILE:
             if is_url(target_name):
                 target_path = os.path.join(self.get_src_root(), escape_url(target_name))
             else:
@@ -413,7 +404,7 @@ class SingleScan(object):
         loader_version = get_loader_version()
 
         if not os.path.exists(target_path) and not self.playbook_yaml and not self.taskfile_yaml:
-            raise ValueError("No such file or directory: {}".format(target_path))
+            raise ValueError(f"No such file or directory: {target_path}")
         if not self.silent:
             logger.debug(f"target_name: {target_name}")
             logger.debug(f"target_type: {target_type}")
@@ -457,7 +448,7 @@ class SingleScan(object):
         output_dir = self.get_definition_path(ld.target_type, ld.target_name)
         if use_cache and os.path.exists(os.path.join(output_dir, "mappings.json")):
             if not self.silent:
-                logger.debug("use cache from {}".format(output_dir))
+                logger.debug(f"use cache from {output_dir}")
             definitions, mappings = Parser.restore_definition_objects(output_dir)
         else:
             definitions, mappings = self._parser.run(load_data=ld)
@@ -468,7 +459,7 @@ class SingleScan(object):
                     os.makedirs(output_dir, exist_ok=True)
                 Parser.dump_definition_objects(output_dir, definitions, mappings)
 
-        key = "{}-{}".format(target_type, target_name)
+        key = f"{target_type}-{target_name}"
         self.ext_definitions[key] = {
             "definitions": definitions,
             "mappings": mappings,
@@ -556,7 +547,7 @@ class SingleScan(object):
         else:
             # only for playbook / taskfile not in `--xxxx-only` mode
             for obj in obj_list:
-                obj_path = getattr(obj, "defined_in")
+                obj_path = obj.defined_in
                 if self.name in obj_path:
                     self.target_object = obj
                     break
@@ -601,7 +592,7 @@ class SingleScan(object):
                 lines = []
                 for t_obj_list in self.trees:
                     lines.append(t_obj_list.to_one_line_json())
-                open(tree_rel_file, "w").write("\n".join(lines))
+                Path(tree_rel_file).write_text("\n".join(lines))
                 if not self.silent:
                     logger.info("  tree file saved")
         return
@@ -617,7 +608,11 @@ class SingleScan(object):
                 "name": self.name,
             }
             ctx = AnsibleRunContext.from_tree(
-                tree=tree, parent=self.target_object, last_item=last_item, ram_client=ram_client, scan_metadata=scan_metadata
+                tree=tree,
+                parent=self.target_object,
+                last_item=last_item,
+                ram_client=ram_client,
+                scan_metadata=scan_metadata,
             )
             self.contexts.append(ctx)
 
@@ -629,7 +624,7 @@ class SingleScan(object):
                 line = jsonpickle.encode(d, make_refs=False)
                 tasks_in_t_lines.append(line)
 
-            open(tasks_in_t_path, "w").write("\n".join(tasks_in_t_lines))
+            Path(tasks_in_t_path).write_text("\n".join(tasks_in_t_lines))
         return
 
     def annotate(self):
@@ -644,13 +639,12 @@ class SingleScan(object):
                 line = jsonpickle.encode(d, make_refs=False)
                 conetxts_a_lines.append(line)
 
-            open(contexts_a_path, "w").write("\n".join(conetxts_a_lines))
+            Path(contexts_a_path).write_text("\n".join(conetxts_a_lines))
 
         return
 
     def _node_to_dict(self, node):
         """Serialize a RunTarget (playcall, rolecall, taskcall, etc.) to a JSON-serializable dict for OPA input."""
-        from .models import RunTargetType
         d = {"type": getattr(node, "type", ""), "key": getattr(node, "key", "")}
         spec = getattr(node, "spec", None)
         if spec:
@@ -689,7 +683,17 @@ class SingleScan(object):
                 if isinstance(opts, dict):
                     d["options"] = self._opts_for_opa(
                         opts,
-                        ["when", "tags", "ignore_errors", "register", "changed_when", "become", "become_user", "run_once", "local_action"],
+                        [
+                            "when",
+                            "tags",
+                            "ignore_errors",
+                            "register",
+                            "changed_when",
+                            "become",
+                            "become_user",
+                            "run_once",
+                            "local_action",
+                        ],
                     )
                 mo = getattr(spec, "module_options", None)
                 if isinstance(mo, dict):
@@ -703,10 +707,8 @@ class SingleScan(object):
             if k not in opts:
                 continue
             v = opts[k]
-            try:
+            with contextlib.suppress(Exception):
                 out[k] = self._json_safe(v)
-            except Exception:
-                pass
         return out
 
     def _json_safe(self, v):
@@ -733,7 +735,8 @@ class SingleScan(object):
 
     def _annotation_to_dict(self, an) -> dict:
         """Serialize a full Annotation (including RiskAnnotation detail) for OPA input."""
-        from .models import RiskAnnotation, Location
+        from .models import Location, RiskAnnotation
+
         d = {
             "type": getattr(an, "type", ""),
             "key": getattr(an, "key", ""),
@@ -804,7 +807,8 @@ class SingleScan(object):
                 continue
             root_key = getattr(ctx, "root_key", "")
             root_type = key_detect_type(root_key) if root_key else ""
-            # Expose root file path for playbook-extension and similar (e.g. "playbook :/path/to/pb.yml" -> "/path/to/pb.yml")
+            # Expose root file path for playbook-extension and similar
+            # (e.g. "playbook :/path/to/pb.yml" -> "/path/to/pb.yml")
             root_path = ""
             if root_key and " " in root_key:
                 root_path = root_key.split(" ", 1)[-1].lstrip(":")
@@ -851,7 +855,7 @@ class SingleScan(object):
             prm=self.prm,
             report={"hierarchy_payload": self.hierarchy_payload},
             summary_txt="",
-            scan_time=datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f'),
+            scan_time=datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f"),
         )
         self.result = None
         return
@@ -905,12 +909,12 @@ class SingleScan(object):
 
     def load_index(self):
         index_location = self.__path_mappings["index"]
-        with open(index_location, "r") as f:
+        with open(index_location) as f:
             self.index = json.load(f)
 
 
 @dataclass
-class ARIScanner(object):
+class ARIScanner:
     config: Config = None
 
     root_dir: str = ""
@@ -1051,7 +1055,9 @@ class ARIScanner(object):
         self.record_begin(time_records, "metadata_load")
         metdata_loaded = False
         read_root_from_ram = (
-            self.read_ram and scandata.type not in [LoadType.PLAYBOOK, LoadType.TASKFILE, LoadType.PROJECT] and not is_local_path(scandata.name)
+            self.read_ram
+            and scandata.type not in [LoadType.PLAYBOOK, LoadType.TASKFILE, LoadType.PROJECT]
+            and not is_local_path(scandata.name)
         )
         if read_root_from_ram:
             loaded, metadata, dependencies = self.load_metadata_from_ram(scandata.type, scandata.name, scandata.version)
@@ -1093,8 +1099,8 @@ class ARIScanner(object):
             for i, (ext_type, ext_name, ext_ver, ext_hash, ext_path, is_local_dir) in enumerate(ext_list):
                 if not self.silent:
                     if i == 0:
-                        logger.info("start loading {} {}(s)".format(ext_count, ext_type))
-                    logger.info("[{}/{}] {} {}".format(i + 1, ext_count, ext_type, ext_name))
+                        logger.info(f"start loading {ext_count} {ext_type}(s)")
+                    logger.info(f"[{i + 1}/{ext_count}] {ext_type} {ext_name}")
 
                 # avoid infinite loop
                 is_root = False
@@ -1104,19 +1110,24 @@ class ARIScanner(object):
                 ext_target_path = os.path.join(self.root_dir, ext_path)
                 role_name_for_local_dep = ""
                 # if a dependency is a local role, set the local path
-                if scandata.type == LoadType.ROLE and ext_type == LoadType.ROLE:
-                    if is_local_dir and is_local_path(scandata.name) and scandata.name != ext_name:
-                        root_role_path = scandata.name[:-1] if scandata.name[-1] == "/" else scandata.name
-                        role_base_dir = os.path.dirname(root_role_path)
-                        dep_role_path = os.path.join(role_base_dir, ext_name)
-                        role_name_for_local_dep = ext_name
-                        ext_name = dep_role_path
-                        ext_target_path = dep_role_path
+                if (
+                    scandata.type == LoadType.ROLE
+                    and ext_type == LoadType.ROLE
+                    and is_local_dir
+                    and is_local_path(scandata.name)
+                    and scandata.name != ext_name
+                ):
+                    root_role_path = scandata.name[:-1] if scandata.name[-1] == "/" else scandata.name
+                    role_base_dir = os.path.dirname(root_role_path)
+                    dep_role_path = os.path.join(role_base_dir, ext_name)
+                    role_name_for_local_dep = ext_name
+                    ext_name = dep_role_path
+                    ext_target_path = dep_role_path
 
                 if not is_root:
-                    key = "{}-{}".format(ext_type, ext_name)
+                    key = f"{ext_type}-{ext_name}"
                     if role_name_for_local_dep:
-                        key = "{}-{}".format(ext_type, role_name_for_local_dep)
+                        key = f"{ext_type}-{role_name_for_local_dep}"
                     read_ram_for_dependency = self.read_ram or self.read_ram_for_dependency
 
                     dep_loaded = False
@@ -1183,7 +1194,9 @@ class ARIScanner(object):
         loaded = False
         self.record_begin(time_records, "target_load")
         if read_root_from_ram:
-            loaded, root_defs = self.load_definitions_from_ram(scandata.type, scandata.name, scandata.version, scandata.hash, allow_unresolved=True)
+            loaded, root_defs = self.load_definitions_from_ram(
+                scandata.type, scandata.name, scandata.version, scandata.hash, allow_unresolved=True
+            )
             logger.debug(f"spec data loaded: {loaded}")
             if loaded:
                 scandata.root_definitions = root_defs
@@ -1203,7 +1216,10 @@ class ARIScanner(object):
             taskfiles_num = len(scandata.root_definitions["definitions"]["taskfiles"])
             tasks_num = len(scandata.root_definitions["definitions"]["tasks"])
             modules_num = len(scandata.root_definitions["definitions"]["modules"])
-            logger.debug(f"playbooks: {playbooks_num}, roles: {roles_num}, taskfiles: {taskfiles_num}, tasks: {tasks_num}, modules: {modules_num}")
+            logger.debug(
+                f"playbooks: {playbooks_num}, roles: {roles_num}, taskfiles: {taskfiles_num}, "
+                f"tasks: {tasks_num}, modules: {modules_num}"
+            )
 
         self.record_begin(time_records, "apply_spec_rules")
         scandata.apply_spec_mutations()
@@ -1263,12 +1279,12 @@ class ARIScanner(object):
         if scandata.out_dir is not None and scandata.out_dir != "":
             self.save_rule_result(scandata.findings, scandata.out_dir)
             if not self.silent:
-                print("The rule result is saved at {}".format(scandata.out_dir))
+                print(f"The rule result is saved at {scandata.out_dir}")
 
             if objects:
                 self.save_definitions(scandata.root_definitions, scandata.out_dir)
                 if not self.silent:
-                    print("The objects is saved at {}".format(scandata.out_dir))
+                    print(f"The objects is saved at {scandata.out_dir}")
 
         if not self.silent:
             summary = summarize_findings(scandata.findings, self.show_all)
@@ -1288,7 +1304,9 @@ class ARIScanner(object):
             _previous = spec_mutations_from_previous_scan
             if _previous and equal(scandata.spec_mutations, _previous):
                 if not self.silent:
-                    logger.warning("Spec mutation loop has been detected! " "Exitting the scan here but the result may be incomplete.")
+                    logger.warning(
+                        "Spec mutation loop has been detected! Exitting the scan here but the result may be incomplete."
+                    )
             else:
                 trigger_rescan = True
 
@@ -1331,7 +1349,9 @@ class ARIScanner(object):
         return loaded, metadata, dependencies
 
     def load_definitions_from_ram(self, type, name, version, hash, allow_unresolved=False):
-        loaded, definitions, mappings = self.ram_client.load_definitions_from_findings(type, name, version, hash, allow_unresolved)
+        loaded, definitions, mappings = self.ram_client.load_definitions_from_findings(
+            type, name, version, hash, allow_unresolved
+        )
         definitions_dict = {}
         if loaded:
             definitions_dict = {
@@ -1384,19 +1404,30 @@ class ARIScanner(object):
 
     def record_begin(self, time_records: dict, record_name: str):
         time_records[record_name] = {}
-        time_records[record_name]["begin"] = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f')
+        time_records[record_name]["begin"] = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S.%f"
+        )
 
     def record_end(self, time_records: dict, record_name: str):
         end = datetime.datetime.now(datetime.timezone.utc)
         end = end.replace(tzinfo=None)
-        time_records[record_name]["end"] = end.strftime('%Y-%m-%dT%H:%M:%S.%f')
+        time_records[record_name]["end"] = end.strftime("%Y-%m-%dT%H:%M:%S.%f")
         begin = datetime.datetime.fromisoformat(time_records[record_name]["begin"])
         elapsed = (end - begin).total_seconds()
         time_records[record_name]["elapsed"] = elapsed
 
 
-def tree(root_definitions, ext_definitions, ram_client=None, target_playbook_path=None, target_taskfile_path=None, load_all_taskfiles=False):
-    tl = TreeLoader(root_definitions, ext_definitions, ram_client, target_playbook_path, target_taskfile_path, load_all_taskfiles)
+def tree(
+    root_definitions,
+    ext_definitions,
+    ram_client=None,
+    target_playbook_path=None,
+    target_taskfile_path=None,
+    load_all_taskfiles=False,
+):
+    tl = TreeLoader(
+        root_definitions, ext_definitions, ram_client, target_playbook_path, target_taskfile_path, load_all_taskfiles
+    )
     trees, additional = tl.run()
     if trees is None:
         raise ValueError("failed to get trees")
@@ -1418,7 +1449,7 @@ def resolve(trees, additional):
         if len(tree.items) == 0:
             continue
         root_key = tree.items[0].spec.key
-        logger.debug("[{}/{}] {}".format(i + 1, len(trees), root_key))
+        logger.debug(f"[{i + 1}/{len(trees)}] {root_key}")
         taskcalls = resolve_variables(tree, additional)
         d = TaskCallsInTree(
             root_key=root_key,

--- a/src/apme_engine/engine/tree.py
+++ b/src/apme_engine/engine/tree.py
@@ -1,29 +1,29 @@
+import json
 import os
 import re
-import json
 from copy import deepcopy
 from dataclasses import dataclass, field
+
 from . import logger
 from .keyutil import detect_type, key_delimiter, object_delimiter
+from .model_loader import load_builtin_modules
 from .models import (
-    ObjectList,
-    Playbook,
-    Play,
-    RoleInPlay,
-    Role,
-    Task,
-    TaskFile,
+    CallObject,
     ExecutableType,
     LoadType,
-    CallObject,
-    TaskCall,
+    ObjectList,
+    Play,
+    Playbook,
     PlayCall,
+    Role,
     RoleCall,
+    RoleInPlay,
+    Task,
+    TaskCall,
+    TaskFile,
     call_obj_from_spec,
 )
-from .model_loader import load_builtin_modules
 from .risk_assessment_model import RAMClient
-
 
 obj_type_dict = {
     "playbook": "playbooks",
@@ -36,7 +36,7 @@ obj_type_dict = {
 
 
 @dataclass
-class TreeNode(object):
+class TreeNode:
     key: str = ""
 
     # children is a list of TreeNode
@@ -47,10 +47,12 @@ class TreeNode(object):
     # load a list of (src, dst) as a tree structure
     # which is composed of multiple TreeNode
     @staticmethod
-    def load(graph=[]):
+    def load(graph=None):
+        if graph is None:
+            graph = []
         root_key_cands = [pair[1] for pair in graph if pair[0] is None]
         if len(root_key_cands) != 1:
-            raise ValueError("tree array must have only one top with src == None, but" " found {}".format(len(root_key_cands)))
+            raise ValueError(f"tree array must have only one top with src == None, but found {len(root_key_cands)}")
         root_key = root_key_cands[0]
         tree = TreeNode()
         tree, _ = tree.recursive_tree_load(root_key, graph)
@@ -85,7 +87,9 @@ class TreeNode(object):
     def to_list(self):
         return self.recursive_convert_to_list(self)
 
-    def recursive_convert_to_list(self, node, nodelist=[]):
+    def recursive_convert_to_list(self, node, nodelist=None):
+        if nodelist is None:
+            nodelist = []
         current = [pair for pair in nodelist]
         current.append(node)
         for child_node in node.children:
@@ -110,7 +114,9 @@ class TreeNode(object):
                 new_parent_keys = new_parent_keys.union(sub_parent_keys)
         return n, new_parent_keys
 
-    def recursive_graph_dump(self, parent_node, node, src_dst_array=[]):
+    def recursive_graph_dump(self, parent_node, node, src_dst_array=None):
+        if src_dst_array is None:
+            src_dst_array = []
         current = [pair for pair in src_dst_array]
         src = None if parent_node is None else parent_node.key
         dst = node.key
@@ -129,7 +135,9 @@ class TreeNode(object):
         path_array = [nodelist2branch(nodelist) for nodelist in path_array]
         return path_array
 
-    def search_branch_to_key(self, search_key, node, ancestors=[]):
+    def search_branch_to_key(self, search_key, node, ancestors=None):
+        if ancestors is None:
+            ancestors = []
         current = [n for n in ancestors]
         found = []
         if node.key == search_key:
@@ -182,10 +190,7 @@ def load_definitions(defs: dict, types: list):
 
 def load_all_definitions(definitions: dict):
     _definitions = {}
-    if "mappings" in definitions:
-        _definitions = {"root": definitions}
-    else:
-        _definitions = definitions
+    _definitions = {"root": definitions} if "mappings" in definitions else definitions
     loaded = {}
     types = ["collections", "roles", "taskfiles", "modules", "playbooks", "plays", "tasks"]
     for type_key in types:
@@ -220,7 +225,9 @@ def make_dicts(root_definitions, ext_definitions):
     return dicts
 
 
-def load_module_redirects(root_definitions, ext_definitions, module_dict={}):
+def load_module_redirects(root_definitions, ext_definitions, module_dict=None):
+    if module_dict is None:
+        module_dict = {}
     collection_list = root_definitions.get("collections", ObjectList())
     ext_collection_list = ext_definitions.get("collections", ObjectList())
     collection_list.merge(ext_collection_list)
@@ -232,7 +239,7 @@ def load_module_redirects(root_definitions, ext_definitions, module_dict={}):
             redirect_to = routing.get("redirect", "")
             if short_name in redirects:
                 continue
-            found_module = module_dict.get(redirect_to, None)
+            found_module = module_dict.get(redirect_to)
             if found_module:
                 module_key = found_module.key
                 redirects[short_name] = module_key
@@ -274,54 +281,63 @@ def resolve(obj, dicts):
     return obj, failed
 
 
-def resolve_module(module_name, module_dict={}, module_redirects={}):
+def resolve_module(module_name, module_dict=None, module_redirects=None):
+    if module_redirects is None:
+        module_redirects = {}
+    if module_dict is None:
+        module_dict = {}
     module_key = ""
-    found_module = module_dict.get(module_name, None)
+    found_module = module_dict.get(module_name)
     if found_module is not None:
         module_key = found_module.key
     if module_key == "":
         for k in module_dict:
-            suffix = ".{}".format(module_name)
+            suffix = f".{module_name}"
             if k.endswith(suffix):
                 module_key = module_dict[k].key
                 break
-    if module_key == "":
-        if module_name in module_redirects:
-            module_key = module_redirects[module_name]
+    if module_key == "" and module_name in module_redirects:
+        module_key = module_redirects[module_name]
     return module_key
 
 
-def resolve_role(role_name, role_dict={}, my_collection_name="", collections_in_play=[]):
+def resolve_role(role_name, role_dict=None, my_collection_name="", collections_in_play=None):
+    if collections_in_play is None:
+        collections_in_play = []
+    if role_dict is None:
+        role_dict = {}
     if os.sep in role_name:
         role_name = os.path.basename(role_name)
 
     role_key = ""
     if "." not in role_name and len(collections_in_play) > 0:
         for coll in collections_in_play:
-            role_name_cand = "{}.{}".format(coll, role_name)
-            found_role = role_dict.get(role_name_cand, None)
+            role_name_cand = f"{coll}.{role_name}"
+            found_role = role_dict.get(role_name_cand)
             if found_role is not None:
                 role_key = found_role.key
     else:
         if "." not in role_name and my_collection_name != "":
-            role_name_cand = "{}.{}".format(my_collection_name, role_name)
-            found_role = role_dict.get(role_name_cand, None)
+            role_name_cand = f"{my_collection_name}.{role_name}"
+            found_role = role_dict.get(role_name_cand)
             if found_role is not None:
                 role_key = found_role.key
     if role_key == "":
-        found_role = role_dict.get(role_name, None)
+        found_role = role_dict.get(role_name)
         if found_role is not None:
             role_key = found_role.key
         else:
             for k in role_dict:
-                suffix = ".{}".format(role_name)
+                suffix = f".{role_name}"
                 if k.endswith(suffix):
                     role_key = role_dict[k].key
                     break
     return role_key
 
 
-def resolve_taskfile(taskfile_ref, taskfile_dict={}, task_key=""):
+def resolve_taskfile(taskfile_ref, taskfile_dict=None, task_key=""):
+    if taskfile_dict is None:
+        taskfile_dict = {}
     type_prefix = "task "
     parts = task_key[len(type_prefix) :].split(object_delimiter)
     parent_key = ""
@@ -334,15 +350,14 @@ def resolve_taskfile(taskfile_ref, taskfile_dict={}, task_key=""):
 
     # include/import tasks can have a path like "roles/xxxx/tasks/yyyy.yml"
     # then try to find roles directory
-    if taskfile_ref.startswith("roles/"):
-        if "roles/" in task_defined_path:
-            roles_parent_dir = task_defined_path.split("roles/")[0]
-            fpath = os.path.join(roles_parent_dir, taskfile_ref)
-            fpath = os.path.normpath(fpath)
-            taskfile_key = "taskfile {}taskfile{}{}".format(parent_key, key_delimiter, fpath)
-            found_tf = taskfile_dict.get(taskfile_key, None)
-            if found_tf is not None:
-                return found_tf.key
+    if taskfile_ref.startswith("roles/") and "roles/" in task_defined_path:
+        roles_parent_dir = task_defined_path.split("roles/")[0]
+        fpath = os.path.join(roles_parent_dir, taskfile_ref)
+        fpath = os.path.normpath(fpath)
+        taskfile_key = f"taskfile {parent_key}taskfile{key_delimiter}{fpath}"
+        found_tf = taskfile_dict.get(taskfile_key)
+        if found_tf is not None:
+            return found_tf.key
 
     task_dir = os.path.dirname(task_defined_path)
     fpath = os.path.join(task_dir, taskfile_ref)
@@ -350,15 +365,17 @@ def resolve_taskfile(taskfile_ref, taskfile_dict={}, task_key=""):
     # something like "../some_taskfile.yml".
     # it should be "tasks/some_taskfile.yml"
     fpath = os.path.normpath(fpath)
-    taskfile_key = "taskfile {}taskfile{}{}".format(parent_key, key_delimiter, fpath)
-    found_tf = taskfile_dict.get(taskfile_key, None)
+    taskfile_key = f"taskfile {parent_key}taskfile{key_delimiter}{fpath}"
+    found_tf = taskfile_dict.get(taskfile_key)
     if found_tf is not None:
         return found_tf.key
 
     return ""
 
 
-def resolve_playbook(playbook_ref, playbook_dict={}, play_key=""):
+def resolve_playbook(playbook_ref, playbook_dict=None, play_key=""):
+    if playbook_dict is None:
+        playbook_dict = {}
     type_prefix = "play "
     parts = play_key[len(type_prefix) :].split(object_delimiter)
     parent_key = ""
@@ -374,8 +391,8 @@ def resolve_playbook(playbook_ref, playbook_dict={}, play_key=""):
     # need to normalize path here because playbook_ref can be
     # something like "../some_playbook.yml"
     fpath = os.path.normpath(fpath)
-    playbook_key = "playbook {}playbook{}{}".format(parent_key, key_delimiter, fpath)
-    found_playbook = playbook_dict.get(playbook_key, None)
+    playbook_key = f"playbook {parent_key}playbook{key_delimiter}{fpath}"
+    found_playbook = playbook_dict.get(playbook_key)
     if found_playbook is not None:
         return found_playbook.key
     return ""
@@ -387,9 +404,15 @@ def init_builtin_modules():
     return modules
 
 
-class TreeLoader(object):
+class TreeLoader:
     def __init__(
-        self, root_definitions, ext_definitions, ram_client=None, target_playbook_path=None, target_taskfile_path=None, load_all_taskfiles=False
+        self,
+        root_definitions,
+        ext_definitions,
+        ram_client=None,
+        target_playbook_path=None,
+        target_taskfile_path=None,
+        load_all_taskfiles=False,
     ):
         self.ram_client: RAMClient = ram_client
 
@@ -402,7 +425,9 @@ class TreeLoader(object):
 
         self.dicts = make_dicts(self.root_definitions, self.ext_definitions)
 
-        self.module_redirects = load_module_redirects(self.root_definitions, self.ext_definitions, self.dicts["modules"])
+        self.module_redirects = load_module_redirects(
+            self.root_definitions, self.ext_definitions, self.dicts["modules"]
+        )
 
         # use mappings just to get tree tops (playbook/role)
         # we don't load any files by this mappings here
@@ -480,7 +505,7 @@ class TreeLoader(object):
                 additional_objects.add(p_defs[0])
         covered_taskfiles = []
         for i, mapping in enumerate(self.playbook_mappings):
-            logger.debug("[{}/{}] {}".format(i + 1, len(self.playbook_mappings), mapping[1]))
+            logger.debug(f"[{i + 1}/{len(self.playbook_mappings)}] {mapping[1]}")
             playbook_key = mapping[1]
             tree_objects = self._recursive_get_calls(playbook_key)
             self.trees.append(tree_objects)
@@ -496,7 +521,7 @@ class TreeLoader(object):
                             covered_taskfiles.append(taskfile_key)
 
         for i, mapping in enumerate(self.role_mappings):
-            logger.debug("[{}/{}] {}".format(i + 1, len(self.role_mappings), mapping[1]))
+            logger.debug(f"[{i + 1}/{len(self.role_mappings)}] {mapping[1]}")
             role_key = mapping[1]
             tree_objects = self._recursive_get_calls(role_key)
             self.trees.append(tree_objects)
@@ -512,7 +537,7 @@ class TreeLoader(object):
                             covered_taskfiles.append(taskfile_key)
 
         for i, mapping in enumerate(self.taskfile_mappings):
-            logger.debug("[{}/{}] {}".format(i + 1, len(self.taskfile_mappings), mapping[1]))
+            logger.debug(f"[{i + 1}/{len(self.taskfile_mappings)}] {mapping[1]}")
             taskfile_key = mapping[1]
             if self.load_all_taskfiles and taskfile_key in covered_taskfiles:
                 continue
@@ -520,7 +545,11 @@ class TreeLoader(object):
             self.trees.append(tree_objects)
         return self.trees, additional_objects
 
-    def _recursive_get_calls(self, key, caller=None, handover={}, index=0, history=[]):
+    def _recursive_get_calls(self, key, caller=None, handover=None, index=0, history=None):
+        if history is None:
+            history = []
+        if handover is None:
+            handover = {}
         obj_list = ObjectList()
         obj = self.get_object(key)
         if obj is None:
@@ -651,7 +680,7 @@ class TreeLoader(object):
     def get_object(self, obj_key, search_ram=False):
         obj_type = detect_type(obj_key)
         if obj_type == "":
-            raise ValueError('failed to detect object type from key "{}"'.format(obj_key))
+            raise ValueError(f'failed to detect object type from key "{obj_key}"')
         type_key = obj_type_dict[obj_type]
         root_definitions = self.root_definitions.get(type_key, ObjectList())
         obj = root_definitions.find_by_key(obj_key)
@@ -676,7 +705,9 @@ class TreeLoader(object):
         obj_list = ObjectList(items=builtin_modules)
         self.ext_definitions["modules"].merge(obj_list)
 
-    def _get_children_keys(self, obj, handover_from_upper_node={}):
+    def _get_children_keys(self, obj, handover_from_upper_node=None):
+        if handover_from_upper_node is None:
+            handover_from_upper_node = {}
         if isinstance(obj, CallObject):
             return self._get_children_keys(obj.spec)
         children_keys = []
@@ -759,7 +790,9 @@ class TreeLoader(object):
                 if tasks_from:
                     target_taskfiles = [tasks_from]
             target_taskfile_key = [
-                tf for tf in obj.taskfiles if tf.split(key_delimiter)[-1].split("/")[-1] in target_taskfiles and "/handlers/" not in tf
+                tf
+                for tf in obj.taskfiles
+                if tf.split(key_delimiter)[-1].split("/")[-1] in target_taskfiles and "/handlers/" not in tf
             ]
             children_keys.extend(target_taskfile_key)
         elif isinstance(obj, TaskFile):
@@ -786,18 +819,23 @@ class TreeLoader(object):
                         if len(matched_modules) > 0:
                             resolved_key = matched_modules[0]["object"].key
                             self.ext_definitions["modules"].add(matched_modules[0]["object"])
-                            if matched_modules[0]["object"].key not in self.extra_requirement_obj_set:
-                                if not matched_modules[0]["object"].builtin:
-                                    self.extra_requirements.append(
-                                        {
-                                            "type": "module",
-                                            "name": matched_modules[0]["object"].fqcn,
-                                            "defined_in": matched_modules[0]["defined_in"],
-                                            "used_in": obj.defined_in,
-                                        }
-                                    )
-                                    self.extra_requirement_obj_set.add(matched_modules[0]["object"].key)
-                            self.resolved_module_from_ram[target_name] = (resolved_key, matched_modules[0]["defined_in"])
+                            if (
+                                matched_modules[0]["object"].key not in self.extra_requirement_obj_set
+                                and not matched_modules[0]["object"].builtin
+                            ):
+                                self.extra_requirements.append(
+                                    {
+                                        "type": "module",
+                                        "name": matched_modules[0]["object"].fqcn,
+                                        "defined_in": matched_modules[0]["defined_in"],
+                                        "used_in": obj.defined_in,
+                                    }
+                                )
+                                self.extra_requirement_obj_set.add(matched_modules[0]["object"].key)
+                            self.resolved_module_from_ram[target_name] = (
+                                resolved_key,
+                                matched_modules[0]["defined_in"],
+                            )
                             from_ram[resolved_key] = matched_modules[0]["defined_in"]
                 if resolved_key == "":
                     if target_name not in self.resolve_failures["module"]:
@@ -877,7 +915,9 @@ class TreeLoader(object):
                         resolved_key, req_info = self.resolved_role_from_ram[target_name]
                         from_ram[resolved_key] = req_info
                     else:
-                        matched_taskfiles = self.ram_client.search_taskfile(target_name, from_path=obj.defined_in, from_key=obj.key)
+                        matched_taskfiles = self.ram_client.search_taskfile(
+                            target_name, from_path=obj.defined_in, from_key=obj.key
+                        )
                         if len(matched_taskfiles) > 0:
                             resolved_key = matched_taskfiles[0]["object"].key
                             self.ext_definitions["taskfiles"].add(matched_taskfiles[0]["object"], update_dict=False)
@@ -904,7 +944,10 @@ class TreeLoader(object):
                                         }
                                     )
                                     self.extra_requirement_obj_set.add(offspr_obj["object"].key)
-                            self.resolved_taskfile_from_ram[target_name] = (resolved_key, matched_taskfiles[0]["defined_in"])
+                            self.resolved_taskfile_from_ram[target_name] = (
+                                resolved_key,
+                                matched_taskfiles[0]["defined_in"],
+                            )
                             from_ram[resolved_key] = matched_taskfiles[0]["defined_in"]
                 if resolved_key == "":
                     if target_name not in self.resolve_failures["taskfile"]:
@@ -924,7 +967,7 @@ class TreeLoader(object):
                 continue
             obj = self.get_object(k)
             if obj is None:
-                logger.warning("object not found for the key {}".format(k))
+                logger.warning(f"object not found for the key {k}")
                 continue
             obj_list.add(obj)
             loaded[k] = obj

--- a/src/apme_engine/engine/utils.py
+++ b/src/apme_engine/engine/utils.py
@@ -1,19 +1,19 @@
-import os
-import traceback
-import subprocess
-import requests
-import hashlib
-import yaml
-import json
 import codecs
-from filelock import FileLock
+import hashlib
+import json
+import os
+import subprocess
+import traceback
 from copy import deepcopy
-from tabulate import tabulate
+from importlib.util import module_from_spec, spec_from_file_location
 from inspect import isclass
-from importlib.util import spec_from_file_location, module_from_spec
+
+import requests
+import yaml
+from filelock import FileLock
+from tabulate import tabulate
 
 from . import logger
-
 
 bool_values_true = frozenset(("y", "yes", "on", "1", "true", "t", 1, 1.0, True))
 bool_values_false = frozenset(("n", "no", "off", "0", "false", "f", 0, 0.0, False))
@@ -57,17 +57,19 @@ def get_lock_file_name(fpath):
 def install_galaxy_target(target, target_type, output_dir, source_repository="", target_version=""):
     server_option = ""
     if source_repository:
-        server_option = "--server {}".format(source_repository)
+        server_option = f"--server {source_repository}"
     target_name = target
     if target_version:
         target_name = f"{target}:{target_version}"
-    logger.debug("exec ansible-galaxy cmd: ansible-galaxy {} install {} {} -p {} --force".format(target_type, target_name, server_option, output_dir))
+    logger.debug(
+        f"exec ansible-galaxy cmd: ansible-galaxy {target_type} install {target_name} "
+        f"{server_option} -p {output_dir} --force"
+    )
     proc = subprocess.run(
-        "ansible-galaxy {} install {} {} -p {} --force".format(target_type, target_name, server_option, output_dir),
+        f"ansible-galaxy {target_type} install {target_name} {server_option} -p {output_dir} --force",
         shell=True,
         stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     return proc.stdout, proc.stderr
@@ -75,11 +77,10 @@ def install_galaxy_target(target, target_type, output_dir, source_repository="",
 
 def install_github_target(target, output_dir):
     proc = subprocess.run(
-        "git clone {} {}".format(target, output_dir),
+        f"git clone {target} {output_dir}",
         shell=True,
         stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
     )
     return proc.stdout
@@ -130,7 +131,7 @@ def get_installed_metadata(type, name, path, dep_dir=None):
             if dir_name.startswith(name) and dir_name.endswith(".info"):
                 galaxy_yml_path = os.path.join(base_dir, dir_name, galaxy_yml)
                 try:
-                    with open(galaxy_yml_path, "r") as galaxy_yml_file:
+                    with open(galaxy_yml_path) as galaxy_yml_file:
                         tmp_galaxy_data = yaml.safe_load(galaxy_yml_file)
                 except Exception:
                     pass
@@ -148,7 +149,7 @@ def get_collection_metadata(path: str):
     manifest_json_path = os.path.join(path, "MANIFEST.json")
     meta = None
     if os.path.exists(manifest_json_path):
-        with open(manifest_json_path, "r") as file:
+        with open(manifest_json_path) as file:
             meta = json.load(file)
     return meta
 
@@ -159,7 +160,7 @@ def get_role_metadata(path: str):
     meta_main_yml_path = os.path.join(path, "meta", "main.yml")
     meta = None
     if os.path.exists(meta_main_yml_path):
-        with open(meta_main_yml_path, "r") as file:
+        with open(meta_main_yml_path) as file:
             meta = yaml.safe_load(file)
     return meta
 
@@ -220,15 +221,12 @@ def version_to_num(ver: str):
     ver_num_part = ver.split("-")[0]
     parts = ver_num_part.split(".")
     num = 0
-    if len(parts) >= 1:
-        if parts[0].isnumeric():
-            num += float(parts[0])
-    if len(parts) >= 2:
-        if parts[1].isnumeric():
-            num += float(parts[1]) * (0.001**1)
-    if len(parts) >= 3:
-        if parts[2].isnumeric():
-            num += float(parts[2]) * (0.001**2)
+    if len(parts) >= 1 and parts[0].isnumeric():
+        num += float(parts[0])
+    if len(parts) >= 2 and parts[1].isnumeric():
+        num += float(parts[1]) * (0.001**1)
+    if len(parts) >= 3 and parts[2].isnumeric():
+        num += float(parts[2]) * (0.001**2)
     return num
 
 
@@ -308,7 +306,9 @@ def summarize_findings(findings, show_all: bool = False):
     return summarize_findings_data(metadata, dependencies, report, resolve_failures, extra_requirements, show_all)
 
 
-def summarize_findings_data(metadata, dependencies, report, resolve_failures, extra_requirements, show_all: bool = False):
+def summarize_findings_data(
+    metadata, dependencies, report, resolve_failures, extra_requirements, show_all: bool = False
+):
     target_name = metadata.get("name", "")
     output_lines = []
 
@@ -330,7 +330,8 @@ def summarize_findings_data(metadata, dependencies, report, resolve_failures, ex
 
     #     print("-" * 90)
     #     print("ARI scan completed!")
-    #     print(f"Findings have been saved at: {self.ram_client.make_findings_dir_path(self.type, self.name, self.version, self.hash)}")
+    #     print(f"Findings have been saved at: "
+    #           f"{self.ram_client.make_findings_dir_path(self.type, self.name, self.version, self.hash)}")
     #     print("-" * 90)
 
     module_failures = resolve_failures.get("module", {})
@@ -341,7 +342,9 @@ def summarize_findings_data(metadata, dependencies, report, resolve_failures, ex
     taskfile_fail_num = len(taskfile_failures)
     total_fail_num = module_fail_num + role_fail_num + taskfile_fail_num
     if total_fail_num > 0:
-        output_lines.append(f"Failed to resolve {module_fail_num} modules, {role_fail_num} roles, {taskfile_fail_num} taskfiles")
+        output_lines.append(
+            f"Failed to resolve {module_fail_num} modules, {role_fail_num} roles, {taskfile_fail_num} taskfiles"
+        )
     if module_fail_num > 0:
         output_lines.append("- modules: ")
         for module_action in module_failures:
@@ -509,7 +512,7 @@ def diff_files_data(files1, files2):
                 }
             )
 
-    for fpath, hash in files_dict2.items():
+    for fpath, _ in files_dict2.items():
         if fpath in files_dict1:
             continue
         else:
@@ -556,7 +559,14 @@ def get_module_specs_by_ansible_doc(module_files: str, fqcn_prefix: str, search_
     cmd_args = [f"ansible-doc {fqcn_list_str} --json"]
     _env = os.environ.copy()
     _env["ANSIBLE_COLLECTIONS_PATH"] = search_path
-    proc = subprocess.run(args=cmd_args, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=_env)
+    proc = subprocess.run(
+        args=cmd_args,
+        shell=True,
+        stdin=subprocess.PIPE,
+        capture_output=True,
+        text=True,
+        env=_env,
+    )
     if proc.stderr and not proc.stdout:
         logger.debug(f"error while getting the documentation for modules `{fqcn_list_str}`: {proc.stderr}")
         return ""
@@ -579,7 +589,7 @@ def get_documentation_in_module_file(fpath: str):
     if not os.path.exists(fpath):
         return ""
     lines = []
-    with open(fpath, "r") as file:
+    with open(fpath) as file:
         for line in file:
             lines.append(line)
     doc_lines = []
@@ -637,7 +647,9 @@ def get_class_by_arg_type(arg_type: str):
     return mapping[arg_type]
 
 
-def load_classes_in_dir(dir_path: str, target_class: type, base_dir: str = "", only_subclass: bool = True, fail_on_error: bool = False):
+def load_classes_in_dir(
+    dir_path: str, target_class: type, base_dir: str = "", only_subclass: bool = True, fail_on_error: bool = False
+):
     search_path = dir_path
     found = False
     if os.path.exists(search_path):
@@ -672,11 +684,11 @@ def load_classes_in_dir(dir_path: str, target_class: type, base_dir: str = "", o
                 if only_subclass and cls == target_class:
                     continue
                 classes.append(cls)
-        except Exception:
+        except Exception as err:
             exc = traceback.format_exc()
             msg = f"failed to load a rule module {s}: {exc}"
             if fail_on_error:
-                raise ValueError(msg)
+                raise ValueError(msg) from err
             else:
                 errors.append(msg)
     return classes, errors
@@ -687,14 +699,14 @@ def equal(a: any, b: any):
     type_b = type(b)
     if type_a != type_b:
         return False
-    if type_a == dict:
+    if type_a is dict:
         all_keys = list(a.keys()) + list(b.keys())
         for key in all_keys:
             val_a = a.get(key, None)
             val_b = b.get(key, None)
             if not equal(val_a, val_b):
                 return False
-    elif type_a == list:
+    elif type_a is list:
         if len(a) != len(b):
             return False
         for i in range(len(a)):

--- a/src/apme_engine/engine/yaml.py
+++ b/src/apme_engine/engine/yaml.py
@@ -1,8 +1,8 @@
 import io
 from contextvars import ContextVar
+
 from ruamel.yaml import YAML
 from ruamel.yaml.emitter import EmitterError
-
 
 _yaml: ContextVar[YAML] = ContextVar("yaml")
 

--- a/src/apme_engine/engine/yaml_utils.py
+++ b/src/apme_engine/engine/yaml_utils.py
@@ -3,10 +3,11 @@
 # pylint: disable=too-many-lines
 from __future__ import annotations
 
+import re
 from io import StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-import re
+
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from ruamel.yaml.composer import ComposerError
 from ruamel.yaml.constructor import RoundTripConstructor
@@ -17,8 +18,8 @@ from ruamel.yaml.emitter import Emitter
 from ruamel.yaml.main import YAML
 from ruamel.yaml.parser import ParserError
 from ruamel.yaml.scalarint import HexInt, ScalarInt
-from . import logger
 
+from . import logger
 
 if TYPE_CHECKING:
     # noinspection PyProtectedMember
@@ -331,7 +332,7 @@ class FormattedYAML(YAML):
     def _prevent_wrapping_flow_style(data: Any) -> None:
         """Walk data and set flow style width hints so short mappings stay on one line."""
         if isinstance(data, (CommentedMap, CommentedSeq)):
-            for item in (data.values() if isinstance(data, CommentedMap) else data):
+            for item in data.values() if isinstance(data, CommentedMap) else data:
                 FormattedYAML._prevent_wrapping_flow_style(item)
 
     def dumps(self, data: Any) -> str:

--- a/src/apme_engine/formatter.py
+++ b/src/apme_engine/formatter.py
@@ -28,16 +28,31 @@ JINJA_NORMALIZE_RE = re.compile(r"\{\{(\s*)(.*?)(\s*)\}\}")
 
 TASK_KEY_ORDER = [
     "name",
-    "block", "rescue", "always",
-    "when", "changed_when", "failed_when",
-    "loop", "loop_control",
-    "with_items", "with_dict", "with_fileglob", "with_subelements",
-    "with_sequence", "with_nested", "with_first_found",
+    "block",
+    "rescue",
+    "always",
+    "when",
+    "changed_when",
+    "failed_when",
+    "loop",
+    "loop_control",
+    "with_items",
+    "with_dict",
+    "with_fileglob",
+    "with_subelements",
+    "with_sequence",
+    "with_nested",
+    "with_first_found",
     "register",
-    "notify", "listen",
-    "become", "become_user", "become_method",
-    "delegate_to", "run_once",
-    "ignore_errors", "ignore_unreachable",
+    "notify",
+    "listen",
+    "become",
+    "become_user",
+    "become_method",
+    "delegate_to",
+    "run_once",
+    "ignore_errors",
+    "ignore_unreachable",
     "no_log",
     "tags",
     "environment",
@@ -239,6 +254,7 @@ def format_directory(
 def _matches_glob(path_str: str, pattern: str) -> bool:
     """Simple glob matching using fnmatch."""
     import fnmatch
+
     return fnmatch.fnmatch(path_str, pattern)
 
 

--- a/src/apme_engine/opa_client.py
+++ b/src/apme_engine/opa_client.py
@@ -23,11 +23,24 @@ def _run_opa_podman(
     """
     bundle_abs = bundle_path.resolve()
     cmd = [
-        "podman", "run", "--rm", "-i",
-        "--userns=keep-id", "-u", "root",
-        "-v", f"{bundle_abs}:/bundle:ro,z",
+        "podman",
+        "run",
+        "--rm",
+        "-i",
+        "--userns=keep-id",
+        "-u",
+        "root",
+        "-v",
+        f"{bundle_abs}:/bundle:ro,z",
         OPA_IMAGE,
-        "eval", "-i", "-", "-d", "/bundle", entrypoint, "--format", "json",
+        "eval",
+        "-i",
+        "-",
+        "-d",
+        "/bundle",
+        entrypoint,
+        "--format",
+        "json",
     ]
     return subprocess.run(
         cmd,
@@ -58,11 +71,18 @@ def _run_opa_test_podman(bundle_path: Path, timeout: int = 120) -> subprocess.Co
     """Run `opa test . -v` inside Podman with bundle mounted. Same volume/user flags as eval."""
     bundle_abs = bundle_path.resolve()
     cmd = [
-        "podman", "run", "--rm",
-        "--userns=keep-id", "-u", "root",
-        "-v", f"{bundle_abs}:/bundle:ro,z",
+        "podman",
+        "run",
+        "--rm",
+        "--userns=keep-id",
+        "-u",
+        "root",
+        "-v",
+        f"{bundle_abs}:/bundle:ro,z",
         OPA_IMAGE,
-        "test", "/bundle", "-v",
+        "test",
+        "/bundle",
+        "-v",
     ]
     return subprocess.run(
         cmd,

--- a/src/apme_engine/remediation/__init__.py
+++ b/src/apme_engine/remediation/__init__.py
@@ -1,8 +1,8 @@
 """Remediation engine — deterministic transforms + AI escalation for scan violations."""
 
-from apme_engine.remediation.registry import TransformRegistry, TransformResult, TransformFn
+from apme_engine.remediation.engine import FixReport, RemediationEngine
 from apme_engine.remediation.partition import is_finding_resolvable
-from apme_engine.remediation.engine import RemediationEngine, FixReport
+from apme_engine.remediation.registry import TransformFn, TransformRegistry, TransformResult
 
 __all__ = [
     "TransformRegistry",

--- a/src/apme_engine/remediation/engine.py
+++ b/src/apme_engine/remediation/engine.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import difflib
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
 
 from apme_engine.remediation.partition import partition_violations
 from apme_engine.remediation.registry import TransformRegistry
@@ -146,19 +146,23 @@ class RemediationEngine:
         patches: list[FilePatch] = []
         for fp in file_paths:
             if file_contents[fp] != originals[fp]:
-                diff = "".join(difflib.unified_diff(
-                    originals[fp].splitlines(keepends=True),
-                    file_contents[fp].splitlines(keepends=True),
-                    fromfile=f"a/{fp}",
-                    tofile=f"b/{fp}",
-                ))
-                patches.append(FilePatch(
-                    path=fp,
-                    original=originals[fp],
-                    patched=file_contents[fp],
-                    diff=diff,
-                    rule_ids=all_applied_rules.get(fp, []),
-                ))
+                diff = "".join(
+                    difflib.unified_diff(
+                        originals[fp].splitlines(keepends=True),
+                        file_contents[fp].splitlines(keepends=True),
+                        fromfile=f"a/{fp}",
+                        tofile=f"b/{fp}",
+                    )
+                )
+                patches.append(
+                    FilePatch(
+                        path=fp,
+                        original=originals[fp],
+                        patched=file_contents[fp],
+                        diff=diff,
+                        rule_ids=all_applied_rules.get(fp, []),
+                    )
+                )
 
         # If not applying, restore originals
         if not apply:

--- a/src/apme_engine/remediation/registry.py
+++ b/src/apme_engine/remediation/registry.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Callable, NamedTuple
+from collections.abc import Callable
+from typing import NamedTuple
 
 
 class TransformResult(NamedTuple):

--- a/src/apme_engine/remediation/transforms/L007_shell_to_command.py
+++ b/src/apme_engine/remediation/transforms/L007_shell_to_command.py
@@ -6,7 +6,6 @@ from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key, rename_key
 
-
 _SHELL_CHARS = ("|", "&&", "||", ";", ">", ">>", "<", "$(", "`", "*", "?")
 
 _SHELL_TO_COMMAND = {

--- a/src/apme_engine/remediation/transforms/L009_empty_string.py
+++ b/src/apme_engine/remediation/transforms/L009_empty_string.py
@@ -8,7 +8,6 @@ from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line
 
-
 _PATTERNS = [
     (re.compile(r'\b(\w+)\s*==\s*""'), r"\1 | length == 0"),
     (re.compile(r"\b(\w+)\s*==\s*''"), r"\1 | length == 0"),

--- a/src/apme_engine/remediation/transforms/L013_changed_when.py
+++ b/src/apme_engine/remediation/transforms/L013_changed_when.py
@@ -6,12 +6,19 @@ from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key
 
-
-_CMD_MODULES = frozenset({
-    "ansible.builtin.command", "ansible.builtin.shell", "ansible.builtin.raw",
-    "ansible.legacy.command", "ansible.legacy.shell", "ansible.legacy.raw",
-    "command", "shell", "raw",
-})
+_CMD_MODULES = frozenset(
+    {
+        "ansible.builtin.command",
+        "ansible.builtin.shell",
+        "ansible.builtin.raw",
+        "ansible.legacy.command",
+        "ansible.legacy.shell",
+        "ansible.legacy.raw",
+        "command",
+        "shell",
+        "raw",
+    }
+)
 
 
 def fix_changed_when(content: str, violation: dict) -> TransformResult:
@@ -42,9 +49,8 @@ def fix_changed_when(content: str, violation: dict) -> TransformResult:
         return TransformResult(content=content, applied=False)
 
     module_args = task.get(module_key)
-    if isinstance(module_args, dict):
-        if "creates" in module_args or "removes" in module_args:
-            return TransformResult(content=content, applied=False)
+    if isinstance(module_args, dict) and ("creates" in module_args or "removes" in module_args):
+        return TransformResult(content=content, applied=False)
 
     task["changed_when"] = False
     return TransformResult(content=yaml.dumps(data), applied=True)

--- a/src/apme_engine/remediation/transforms/L020_octal_mode.py
+++ b/src/apme_engine/remediation/transforms/L020_octal_mode.py
@@ -39,10 +39,7 @@ def fix_octal_mode(content: str, violation: dict) -> TransformResult:
         m = _MODE_NUMERIC.match(stripped)
         if m:
             prefix, digits, suffix = m.group(1), m.group(2), m.group(3) or ""
-            if digits.startswith("0") and len(digits) >= 4:
-                quoted = f'"{digits}"'
-            else:
-                quoted = f'"0{digits}"'
+            quoted = f'"{digits}"' if digits.startswith("0") and len(digits) >= 4 else f'"0{digits}"'
             lines[i] = prefix + quoted + suffix + nl
             applied = True
             break
@@ -51,7 +48,7 @@ def fix_octal_mode(content: str, violation: dict) -> TransformResult:
         if m2:
             prefix, quote, digits, suffix = m2.group(1), m2.group(2), m2.group(3), m2.group(4) or ""
             if not digits.startswith("0"):
-                lines[i] = f'{prefix}{quote}0{digits}{quote}{suffix}{nl}'
+                lines[i] = f"{prefix}{quote}0{digits}{quote}{suffix}{nl}"
                 applied = True
                 break
 

--- a/src/apme_engine/remediation/transforms/L021_missing_mode.py
+++ b/src/apme_engine/remediation/transforms/L021_missing_mode.py
@@ -6,15 +6,28 @@ from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key
 
-
-_FILE_MODULES = frozenset({
-    "ansible.builtin.copy", "ansible.builtin.file", "ansible.builtin.template",
-    "ansible.builtin.lineinfile", "ansible.builtin.replace",
-    "ansible.builtin.unarchive", "ansible.builtin.synchronize",
-    "ansible.legacy.copy", "ansible.legacy.file", "ansible.legacy.template",
-    "copy", "file", "template", "lineinfile", "replace",
-    "synchronize", "unarchive", "assemble",
-})
+_FILE_MODULES = frozenset(
+    {
+        "ansible.builtin.copy",
+        "ansible.builtin.file",
+        "ansible.builtin.template",
+        "ansible.builtin.lineinfile",
+        "ansible.builtin.replace",
+        "ansible.builtin.unarchive",
+        "ansible.builtin.synchronize",
+        "ansible.legacy.copy",
+        "ansible.legacy.file",
+        "ansible.legacy.template",
+        "copy",
+        "file",
+        "template",
+        "lineinfile",
+        "replace",
+        "synchronize",
+        "unarchive",
+        "assemble",
+    }
+)
 
 
 def fix_missing_mode(content: str, violation: dict) -> TransformResult:

--- a/src/apme_engine/remediation/transforms/L022_pipefail.py
+++ b/src/apme_engine/remediation/transforms/L022_pipefail.py
@@ -6,10 +6,13 @@ from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key
 
-
-_SHELL_MODULES = frozenset({
-    "ansible.builtin.shell", "ansible.legacy.shell", "shell",
-})
+_SHELL_MODULES = frozenset(
+    {
+        "ansible.builtin.shell",
+        "ansible.legacy.shell",
+        "shell",
+    }
+)
 
 
 def fix_pipefail(content: str, violation: dict) -> TransformResult:

--- a/src/apme_engine/remediation/transforms/L043_bare_vars.py
+++ b/src/apme_engine/remediation/transforms/L043_bare_vars.py
@@ -10,8 +10,15 @@ from apme_engine.remediation.transforms._helpers import find_task_at_line
 
 _BARE_VAR = re.compile(r"^([a-zA-Z_]\w*)$")
 
-_LOOP_KEYS = ("with_items", "with_dict", "with_fileglob", "with_subelements",
-              "with_sequence", "with_nested", "with_first_found")
+_LOOP_KEYS = (
+    "with_items",
+    "with_dict",
+    "with_fileglob",
+    "with_subelements",
+    "with_sequence",
+    "with_nested",
+    "with_first_found",
+)
 
 
 def fix_bare_vars(content: str, violation: dict) -> TransformResult:

--- a/src/apme_engine/remediation/transforms/L046_no_free_form.py
+++ b/src/apme_engine/remediation/transforms/L046_no_free_form.py
@@ -8,13 +8,21 @@ from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key
 
-
-_FREE_FORM_MODULES = frozenset({
-    "ansible.builtin.command", "ansible.builtin.shell", "ansible.builtin.raw",
-    "ansible.builtin.script",
-    "ansible.legacy.command", "ansible.legacy.shell", "ansible.legacy.raw",
-    "command", "shell", "raw", "script",
-})
+_FREE_FORM_MODULES = frozenset(
+    {
+        "ansible.builtin.command",
+        "ansible.builtin.shell",
+        "ansible.builtin.raw",
+        "ansible.builtin.script",
+        "ansible.legacy.command",
+        "ansible.legacy.shell",
+        "ansible.legacy.raw",
+        "command",
+        "shell",
+        "raw",
+        "script",
+    }
+)
 
 
 def fix_free_form(content: str, violation: dict) -> TransformResult:

--- a/src/apme_engine/remediation/transforms/M001_fqcn.py
+++ b/src/apme_engine/remediation/transforms/M001_fqcn.py
@@ -10,7 +10,6 @@ from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key, rename_key
 
-
 _BUILTIN_FQCN: dict[str, str] = {
     "debug": "ansible.builtin.debug",
     "command": "ansible.builtin.command",

--- a/src/apme_engine/remediation/transforms/M009_with_to_loop.py
+++ b/src/apme_engine/remediation/transforms/M009_with_to_loop.py
@@ -6,10 +6,13 @@ from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line
 
-
-_WITH_SIMPLE = frozenset({
-    "with_items", "with_list", "with_flattened",
-})
+_WITH_SIMPLE = frozenset(
+    {
+        "with_items",
+        "with_list",
+        "with_flattened",
+    }
+)
 
 
 def fix_with_to_loop(content: str, violation: dict) -> TransformResult:

--- a/src/apme_engine/remediation/transforms/__init__.py
+++ b/src/apme_engine/remediation/transforms/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from apme_engine.remediation.registry import TransformRegistry
-
 from apme_engine.remediation.transforms.L007_shell_to_command import fix_shell_to_command
 from apme_engine.remediation.transforms.L008_local_action import fix_local_action
 from apme_engine.remediation.transforms.L009_empty_string import fix_empty_string

--- a/src/apme_engine/remediation/transforms/_helpers.py
+++ b/src/apme_engine/remediation/transforms/_helpers.py
@@ -34,8 +34,7 @@ def _search_node(node: Any, target_line: int) -> CommentedMap | None:
     if hasattr(node, "lc") and node.lc.line == target_line:
         return node
 
-    for task_list_key in ("tasks", "pre_tasks", "post_tasks", "handlers",
-                          "block", "rescue", "always"):
+    for task_list_key in ("tasks", "pre_tasks", "post_tasks", "handlers", "block", "rescue", "always"):
         tasks = node.get(task_list_key)
         if isinstance(tasks, CommentedSeq):
             for task in tasks:
@@ -46,23 +45,56 @@ def _search_node(node: Any, target_line: int) -> CommentedMap | None:
     return None
 
 
-_TASK_META_KEYS = frozenset({
-    "name", "when", "changed_when", "failed_when",
-    "register", "notify", "listen",
-    "become", "become_user", "become_method", "become_flags",
-    "delegate_to", "run_once", "connection",
-    "ignore_errors", "ignore_unreachable",
-    "no_log", "tags", "environment", "vars", "args",
-    "loop", "loop_control",
-    "with_items", "with_dict", "with_fileglob", "with_subelements",
-    "with_sequence", "with_nested", "with_first_found",
-    "block", "rescue", "always",
-    "any_errors_fatal", "max_fail_percentage",
-    "check_mode", "diff", "throttle", "timeout",
-    "retries", "delay", "until",
-    "debugger", "module_defaults", "collections",
-    "local_action",
-})
+_TASK_META_KEYS = frozenset(
+    {
+        "name",
+        "when",
+        "changed_when",
+        "failed_when",
+        "register",
+        "notify",
+        "listen",
+        "become",
+        "become_user",
+        "become_method",
+        "become_flags",
+        "delegate_to",
+        "run_once",
+        "connection",
+        "ignore_errors",
+        "ignore_unreachable",
+        "no_log",
+        "tags",
+        "environment",
+        "vars",
+        "args",
+        "loop",
+        "loop_control",
+        "with_items",
+        "with_dict",
+        "with_fileglob",
+        "with_subelements",
+        "with_sequence",
+        "with_nested",
+        "with_first_found",
+        "block",
+        "rescue",
+        "always",
+        "any_errors_fatal",
+        "max_fail_percentage",
+        "check_mode",
+        "diff",
+        "throttle",
+        "timeout",
+        "retries",
+        "delay",
+        "until",
+        "debugger",
+        "module_defaults",
+        "collections",
+        "local_action",
+    }
+)
 
 
 def get_module_key(task: CommentedMap) -> str | None:

--- a/src/apme_engine/runner.py
+++ b/src/apme_engine/runner.py
@@ -1,8 +1,8 @@
 """Run the integrated scan engine and return a ScanContext."""
 
 import os
-import time
 import tempfile
+import time
 from pathlib import Path
 
 from apme_engine.engine.scanner import ARIScanner
@@ -26,7 +26,7 @@ def run_scan_playbook_yaml(
     Returns:
         ScanContext with hierarchy_payload and optionally scandata.
     """
-    root_dir = project_root or os.path.expanduser("~/.apme-data")
+    project_root or os.path.expanduser("~/.apme-data")
     with tempfile.TemporaryDirectory(prefix="apme_rule_doc_") as tmpdir:
         playbook_path = os.path.join(tmpdir, "playbook.yml")
         with open(playbook_path, "w") as f:
@@ -84,7 +84,12 @@ def run_scan(
     diag = _extract_engine_diagnostics(scandata, engine_total_ms)
 
     if not scandata or not getattr(scandata, "hierarchy_payload", None):
-        return ScanContext(hierarchy_payload={}, scandata=scandata if include_scandata else None, root_dir=root_dir, engine_diagnostics=diag)
+        return ScanContext(
+            hierarchy_payload={},
+            scandata=scandata if include_scandata else None,
+            root_dir=root_dir,
+            engine_diagnostics=diag,
+        )
     return ScanContext(
         hierarchy_payload=scandata.hierarchy_payload,
         scandata=scandata if include_scandata else None,

--- a/src/apme_engine/validators/__init__.py
+++ b/src/apme_engine/validators/__init__.py
@@ -1,8 +1,8 @@
 """Validator abstraction: ScanContext and Validator protocol."""
 
-from .base import ScanContext, Validator
-from .opa import OpaValidator
-from .native import NativeValidator
 from .ansible import AnsibleValidator
+from .base import ScanContext, Validator
+from .native import NativeValidator
+from .opa import OpaValidator
 
 __all__ = ["ScanContext", "Validator", "OpaValidator", "NativeValidator", "AnsibleValidator"]

--- a/src/apme_engine/validators/ansible/_venv.py
+++ b/src/apme_engine/validators/ansible/_venv.py
@@ -4,7 +4,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 SUPPORTED_VERSIONS = ["2.18", "2.19", "2.20"]
 DEFAULT_VERSION = "2.20"
 
@@ -60,6 +59,7 @@ def setup_collections_env(collection_specs: list[str], cache_root: Path) -> dict
     if not collection_specs:
         return None
     from apme_engine.collection_cache.config import galaxy_cache_dir, github_cache_dir
+
     paths = []
     galaxy = galaxy_cache_dir(cache_root)
     if galaxy.is_dir():

--- a/src/apme_engine/validators/ansible/rules/L057_syntax.py
+++ b/src/apme_engine/validators/ansible/rules/L057_syntax.py
@@ -35,14 +35,16 @@ def run(
     violations: list[dict] = []
 
     if not ansible_playbook.exists():
-        violations.append({
-            "rule_id": RULE_ID,
-            "level": "error",
-            "message": f"ansible-playbook not found: {ansible_playbook}",
-            "file": "",
-            "line": 1,
-            "path": "",
-        })
+        violations.append(
+            {
+                "rule_id": RULE_ID,
+                "level": "error",
+                "message": f"ansible-playbook not found: {ansible_playbook}",
+                "file": "",
+                "line": 1,
+                "path": "",
+            }
+        )
         return violations
 
     env = dict(os.environ)
@@ -61,14 +63,16 @@ def run(
                 env=env,
             )
         except subprocess.TimeoutExpired:
-            violations.append({
-                "rule_id": RULE_ID,
-                "level": "error",
-                "message": "ansible-playbook --syntax-check timed out",
-                "file": rel_path,
-                "line": 1,
-                "path": "",
-            })
+            violations.append(
+                {
+                    "rule_id": RULE_ID,
+                    "level": "error",
+                    "message": "ansible-playbook --syntax-check timed out",
+                    "file": rel_path,
+                    "line": 1,
+                    "path": "",
+                }
+            )
             continue
 
         if result.returncode != 0:
@@ -77,13 +81,15 @@ def run(
             line_match = re.search(r"\bline\s+(\d+)\b", stderr, re.I)
             if line_match:
                 line = int(line_match.group(1))
-            violations.append({
-                "rule_id": RULE_ID,
-                "level": "error",
-                "message": stderr or "syntax check failed",
-                "file": rel_path,
-                "line": line,
-                "path": "",
-            })
+            violations.append(
+                {
+                    "rule_id": RULE_ID,
+                    "level": "error",
+                    "message": stderr or "syntax check failed",
+                    "file": rel_path,
+                    "line": line,
+                    "path": "",
+                }
+            )
 
     return violations

--- a/src/apme_engine/validators/ansible/rules/L058_argspec_doc.py
+++ b/src/apme_engine/validators/ansible/rules/L058_argspec_doc.py
@@ -104,7 +104,10 @@ for task in tasks:
             if val not in choices:
                 violations.append({
                     "module": module,
-                    "message": f"Value '{val}' for parameter '{pname}' of {module} is not one of: {', '.join(str(c) for c in choices)}",
+                    "message": (
+                        f"Value '{val}' for parameter '{pname}' of {module} "
+                        f"is not one of: {', '.join(str(c) for c in choices)}"
+                    ),
                     "task_key": task.get("key", ""),
                 })
 
@@ -136,13 +139,15 @@ def _run_argspec_script(
         if not module or not isinstance(module_options, dict) or not module_options:
             continue
         task_modules[module] = True
-        tasks_for_check.append({
-            "module": module,
-            "module_options": module_options,
-            "key": node.get("key", ""),
-            "file": node.get("file", ""),
-            "line": node.get("line"),
-        })
+        tasks_for_check.append(
+            {
+                "module": module,
+                "module_options": module_options,
+                "key": node.get("key", ""),
+                "file": node.get("file", ""),
+                "line": node.get("line"),
+            }
+        )
 
     if not tasks_for_check:
         return []
@@ -186,13 +191,15 @@ def _run_argspec_script(
         task = task_by_key.get(task_key, {})
         line = task.get("line")
         line_num = line[0] if isinstance(line, (list, tuple)) and line else 1
-        violations.append({
-            "rule_id": RULE_ID,
-            "level": "error",
-            "message": rv.get("message", "argument validation failed"),
-            "file": task.get("file", ""),
-            "line": line_num,
-            "path": task_key,
-        })
+        violations.append(
+            {
+                "rule_id": RULE_ID,
+                "level": "error",
+                "message": rv.get("message", "argument validation failed"),
+                "file": task.get("file", ""),
+                "line": line_num,
+                "path": task_key,
+            }
+        )
 
     return violations

--- a/src/apme_engine/validators/ansible/rules/L059_argspec_mock.py
+++ b/src/apme_engine/validators/ansible/rules/L059_argspec_mock.py
@@ -140,7 +140,10 @@ for task in tasks:
             if val not in choices:
                 violations.append({
                     "module": module,
-                    "message": f"Value '{val}' for parameter '{pname}' of {module} is not one of: {', '.join(str(c) for c in choices)}",
+                    "message": (
+                        f"Value '{val}' for parameter '{pname}' of {module} "
+                        f"is not one of: {', '.join(str(c) for c in choices)}"
+                    ),
                     "task_key": task.get("key", ""),
                 })
 
@@ -161,7 +164,10 @@ for task in tasks:
             missing = [p for p in group if p not in user_keys]
             violations.append({
                 "module": module,
-                "message": f"Parameters must be used together for {module}: {', '.join(group)} (missing: {', '.join(missing)})",
+                "message": (
+                    f"Parameters must be used together for {module}: "
+                    f"{', '.join(group)} (missing: {', '.join(missing)})"
+                ),
                 "task_key": task.get("key", ""),
             })
 
@@ -184,13 +190,15 @@ def run(
         if not module or not isinstance(module_options, dict) or not module_options:
             continue
         task_modules[module] = True
-        tasks_for_check.append({
-            "module": module,
-            "module_options": module_options,
-            "key": node.get("key", ""),
-            "file": node.get("file", ""),
-            "line": node.get("line"),
-        })
+        tasks_for_check.append(
+            {
+                "module": module,
+                "module_options": module_options,
+                "key": node.get("key", ""),
+                "file": node.get("file", ""),
+                "line": node.get("line"),
+            }
+        )
 
     if not tasks_for_check:
         return []
@@ -234,13 +242,15 @@ def run(
         task = task_by_key.get(task_key, {})
         line = task.get("line")
         line_num = line[0] if isinstance(line, (list, tuple)) and line else 1
-        violations.append({
-            "rule_id": RULE_ID,
-            "level": "error",
-            "message": rv.get("message", "argument validation failed"),
-            "file": task.get("file", ""),
-            "line": line_num,
-            "path": task_key,
-        })
+        violations.append(
+            {
+                "rule_id": RULE_ID,
+                "level": "error",
+                "message": rv.get("message", "argument validation failed"),
+                "file": task.get("file", ""),
+                "line": line_num,
+                "path": task_key,
+            }
+        )
 
     return violations

--- a/src/apme_engine/validators/ansible/rules/M001_M004_introspect.py
+++ b/src/apme_engine/validators/ansible/rules/M001_M004_introspect.py
@@ -122,57 +122,65 @@ def run(
 
         # M004: Tombstoned / removed module
         if info.get("removed"):
-            violations.append({
-                "rule_id": "M004",
-                "level": "error",
-                "message": info.get("removal_msg") or f"Module {module_name} has been removed",
-                "file": file_path,
-                "line": line_num,
-                "path": node.get("key", ""),
-            })
+            violations.append(
+                {
+                    "rule_id": "M004",
+                    "level": "error",
+                    "message": info.get("removal_msg") or f"Module {module_name} has been removed",
+                    "file": file_path,
+                    "line": line_num,
+                    "path": node.get("key", ""),
+                }
+            )
             continue
 
         # M001: FQCN resolution
         fqcn = info.get("fqcn", "")
         if fqcn and fqcn != module_name and module_name.count(".") < 2:
-            violations.append({
-                "rule_id": "M001",
-                "level": "warning",
-                "message": f"Use FQCN for module: {module_name} -> {fqcn}",
-                "file": file_path,
-                "line": line_num,
-                "path": node.get("key", ""),
-                "resolved_fqcn": fqcn,
-                "original_module": module_name,
-            })
+            violations.append(
+                {
+                    "rule_id": "M001",
+                    "level": "warning",
+                    "message": f"Use FQCN for module: {module_name} -> {fqcn}",
+                    "file": file_path,
+                    "line": line_num,
+                    "path": node.get("key", ""),
+                    "resolved_fqcn": fqcn,
+                    "original_module": module_name,
+                }
+            )
 
         # M002: Deprecation
         if info.get("deprecated") or info.get("warnings"):
             warnings = info.get("warnings", [])
             msg = warnings[0] if warnings else f"Module {module_name} is deprecated"
-            violations.append({
-                "rule_id": "M002",
-                "level": "warning",
-                "message": msg,
-                "file": file_path,
-                "line": line_num,
-                "path": node.get("key", ""),
-            })
+            violations.append(
+                {
+                    "rule_id": "M002",
+                    "level": "warning",
+                    "message": msg,
+                    "file": file_path,
+                    "line": line_num,
+                    "path": node.get("key", ""),
+                }
+            )
 
         # M003: Redirects
         redirects = info.get("redirects", [])
         if len(redirects) > 1:
             chain = " -> ".join(redirects)
-            violations.append({
-                "rule_id": "M003",
-                "level": "info",
-                "message": f"Module has been redirected: {chain}",
-                "file": file_path,
-                "line": line_num,
-                "path": node.get("key", ""),
-                "original_module": module_name,
-                "resolved_fqcn": redirects[-1],
-                "redirect_chain": redirects,
-            })
+            violations.append(
+                {
+                    "rule_id": "M003",
+                    "level": "info",
+                    "message": f"Module has been redirected: {chain}",
+                    "file": file_path,
+                    "line": line_num,
+                    "path": node.get("key", ""),
+                    "original_module": module_name,
+                    "resolved_fqcn": redirects[-1],
+                    "redirect_chain": redirects,
+                }
+            )
 
     return violations

--- a/src/apme_engine/validators/gitleaks/scanner.py
+++ b/src/apme_engine/validators/gitleaks/scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import re
 import subprocess
@@ -44,10 +45,14 @@ def run_gitleaks(scan_dir: str | Path, *, timeout: int = 120) -> list[dict]:
         GITLEAKS_BIN,
         "detect",
         "--no-git",
-        "--source", str(scan_dir),
-        "--report-format", "json",
-        "--report-path", report_path,
-        "--exit-code", "0",
+        "--source",
+        str(scan_dir),
+        "--report-format",
+        "json",
+        "--report-path",
+        report_path,
+        "--exit-code",
+        "0",
     ]
 
     try:
@@ -75,10 +80,8 @@ def run_gitleaks(scan_dir: str | Path, *, timeout: int = 120) -> list[dict]:
         sys.stderr.flush()
         return []
     finally:
-        try:
+        with contextlib.suppress(OSError):
             Path(report_path).unlink()
-        except OSError:
-            pass
 
     return _convert_findings(findings, scan_dir)
 
@@ -109,13 +112,15 @@ def _convert_findings(findings: list[dict], scan_dir: Path) -> list[dict]:
         end_line = f.get("EndLine", line)
         gitleaks_rule = f.get("RuleID", "unknown")
 
-        violations.append({
-            "rule_id": _build_rule_id(gitleaks_rule),
-            "level": "error",
-            "message": f.get("Description", f"Secret detected: {gitleaks_rule}"),
-            "file": rel,
-            "line": line if line == end_line else [line, end_line],
-            "path": "",
-        })
+        violations.append(
+            {
+                "rule_id": _build_rule_id(gitleaks_rule),
+                "level": "error",
+                "message": f.get("Description", f"Secret detected: {gitleaks_rule}"),
+                "file": rel,
+                "line": line if line == end_line else [line, end_line],
+                "path": "",
+            }
+        )
 
     return violations

--- a/src/apme_engine/validators/native/__init__.py
+++ b/src/apme_engine/validators/native/__init__.py
@@ -3,13 +3,12 @@
 import os
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Tuple
+from typing import Any
 
 from apme_engine.engine.risk_detector import detect
-from apme_engine.validators.base import ScanContext, Validator
+from apme_engine.validators.base import ScanContext
 
-
-RULES_REQUIRING_ANSIBLE: Tuple[str, ...] = ("P001", "P002", "P003", "P004")
+RULES_REQUIRING_ANSIBLE: tuple[str, ...] = ("P001", "P002", "P003", "P004")
 
 
 @dataclass
@@ -55,10 +54,7 @@ def _extract_results(data_report: dict) -> NativeRunResult:
                 severity = getattr(rule_meta, "severity", "") or "medium"
                 description = getattr(rule_meta, "description", "") or ""
                 detail = getattr(r, "detail", None)
-                if isinstance(detail, dict) and detail.get("message"):
-                    message = detail["message"]
-                else:
-                    message = description
+                message = detail["message"] if isinstance(detail, dict) and detail.get("message") else description
                 file_info = getattr(r, "file", None)
                 if isinstance(file_info, (list, tuple)) and len(file_info) >= 1:
                     file_path = str(file_info[0]) if file_info[0] else ""
@@ -70,14 +66,16 @@ def _extract_results(data_report: dict) -> NativeRunResult:
                 path = ""
                 if node and hasattr(node, "spec") and hasattr(node.spec, "key"):
                     path = getattr(node.spec, "key", "") or ""
-                violations.append({
-                    "rule_id": f"native:{rule_id}" if rule_id else "native:unknown",
-                    "level": severity,
-                    "message": message,
-                    "file": file_path,
-                    "line": line,
-                    "path": path,
-                })
+                violations.append(
+                    {
+                        "rule_id": f"native:{rule_id}" if rule_id else "native:unknown",
+                        "level": severity,
+                        "message": message,
+                        "file": file_path,
+                        "line": line,
+                        "path": path,
+                    }
+                )
 
     rule_timings = [
         NativeRuleTiming(rule_id=rid, elapsed_ms=v["elapsed_ms"], violations=v["violations"])
@@ -89,9 +87,11 @@ def _extract_results(data_report: dict) -> NativeRunResult:
 class NativeValidator:
     """Validator that runs in-tree native (Python) rules on context.scandata (no second parse)."""
 
-    def __init__(self, rules_dir: str = "", exclude_rule_ids: Tuple[str, ...] = None):
+    def __init__(self, rules_dir: str = "", exclude_rule_ids: tuple[str, ...] = None):
         self._rules_dir = rules_dir or _default_rules_dir()
-        self._exclude_rule_ids = list(exclude_rule_ids) if exclude_rule_ids is not None else list(RULES_REQUIRING_ANSIBLE)
+        self._exclude_rule_ids = (
+            list(exclude_rule_ids) if exclude_rule_ids is not None else list(RULES_REQUIRING_ANSIBLE)
+        )
 
     def run(self, context: ScanContext) -> list[dict]:
         """Run native rules on context.scandata; return list of violation dicts."""

--- a/src/apme_engine/validators/native/rules/L026_non_fqcn_use.py
+++ b/src/apme_engine/validators/native/rules/L026_non_fqcn_use.py
@@ -1,12 +1,17 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    ExecutableType as ActionType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    ExecutableType as ActionType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L026_non_fqcn_use_test.py
+++ b/src/apme_engine/validators/native/rules/L026_non_fqcn_use_test.py
@@ -1,14 +1,13 @@
 # Colocated tests for L026 (NonFQCNUseRule). Uses Python-object context from _test_helpers.
 
-import pytest
 
+from apme_engine.engine.models import ExecutableType
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L026_non_fqcn_use import NonFQCNUseRule
-from apme_engine.engine.models import ExecutableType
 
 
 def test_L026_fires_when_short_module_not_builtin():
@@ -43,7 +42,8 @@ def test_L026_does_not_fire_when_fqcn_builtin():
 
 
 def test_L026_does_not_fire_for_non_task():
-    from apme_engine.validators.native.rules._test_helpers import make_role_spec, make_role_call
+    from apme_engine.validators.native.rules._test_helpers import make_role_call, make_role_spec
+
     role_spec = make_role_spec(name="foo")
     role = make_role_call(role_spec)
     ctx = make_context(role)

--- a/src/apme_engine/validators/native/rules/L027_role_without_metadata.py
+++ b/src/apme_engine/validators/native/rules/L027_role_without_metadata.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L027_role_without_metadata_test.py
+++ b/src/apme_engine/validators/native/rules/L027_role_without_metadata_test.py
@@ -1,11 +1,10 @@
 # Colocated tests for L027 (RoleWithoutMetadataRule). Uses Python-object context from _test_helpers.
 
-import pytest
 
 from apme_engine.validators.native.rules._test_helpers import (
-    make_role_spec,
-    make_role_call,
     make_context,
+    make_role_call,
+    make_role_spec,
 )
 from apme_engine.validators.native.rules.L027_role_without_metadata import RoleWithoutMetadataRule
 
@@ -42,7 +41,8 @@ def test_L027_does_not_fire_when_role_has_metadata():
 
 
 def test_L027_does_not_fire_for_task():
-    from apme_engine.validators.native.rules._test_helpers import make_task_spec, make_task_call
+    from apme_engine.validators.native.rules._test_helpers import make_task_call, make_task_spec
+
     spec = make_task_spec(module="copy")
     task = make_task_call(spec)
     ctx = make_context(task)

--- a/src/apme_engine/validators/native/rules/L028_task_without_name.py
+++ b/src/apme_engine/validators/native/rules/L028_task_without_name.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L028_task_without_name_test.py
+++ b/src/apme_engine/validators/native/rules/L028_task_without_name_test.py
@@ -1,11 +1,10 @@
 # Colocated tests for L028 (TaskWithoutNameRule). Uses Python-object context from _test_helpers.
 
-import pytest
 
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L028_task_without_name import TaskWithoutNameRule
 
@@ -33,7 +32,8 @@ def test_L028_does_not_fire_when_task_has_name():
 
 
 def test_L028_does_not_fire_for_role():
-    from apme_engine.validators.native.rules._test_helpers import make_role_spec, make_role_call
+    from apme_engine.validators.native.rules._test_helpers import make_role_call, make_role_spec
+
     spec = make_role_spec(name="foo")
     role = make_role_call(spec)
     ctx = make_context(role)

--- a/src/apme_engine/validators/native/rules/L029_command_instead_of_shell.py
+++ b/src/apme_engine/validators/native/rules/L029_command_instead_of_shell.py
@@ -2,12 +2,16 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    ExecutableType as ActionType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    ExecutableType as ActionType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L029_command_instead_of_shell_test.py
+++ b/src/apme_engine/validators/native/rules/L029_command_instead_of_shell_test.py
@@ -1,14 +1,13 @@
 # Colocated tests for L029 (UseShellRule). Uses Python-object context from _test_helpers.
 
-import pytest
 
+from apme_engine.engine.models import ExecutableType
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L029_command_instead_of_shell import UseShellRule
-from apme_engine.engine.models import ExecutableType
 
 
 def test_L029_fires_when_resolved_is_shell():

--- a/src/apme_engine/validators/native/rules/L030_non_builtin_use.py
+++ b/src/apme_engine/validators/native/rules/L030_non_builtin_use.py
@@ -1,12 +1,17 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    ExecutableType as ActionType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    ExecutableType as ActionType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 
@@ -26,7 +31,11 @@ class NonBuiltinUseRule(Rule):
     def process(self, ctx: AnsibleRunContext):
         task = ctx.current
 
-        verdict = task.action_type == ActionType.MODULE_TYPE and task.resolved_action and not task.resolved_action.startswith("ansible.builtin.")
+        verdict = (
+            task.action_type == ActionType.MODULE_TYPE
+            and task.resolved_action
+            and not task.resolved_action.startswith("ansible.builtin.")
+        )
 
         detail = {
             "fqcn": task.resolved_name,

--- a/src/apme_engine/validators/native/rules/L030_non_builtin_use_test.py
+++ b/src/apme_engine/validators/native/rules/L030_non_builtin_use_test.py
@@ -1,14 +1,13 @@
 # Colocated tests for L030 (NonBuiltinUseRule). Uses Python-object context from _test_helpers.
 
-import pytest
 
+from apme_engine.engine.models import ExecutableType
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L030_non_builtin_use import NonBuiltinUseRule
-from apme_engine.engine.models import ExecutableType
 
 
 def test_L030_fires_when_module_not_builtin():

--- a/src/apme_engine/validators/native/rules/L031_insecure_file_permission.py
+++ b/src/apme_engine/validators/native/rules/L031_insecure_file_permission.py
@@ -1,14 +1,18 @@
 from dataclasses import dataclass
 
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
     AnnotationCondition,
+    AnsibleRunContext,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L031_insecure_file_permission_test.py
+++ b/src/apme_engine/validators/native/rules/L031_insecure_file_permission_test.py
@@ -1,6 +1,6 @@
 # Colocated tests for R116 (FilePermissionRule). Rule uses annotations; test no fire without annotation.
 
-from apme_engine.validators.native.rules._test_helpers import make_task_spec, make_task_call, make_context
+from apme_engine.validators.native.rules._test_helpers import make_context, make_task_call, make_task_spec
 from apme_engine.validators.native.rules.L031_insecure_file_permission import FilePermissionRule
 
 

--- a/src/apme_engine/validators/native/rules/L032_changed_data_dependence.py
+++ b/src/apme_engine/validators/native/rules/L032_changed_data_dependence.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L032_changed_data_dependence_test.py
+++ b/src/apme_engine/validators/native/rules/L032_changed_data_dependence_test.py
@@ -2,9 +2,9 @@
 
 from apme_engine.engine.models import Variable
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L032_changed_data_dependence import ChangedDataDependenceRule
 

--- a/src/apme_engine/validators/native/rules/L033_unconditional_override.py
+++ b/src/apme_engine/validators/native/rules/L033_unconditional_override.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 
@@ -28,18 +30,17 @@ class UnconditionalOverrideRule(Rule):
 
         verdict = False
         detail = {"variables": []}
-        if not task.spec.tags and not task.spec.when:
-            if task.spec.defined_vars:
-                for v in task.spec.defined_vars:
-                    all_definitions = task.variable_set.get(v, [])
-                    if len(all_definitions) > 1:
-                        detail["variables"].append(
-                            {
-                                "name": v,
-                                "defined_by": [d.setter for d in all_definitions],
-                                "type": [d.type for d in all_definitions],
-                            }
-                        )
-                        verdict = True
+        if not task.spec.tags and not task.spec.when and task.spec.defined_vars:
+            for v in task.spec.defined_vars:
+                all_definitions = task.variable_set.get(v, [])
+                if len(all_definitions) > 1:
+                    detail["variables"].append(
+                        {
+                            "name": v,
+                            "defined_by": [d.setter for d in all_definitions],
+                            "type": [d.type for d in all_definitions],
+                        }
+                    )
+                    verdict = True
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L033_unconditional_override_test.py
+++ b/src/apme_engine/validators/native/rules/L033_unconditional_override_test.py
@@ -1,9 +1,9 @@
 # Colocated tests for L033 (UnconditionalOverrideRule / R202).
 
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L033_unconditional_override import UnconditionalOverrideRule
 

--- a/src/apme_engine/validators/native/rules/L034_unused_override.py
+++ b/src/apme_engine/validators/native/rules/L034_unused_override.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L034_unused_override_test.py
+++ b/src/apme_engine/validators/native/rules/L034_unused_override_test.py
@@ -1,10 +1,10 @@
 # Colocated tests for L034 (UnusedOverrideRule / R203).
 
-from apme_engine.engine.models import VariableType, Variable
+from apme_engine.engine.models import Variable, VariableType
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L034_unused_override import UnusedOverrideRule
 

--- a/src/apme_engine/validators/native/rules/L035_unnecessary_set_fact.py
+++ b/src/apme_engine/validators/native/rules/L035_unnecessary_set_fact.py
@@ -2,12 +2,16 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    ExecutableType as ActionType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    ExecutableType as ActionType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 
@@ -43,7 +47,10 @@ class UnnecessarySetFactRule(Rule):
                     detail["impure_args"] = current.append(v)
 
         verdict = (
-            task.action_type == ActionType.MODULE_TYPE and task.resolved_action and task.resolved_action == "ansible.builtin.set_fact" and is_impure
+            task.action_type == ActionType.MODULE_TYPE
+            and task.resolved_action
+            and task.resolved_action == "ansible.builtin.set_fact"
+            and is_impure
         )
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L035_unnecessary_set_fact_test.py
+++ b/src/apme_engine/validators/native/rules/L035_unnecessary_set_fact_test.py
@@ -1,12 +1,12 @@
 # Colocated tests for L035 (UnnecessarySetFactRule / R204).
 
+from apme_engine.engine.models import ExecutableType
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L035_unnecessary_set_fact import UnnecessarySetFactRule
-from apme_engine.engine.models import ExecutableType
 
 
 def test_L035_fires_when_set_fact_with_random_in_args():

--- a/src/apme_engine/validators/native/rules/L036_unnecessary_include_vars.py
+++ b/src/apme_engine/validators/native/rules/L036_unnecessary_include_vars.py
@@ -2,12 +2,16 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    ExecutableType as ActionType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    ExecutableType as ActionType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L036_unnecessary_include_vars_test.py
+++ b/src/apme_engine/validators/native/rules/L036_unnecessary_include_vars_test.py
@@ -1,12 +1,12 @@
 # Colocated tests for L036 (UnnecessaryIncludeVarsRule).
 
+from apme_engine.engine.models import ExecutableType
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L036_unnecessary_include_vars import UnnecessaryIncludeVarsRule
-from apme_engine.engine.models import ExecutableType
 
 
 def test_L036_fires_when_include_vars_no_tags_no_when():

--- a/src/apme_engine/validators/native/rules/L037_unresolved_module.py
+++ b/src/apme_engine/validators/native/rules/L037_unresolved_module.py
@@ -1,12 +1,17 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    ExecutableType as ActionType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    ExecutableType as ActionType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L037_unresolved_module_test.py
+++ b/src/apme_engine/validators/native/rules/L037_unresolved_module_test.py
@@ -1,12 +1,12 @@
 # Colocated tests for L037 (UnresolvedModuleRule).
 
+from apme_engine.engine.models import ExecutableType
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L037_unresolved_module import UnresolvedModuleRule
-from apme_engine.engine.models import ExecutableType
 
 
 def test_L037_fires_when_module_unresolved():

--- a/src/apme_engine/validators/native/rules/L038_unresolved_role.py
+++ b/src/apme_engine/validators/native/rules/L038_unresolved_role.py
@@ -1,12 +1,17 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    ExecutableType as ActionType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    ExecutableType as ActionType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L038_unresolved_role_test.py
+++ b/src/apme_engine/validators/native/rules/L038_unresolved_role_test.py
@@ -1,12 +1,12 @@
 # Colocated tests for L038 (UnresolvedRoleRule).
 
+from apme_engine.engine.models import ExecutableType
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L038_unresolved_role import UnresolvedRoleRule
-from apme_engine.engine.models import ExecutableType
 
 
 def test_L038_fires_when_role_unresolved():

--- a/src/apme_engine/validators/native/rules/L039_undefined_variable.py
+++ b/src/apme_engine/validators/native/rules/L039_undefined_variable.py
@@ -2,12 +2,14 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    VariableType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+    VariableType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L039_undefined_variable_test.py
+++ b/src/apme_engine/validators/native/rules/L039_undefined_variable_test.py
@@ -1,10 +1,10 @@
 # Colocated tests for L039 (UndefinedVariableRule / R306).
 
-from apme_engine.engine.models import VariableType, Variable
+from apme_engine.engine.models import Variable, VariableType
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L039_undefined_variable import UndefinedVariableRule
 

--- a/src/apme_engine/validators/native/rules/L040_no_tabs.py
+++ b/src/apme_engine/validators/native/rules/L040_no_tabs.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L040_no_tabs_test.py
+++ b/src/apme_engine/validators/native/rules/L040_no_tabs_test.py
@@ -1,11 +1,10 @@
 # Colocated tests for L040 (NoTabsRule). Uses Python-object context from _test_helpers.
 
-import pytest
 
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L040_no_tabs import NoTabsRule
 
@@ -35,7 +34,8 @@ def test_L040_does_not_fire_when_no_tabs():
 
 
 def test_L040_does_not_fire_for_role():
-    from apme_engine.validators.native.rules._test_helpers import make_role_spec, make_role_call
+    from apme_engine.validators.native.rules._test_helpers import make_role_call, make_role_spec
+
     role = make_role_call(make_role_spec(name="foo"))
     ctx = make_context(role)
     rule = NoTabsRule()

--- a/src/apme_engine/validators/native/rules/L041_key_order.py
+++ b/src/apme_engine/validators/native/rules/L041_key_order.py
@@ -1,13 +1,15 @@
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 # Canonical order: name first, then block keys, then module/action, then task options (tags, when, etc.), then args.

--- a/src/apme_engine/validators/native/rules/L041_key_order_test.py
+++ b/src/apme_engine/validators/native/rules/L041_key_order_test.py
@@ -1,11 +1,10 @@
 # Colocated tests for L041 (KeyOrderRule). Uses Python-object context from _test_helpers.
 
-import pytest
 
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.L041_key_order import KeyOrderRule
 
@@ -37,7 +36,8 @@ def test_L041_does_not_fire_when_name_before_action():
 
 
 def test_L041_does_not_fire_for_role():
-    from apme_engine.validators.native.rules._test_helpers import make_role_spec, make_role_call
+    from apme_engine.validators.native.rules._test_helpers import make_role_call, make_role_spec
+
     role = make_role_call(make_role_spec(name="foo"))
     ctx = make_context(role)
     rule = KeyOrderRule()

--- a/src/apme_engine/validators/native/rules/L042_complexity.py
+++ b/src/apme_engine/validators/native/rules/L042_complexity.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 # Default threshold: play/block with more than this many tasks may be considered complex

--- a/src/apme_engine/validators/native/rules/L043_deprecated_bare_vars.py
+++ b/src/apme_engine/validators/native/rules/L043_deprecated_bare_vars.py
@@ -1,13 +1,15 @@
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 # Bare variable: {{ var }} or {{var}} with no filter (no |)

--- a/src/apme_engine/validators/native/rules/L044_avoid_implicit.py
+++ b/src/apme_engine/validators/native/rules/L044_avoid_implicit.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 # Modules that commonly require explicit "state" to avoid implicit default behavior

--- a/src/apme_engine/validators/native/rules/L045_inline_env_var.py
+++ b/src/apme_engine/validators/native/rules/L045_inline_env_var.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L046_no_free_form.py
+++ b/src/apme_engine/validators/native/rules/L046_no_free_form.py
@@ -2,12 +2,16 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    ExecutableType as ActionType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    ExecutableType as ActionType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 FREE_FORM_ACTIONS = frozenset(

--- a/src/apme_engine/validators/native/rules/L047_no_log_password.py
+++ b/src/apme_engine/validators/native/rules/L047_no_log_password.py
@@ -2,25 +2,22 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
-PASSWORD_LIKE_KEYS = frozenset(
-    {"password", "passwd", "pwd", "secret", "token", "api_key", "apikey", "private_key"}
-)
+PASSWORD_LIKE_KEYS = frozenset({"password", "passwd", "pwd", "secret", "token", "api_key", "apikey", "private_key"})
 
 
 def _option_keys_look_like_password(module_options):
     if not isinstance(module_options, dict):
         return False
-    for k in module_options:
-        if k and k.lower() in PASSWORD_LIKE_KEYS:
-            return True
-    return False
+    return any(k and k.lower() in PASSWORD_LIKE_KEYS for k in module_options)
 
 
 @dataclass
@@ -41,9 +38,7 @@ class NoLogPasswordRule(Rule):
         options = getattr(task.spec, "options", None) or {}
         module_options = getattr(task.spec, "module_options", None) or {}
         has_no_log = options.get("no_log") is True
-        has_password_like = _option_keys_look_like_password(module_options) or _option_keys_look_like_password(
-            options
-        )
+        has_password_like = _option_keys_look_like_password(module_options) or _option_keys_look_like_password(options)
         verdict = has_password_like and not has_no_log
         detail = {}
         if verdict:

--- a/src/apme_engine/validators/native/rules/L048_no_same_owner.py
+++ b/src/apme_engine/validators/native/rules/L048_no_same_owner.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 COPY_MODULES = frozenset(

--- a/src/apme_engine/validators/native/rules/L049_loop_var_prefix.py
+++ b/src/apme_engine/validators/native/rules/L049_loop_var_prefix.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 DEFAULT_LOOP_VAR = "item"

--- a/src/apme_engine/validators/native/rules/L050_var_naming.py
+++ b/src/apme_engine/validators/native/rules/L050_var_naming.py
@@ -1,13 +1,15 @@
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 VAR_NAMING_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")

--- a/src/apme_engine/validators/native/rules/L051_jinja.py
+++ b/src/apme_engine/validators/native/rules/L051_jinja.py
@@ -1,13 +1,15 @@
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 # Jinja should have spaces inside {{ }}: {{ foo }} not {{foo}}

--- a/src/apme_engine/validators/native/rules/L052_galaxy_version_incorrect.py
+++ b/src/apme_engine/validators/native/rules/L052_galaxy_version_incorrect.py
@@ -1,15 +1,17 @@
-# -*- mode:python; coding:utf-8 -*-
 # L052: Galaxy version in meta should follow semantic version format
 
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 GALAXY_VERSION_PATTERN = re.compile(r"^\d+\.\d+(\.\d+)?$")

--- a/src/apme_engine/validators/native/rules/L053_meta_incorrect.py
+++ b/src/apme_engine/validators/native/rules/L053_meta_incorrect.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 
@@ -27,11 +29,26 @@ class MetaIncorrectRule(Rule):
         role = ctx.current
         metadata = getattr(role.spec, "metadata", None) or {}
         if not isinstance(metadata, dict):
-            return RuleResult(verdict=True, detail={"message": "metadata must be a dict"}, file=role.file_info(), rule=self.get_metadata())
+            return RuleResult(
+                verdict=True,
+                detail={"message": "metadata must be a dict"},
+                file=role.file_info(),
+                rule=self.get_metadata(),
+            )
         galaxy_info = metadata.get("galaxy_info")
         if galaxy_info is not None and not isinstance(galaxy_info, dict):
-            return RuleResult(verdict=True, detail={"message": "galaxy_info must be a dict"}, file=role.file_info(), rule=self.get_metadata())
+            return RuleResult(
+                verdict=True,
+                detail={"message": "galaxy_info must be a dict"},
+                file=role.file_info(),
+                rule=self.get_metadata(),
+            )
         deps = metadata.get("dependencies")
         if deps is not None and not isinstance(deps, list):
-            return RuleResult(verdict=True, detail={"message": "dependencies must be a list"}, file=role.file_info(), rule=self.get_metadata())
+            return RuleResult(
+                verdict=True,
+                detail={"message": "dependencies must be a list"},
+                file=role.file_info(),
+                rule=self.get_metadata(),
+            )
         return RuleResult(verdict=False, file=role.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L054_meta_no_tags.py
+++ b/src/apme_engine/validators/native/rules/L054_meta_no_tags.py
@@ -1,14 +1,16 @@
-# -*- mode:python; coding:utf-8 -*-
 # L054: Role meta galaxy_info should include galaxy_tags
 
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/L055_meta_video_links.py
+++ b/src/apme_engine/validators/native/rules/L055_meta_video_links.py
@@ -1,13 +1,15 @@
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 URL_PATTERN = re.compile(r"^https?://\S+$")
@@ -34,7 +36,12 @@ class MetaVideoLinksRule(Rule):
         if not video_links:
             return RuleResult(verdict=False, file=role.file_info(), rule=self.get_metadata())
         if not isinstance(video_links, list):
-            return RuleResult(verdict=True, detail={"message": "video_links must be a list"}, file=role.file_info(), rule=self.get_metadata())
+            return RuleResult(
+                verdict=True,
+                detail={"message": "video_links must be a list"},
+                file=role.file_info(),
+                rule=self.get_metadata(),
+            )
         invalid = [u for u in video_links if not (isinstance(u, str) and URL_PATTERN.match(u.strip()))]
         verdict = len(invalid) > 0
         detail = {}

--- a/src/apme_engine/validators/native/rules/L056_sanity.py
+++ b/src/apme_engine/validators/native/rules/L056_sanity.py
@@ -1,13 +1,15 @@
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 # Paths that are commonly ignored by ansible-lint / sanity (e.g. .git, files in certain dirs)

--- a/src/apme_engine/validators/native/rules/M005_data_tagging.py
+++ b/src/apme_engine/validators/native/rules/M005_data_tagging.py
@@ -10,11 +10,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 _JINJA_VAR_REF = re.compile(r"\{\{\s*(\w+)")
@@ -66,6 +68,8 @@ class DataTaggingRule(Rule):
         verdict = len(flagged) > 0
         detail = {}
         if flagged:
-            detail["message"] = f"Registered variable(s) {', '.join(set(flagged))} used in Jinja template; may be untrusted in 2.19+"
+            detail["message"] = (
+                f"Registered variable(s) {', '.join(set(flagged))} used in Jinja template; may be untrusted in 2.19+"
+            )
             detail["registered_vars"] = list(set(flagged))
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/M010_python2_interpreter.py
+++ b/src/apme_engine/validators/native/rules/M010_python2_interpreter.py
@@ -5,11 +5,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 _PY2_PATH = re.compile(r"python2(\.\d+)?$")

--- a/src/apme_engine/validators/native/rules/P001_module_name_validation.py
+++ b/src/apme_engine/validators/native/rules/P001_module_name_validation.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    Rule,
-    Severity,
-    RuleTag as Tag,
     ExecutableType,
+    Rule,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 
@@ -37,7 +39,6 @@ class ModuleNameValidationRule(Rule):
 
         # normal task
         if task.spec.executable_type == ExecutableType.MODULE_TYPE:
-
             resolved_fqcn = task.spec.resolved_name
             suggested_fqcns = [cand[0] for cand in task.spec.possible_candidates]
             suggested_dependency = [cand[1] for cand in task.spec.possible_candidates]
@@ -60,17 +61,10 @@ class ModuleNameValidationRule(Rule):
                 need_correction = True
 
         # include_role, import_role
-        elif task.spec.executable_type == ExecutableType.ROLE_TYPE:
-            if "ansible.builtin." in task.spec.module:
-                resolved_fqcn = task.spec.module
-                correct_fqcn = resolved_fqcn
-            else:
-                resolved_fqcn = "ansible.builtin." + task.spec.module
-                correct_fqcn = resolved_fqcn
-                need_correction = True
-
-        # include_tasks, import_tasks
-        elif task.spec.executable_type == ExecutableType.TASKFILE_TYPE:
+        elif (
+            task.spec.executable_type == ExecutableType.ROLE_TYPE
+            or task.spec.executable_type == ExecutableType.TASKFILE_TYPE
+        ):
             if "ansible.builtin." in task.spec.module:
                 resolved_fqcn = task.spec.module
                 correct_fqcn = resolved_fqcn

--- a/src/apme_engine/validators/native/rules/P002_module_argument_key_validation.py
+++ b/src/apme_engine/validators/native/rules/P002_module_argument_key_validation.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass
 
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    Rule,
-    Severity,
-    RuleTag as Tag,
-    ExecutableType,
     ActionGroupMetadata,
+    AnsibleRunContext,
+    ExecutableType,
+    Rule,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 
@@ -37,7 +39,6 @@ class ModuleArgumentKeyValidationRule(Rule):
         task = ctx.current
 
         if task.spec.executable_type == ExecutableType.MODULE_TYPE and task.module and task.module.arguments:
-
             mo = task.spec.module_options
             module_fqcn = task.get_annotation(key="module.correct_fqcn")
             module_short = ""
@@ -67,11 +68,12 @@ class ModuleArgumentKeyValidationRule(Rule):
                         if not isinstance(group_dict, dict):
                             continue
                         group = ActionGroupMetadata.from_dict(group_dict)
-                        if module_short and module_short in group.group_modules:
-                            found = True
-                            default_args = tmp_args
-                            break
-                        elif module_fqcn and module_fqcn in group.group_modules:
+                        if (
+                            module_short
+                            and module_short in group.group_modules
+                            or module_fqcn
+                            and module_fqcn in group.group_modules
+                        ):
                             found = True
                             default_args = tmp_args
                             break

--- a/src/apme_engine/validators/native/rules/P003_module_argument_value_validation.py
+++ b/src/apme_engine/validators/native/rules/P003_module_argument_value_validation.py
@@ -2,13 +2,15 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    Rule,
-    Severity,
-    RuleTag as Tag,
     ArgumentsType,
     ExecutableType,
+    Rule,
+    RunTargetType,
+    Severity,
     VariableType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 
@@ -50,7 +52,6 @@ class ModuleArgumentValueValidationRule(Rule):
         task = ctx.current
 
         if task.spec.executable_type == ExecutableType.MODULE_TYPE and task.module and task.module.arguments:
-
             wrong_values = []
             undefined_values = []
             unknown_type_values = []
@@ -146,7 +147,9 @@ class ModuleArgumentValueValidationRule(Rule):
                                 undefined_vars.append(v.name)
 
                         if undefined_vars:
-                            undefined_values.append({"key": key, "value": raw_value, "undefined_variables": undefined_vars})
+                            undefined_values.append(
+                                {"key": key, "value": raw_value, "undefined_variables": undefined_vars}
+                            )
 
             task.set_annotation("module.wrong_arg_values", wrong_values, rule_id=self.rule_id)
             task.set_annotation("module.undefined_values", undefined_values, rule_id=self.rule_id)

--- a/src/apme_engine/validators/native/rules/P004_variable_validation.py
+++ b/src/apme_engine/validators/native/rules/P004_variable_validation.py
@@ -2,12 +2,14 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    Rule,
-    Severity,
-    RuleTag as Tag,
-    VariableType,
     ArgumentsType,
+    Rule,
+    RunTargetType,
+    Severity,
+    VariableType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R101_command_exec.py
+++ b/src/apme_engine/validators/native/rules/R101_command_exec.py
@@ -1,13 +1,16 @@
 from dataclasses import dataclass
+
+from apme_engine.engine.models import (
+    AnnotationCondition,
+    AnsibleRunContext,
+    Rule,
+    RuleResult,
+    RunTargetType,
+    Severity,
+)
 from apme_engine.engine.models import DefaultRiskType as RiskType
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    AnnotationCondition,
-    Rule,
-    Severity,
     RuleTag as Tag,
-    RuleResult,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R101_command_exec_test.py
+++ b/src/apme_engine/validators/native/rules/R101_command_exec_test.py
@@ -1,6 +1,6 @@
 # Colocated tests for R101 (CommandExecRule). Rule uses annotations; test no fire without annotation.
 
-from apme_engine.validators.native.rules._test_helpers import make_task_spec, make_task_call, make_context
+from apme_engine.validators.native.rules._test_helpers import make_context, make_task_call, make_task_spec
 from apme_engine.validators.native.rules.R101_command_exec import CommandExecRule
 
 
@@ -15,7 +15,8 @@ def test_R101_does_not_fire_when_no_annotation():
 
 
 def test_R101_match_only_tasks():
-    from apme_engine.validators.native.rules._test_helpers import make_role_spec, make_role_call
+    from apme_engine.validators.native.rules._test_helpers import make_role_call, make_role_spec
+
     role = make_role_call(make_role_spec(name="foo"))
     ctx = make_context(role)
     rule = CommandExecRule()

--- a/src/apme_engine/validators/native/rules/R103_download_exec.py
+++ b/src/apme_engine/validators/native/rules/R103_download_exec.py
@@ -1,13 +1,18 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
     AnnotationCondition,
+    AnsibleRunContext,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R103_download_exec_test.py
+++ b/src/apme_engine/validators/native/rules/R103_download_exec_test.py
@@ -1,6 +1,6 @@
 # Colocated tests for R103 (DownloadExecRule). Rule uses annotations and ctx.before(); test no fire without annotation.
 
-from apme_engine.validators.native.rules._test_helpers import make_task_spec, make_task_call, make_context
+from apme_engine.validators.native.rules._test_helpers import make_context, make_task_call, make_task_spec
 from apme_engine.validators.native.rules.R103_download_exec import DownloadExecRule
 
 

--- a/src/apme_engine/validators/native/rules/R104_unauthorized_download_src.py
+++ b/src/apme_engine/validators/native/rules/R104_unauthorized_download_src.py
@@ -1,16 +1,20 @@
 import re
 from dataclasses import dataclass
-from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
-    AnnotationCondition,
-    Rule,
-    Severity,
-    RuleTag as Tag,
-    RuleResult,
-)
 
+from apme_engine.engine.models import (
+    AnnotationCondition,
+    AnsibleRunContext,
+    Rule,
+    RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
+)
 
 allow_url_list = ["https://*"]
 
@@ -39,10 +43,9 @@ class InvalidDownloadSourceRule(Rule):
         detail = {}
 
         anno = task.get_annotation_by_condition(ac)
-        if anno:
-            if not self.is_allowed_url(anno.src.value, allow_url_list, deny_url_list):
-                verdict = True
-                detail["invalid_src"] = anno.src.value
+        if anno and not self.is_allowed_url(anno.src.value, allow_url_list, deny_url_list):
+            verdict = True
+            detail["invalid_src"] = anno.src.value
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())
 

--- a/src/apme_engine/validators/native/rules/R105_outbound_transfer.py
+++ b/src/apme_engine/validators/native/rules/R105_outbound_transfer.py
@@ -1,13 +1,18 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
     AnnotationCondition,
+    AnsibleRunContext,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R106_inbound_transfer.py
+++ b/src/apme_engine/validators/native/rules/R106_inbound_transfer.py
@@ -1,13 +1,18 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
     AnnotationCondition,
+    AnsibleRunContext,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R106_inbound_transfer_test.py
+++ b/src/apme_engine/validators/native/rules/R106_inbound_transfer_test.py
@@ -1,6 +1,6 @@
 # Colocated tests for R106 (InboundTransferRule). Rule uses annotations; test no fire without annotation.
 
-from apme_engine.validators.native.rules._test_helpers import make_task_spec, make_task_call, make_context
+from apme_engine.validators.native.rules._test_helpers import make_context, make_task_call, make_task_spec
 from apme_engine.validators.native.rules.R106_inbound_transfer import InboundTransferRule
 
 

--- a/src/apme_engine/validators/native/rules/R107_pkg_install_with_insecure_option.py
+++ b/src/apme_engine/validators/native/rules/R107_pkg_install_with_insecure_option.py
@@ -1,13 +1,18 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
     AnnotationCondition,
+    AnsibleRunContext,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R108_privilege_escalation.py
+++ b/src/apme_engine/validators/native/rules/R108_privilege_escalation.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R108_privilege_escalation_test.py
+++ b/src/apme_engine/validators/native/rules/R108_privilege_escalation_test.py
@@ -1,6 +1,6 @@
 # Colocated tests for R108 (PrivilegeEscalationRule). Rule uses annotations; test no fire without annotation.
 
-from apme_engine.validators.native.rules._test_helpers import make_task_spec, make_task_call, make_context
+from apme_engine.validators.native.rules._test_helpers import make_context, make_task_call, make_task_spec
 from apme_engine.validators.native.rules.R108_privilege_escalation import PrivilegeEscalationRule
 
 

--- a/src/apme_engine/validators/native/rules/R109_key_config_change.py
+++ b/src/apme_engine/validators/native/rules/R109_key_config_change.py
@@ -1,13 +1,18 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
     AnnotationCondition,
+    AnsibleRunContext,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R109_key_config_change_test.py
+++ b/src/apme_engine/validators/native/rules/R109_key_config_change_test.py
@@ -1,6 +1,6 @@
 # Colocated tests for R109 (KeyConfigChangeRule). Rule uses annotations; test no fire without annotation.
 
-from apme_engine.validators.native.rules._test_helpers import make_task_spec, make_task_call, make_context
+from apme_engine.validators.native.rules._test_helpers import make_context, make_task_call, make_task_spec
 from apme_engine.validators.native.rules.R109_key_config_change import KeyConfigChangeRule
 
 

--- a/src/apme_engine/validators/native/rules/R111_parameterized_import_role.py
+++ b/src/apme_engine/validators/native/rules/R111_parameterized_import_role.py
@@ -1,12 +1,17 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    ExecutableType as ActionType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    ExecutableType as ActionType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R112_parameterized_import_taskfile.py
+++ b/src/apme_engine/validators/native/rules/R112_parameterized_import_taskfile.py
@@ -1,12 +1,17 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
-    ExecutableType as ActionType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    ExecutableType as ActionType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R113_parameterized_pkg_install.py
+++ b/src/apme_engine/validators/native/rules/R113_parameterized_pkg_install.py
@@ -1,13 +1,18 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
     AnnotationCondition,
+    AnsibleRunContext,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R113_parameterized_pkg_install_test.py
+++ b/src/apme_engine/validators/native/rules/R113_parameterized_pkg_install_test.py
@@ -1,6 +1,6 @@
 # Colocated tests for R113 (PkgInstallRule). Rule uses annotations; test no fire without annotation.
 
-from apme_engine.validators.native.rules._test_helpers import make_task_spec, make_task_call, make_context
+from apme_engine.validators.native.rules._test_helpers import make_context, make_task_call, make_task_spec
 from apme_engine.validators.native.rules.R113_parameterized_pkg_install import PkgInstallRule
 
 

--- a/src/apme_engine/validators/native/rules/R114_file_change.py
+++ b/src/apme_engine/validators/native/rules/R114_file_change.py
@@ -1,13 +1,18 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
     AnnotationCondition,
+    AnsibleRunContext,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R114_file_change_test.py
+++ b/src/apme_engine/validators/native/rules/R114_file_change_test.py
@@ -1,6 +1,6 @@
 # Colocated tests for R114 (FileChangeRule). Rule uses annotations; test no fire without annotation.
 
-from apme_engine.validators.native.rules._test_helpers import make_task_spec, make_task_call, make_context
+from apme_engine.validators.native.rules._test_helpers import make_context, make_task_call, make_task_spec
 from apme_engine.validators.native.rules.R114_file_change import FileChangeRule
 
 

--- a/src/apme_engine/validators/native/rules/R115_file_deletion.py
+++ b/src/apme_engine/validators/native/rules/R115_file_deletion.py
@@ -1,14 +1,18 @@
 from dataclasses import dataclass
 
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
     AnnotationCondition,
+    AnsibleRunContext,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R115_file_deletion_test.py
+++ b/src/apme_engine/validators/native/rules/R115_file_deletion_test.py
@@ -1,6 +1,6 @@
 # Colocated tests for R115 (FileDeletionRule). Rule uses annotations; test no fire without annotation.
 
-from apme_engine.validators.native.rules._test_helpers import make_task_spec, make_task_call, make_context
+from apme_engine.validators.native.rules._test_helpers import make_context, make_task_call, make_task_spec
 from apme_engine.validators.native.rules.R115_file_deletion import FileDeletionRule
 
 

--- a/src/apme_engine/validators/native/rules/R117_external_role.py
+++ b/src/apme_engine/validators/native/rules/R117_external_role.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 
@@ -32,7 +35,10 @@ class ExternalRoleRule(Rule):
         role = ctx.current
 
         verdict = (
-            not ctx.is_begin(role) and role.spec.metadata and isinstance(role.spec.metadata, dict) and role.spec.metadata.get("galaxy_info", None)
+            not ctx.is_begin(role)
+            and role.spec.metadata
+            and isinstance(role.spec.metadata, dict)
+            and role.spec.metadata.get("galaxy_info", None)
         )
 
         return RuleResult(verdict=verdict, file=role.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/R117_external_role_test.py
+++ b/src/apme_engine/validators/native/rules/R117_external_role_test.py
@@ -1,11 +1,10 @@
 # Colocated tests for R117 (ExternalRoleRule).
 
-import pytest
 
 from apme_engine.validators.native.rules._test_helpers import (
-    make_role_spec,
-    make_role_call,
     make_context,
+    make_role_call,
+    make_role_spec,
 )
 from apme_engine.validators.native.rules.R117_external_role import ExternalRoleRule
 

--- a/src/apme_engine/validators/native/rules/R401_list_all_inbound_src.py
+++ b/src/apme_engine/validators/native/rules/R401_list_all_inbound_src.py
@@ -1,14 +1,18 @@
 from dataclasses import dataclass
 
 from apme_engine.engine.models import (
-    AnsibleRunContext,
-    RunTargetType,
-    DefaultRiskType as RiskType,
     AnnotationCondition,
+    AnsibleRunContext,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    DefaultRiskType as RiskType,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R401_list_all_inbound_src_test.py
+++ b/src/apme_engine/validators/native/rules/R401_list_all_inbound_src_test.py
@@ -1,9 +1,9 @@
 # Colocated tests for R401 (ListAllInboundSrcRule).
 
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.R401_list_all_inbound_src import ListAllInboundSrcRule
 

--- a/src/apme_engine/validators/native/rules/R402_list_all_used_variables.py
+++ b/src/apme_engine/validators/native/rules/R402_list_all_used_variables.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 
@@ -29,7 +31,6 @@ class ListAllUsedVariablesRule(Rule):
         verdict = False
         detail = {}
         if ctx.is_end(task):
-
             verdict = True
             detail["metadata"] = ctx.info
             detail["variables"] = list(task.variable_use.keys())

--- a/src/apme_engine/validators/native/rules/R402_list_all_used_variables_test.py
+++ b/src/apme_engine/validators/native/rules/R402_list_all_used_variables_test.py
@@ -1,9 +1,9 @@
 # Colocated tests for R402 (ListAllUsedVariablesRule).
 
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.R402_list_all_used_variables import ListAllUsedVariablesRule
 

--- a/src/apme_engine/validators/native/rules/R404_show_variables.py
+++ b/src/apme_engine/validators/native/rules/R404_show_variables.py
@@ -2,12 +2,14 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    VariableDict,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+    VariableDict,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R404_show_variables_test.py
+++ b/src/apme_engine/validators/native/rules/R404_show_variables_test.py
@@ -1,9 +1,9 @@
 # Colocated tests for R404 (ShowVariablesRule).
 
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.R404_show_variables import ShowVariablesRule
 

--- a/src/apme_engine/validators/native/rules/R501_dependency_suggestion.py
+++ b/src/apme_engine/validators/native/rules/R501_dependency_suggestion.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
-    RuleTag as Tag,
     RuleResult,
+    RunTargetType,
+    Severity,
+)
+from apme_engine.engine.models import (
+    RuleTag as Tag,
 )
 
 

--- a/src/apme_engine/validators/native/rules/R501_dependency_suggestion_test.py
+++ b/src/apme_engine/validators/native/rules/R501_dependency_suggestion_test.py
@@ -1,9 +1,9 @@
 # Colocated tests for R501 (DependencySuggestionRule).
 
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.R501_dependency_suggestion import DependencySuggestionRule
 

--- a/src/apme_engine/validators/native/rules/_test_helpers.py
+++ b/src/apme_engine/validators/native/rules/_test_helpers.py
@@ -1,13 +1,12 @@
 # Test helpers for colocated native rule tests. Build minimal Python context/task objects.
 
 from apme_engine.engine.models import (
-    Task,
-    TaskCall,
+    AnsibleRunContext,
+    ExecutableType,
     Role,
     RoleCall,
-    AnsibleRunContext,
-    RunTargetType,
-    ExecutableType,
+    Task,
+    TaskCall,
 )
 
 

--- a/src/apme_engine/validators/native/rules/sample_rule.py
+++ b/src/apme_engine/validators/native/rules/sample_rule.py
@@ -2,10 +2,10 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
-    RunTargetType,
     Rule,
-    Severity,
     RuleResult,
+    RunTargetType,
+    Severity,
 )
 
 

--- a/src/apme_engine/validators/native/rules/sample_rule_test.py
+++ b/src/apme_engine/validators/native/rules/sample_rule_test.py
@@ -2,9 +2,9 @@
 
 from apme_engine.engine.models import MutableContent
 from apme_engine.validators.native.rules._test_helpers import (
-    make_task_spec,
-    make_task_call,
     make_context,
+    make_task_call,
+    make_task_spec,
 )
 from apme_engine.validators.native.rules.sample_rule import SampleRule
 

--- a/src/apme_engine/validators/opa/__init__.py
+++ b/src/apme_engine/validators/opa/__init__.py
@@ -3,7 +3,7 @@
 import os
 
 from apme_engine.opa_client import run_opa
-from apme_engine.validators.base import ScanContext, Validator
+from apme_engine.validators.base import ScanContext
 
 
 def _default_bundle_path() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,14 @@ def opa_eval_result_with_violations():
                 "expressions": [
                     {
                         "value": [
-                            {"rule_id": "task-name", "level": "warning", "message": "Task using shell module should have a name", "file": "/examples/pb.yml", "line": 5, "path": "taskcall#y"},
+                            {
+                                "rule_id": "task-name",
+                                "level": "warning",
+                                "message": "Task using shell module should have a name",
+                                "file": "/examples/pb.yml",
+                                "line": 5,
+                                "path": "taskcall#y",
+                            },
                         ]
                     }
                 ]

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -84,15 +84,27 @@ def pod():
 def scan_result(pod) -> dict:
     """Run a scan of the test playbook via the CLI container and return parsed JSON."""
     test_dir = str(REPO_ROOT / "tests" / "integration")
-    r = _run([
-        "podman", "run", "--rm", "--pod", POD_NAME,
-        "-v", f"{test_dir}:/workspace:ro,Z",
-        "-w", "/workspace",
-        "-e", f"APME_PRIMARY_ADDRESS={PRIMARY_ADDR}",
-        "--entrypoint", "apme-scan",
-        CLI_IMAGE,
-        "scan", "--json", ".",
-    ])
+    r = _run(
+        [
+            "podman",
+            "run",
+            "--rm",
+            "--pod",
+            POD_NAME,
+            "-v",
+            f"{test_dir}:/workspace:ro,Z",
+            "-w",
+            "/workspace",
+            "-e",
+            f"APME_PRIMARY_ADDRESS={PRIMARY_ADDR}",
+            "--entrypoint",
+            "apme-scan",
+            CLI_IMAGE,
+            "scan",
+            "--json",
+            ".",
+        ]
+    )
     assert r.returncode == 0, f"Scan failed (rc={r.returncode}):\n{r.stdout}\n{r.stderr}"
     try:
         return json.loads(r.stdout)
@@ -112,13 +124,23 @@ def _violation_rule_ids(scan_result: dict) -> set[str]:
 @pytest.mark.integration
 class TestHealthCheck:
     def test_overall_ok(self, pod):
-        r = _run([
-            "podman", "run", "--rm", "--pod", POD_NAME,
-            "-e", f"APME_PRIMARY_ADDRESS={PRIMARY_ADDR}",
-            "--entrypoint", "apme-scan",
-            CLI_IMAGE,
-            "health-check", "--primary-addr", PRIMARY_ADDR,
-        ])
+        r = _run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "--pod",
+                POD_NAME,
+                "-e",
+                f"APME_PRIMARY_ADDRESS={PRIMARY_ADDR}",
+                "--entrypoint",
+                "apme-scan",
+                CLI_IMAGE,
+                "health-check",
+                "--primary-addr",
+                PRIMARY_ADDR,
+            ]
+        )
         combined = r.stdout + r.stderr
         assert "overall: ok" in combined, f"Health check did not report ok:\n{combined}"
 
@@ -135,22 +157,28 @@ class TestScanViolations:
         assert count > 0, f"Expected >0 violations, got {count}"
 
     # OPA rules
-    @pytest.mark.parametrize("rule_id,desc", [
-        ("L007", "shell when command suffices"),
-        ("L010", "ignore_errors without register"),
-        ("L021", "missing explicit mode on file/copy"),
-        ("L025", "name not starting uppercase"),
-        ("R118", "inbound transfer (annotation-based)"),
-    ])
+    @pytest.mark.parametrize(
+        "rule_id,desc",
+        [
+            ("L007", "shell when command suffices"),
+            ("L010", "ignore_errors without register"),
+            ("L021", "missing explicit mode on file/copy"),
+            ("L025", "name not starting uppercase"),
+            ("R118", "inbound transfer (annotation-based)"),
+        ],
+    )
     def test_opa_rule(self, scan_result, rule_id, desc):
         assert rule_id in _violation_rule_ids(scan_result), f"{rule_id} ({desc}) not found"
 
     # Native rules
-    @pytest.mark.parametrize("rule_id,desc", [
-        ("native:L028", "task without name"),
-        ("native:L029", "command instead of shell"),
-        ("native:L046", "free-form args"),
-    ])
+    @pytest.mark.parametrize(
+        "rule_id,desc",
+        [
+            ("native:L028", "task without name"),
+            ("native:L029", "command instead of shell"),
+            ("native:L046", "free-form args"),
+        ],
+    )
     def test_native_rule(self, scan_result, rule_id, desc):
         assert rule_id in _violation_rule_ids(scan_result), f"{rule_id} ({desc}) not found"
 
@@ -159,10 +187,13 @@ class TestScanViolations:
         assert "M001" in _violation_rule_ids(scan_result), "M001 (FQCN resolution) not found"
 
     # Ansible validator rules
-    @pytest.mark.parametrize("rule_id,desc", [
-        ("L058", "argspec validation - docstring"),
-        ("L059", "argspec validation - mock/patch"),
-    ])
+    @pytest.mark.parametrize(
+        "rule_id,desc",
+        [
+            ("L058", "argspec validation - docstring"),
+            ("L059", "argspec validation - mock/patch"),
+        ],
+    )
     def test_ansible_rule(self, scan_result, rule_id, desc):
         assert rule_id in _violation_rule_ids(scan_result), f"{rule_id} ({desc}) not found"
 
@@ -230,16 +261,27 @@ SECRETS_FIXTURE = REPO_ROOT / "tests" / "integration" / "test_secrets_playbook.y
 @pytest.mark.integration
 class TestGitleaks:
     def test_gitleaks_container_healthy(self, pod):
-        r = _run([
-            "podman", "run", "--rm", "--pod", POD_NAME,
-            "-e", f"APME_PRIMARY_ADDRESS={PRIMARY_ADDR}",
-            "--entrypoint", "apme-scan",
-            CLI_IMAGE,
-            "health-check", "--primary-addr", PRIMARY_ADDR,
-        ])
+        r = _run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "--pod",
+                POD_NAME,
+                "-e",
+                f"APME_PRIMARY_ADDRESS={PRIMARY_ADDR}",
+                "--entrypoint",
+                "apme-scan",
+                CLI_IMAGE,
+                "health-check",
+                "--primary-addr",
+                PRIMARY_ADDR,
+            ]
+        )
         combined = r.stdout + r.stderr
-        assert "gitleaks" in combined.lower() or "overall: ok" in combined, \
+        assert "gitleaks" in combined.lower() or "overall: ok" in combined, (
             f"Gitleaks not reported in health check:\n{combined}"
+        )
 
     def test_gitleaks_logged(self, scan_result):
         logs = _container_logs("gitleaks")
@@ -262,53 +304,96 @@ class TestFormat:
     def test_format_check_detects_issues(self, pod):
         """format --check on messy fixture exits 1."""
         test_dir = str(FORMAT_FIXTURE.parent)
-        r = _run([
-            "podman", "run", "--rm", "--pod", POD_NAME,
-            "-v", f"{test_dir}:/workspace:ro,Z",
-            "-w", "/workspace",
-            "--entrypoint", "apme-scan",
-            CLI_IMAGE,
-            "format", "--check", "test_format_playbook.yml",
-        ])
+        r = _run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "--pod",
+                POD_NAME,
+                "-v",
+                f"{test_dir}:/workspace:ro,Z",
+                "-w",
+                "/workspace",
+                "--entrypoint",
+                "apme-scan",
+                CLI_IMAGE,
+                "format",
+                "--check",
+                "test_format_playbook.yml",
+            ]
+        )
         assert r.returncode == 1, f"Expected exit 1 for messy file:\n{r.stdout}\n{r.stderr}"
 
     def test_format_diff_shows_transforms(self, pod):
         """format (no --apply) shows unified diff with expected transforms."""
         test_dir = str(FORMAT_FIXTURE.parent)
-        r = _run([
-            "podman", "run", "--rm", "--pod", POD_NAME,
-            "-v", f"{test_dir}:/workspace:ro,Z",
-            "-w", "/workspace",
-            "--entrypoint", "apme-scan",
-            CLI_IMAGE,
-            "format", "test_format_playbook.yml",
-        ])
+        r = _run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "--pod",
+                POD_NAME,
+                "-v",
+                f"{test_dir}:/workspace:ro,Z",
+                "-w",
+                "/workspace",
+                "--entrypoint",
+                "apme-scan",
+                CLI_IMAGE,
+                "format",
+                "test_format_playbook.yml",
+            ]
+        )
         assert r.returncode == 0
-        assert "@@" in r.stdout or "---" in r.stdout, \
-            f"Expected unified diff output:\n{r.stdout[:500]}"
+        assert "@@" in r.stdout or "---" in r.stdout, f"Expected unified diff output:\n{r.stdout[:500]}"
 
     def test_format_apply_then_check_passes(self, pod, tmp_path):
         """format --apply writes file; subsequent --check exits 0."""
         import shutil
+
         work = tmp_path / "fmt_test"
         work.mkdir()
         shutil.copy2(FORMAT_FIXTURE, work / "play.yml")
-        r = _run([
-            "podman", "run", "--rm", "--pod", POD_NAME,
-            "-v", f"{work}:/workspace:Z",
-            "-w", "/workspace",
-            "--entrypoint", "apme-scan",
-            CLI_IMAGE,
-            "format", "--apply", "play.yml",
-        ])
+        r = _run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "--pod",
+                POD_NAME,
+                "-v",
+                f"{work}:/workspace:Z",
+                "-w",
+                "/workspace",
+                "--entrypoint",
+                "apme-scan",
+                CLI_IMAGE,
+                "format",
+                "--apply",
+                "play.yml",
+            ]
+        )
         assert r.returncode == 0, f"format --apply failed:\n{r.stderr}"
 
-        r2 = _run([
-            "podman", "run", "--rm", "--pod", POD_NAME,
-            "-v", f"{work}:/workspace:ro,Z",
-            "-w", "/workspace",
-            "--entrypoint", "apme-scan",
-            CLI_IMAGE,
-            "format", "--check", "play.yml",
-        ])
+        r2 = _run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "--pod",
+                POD_NAME,
+                "-v",
+                f"{work}:/workspace:ro,Z",
+                "-w",
+                "/workspace",
+                "--entrypoint",
+                "apme-scan",
+                CLI_IMAGE,
+                "format",
+                "--check",
+                "play.yml",
+            ]
+        )
         assert r2.returncode == 0, f"format --check failed after --apply:\n{r2.stderr}"

--- a/tests/rule_doc_integration_test.py
+++ b/tests/rule_doc_integration_test.py
@@ -7,8 +7,7 @@ import pytest
 from apme_engine.runner import run_scan_playbook_yaml
 from apme_engine.validators.native import NativeValidator
 from apme_engine.validators.opa import OpaValidator
-
-from tests.rule_doc_parser import discover_rule_docs, parse_rule_doc
+from tests.rule_doc_parser import discover_rule_docs
 
 
 def _repo_root():
@@ -25,16 +24,14 @@ def _opa_bundle_dir():
 
 def _violation_ids_for_rule(violations: list[dict], rule_id: str, validator: str) -> list[str]:
     """Return violation rule_id values that match this doc rule (for assertion)."""
-    if validator == "native":
-        expected = f"native:{rule_id}"
-    else:
-        expected = rule_id
+    expected = f"native:{rule_id}" if validator == "native" else rule_id
     return [v["rule_id"] for v in violations if v.get("rule_id") == expected]
 
 
 def _ensure_playbook(yaml_content: str) -> str:
     """If content is a single task or task list without a play, wrap in a play."""
     import yaml
+
     try:
         data = yaml.safe_load(yaml_content)
     except Exception:
@@ -47,7 +44,8 @@ def _ensure_playbook(yaml_content: str) -> str:
             return yaml_content
         return (
             "- name: Example play\n  hosts: localhost\n  connection: local\n  tasks:\n"
-            + "    - " + yaml.dump(data, default_flow_style=False).strip().replace("\n", "\n    ")
+            + "    - "
+            + yaml.dump(data, default_flow_style=False).strip().replace("\n", "\n    ")
         )
     # List: could be list of plays or list of tasks
     if isinstance(data, list) and data:
@@ -56,9 +54,8 @@ def _ensure_playbook(yaml_content: str) -> str:
             return yaml_content
         # List of tasks
         tasks_yaml = yaml.dump(data, default_flow_style=False)
-        return (
-            "- name: Example play\n  hosts: localhost\n  connection: local\n  tasks:\n"
-            + "\n".join("    " + line for line in tasks_yaml.splitlines())
+        return "- name: Example play\n  hosts: localhost\n  connection: local\n  tasks:\n" + "\n".join(
+            "    " + line for line in tasks_yaml.splitlines()
         )
     return yaml_content
 
@@ -124,10 +121,7 @@ def test_rule_doc_examples(md_path, doc, validators):
                 f"got: {[v['rule_id'] for v in violations]}"
             )
         else:
-            assert not matching, (
-                f"{md_path} example {i + 1} (pass): expected no {rule_id}, "
-                f"got: {matching}"
-            )
+            assert not matching, f"{md_path} example {i + 1} (pass): expected no {rule_id}, got: {matching}"
 
 
 def test_rule_doc_parser_smoke():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,9 @@
 """Tests for apme_engine.cli."""
 
-import contextlib
 import json
-import sys
 from io import StringIO
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -28,24 +26,28 @@ class TestMain:
     def test_main_scan_failure_exits_1(self):
         """When run_scan raises, main writes to stderr and exits 1."""
         stderr_io = StringIO()
-        with patch.object(cli_module, "run_scan", side_effect=FileNotFoundError("path not found")):
-            with patch("sys.stderr", stderr_io):
-                with patch("sys.argv", ["apme-scan", "scan", "."]):
-                    with pytest.raises(SystemExit) as exc_info:
-                        cli_module.main()
-                    assert exc_info.value.code == 1
+        with (
+            patch.object(cli_module, "run_scan", side_effect=FileNotFoundError("path not found")),
+            patch("sys.stderr", stderr_io),
+            patch("sys.argv", ["apme-scan", "scan", "."]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_module.main()
+        assert exc_info.value.code == 1
         assert "path not found" in stderr_io.getvalue() or "Scan failed" in stderr_io.getvalue()
 
     def test_main_empty_payload_exits_0_with_json(self):
         """When hierarchy_payload is empty and --json, print JSON and exit 0."""
         stdout_io = StringIO()
-        with patch.object(cli_module, "run_scan", return_value=_make_context({})):
-            with patch("sys.stderr", StringIO()):
-                with patch("sys.stdout", stdout_io):
-                    with patch("sys.argv", ["apme-scan", "scan", "--json", "."]):
-                        with pytest.raises(SystemExit) as exc_info:
-                            cli_module.main()
-                        assert exc_info.value.code == 0
+        with (
+            patch.object(cli_module, "run_scan", return_value=_make_context({})),
+            patch("sys.stderr", StringIO()),
+            patch("sys.stdout", stdout_io),
+            patch("sys.argv", ["apme-scan", "scan", "--json", "."]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_module.main()
+        assert exc_info.value.code == 0
         out = stdout_io.getvalue()
         data = json.loads(out)
         assert data["violations"] == []
@@ -54,21 +56,25 @@ class TestMain:
     def test_main_empty_payload_exits_0_without_json(self):
         """When hierarchy_payload is empty and no --json, exit 0 after stderr message."""
         stderr_io = StringIO()
-        with patch.object(cli_module, "run_scan", return_value=_make_context({})):
-            with patch("sys.stderr", stderr_io):
-                with patch("sys.argv", ["apme-scan", "scan", "."]):
-                    with pytest.raises(SystemExit) as exc_info:
-                        cli_module.main()
-                    assert exc_info.value.code == 0
+        with (
+            patch.object(cli_module, "run_scan", return_value=_make_context({})),
+            patch("sys.stderr", stderr_io),
+            patch("sys.argv", ["apme-scan", "scan", "."]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_module.main()
+        assert exc_info.value.code == 0
         assert "No hierarchy payload" in stderr_io.getvalue()
 
     def test_main_no_validators_json_outputs_hierarchy_only(self, sample_hierarchy_payload):
         """With --no-opa --no-native and --json, output is hierarchy_payload only."""
         stdout_io = StringIO()
-        with patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)):
-            with patch("sys.argv", ["apme-scan", "scan", "--no-opa", "--no-native", "--json", "."]):
-                with patch("sys.stdout", stdout_io):
-                    cli_module.main()
+        with (
+            patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)),
+            patch("sys.argv", ["apme-scan", "scan", "--no-opa", "--no-native", "--json", "."]),
+            patch("sys.stdout", stdout_io),
+        ):
+            cli_module.main()
         out = stdout_io.getvalue()
         data = json.loads(out)
         assert "hierarchy_payload" in data
@@ -78,21 +84,27 @@ class TestMain:
     def test_main_no_validators_no_json_prints_message(self, sample_hierarchy_payload):
         """With --no-opa --no-native and no --json, print message about validators skipped."""
         stdout_io = StringIO()
-        with patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)):
-            with patch("sys.argv", ["apme-scan", "scan", "--no-opa", "--no-native", "."]):
-                with patch("sys.stdout", stdout_io):
-                    cli_module.main()
+        with (
+            patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)),
+            patch("sys.argv", ["apme-scan", "scan", "--no-opa", "--no-native", "."]),
+            patch("sys.stdout", stdout_io),
+        ):
+            cli_module.main()
         assert "validators skipped" in stdout_io.getvalue().lower() or "hierarchy" in stdout_io.getvalue().lower()
 
-    def test_main_with_opa_json_outputs_violations_and_count(self, sample_hierarchy_payload, opa_eval_result_with_violations):
+    def test_main_with_opa_json_outputs_violations_and_count(
+        self, sample_hierarchy_payload, opa_eval_result_with_violations
+    ):
         """With OPA and --json, output includes violations and count."""
         stdout_io = StringIO()
         violations = opa_eval_result_with_violations["result"][0]["expressions"][0]["value"]
-        with patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)):
-            with patch("apme_engine.validators.opa.run_opa", return_value=violations):
-                with patch("sys.argv", ["apme-scan", "scan", "--no-native", "--json", "."]):
-                    with patch("sys.stdout", stdout_io):
-                        cli_module.main()
+        with (
+            patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)),
+            patch("apme_engine.validators.opa.run_opa", return_value=violations),
+            patch("sys.argv", ["apme-scan", "scan", "--no-native", "--json", "."]),
+            patch("sys.stdout", stdout_io),
+        ):
+            cli_module.main()
         out = stdout_io.getvalue()
         data = json.loads(out)
         assert "violations" in data
@@ -103,11 +115,13 @@ class TestMain:
         """With OPA and no --json, print Scan line and violation lines."""
         stdout_io = StringIO()
         violations = [{"rule_id": "r1", "level": "warning", "message": "msg", "file": "f.yml", "line": 1, "path": "p"}]
-        with patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)):
-            with patch("apme_engine.validators.opa.run_opa", return_value=violations):
-                with patch("sys.argv", ["apme-scan", "scan", "--no-native", "."]):
-                    with patch("sys.stdout", stdout_io):
-                        cli_module.main()
+        with (
+            patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)),
+            patch("apme_engine.validators.opa.run_opa", return_value=violations),
+            patch("sys.argv", ["apme-scan", "scan", "--no-native", "."]),
+            patch("sys.stdout", stdout_io),
+        ):
+            cli_module.main()
         out = stdout_io.getvalue()
         assert "Violations: 1" in out or "Violations:" in out
         assert "r1" in out
@@ -117,21 +131,25 @@ class TestMain:
     def test_main_with_opa_no_violations_prints_no_violations(self, sample_hierarchy_payload):
         """With OPA and no violations, print 'No violations.'"""
         stdout_io = StringIO()
-        with patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)):
-            with patch("apme_engine.validators.opa.run_opa", return_value=[]):
-                with patch("sys.argv", ["apme-scan", "scan", "--no-native", "."]):
-                    with patch("sys.stdout", stdout_io):
-                        cli_module.main()
+        with (
+            patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)),
+            patch("apme_engine.validators.opa.run_opa", return_value=[]),
+            patch("sys.argv", ["apme-scan", "scan", "--no-native", "."]),
+            patch("sys.stdout", stdout_io),
+        ):
+            cli_module.main()
         assert "No violations" in stdout_io.getvalue()
 
     def test_main_uses_custom_opa_bundle_when_provided(self, sample_hierarchy_payload, tmp_path):
         """When --opa-bundle is passed, OpaValidator receives that path."""
         bundle = tmp_path / "custom_bundle"
         bundle.mkdir()
-        with patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)):
-            with patch("apme_engine.validators.opa.run_opa", return_value=[]) as mock_opa:
-                with patch("sys.argv", ["apme-scan", "scan", "--no-native", "--opa-bundle", str(bundle), "."]):
-                    cli_module.main()
+        with (
+            patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)),
+            patch("apme_engine.validators.opa.run_opa", return_value=[]) as mock_opa,
+            patch("sys.argv", ["apme-scan", "scan", "--no-native", "--opa-bundle", str(bundle), "."]),
+        ):
+            cli_module.main()
         mock_opa.assert_called_once()
         assert mock_opa.call_args[0][1] == str(bundle)
 
@@ -141,19 +159,25 @@ class TestRunScan:
 
     def test_run_scan_nonexistent_path_raises(self, repo_root):
         """run_scan raises FileNotFoundError when target does not exist."""
-        with patch.object(cli_module, "run_scan", side_effect=FileNotFoundError("Target path does not exist: /nonexistent")):
-            with pytest.raises(SystemExit):
-                with patch("sys.argv", ["apme-scan", "scan", "/nonexistent/path/xyz"]):
-                    cli_module.main()
+        with (
+            patch.object(
+                cli_module, "run_scan", side_effect=FileNotFoundError("Target path does not exist: /nonexistent")
+            ),
+            pytest.raises(SystemExit),
+            patch("sys.argv", ["apme-scan", "scan", "/nonexistent/path/xyz"]),
+        ):
+            cli_module.main()
 
     def test_run_scan_playbook_file_called_with_correct_args(self, repo_root, tmp_path, sample_hierarchy_payload):
         """When target is a file, run_scan is called with playbook path and repo_root (from CLI's __file__)."""
         playbook = tmp_path / "play.yml"
         playbook.write_text("---\n- hosts: localhost\n  tasks: []\n")
-        with patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)) as mock_run_scan:
-            with patch("apme_engine.validators.opa.run_opa", return_value=[]):
-                with patch("sys.argv", ["apme-scan", "scan", "--no-native", str(playbook)]):
-                    cli_module.main()
+        with (
+            patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)) as mock_run_scan,
+            patch("apme_engine.validators.opa.run_opa", return_value=[]),
+            patch("sys.argv", ["apme-scan", "scan", "--no-native", str(playbook)]),
+        ):
+            cli_module.main()
         mock_run_scan.assert_called_once()
         call_args = mock_run_scan.call_args
         assert call_args[0][0] == str(playbook)
@@ -165,6 +189,7 @@ class TestRunScan:
     def test_run_scan_returns_context_with_payload(self, repo_root, tmp_path, sample_hierarchy_payload):
         """run_scan returns ScanContext with hierarchy_payload."""
         from apme_engine.runner import run_scan
+
         playbook = tmp_path / "play.yml"
         playbook.write_text("---\n- hosts: localhost\n  tasks: []\n")
         with patch("apme_engine.runner.ARIScanner") as MockScanner:

--- a/tests/test_collection_cache_venv_builder.py
+++ b/tests/test_collection_cache_venv_builder.py
@@ -2,14 +2,14 @@
 
 import os
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from apme_engine.collection_cache.venv_builder import (
+    _resolve_collection_path,
     _venv_key,
     _venv_site_packages,
-    _resolve_collection_path,
     build_venv,
     get_venv_python,
 )
@@ -17,9 +17,7 @@ from apme_engine.collection_cache.venv_builder import (
 
 class TestVenvKey:
     def test_stable_for_same_inputs(self):
-        assert _venv_key("2.15.0", ["ansible.builtin.debug"]) == _venv_key(
-            "2.15.0", ["ansible.builtin.debug"]
-        )
+        assert _venv_key("2.15.0", ["ansible.builtin.debug"]) == _venv_key("2.15.0", ["ansible.builtin.debug"])
 
     def test_different_version_different_key(self):
         k1 = _venv_key("2.14.0", [])
@@ -97,14 +95,16 @@ class TestBuildVenv:
                 (venv_path / "pyvenv.cfg").write_text("[venv]")
             return MagicMock(returncode=0)
 
-        with patch("subprocess.run", side_effect=run_side_effect):
-            with pytest.raises(FileNotFoundError, match="Collection not in cache"):
-                build_venv(
-                    "2.15.0",
-                    ["ns.missing"],
-                    cache_root=tmp_path,
-                    venvs_root=base,
-                )
+        with (
+            patch("subprocess.run", side_effect=run_side_effect),
+            pytest.raises(FileNotFoundError, match="Collection not in cache"),
+        ):
+            build_venv(
+                "2.15.0",
+                ["ns.missing"],
+                cache_root=tmp_path,
+                venvs_root=base,
+            )
 
     @pytest.mark.integration
     def test_build_venv_empty_collections(self, tmp_path):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -13,10 +13,10 @@ from apme_engine.formatter import (
     format_file,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _fmt(text: str, filename: str = "test.yml") -> FormatResult:
     return format_content(textwrap.dedent(text), filename=filename)
@@ -25,6 +25,7 @@ def _fmt(text: str, filename: str = "test.yml") -> FormatResult:
 # ---------------------------------------------------------------------------
 # Tab removal (L040)
 # ---------------------------------------------------------------------------
+
 
 class TestTabRemoval:
     def test_tabs_replaced_with_spaces(self):
@@ -42,6 +43,7 @@ class TestTabRemoval:
 # Key reorder (L041)
 # ---------------------------------------------------------------------------
 
+
 class TestKeyReorder:
     def test_name_moved_before_module(self):
         text = textwrap.dedent("""\
@@ -51,8 +53,8 @@ class TestKeyReorder:
         """)
         result = format_content(text)
         lines = result.formatted.splitlines()
-        name_line = next(i for i, l in enumerate(lines) if "name:" in l)
-        debug_line = next(i for i, l in enumerate(lines) if "debug" in l)
+        name_line = next(i for i, line in enumerate(lines) if "name:" in line)
+        debug_line = next(i for i, line in enumerate(lines) if "debug" in line)
         assert name_line < debug_line, "name should come before module"
         assert result.changed
 
@@ -65,8 +67,8 @@ class TestKeyReorder:
         result = format_content(text)
         # May still change due to other formatting; key order should be stable
         lines = result.formatted.splitlines()
-        name_line = next(i for i, l in enumerate(lines) if "name:" in l)
-        debug_line = next(i for i, l in enumerate(lines) if "debug" in l)
+        name_line = next(i for i, line in enumerate(lines) if "name:" in line)
+        debug_line = next(i for i, line in enumerate(lines) if "debug" in line)
         assert name_line < debug_line
 
     def test_play_level_key_order(self):
@@ -81,7 +83,7 @@ class TestKeyReorder:
         result = format_content(text)
         assert "name:" in result.formatted
         lines = result.formatted.splitlines()
-        name_lines = [i for i, l in enumerate(lines) if "name:" in l]
+        name_lines = [i for i, line in enumerate(lines) if "name:" in line]
         assert len(name_lines) >= 1
 
 
@@ -89,25 +91,26 @@ class TestKeyReorder:
 # Jinja spacing (L051)
 # ---------------------------------------------------------------------------
 
+
 class TestJinjaSpacing:
     def test_no_space_gets_space(self):
-        text = "- name: Test\n  ansible.builtin.debug:\n    msg: \"{{foo}}\"\n"
+        text = '- name: Test\n  ansible.builtin.debug:\n    msg: "{{foo}}"\n'
         result = format_content(text)
         assert "{{ foo }}" in result.formatted
         assert result.changed
 
     def test_extra_spaces_normalized(self):
-        text = "- name: Test\n  ansible.builtin.debug:\n    msg: \"{{  foo  }}\"\n"
+        text = '- name: Test\n  ansible.builtin.debug:\n    msg: "{{  foo  }}"\n'
         result = format_content(text)
         assert "{{ foo }}" in result.formatted
 
     def test_already_correct_unchanged(self):
-        text = "- name: Test\n  ansible.builtin.debug:\n    msg: \"{{ foo }}\"\n"
+        text = '- name: Test\n  ansible.builtin.debug:\n    msg: "{{ foo }}"\n'
         result = format_content(text)
         assert "{{ foo }}" in result.formatted
 
     def test_complex_expression(self):
-        text = '- name: Test\n  ansible.builtin.debug:\n    msg: "{{item.name | default(\'none\')}}"\n'
+        text = "- name: Test\n  ansible.builtin.debug:\n    msg: \"{{item.name | default('none')}}\"\n"
         result = format_content(text)
         assert "{{ item.name | default('none') }}" in result.formatted
 
@@ -115,6 +118,7 @@ class TestJinjaSpacing:
 # ---------------------------------------------------------------------------
 # Indentation normalization
 # ---------------------------------------------------------------------------
+
 
 class TestIndentation:
     def test_mixed_indent_normalized(self):
@@ -131,6 +135,7 @@ class TestIndentation:
 # ---------------------------------------------------------------------------
 # Comment preservation
 # ---------------------------------------------------------------------------
+
 
 class TestComments:
     def test_inline_comment_preserved(self):
@@ -153,6 +158,7 @@ class TestComments:
 # Octal preservation
 # ---------------------------------------------------------------------------
 
+
 class TestOctal:
     def test_octal_mode_preserved(self):
         text = textwrap.dedent("""\
@@ -168,6 +174,7 @@ class TestOctal:
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
+
 
 class TestEdgeCases:
     def test_empty_file(self):
@@ -203,14 +210,18 @@ class TestEdgeCases:
 # Idempotency
 # ---------------------------------------------------------------------------
 
+
 class TestIdempotency:
-    @pytest.mark.parametrize("text,desc", [
-        ("- name: Test\n\tansible.builtin.debug:\n\t\tmsg: hello\n", "tabs"),
-        ("- ansible.builtin.debug:\n    msg: hello\n  name: Reorder\n", "key order"),
-        ('- name: T\n  ansible.builtin.debug:\n    msg: "{{foo}}"\n', "jinja spacing"),
-        ("- name: Test\n    ansible.builtin.debug:\n        msg: deep\n", "mixed indent"),
-        ("# comment\n- name: Test\n  ansible.builtin.debug:\n    msg: hi\n", "with comment"),
-    ])
+    @pytest.mark.parametrize(
+        "text,desc",
+        [
+            ("- name: Test\n\tansible.builtin.debug:\n\t\tmsg: hello\n", "tabs"),
+            ("- ansible.builtin.debug:\n    msg: hello\n  name: Reorder\n", "key order"),
+            ('- name: T\n  ansible.builtin.debug:\n    msg: "{{foo}}"\n', "jinja spacing"),
+            ("- name: Test\n    ansible.builtin.debug:\n        msg: deep\n", "mixed indent"),
+            ("# comment\n- name: Test\n  ansible.builtin.debug:\n    msg: hi\n", "with comment"),
+        ],
+    )
     def test_format_twice_no_diff(self, text, desc):
         first = format_content(text, filename=f"test_{desc}.yml")
         assert check_idempotent(first), f"Formatter is not idempotent for: {desc}"
@@ -250,6 +261,7 @@ class TestIdempotency:
 # format_file (filesystem)
 # ---------------------------------------------------------------------------
 
+
 class TestFormatFile:
     def test_format_file_reads_and_formats(self, tmp_path):
         p = tmp_path / "test.yml"
@@ -258,14 +270,15 @@ class TestFormatFile:
         assert result.path == p
         assert result.changed
         lines = result.formatted.splitlines()
-        name_line = next(i for i, l in enumerate(lines) if "name:" in l)
-        debug_line = next(i for i, l in enumerate(lines) if "debug" in l)
+        name_line = next(i for i, line in enumerate(lines) if "name:" in line)
+        debug_line = next(i for i, line in enumerate(lines) if "debug" in line)
         assert name_line < debug_line
 
 
 # ---------------------------------------------------------------------------
 # format_directory
 # ---------------------------------------------------------------------------
+
 
 class TestFormatDirectory:
     def test_discovers_yaml_files(self, tmp_path):
@@ -296,7 +309,7 @@ class TestFormatDirectory:
         (roles / "main.yml").write_text("- ansible.builtin.shell: echo\n  name: Deep task\n")
         group_vars = tmp_path / "inventory" / "group_vars"
         group_vars.mkdir(parents=True)
-        (group_vars / "all.yml").write_text("my_var: \"{{foo}}\"\n")
+        (group_vars / "all.yml").write_text('my_var: "{{foo}}"\n')
 
         results = format_directory(tmp_path)
         result_paths = {str(r.path.relative_to(tmp_path)) for r in results}
@@ -326,6 +339,7 @@ class TestFormatDirectory:
 # ---------------------------------------------------------------------------
 # FormatResult.diff content
 # ---------------------------------------------------------------------------
+
 
 class TestDiffOutput:
     def test_diff_contains_file_paths(self):

--- a/tests/test_formatter_cli.py
+++ b/tests/test_formatter_cli.py
@@ -29,6 +29,7 @@ def _cli(*args: str, cwd: str | None = None) -> subprocess.CompletedProcess:
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def messy_dir(tmp_path: Path) -> Path:
     """Copy the messy fixture into a temp directory so tests can mutate it."""
@@ -46,6 +47,7 @@ def messy_file(messy_dir: Path) -> Path:
 # ---------------------------------------------------------------------------
 # format subcommand
 # ---------------------------------------------------------------------------
+
 
 class TestFormatDiff:
     """format (no flags) — show diff on stdout, exit 0."""
@@ -141,9 +143,7 @@ class TestFormatDirectory:
     """format on a directory discovers all YAML files."""
 
     def test_formats_all_yaml_in_dir(self, messy_dir: Path):
-        (messy_dir / "extra.yml").write_text(
-            "- ansible.builtin.debug:\n    msg: hi\n  name: Reorder me\n"
-        )
+        (messy_dir / "extra.yml").write_text("- ansible.builtin.debug:\n    msg: hi\n  name: Reorder me\n")
         r = _cli("format", "--check", str(messy_dir))
         assert r.returncode == 1
         assert "2 file(s)" in r.stderr or "file(s) would be" in r.stderr
@@ -171,6 +171,7 @@ class TestFormatExclude:
 # ---------------------------------------------------------------------------
 # fix subcommand
 # ---------------------------------------------------------------------------
+
 
 class TestFixApply:
     """fix --apply — format → idempotency check → (modernize stub)."""

--- a/tests/test_gitleaks_scanner.py
+++ b/tests/test_gitleaks_scanner.py
@@ -3,18 +3,15 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
-from unittest.mock import patch, MagicMock, AsyncMock
-
-import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from apme_engine.validators.gitleaks.scanner import (
-    _is_vault_encrypted,
-    _value_is_jinja,
+    RULE_PREFIX,
     _build_rule_id,
     _convert_findings,
+    _is_vault_encrypted,
+    _value_is_jinja,
     run_gitleaks,
-    RULE_PREFIX,
 )
 
 
@@ -34,7 +31,7 @@ class TestJinjaFiltering:
         assert _value_is_jinja("{{ vault_password }}")
 
     def test_quoted_jinja(self):
-        assert _value_is_jinja("'{{ lookup(\"env\", \"SECRET\") }}'")
+        assert _value_is_jinja('\'{{ lookup("env", "SECRET") }}\'')
 
     def test_literal_value(self):
         assert not _value_is_jinja("hardcoded_secret_123")
@@ -57,14 +54,16 @@ class TestConvertFindings:
         secret_file = tmp_path / "vars.yml"
         secret_file.write_text("password: s3cret123\n")
 
-        findings = [{
-            "RuleID": "generic-api-key",
-            "Description": "Generic API Key",
-            "File": str(secret_file),
-            "StartLine": 1,
-            "EndLine": 1,
-            "Match": "password: s3cret123",
-        }]
+        findings = [
+            {
+                "RuleID": "generic-api-key",
+                "Description": "Generic API Key",
+                "File": str(secret_file),
+                "StartLine": 1,
+                "EndLine": 1,
+                "Match": "password: s3cret123",
+            }
+        ]
         violations = _convert_findings(findings, tmp_path)
         assert len(violations) == 1
         assert violations[0]["rule_id"] == f"{RULE_PREFIX}:generic-api-key"
@@ -76,14 +75,16 @@ class TestConvertFindings:
         jinja_file = tmp_path / "vars.yml"
         jinja_file.write_text("password: '{{ vault_pw }}'\n")
 
-        findings = [{
-            "RuleID": "generic-api-key",
-            "Description": "Generic API Key",
-            "File": str(jinja_file),
-            "StartLine": 1,
-            "EndLine": 1,
-            "Match": "{{ vault_pw }}",
-        }]
+        findings = [
+            {
+                "RuleID": "generic-api-key",
+                "Description": "Generic API Key",
+                "File": str(jinja_file),
+                "StartLine": 1,
+                "EndLine": 1,
+                "Match": "{{ vault_pw }}",
+            }
+        ]
         violations = _convert_findings(findings, tmp_path)
         assert len(violations) == 0
 
@@ -91,14 +92,16 @@ class TestConvertFindings:
         vault_file = tmp_path / "secrets.yml"
         vault_file.write_text("$ANSIBLE_VAULT;1.1;AES256\ndeadbeef\n")
 
-        findings = [{
-            "RuleID": "generic-api-key",
-            "Description": "API Key",
-            "File": str(vault_file),
-            "StartLine": 2,
-            "EndLine": 2,
-            "Match": "deadbeef",
-        }]
+        findings = [
+            {
+                "RuleID": "generic-api-key",
+                "Description": "API Key",
+                "File": str(vault_file),
+                "StartLine": 2,
+                "EndLine": 2,
+                "Match": "deadbeef",
+            }
+        ]
         violations = _convert_findings(findings, tmp_path)
         assert len(violations) == 0
 
@@ -106,14 +109,16 @@ class TestConvertFindings:
         f = tmp_path / "key.pem"
         f.write_text("-----BEGIN RSA PRIVATE KEY-----\ndata\n-----END RSA PRIVATE KEY-----\n")
 
-        findings = [{
-            "RuleID": "private-key",
-            "Description": "Private Key",
-            "File": str(f),
-            "StartLine": 1,
-            "EndLine": 3,
-            "Match": "-----BEGIN RSA PRIVATE KEY-----",
-        }]
+        findings = [
+            {
+                "RuleID": "private-key",
+                "Description": "Private Key",
+                "File": str(f),
+                "StartLine": 1,
+                "EndLine": 3,
+                "Match": "-----BEGIN RSA PRIVATE KEY-----",
+            }
+        ]
         violations = _convert_findings(findings, tmp_path)
         assert len(violations) == 1
         assert violations[0]["line"] == [1, 3]
@@ -135,8 +140,10 @@ class TestRunGitleaks:
         mock_proc.returncode = 0
         mock_proc.stderr = ""
 
-        with patch("apme_engine.validators.gitleaks.scanner.subprocess.run", return_value=mock_proc), \
-             patch("apme_engine.validators.gitleaks.scanner.tempfile.NamedTemporaryFile") as mock_tmp:
+        with (
+            patch("apme_engine.validators.gitleaks.scanner.subprocess.run", return_value=mock_proc),
+            patch("apme_engine.validators.gitleaks.scanner.tempfile.NamedTemporaryFile") as mock_tmp,
+        ):
             mock_tmp.return_value.__enter__ = lambda s: s
             mock_tmp.return_value.__exit__ = lambda s, *a: None
             mock_tmp.return_value.name = str(report)
@@ -149,14 +156,18 @@ class TestRunGitleaks:
         secret_file = tmp_path / "vars.yml"
         secret_file.write_text("api_key: AKIAIOSFODNN7EXAMPLE\n")
 
-        finding_data = json.dumps([{
-            "RuleID": "aws-access-key-id",
-            "Description": "AWS Access Key ID",
-            "File": str(secret_file),
-            "StartLine": 1,
-            "EndLine": 1,
-            "Match": "AKIAIOSFODNN7EXAMPLE",
-        }])
+        finding_data = json.dumps(
+            [
+                {
+                    "RuleID": "aws-access-key-id",
+                    "Description": "AWS Access Key ID",
+                    "File": str(secret_file),
+                    "StartLine": 1,
+                    "EndLine": 1,
+                    "Match": "AKIAIOSFODNN7EXAMPLE",
+                }
+            ]
+        )
 
         mock_proc = MagicMock()
         mock_proc.returncode = 0
@@ -164,8 +175,10 @@ class TestRunGitleaks:
 
         report_file = tmp_path / "report.json"
 
-        with patch("apme_engine.validators.gitleaks.scanner.subprocess.run", return_value=mock_proc), \
-             patch("apme_engine.validators.gitleaks.scanner.tempfile.NamedTemporaryFile") as mock_tmp:
+        with (
+            patch("apme_engine.validators.gitleaks.scanner.subprocess.run", return_value=mock_proc),
+            patch("apme_engine.validators.gitleaks.scanner.tempfile.NamedTemporaryFile") as mock_tmp,
+        ):
             mock_tmp.return_value.__enter__ = lambda s: s
             mock_tmp.return_value.__exit__ = lambda s, *a: None
             mock_tmp.return_value.name = str(report_file)
@@ -178,7 +191,10 @@ class TestRunGitleaks:
 
     def test_timeout_handled(self, tmp_path):
         import subprocess as sp
-        with patch("apme_engine.validators.gitleaks.scanner.subprocess.run", side_effect=sp.TimeoutExpired("gitleaks", 120)):
+
+        with patch(
+            "apme_engine.validators.gitleaks.scanner.subprocess.run", side_effect=sp.TimeoutExpired("gitleaks", 120)
+        ):
             result = run_gitleaks(tmp_path)
         assert result == []
 
@@ -187,8 +203,8 @@ class TestGitleaksServicer:
     """Test the async gRPC servicer layer."""
 
     async def test_validate_no_files(self):
-        from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
         from apme.v1 import validate_pb2
+        from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
 
         servicer = GitleaksValidatorServicer()
         request = validate_pb2.ValidateRequest(files=[], request_id="gl-1")
@@ -197,23 +213,24 @@ class TestGitleaksServicer:
         assert resp.request_id == "gl-1"
 
     async def test_validate_with_files(self):
+        from apme.v1 import common_pb2, validate_pb2
         from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
-        from apme.v1 import validate_pb2, common_pb2
 
         servicer = GitleaksValidatorServicer()
 
-        fake_violations = [{
-            "rule_id": "SEC:aws-access-key-id",
-            "level": "error",
-            "message": "AWS Key",
-            "file": "vars.yml",
-            "line": 1,
-            "path": "",
-        }]
+        fake_violations = [
+            {
+                "rule_id": "SEC:aws-access-key-id",
+                "level": "error",
+                "message": "AWS Key",
+                "file": "vars.yml",
+                "line": 1,
+                "path": "",
+            }
+        ]
 
         request = validate_pb2.ValidateRequest(
-            request_id="gl-2",
-            files=[common_pb2.File(path="vars.yml", content=b"api_key: AKIAIOSFODNN7EXAMPLE\n")]
+            request_id="gl-2", files=[common_pb2.File(path="vars.yml", content=b"api_key: AKIAIOSFODNN7EXAMPLE\n")]
         )
 
         with patch("apme_engine.daemon.gitleaks_validator_server.run_gitleaks", return_value=fake_violations):
@@ -224,9 +241,9 @@ class TestGitleaksServicer:
         assert resp.request_id == "gl-2"
 
     async def test_health_binary_present(self):
-        from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
+
         from apme.v1 import common_pb2
-        import asyncio
+        from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
 
         servicer = GitleaksValidatorServicer()
 
@@ -240,8 +257,8 @@ class TestGitleaksServicer:
         assert "8.18.0" in resp.status
 
     async def test_health_binary_missing(self):
-        from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
         from apme.v1 import common_pb2
+        from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
 
         servicer = GitleaksValidatorServicer()
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, side_effect=FileNotFoundError):

--- a/tests/test_opa_client.py
+++ b/tests/test_opa_client.py
@@ -1,8 +1,7 @@
 """Tests for apme_engine.opa_client."""
 
 import json
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -27,9 +26,11 @@ class TestRunOpa:
 
     def test_opa_not_found_returns_empty_list(self, opa_bundle_path):
         """When opa command is not found, returns [] and writes to stderr."""
-        with patch("apme_engine.opa_client.subprocess.run", side_effect=FileNotFoundError("opa not found")):
-            with patch("sys.stderr.write") as mock_stderr:
-                result = run_opa({"hierarchy": []}, str(opa_bundle_path))
+        with (
+            patch("apme_engine.opa_client.subprocess.run", side_effect=FileNotFoundError("opa not found")),
+            patch("sys.stderr.write") as mock_stderr,
+        ):
+            result = run_opa({"hierarchy": []}, str(opa_bundle_path))
         assert result == []
         mock_stderr.assert_called_once()
         assert "opa" in mock_stderr.call_args[0][0].lower()
@@ -54,7 +55,9 @@ class TestRunOpa:
         mock_stderr.assert_called_once()
         assert "invalid JSON" in mock_stderr.call_args[0][0]
 
-    def test_opa_empty_result_returns_empty_list(self, opa_bundle_path, sample_hierarchy_payload, opa_eval_result_empty):
+    def test_opa_empty_result_returns_empty_list(
+        self, opa_bundle_path, sample_hierarchy_payload, opa_eval_result_empty
+    ):
         """When OPA result has no expressions, returns []."""
         with patch("apme_engine.opa_client.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"result": []}), stderr="")

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -2,10 +2,9 @@
 
 import textwrap
 
-import pytest
-
-from apme_engine.remediation.registry import TransformRegistry, TransformResult
+from apme_engine.remediation.engine import RemediationEngine
 from apme_engine.remediation.partition import is_finding_resolvable, partition_violations
+from apme_engine.remediation.registry import TransformRegistry, TransformResult
 from apme_engine.remediation.transforms import build_default_registry
 from apme_engine.remediation.transforms.L007_shell_to_command import fix_shell_to_command
 from apme_engine.remediation.transforms.L008_local_action import fix_local_action
@@ -25,12 +24,11 @@ from apme_engine.remediation.transforms.M001_fqcn import fix_fqcn
 from apme_engine.remediation.transforms.M006_become_unreachable import fix_become_unreachable
 from apme_engine.remediation.transforms.M008_bare_include import fix_bare_include
 from apme_engine.remediation.transforms.M009_with_to_loop import fix_with_to_loop
-from apme_engine.remediation.engine import RemediationEngine, FixReport
-
 
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
+
 
 class TestTransformRegistry:
     def test_register_and_contains(self):
@@ -70,6 +68,7 @@ class TestTransformRegistry:
 # Partition
 # ---------------------------------------------------------------------------
 
+
 class TestPartition:
     def test_is_finding_resolvable(self):
         reg = TransformRegistry()
@@ -99,13 +98,32 @@ class TestPartition:
 # Default registry
 # ---------------------------------------------------------------------------
 
+
 class TestDefaultRegistry:
     def test_build_default_registry(self):
         reg = build_default_registry()
-        for rule_id in ("L002", "L007", "L008", "L009", "L011", "L012", "L013",
-                        "L015", "L018", "L020", "L021", "L022", "L025",
-                        "L043", "L046", "M001", "M003",
-                        "M006", "M008", "M009"):
+        for rule_id in (
+            "L002",
+            "L007",
+            "L008",
+            "L009",
+            "L011",
+            "L012",
+            "L013",
+            "L015",
+            "L018",
+            "L020",
+            "L021",
+            "L022",
+            "L025",
+            "L043",
+            "L046",
+            "M001",
+            "M003",
+            "M006",
+            "M008",
+            "M009",
+        ):
             assert rule_id in reg, f"{rule_id} missing from default registry"
         assert len(reg) == 20
 
@@ -113,6 +131,7 @@ class TestDefaultRegistry:
 # ---------------------------------------------------------------------------
 # L021 transform: missing mode
 # ---------------------------------------------------------------------------
+
 
 class TestL021MissingMode:
     def test_adds_mode_to_file_module(self):
@@ -166,6 +185,7 @@ class TestL021MissingMode:
 # ---------------------------------------------------------------------------
 # L007 transform: shell to command
 # ---------------------------------------------------------------------------
+
 
 class TestL007ShellToCommand:
     def test_replaces_shell_with_command(self):
@@ -235,6 +255,7 @@ class TestL007ShellToCommand:
 # ---------------------------------------------------------------------------
 # M001/L002 transform: FQCN
 # ---------------------------------------------------------------------------
+
 
 class TestFQCNTransform:
     def test_rewrites_short_name_with_resolved_fqcn(self):
@@ -320,15 +341,18 @@ class TestFQCNTransform:
 # RemediationEngine convergence loop
 # ---------------------------------------------------------------------------
 
+
 class TestRemediationEngine:
     def test_converges_in_one_pass(self, tmp_path):
         playbook = tmp_path / "play.yml"
-        playbook.write_text(textwrap.dedent("""\
+        playbook.write_text(
+            textwrap.dedent("""\
         - name: Copy file
           ansible.builtin.copy:
             src: /a
             dest: /b
-        """))
+        """)
+        )
 
         def scan_fn(paths):
             content = playbook.read_text()
@@ -431,6 +455,7 @@ class TestRemediationEngine:
 # L008 transform: local_action
 # ---------------------------------------------------------------------------
 
+
 class TestL008LocalAction:
     def test_string_form(self):
         content = textwrap.dedent("""\
@@ -480,6 +505,7 @@ class TestL008LocalAction:
 # L009 transform: empty string comparison
 # ---------------------------------------------------------------------------
 
+
 class TestL009EmptyString:
     def test_double_quote_equality(self):
         content = textwrap.dedent("""\
@@ -528,6 +554,7 @@ class TestL009EmptyString:
 # ---------------------------------------------------------------------------
 # L011 transform: literal bool comparison
 # ---------------------------------------------------------------------------
+
 
 class TestL011LiteralBool:
     def test_eq_true(self):
@@ -589,6 +616,7 @@ class TestL011LiteralBool:
 # L015 transform: Jinja in when
 # ---------------------------------------------------------------------------
 
+
 class TestL015JinjaWhen:
     def test_strips_jinja_delimiters(self):
         content = textwrap.dedent("""\
@@ -628,6 +656,7 @@ class TestL015JinjaWhen:
 # ---------------------------------------------------------------------------
 # L020 transform: octal mode
 # ---------------------------------------------------------------------------
+
 
 class TestL020OctalMode:
     def test_octal_literal_to_string(self):
@@ -680,6 +709,7 @@ class TestL020OctalMode:
 # L025 transform: name casing
 # ---------------------------------------------------------------------------
 
+
 class TestL025NameCasing:
     def test_capitalizes_task_name(self):
         content = textwrap.dedent("""\
@@ -714,6 +744,7 @@ class TestL025NameCasing:
 # ---------------------------------------------------------------------------
 # L046 transform: free-form to dict
 # ---------------------------------------------------------------------------
+
 
 class TestL046FreeForm:
     def test_converts_string_to_dict(self):
@@ -758,6 +789,7 @@ class TestL046FreeForm:
 # L043 transform: bare vars
 # ---------------------------------------------------------------------------
 
+
 class TestL043BareVars:
     def test_wraps_bare_var_in_with_items(self):
         content = textwrap.dedent("""\
@@ -793,6 +825,7 @@ class TestL043BareVars:
 # ---------------------------------------------------------------------------
 # L013 transform: changed_when
 # ---------------------------------------------------------------------------
+
 
 class TestL013ChangedWhen:
     def test_adds_changed_when(self):
@@ -837,6 +870,7 @@ class TestL013ChangedWhen:
 # L018 transform: become
 # ---------------------------------------------------------------------------
 
+
 class TestL018Become:
     def test_adds_become(self):
         content = textwrap.dedent("""\
@@ -876,14 +910,15 @@ class TestL018Become:
         result = fix_become(content, {"rule_id": "L018", "line": 1})
         assert result.applied is True
         lines = result.content.splitlines()
-        bu_line = next(i for i, l in enumerate(lines) if "become_user" in l)
-        b_line = next(i for i, l in enumerate(lines) if l.strip().startswith("become:"))
+        bu_line = next(i for i, line in enumerate(lines) if "become_user" in line)
+        b_line = next(i for i, line in enumerate(lines) if line.strip().startswith("become:"))
         assert b_line == bu_line + 1
 
 
 # ---------------------------------------------------------------------------
 # L022 transform: pipefail
 # ---------------------------------------------------------------------------
+
 
 class TestL022Pipefail:
     def test_prepends_pipefail_string_form(self):
@@ -935,6 +970,7 @@ class TestL022Pipefail:
 # L012 transform: latest → present
 # ---------------------------------------------------------------------------
 
+
 class TestL012Latest:
     def test_replaces_latest_with_present(self):
         content = textwrap.dedent("""\
@@ -984,6 +1020,7 @@ class TestL012Latest:
 # M006 transform: become + ignore_errors -> add ignore_unreachable
 # ---------------------------------------------------------------------------
 
+
 class TestM006BecomeUnreachable:
     def test_adds_ignore_unreachable(self):
         content = textwrap.dedent("""\
@@ -1025,14 +1062,15 @@ class TestM006BecomeUnreachable:
         """)
         result = fix_become_unreachable(content, {"rule_id": "M006", "line": 1})
         lines = result.content.splitlines()
-        ie_line = next(i for i, l in enumerate(lines) if "ignore_errors" in l)
-        iu_line = next(i for i, l in enumerate(lines) if "ignore_unreachable" in l)
+        ie_line = next(i for i, line in enumerate(lines) if "ignore_errors" in line)
+        iu_line = next(i for i, line in enumerate(lines) if "ignore_unreachable" in line)
         assert iu_line == ie_line + 1
 
 
 # ---------------------------------------------------------------------------
 # M008 transform: bare include -> include_tasks
 # ---------------------------------------------------------------------------
+
 
 class TestM008BareInclude:
     def test_replaces_include(self):
@@ -1063,6 +1101,7 @@ class TestM008BareInclude:
 # ---------------------------------------------------------------------------
 # M009 transform: with_items -> loop
 # ---------------------------------------------------------------------------
+
 
 class TestM009WithToLoop:
     def test_with_items_to_loop(self):

--- a/tests/test_rule_doc_coverage.py
+++ b/tests/test_rule_doc_coverage.py
@@ -98,8 +98,7 @@ def test_rule_has_doc(validator, rule_id, source_file, md_dir):
         pytest.skip("No rules discovered")
     md_path = _find_md_for_rule(rule_id, md_dir)
     assert md_path is not None, (
-        f"Rule {rule_id} (from {source_file}, validator={validator}) "
-        f"has no .md doc file in {md_dir}"
+        f"Rule {rule_id} (from {source_file}, validator={validator}) has no .md doc file in {md_dir}"
     )
 
 

--- a/tests/test_scanner_hierarchy.py
+++ b/tests/test_scanner_hierarchy.py
@@ -9,6 +9,7 @@ def _import_single_scan():
     """Import SingleScan from apme_engine.engine; return None if import fails."""
     try:
         from apme_engine.engine.scanner import SingleScan
+
         return SingleScan
     except Exception:
         return None

--- a/tests/test_validator_servicers.py
+++ b/tests/test_validator_servicers.py
@@ -4,17 +4,23 @@ All servicers are now async (grpc.aio), so tests use pytest-asyncio.
 """
 
 import json
-from unittest.mock import MagicMock, patch, AsyncMock
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 import jsonpickle
-from apme.v1 import validate_pb2, common_pb2
+import pytest
+
+from apme.v1 import common_pb2, validate_pb2
 
 
 class FakeGrpcContext:
     """Minimal stub for grpc.ServicerContext."""
-    def set_code(self, code): pass
-    def set_details(self, details): pass
+
+    def set_code(self, code):
+        pass
+
+    def set_details(self, details):
+        pass
 
 
 class TestOpaValidatorServicer:
@@ -142,7 +148,7 @@ class TestOpaValidatorServicer:
 class TestNativeValidatorServicer:
     async def test_validate_deserializes_scandata_and_runs(self):
         from apme_engine.daemon.native_validator_server import NativeValidatorServicer
-        from apme_engine.validators.native import NativeRunResult, NativeRuleTiming
+        from apme_engine.validators.native import NativeRuleTiming, NativeRunResult
 
         mock_scandata = type("Scandata", (), {"contexts": []})()
         hierarchy = {"hierarchy": []}
@@ -154,7 +160,14 @@ class TestNativeValidatorServicer:
 
         mock_result = NativeRunResult(
             violations=[
-                {"rule_id": "native:L028", "level": "warning", "message": "no name", "file": "f.yml", "line": 5, "path": "p"},
+                {
+                    "rule_id": "native:L028",
+                    "level": "warning",
+                    "message": "no name",
+                    "file": "f.yml",
+                    "line": 5,
+                    "path": "p",
+                },
             ],
             rule_timings=[
                 NativeRuleTiming(rule_id="L028", elapsed_ms=3.5, violations=1),
@@ -171,7 +184,7 @@ class TestNativeValidatorServicer:
 
     async def test_validate_returns_diagnostics(self):
         from apme_engine.daemon.native_validator_server import NativeValidatorServicer
-        from apme_engine.validators.native import NativeRunResult, NativeRuleTiming
+        from apme_engine.validators.native import NativeRuleTiming, NativeRunResult
 
         mock_scandata = type("Scandata", (), {"contexts": []})()
         request = validate_pb2.ValidateRequest(
@@ -285,16 +298,19 @@ class TestAnsibleValidatorServicerMigration:
 
     def test_servicer_extends_validator_servicer(self):
         from apme_engine.daemon.ansible_validator_server import AnsibleValidatorServicer
+
         assert hasattr(AnsibleValidatorServicer, "Validate")
 
     def test_serve_is_async(self):
         import inspect
+
         from apme_engine.daemon.ansible_validator_server import serve
+
         assert inspect.iscoroutinefunction(serve)
 
     async def test_validate_returns_diagnostics(self):
         from apme_engine.daemon.ansible_validator_server import AnsibleValidatorServicer, _AnsibleResult
-        from apme_engine.validators.ansible import AnsibleRunResult, AnsibleRuleTiming
+        from apme_engine.validators.ansible import AnsibleRuleTiming, AnsibleRunResult
 
         request = validate_pb2.ValidateRequest(
             request_id="diag-ans-1",
@@ -305,7 +321,14 @@ class TestAnsibleValidatorServicerMigration:
         mock_result = _AnsibleResult(
             run_result=AnsibleRunResult(
                 violations=[
-                    {"rule_id": "L057", "level": "error", "message": "syntax", "file": "playbook.yml", "line": 1, "path": ""},
+                    {
+                        "rule_id": "L057",
+                        "level": "error",
+                        "message": "syntax",
+                        "file": "playbook.yml",
+                        "line": 1,
+                        "path": "",
+                    },
                 ],
                 rule_timings=[
                     AnsibleRuleTiming(rule_id="L057", elapsed_ms=120.0, violations=1),
@@ -387,32 +410,38 @@ class TestPrimaryFanOut:
     def test_primary_no_longer_imports_native_validator(self):
         """Primary should not import NativeValidator directly (it's in its own container)."""
         import apme_engine.daemon.primary_server as ps
-        source = open(ps.__file__).read()
+
+        source = Path(ps.__file__).read_text()
         assert "from apme_engine.validators.native" not in source
         assert "NativeValidator()" not in source
 
     def test_primary_no_longer_imports_opa_client(self):
         """Primary should not import opa_client (OPA is behind gRPC now)."""
         import apme_engine.daemon.primary_server as ps
-        source = open(ps.__file__).read()
+
+        source = Path(ps.__file__).read_text()
         assert "from apme_engine.opa_client" not in source
         assert "_call_opa" not in source
 
     def test_primary_propagates_request_id(self):
         """Primary should set request_id on ValidateRequest."""
         import apme_engine.daemon.primary_server as ps
-        source = open(ps.__file__).read()
+
+        source = Path(ps.__file__).read_text()
         assert "request_id=scan_id" in source
 
     def test_primary_serve_is_async(self):
         import inspect
+
         from apme_engine.daemon.primary_server import serve
+
         assert inspect.iscoroutinefunction(serve)
 
     def test_primary_aggregates_diagnostics(self):
         """Primary should collect validator diagnostics into ScanDiagnostics."""
         import apme_engine.daemon.primary_server as ps
-        source = open(ps.__file__).read()
+
+        source = Path(ps.__file__).read_text()
         assert "ScanDiagnostics" in source
         assert "validator_diagnostics" in source
         assert "engine_diagnostics" in source
@@ -421,55 +450,71 @@ class TestPrimaryFanOut:
 class TestGrpcAioConsistency:
     """Verify all servers use grpc.aio."""
 
-    @pytest.mark.parametrize("module_path", [
-        "apme_engine.daemon.primary_server",
-        "apme_engine.daemon.native_validator_server",
-        "apme_engine.daemon.opa_validator_server",
-        "apme_engine.daemon.ansible_validator_server",
-        "apme_engine.daemon.gitleaks_validator_server",
-    ])
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "apme_engine.daemon.primary_server",
+            "apme_engine.daemon.native_validator_server",
+            "apme_engine.daemon.opa_validator_server",
+            "apme_engine.daemon.ansible_validator_server",
+            "apme_engine.daemon.gitleaks_validator_server",
+        ],
+    )
     def test_serve_is_async_coroutine(self, module_path):
-        import inspect
         import importlib
+        import inspect
+
         mod = importlib.import_module(module_path)
         assert inspect.iscoroutinefunction(mod.serve), f"{module_path}.serve should be async"
 
-    @pytest.mark.parametrize("module_path", [
-        "apme_engine.daemon.primary_server",
-        "apme_engine.daemon.native_validator_server",
-        "apme_engine.daemon.opa_validator_server",
-        "apme_engine.daemon.ansible_validator_server",
-        "apme_engine.daemon.gitleaks_validator_server",
-    ])
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "apme_engine.daemon.primary_server",
+            "apme_engine.daemon.native_validator_server",
+            "apme_engine.daemon.opa_validator_server",
+            "apme_engine.daemon.ansible_validator_server",
+            "apme_engine.daemon.gitleaks_validator_server",
+        ],
+    )
     def test_server_uses_grpc_aio(self, module_path):
         import importlib
+
         mod = importlib.import_module(module_path)
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text()
         assert "grpc.aio" in source, f"{module_path} should use grpc.aio"
 
-    @pytest.mark.parametrize("module_path", [
-        "apme_engine.daemon.native_validator_server",
-        "apme_engine.daemon.opa_validator_server",
-        "apme_engine.daemon.ansible_validator_server",
-        "apme_engine.daemon.gitleaks_validator_server",
-    ])
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "apme_engine.daemon.native_validator_server",
+            "apme_engine.daemon.opa_validator_server",
+            "apme_engine.daemon.ansible_validator_server",
+            "apme_engine.daemon.gitleaks_validator_server",
+        ],
+    )
     def test_validator_echoes_request_id(self, module_path):
         import importlib
+
         mod = importlib.import_module(module_path)
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text()
         assert "request_id" in source, f"{module_path} should handle request_id"
 
-    @pytest.mark.parametrize("module_path", [
-        "apme_engine.daemon.native_validator_server",
-        "apme_engine.daemon.opa_validator_server",
-        "apme_engine.daemon.ansible_validator_server",
-        "apme_engine.daemon.gitleaks_validator_server",
-    ])
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "apme_engine.daemon.native_validator_server",
+            "apme_engine.daemon.opa_validator_server",
+            "apme_engine.daemon.ansible_validator_server",
+            "apme_engine.daemon.gitleaks_validator_server",
+        ],
+    )
     def test_validator_returns_diagnostics(self, module_path):
         """All validator servicers should populate diagnostics in ValidateResponse."""
         import importlib
+
         mod = importlib.import_module(module_path)
-        source = open(mod.__file__).read()
+        source = Path(mod.__file__).read_text()
         assert "ValidatorDiagnostics" in source, f"{module_path} should build ValidatorDiagnostics"
         assert "diagnostics=" in source, f"{module_path} should set diagnostics= in response"
 
@@ -552,19 +597,22 @@ class TestCliDiagnosticsDisplay:
 
     def test_fmt_ms_sub_1(self):
         from apme_engine.cli import _fmt_ms
+
         assert _fmt_ms(0.5) == "<1ms"
 
     def test_fmt_ms_normal(self):
         from apme_engine.cli import _fmt_ms
+
         assert _fmt_ms(42.3) == "42ms"
 
     def test_fmt_ms_seconds(self):
         from apme_engine.cli import _fmt_ms
+
         assert _fmt_ms(1500.0) == "1.5s"
 
     def test_diag_to_dict(self):
-        from apme_engine.cli import _diag_to_dict
         from apme.v1 import primary_pb2
+        from apme_engine.cli import _diag_to_dict
 
         vd = common_pb2.ValidatorDiagnostics(
             validator_name="native",
@@ -597,8 +645,8 @@ class TestCliDiagnosticsDisplay:
         assert v["metadata"] == {"foo": "bar"}
 
     def test_print_diagnostics_v_no_crash(self, capsys):
-        from apme_engine.cli import _print_diagnostics_v
         from apme.v1 import primary_pb2
+        from apme_engine.cli import _print_diagnostics_v
 
         vd = common_pb2.ValidatorDiagnostics(
             validator_name="native",
@@ -620,8 +668,8 @@ class TestCliDiagnosticsDisplay:
         assert "L028" in captured.err
 
     def test_print_diagnostics_vv_no_crash(self, capsys):
-        from apme_engine.cli import _print_diagnostics_vv
         from apme.v1 import primary_pb2
+        from apme_engine.cli import _print_diagnostics_vv
 
         vd = common_pb2.ValidatorDiagnostics(
             validator_name="opa",

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,10 +1,8 @@
 """Tests for validator abstraction (ScanContext, OpaValidator, NativeValidator)."""
 
-import pytest
-
 from apme_engine.validators.base import ScanContext
-from apme_engine.validators.opa import OpaValidator
 from apme_engine.validators.native import NativeValidator
+from apme_engine.validators.opa import OpaValidator
 
 
 class TestScanContext:
@@ -24,6 +22,7 @@ class TestScanContext:
 class TestOpaValidator:
     def test_opa_validator_run_calls_run_opa(self, opa_bundle_path, sample_hierarchy_payload):
         from unittest.mock import patch
+
         ctx = ScanContext(hierarchy_payload=sample_hierarchy_payload)
         v = OpaValidator(str(opa_bundle_path))
         with patch("apme_engine.validators.opa.run_opa", return_value=[]) as mock_opa:
@@ -35,6 +34,7 @@ class TestOpaValidator:
 
     def test_opa_validator_run_returns_violations(self, sample_hierarchy_payload, tmp_path):
         from unittest.mock import patch
+
         (tmp_path / "bundle").mkdir()
         ctx = ScanContext(hierarchy_payload=sample_hierarchy_payload)
         v = OpaValidator(str(tmp_path / "bundle"))


### PR DESCRIPTION
## Summary
- Adopt ruff as the project linter/formatter and prek as the pre-commit hook framework
- Remediate all existing ruff violations across the codebase
- Add a PR submission Agent Skill to standardize the contribution workflow

## Changes
- **pyproject.toml**: Add `ruff` to dev deps, add `[tool.ruff]` config (rules: E, F, W, I, UP, B, SIM; target py310; line-length 120; generated gRPC stubs excluded)
- **.pre-commit-config.yaml**: New file with `ruff` (lint + auto-fix) and `ruff-format` hooks via `astral-sh/ruff-pre-commit`
- **207 source/test files**: Remediate all existing ruff violations (unused imports, import sorting, formatting, context managers, raise-from, type comparisons, ambiguous variable names, line length, collapsible ifs, mutable defaults, etc.)
- **.agents/skills/submit-pr/SKILL.md**: New PR submission skill covering upstream sync, feature branch creation, prek checks, doc/ADR updates, conventional commits format, and `gh pr create` workflow
- **docs/DEVELOPMENT.md**: New "Pre-commit hooks (prek)" section with install, setup, and usage instructions
- **docs/ADR.md**: ADR-014 documenting the adoption of ruff and prek

## Test plan
- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check src/ tests/` — 232 files already formatted
- [ ] pytest passes (no test logic changed, only formatting and lint fixes)
- [x] Docs updated (DEVELOPMENT.md)
- [x] ADR added (ADR-014)

Made with [Cursor](https://cursor.com)