### PR TITLE
docs(skills): add PR maintenance guidance to submit-pr skill

### DIFF
--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -149,7 +149,7 @@ The PR targets upstream's `main` branch from the fork. Return the PR URL to the 
 When pushing additional commits to an existing PR, **always update the PR body** to reflect the new changes:
 
 ```bash
-gh pr edit <number> --body "$(cat <<'EOF'
+gh pr edit <pr-number> --body "$(cat <<'EOF'
 ...updated body...
 EOF
 )"


### PR DESCRIPTION
## Summary
- Add guidance to the submit-pr skill for keeping PR descriptions current when pushing follow-up commits

## Changes
- **`.agents/skills/submit-pr/SKILL.md`**: Add "Maintaining the PR" section instructing the agent to update the PR body via `gh pr edit` whenever additional commits are pushed
- **`.agents/skills/submit-pr/SKILL.md`**: Rename `<number>` placeholder to `<pr-number>` for consistency (Copilot review feedback)

## Test plan
- [x] `prek run --all-files` passes
- [x] Copilot review feedback addressed and thread resolved