### PR TITLE
build: add mypy strict mode with type annotations across entire codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,15 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        args: [--strict, src/, tests/, scripts/]
+        pass_filenames: false
+        additional_dependencies:
+          - types-protobuf
+          - types-PyYAML
+          - types-requests
+          - types-tabulate
+          - grpc-stubs

--- a/.sdlc/adrs/ADR-018-mypy-strict-type-checking.md
+++ b/.sdlc/adrs/ADR-018-mypy-strict-type-checking.md
@@ -1,0 +1,67 @@
+# ADR-018: mypy Strict Mode Type Checking
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03
+
+## Context
+
+The APME codebase (~244 Python files) had no static type checking configured. Type hints were used inconsistently — some functions had annotations, most did not. Without enforcement, type mismatches, missing return types, and bare generic types (e.g., `dict` instead of `dict[str, Any]`) accumulated throughout the codebase.
+
+Python's type system, when enforced via mypy in strict mode, catches entire categories of bugs at development time: attribute access on None, wrong argument types, missing return values, and incompatible assignments. These errors otherwise surface only at runtime, often in production.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| No type checking | Zero upfront cost | Bugs caught only at runtime |
+| mypy basic mode | Low friction, catches obvious errors | Permits untyped functions, misses strict violations |
+| mypy strict mode | Maximum coverage, catches all type errors | Significant upfront effort to annotate entire codebase |
+| pyright / pytype | Alternative checkers with different trade-offs | Less ecosystem adoption, different configuration model |
+
+## Decision
+
+**Adopt mypy strict mode globally.** All Python source files (src/, tests/, scripts/) must pass `mypy --strict`. The check is enforced via the prek pre-commit hook and CI.
+
+## Rationale
+
+- Strict mode catches the widest range of type errors — no-untyped-def, type-arg, union-attr, attr-defined, assignment mismatches
+- The upfront cost (~3,800 errors fixed) is a one-time investment; ongoing cost is near-zero since prek enforces compliance on every commit
+- Protobuf generated files (src/apme/v1/*_pb2*.py) are excluded — they are machine-generated and not under our control
+- Third-party libraries without type stubs (ruamel.yaml, ansible, jsonpickle, etc.) use `ignore_missing_imports` overrides
+- Aligns with ADR-014 (prek hooks) and ADR-015 (CI enforcement) — mypy is another quality gate in the same pipeline
+
+## Configuration
+
+```toml
+[tool.mypy]
+strict = true
+python_version = "3.10"
+exclude = ["src/apme/v1/.*_pb2"]
+```
+
+Type stub packages added to dev dependencies: `mypy`, `types-protobuf`, `types-PyYAML`, `types-requests`, `types-tabulate`, `grpc-stubs`.
+
+The mypy hook in `.pre-commit-config.yaml` runs with `pass_filenames: false` and checks `src/ tests/ scripts/` as a whole, ensuring the pyproject.toml configuration (excludes, overrides) is respected.
+
+## Consequences
+
+### Positive
+- All functions have explicit parameter and return types
+- Generic collections are parameterized (`dict[str, Any]`, `list[str]`, etc.)
+- Optional/nullable values are explicitly typed and checked before access
+- New code must be fully typed to pass prek — no regression possible
+- IDE support (autocomplete, refactoring) is significantly improved
+
+### Negative
+- Some genuinely dynamic code (e.g., protobuf attribute access, sample annotators) requires targeted `# type: ignore` comments
+- Third-party libraries without stubs need `ignore_missing_imports` overrides, reducing coverage at module boundaries
+
+## Related Decisions
+
+- ADR-014: Ruff linter and prek pre-commit hooks (established the prek pipeline)
+- ADR-015: GitHub Actions CI with prek (enforces hooks in CI)

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -23,6 +23,7 @@ This directory contains the Architecture Decision Records (ADRs) for APME.
 | [ADR-015](ADR-015-github-actions-prek.md) | GitHub Actions CI with prek | Accepted | 2026-03 |
 | [ADR-016](ADR-016-single-branch-main.md) | Single-branch `main` Strategy | Accepted | 2026-03 |
 | [ADR-017](ADR-017-trust-and-verify-agent-sdlc.md) | Trust-and-verify Agent SDLC Invocation | Accepted | 2026-03 |
+| [ADR-018](ADR-018-mypy-strict-type-checking.md) | mypy Strict Mode Type Checking | Accepted | 2026-03 |
 
 ## Categories
 
@@ -68,7 +69,7 @@ Original planning ADRs that were superseded by implementation decisions:
 ## Creating New ADRs
 
 1. Copy the template from `../.sdlc/templates/adr.md`
-2. Use the next available number (currently ADR-018)
+2. Use the next available number (currently ADR-019)
 3. Include:
    - Status (Proposed → Accepted)
    - Date
@@ -101,3 +102,4 @@ Original planning ADRs that were superseded by implementation decisions:
 | 015 | 2026-03 | GitHub Actions CI with prek |
 | 016 | 2026-03 | Single-branch `main` strategy |
 | 017 | 2026-03 | Trust-and-verify agent SDLC invocation |
+| 018 | 2026-03 | mypy strict mode type checking |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,19 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "pytest-mock", "pytest-asyncio>=0.24", "ruff"]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-asyncio>=0.24",
+    "ruff",
+    "mypy",
+    "types-protobuf",
+    "types-PyYAML",
+    "types-requests",
+    "types-tabulate",
+    "grpc-stubs",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src/apme_engine/validators/native/rules"]
@@ -70,6 +82,42 @@ select = ["E", "F", "W", "I", "UP", "B", "SIM"]
 
 [tool.ruff.lint.per-file-ignores]
 "src/apme_engine/engine/annotators/ansible.builtin/*.py" = ["E501"]
+
+[tool.mypy]
+strict = true
+python_version = "3.10"
+mypy_path = "src"
+exclude = ["src/apme/v1/.*_pb2"]
+
+[[tool.mypy.overrides]]
+module = [
+    "pytest",
+    "ruamel.*",
+    "ansible.*",
+    "jsonpickle",
+    "filelock",
+    "rapidfuzz.*",
+    "joblib",
+    "httpx",
+    "gitdb",
+    "smmap",
+    "tabulate",
+    "yaml",
+    "grpc",
+    "grpc.*",
+]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = [
+    "apme.v1.ansible_pb2",
+    "apme.v1.ansible_pb2_grpc",
+    "apme.v1.cache_pb2_grpc",
+    "apme.v1.common_pb2_grpc",
+    "apme.v1.primary_pb2_grpc",
+    "apme.v1.validate_pb2_grpc",
+]
+ignore_errors = true
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/generate_rule_catalog.py
+++ b/scripts/generate_rule_catalog.py
@@ -36,7 +36,7 @@ def _parse_frontmatter(path: Path) -> dict[str, str]:
     return dict(_KV.findall(m.group(1)))
 
 
-def _collect_opa_rules() -> list[dict]:
+def _collect_opa_rules() -> list[dict[str, str]]:
     rules = []
     for md in sorted(OPA_DIR.glob("*.md")):
         fm = _parse_frontmatter(md)
@@ -53,7 +53,7 @@ def _collect_opa_rules() -> list[dict]:
     return rules
 
 
-def _collect_native_rules() -> list[dict]:
+def _collect_native_rules() -> list[dict[str, str]]:
     rules = []
     for md in sorted(NATIVE_DIR.glob("*.md")):
         fm = _parse_frontmatter(md)
@@ -70,7 +70,7 @@ def _collect_native_rules() -> list[dict]:
     return rules
 
 
-def _collect_ansible_rules() -> list[dict]:
+def _collect_ansible_rules() -> list[dict[str, str]]:
     rules = []
     for md in sorted(ANSIBLE_DIR.glob("*.md")):
         fm = _parse_frontmatter(md)
@@ -87,7 +87,7 @@ def _collect_ansible_rules() -> list[dict]:
     return rules
 
 
-def _collect_gitleaks_rules() -> list[dict]:
+def _collect_gitleaks_rules() -> list[dict[str, str]]:
     return [
         {
             "rule_id": "SEC:*",
@@ -109,7 +109,7 @@ def _get_fixable_ids() -> set[str]:
         return set()
 
 
-def _sort_key(rule: dict) -> tuple:
+def _sort_key(rule: dict[str, str]) -> tuple[str, int]:
     rid = rule["rule_id"]
     prefix = rid.rstrip("0123456789:*")
     num_str = rid[len(prefix) :].split(":")[0].split("*")[0]
@@ -118,7 +118,7 @@ def _sort_key(rule: dict) -> tuple:
 
 
 def generate() -> str:
-    all_rules: list[dict] = []
+    all_rules: list[dict[str, str]] = []
     all_rules.extend(_collect_opa_rules())
     all_rules.extend(_collect_native_rules())
     all_rules.extend(_collect_ansible_rules())
@@ -150,7 +150,7 @@ def generate() -> str:
     lines.append("## By Validator")
     lines.append("")
 
-    validators = {}
+    validators: dict[str, list[dict[str, str]]] = {}
     for r in all_rules:
         validators.setdefault(r["validator"], []).append(r)
 
@@ -176,7 +176,7 @@ def generate() -> str:
     lines.append("| Rule ID | Transform |")
     lines.append("|---------|-----------|")
 
-    rule_map = {r["rule_id"]: r["description"] for r in all_rules}
+    rule_map: dict[str, str] = {r["rule_id"]: r["description"] for r in all_rules}
     for rid in sorted(fixable):
         desc = rule_map.get(rid, "")
         lines.append(f"| {rid} | {desc} |")
@@ -185,7 +185,7 @@ def generate() -> str:
     return "\n".join(lines)
 
 
-def main():
+def main() -> None:
     content = generate()
     OUTPUT.write_text(content, encoding="utf-8")
     print(f"Wrote {OUTPUT} ({content.count(chr(10))} lines)")

--- a/scripts/generate_rule_docs.py
+++ b/scripts/generate_rule_docs.py
@@ -22,7 +22,7 @@ def playbook(*tasks_yaml: str) -> str:
     return PLAYBOOK_WRAP + "\n".join(lines)
 
 
-def write_native(name: str, rule_id: str, title: str, desc: str, violation: str, pass_yaml: str):
+def write_native(name: str, rule_id: str, title: str, desc: str, violation: str, pass_yaml: str) -> None:
     path = NATIVE_RULES / f"{name}.md"
     path.write_text(
         f"""---
@@ -52,7 +52,7 @@ description: {desc}
     print(path.name)
 
 
-def write_opa(num: int, rule_id: str, title: str, desc: str, violation: str, pass_yaml: str):
+def write_opa(num: int, rule_id: str, title: str, desc: str, violation: str, pass_yaml: str) -> None:
     path = OPA_BUNDLE / f"L{num:03d}.md"
     path.write_text(
         f"""---
@@ -82,7 +82,7 @@ description: {desc}
     print(path.name)
 
 
-def main():
+def main() -> None:
     pb_v = playbook("- name: Bad\n  ansible.builtin.shell: whoami")
     pb_p = playbook("- name: Ok\n  ansible.builtin.command: whoami")
 

--- a/src/apme/v1/cache_pb2.pyi
+++ b/src/apme/v1/cache_pb2.pyi
@@ -1,0 +1,21 @@
+"""Stub for generated cache_pb2 (proto types)."""
+
+from typing import Any
+
+class PullGalaxyRequest:
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class PullGalaxyResponse:
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class PullRequirementsRequest:
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class PullRequirementsResponse:
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class CloneOrgRequest:
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class CloneOrgResponse:
+    def __init__(self, **kwargs: Any) -> None: ...

--- a/src/apme/v1/common_pb2.pyi
+++ b/src/apme/v1/common_pb2.pyi
@@ -1,0 +1,49 @@
+"""Stub for generated common_pb2 (proto types)."""
+
+from typing import Any
+
+class Violation:
+    rule_id: str
+    level: str
+    message: str
+    file: str
+    path: str
+    line: int
+    line_range: LineRange
+    def __init__(self, **kwargs: Any) -> None: ...
+    def HasField(self, name: str) -> bool: ...
+    def CopyFrom(self, other: Any) -> None: ...
+
+class LineRange:
+    start: int
+    end: int
+    def __init__(self, **kwargs: Any) -> None: ...
+    def CopyFrom(self, other: Any) -> None: ...
+
+class File:
+    path: str
+    content: bytes
+    def __init__(self, *, path: str = "", content: bytes = b"", **kwargs: Any) -> None: ...
+
+class HealthRequest:
+    def __init__(self) -> None: ...
+
+class HealthResponse:
+    status: str
+    def __init__(self, *, status: str = "", **kwargs: Any) -> None: ...
+
+class RuleTiming:
+    rule_id: str
+    elapsed_ms: float
+    violations: int
+    def __init__(self, *, rule_id: str = "", elapsed_ms: float = 0.0, violations: int = 0, **kwargs: Any) -> None: ...
+
+class ValidatorDiagnostics:
+    validator_name: str
+    request_id: str
+    total_ms: float
+    files_received: int
+    violations_found: int
+    rule_timings: list[RuleTiming]
+    metadata: dict[str, str]
+    def __init__(self, **kwargs: Any) -> None: ...

--- a/src/apme/v1/primary_pb2.pyi
+++ b/src/apme/v1/primary_pb2.pyi
@@ -1,0 +1,35 @@
+"""Stub for generated primary_pb2 (proto types)."""
+
+from typing import Any
+
+class ScanOptions:
+    ansible_core_version: str
+    collection_specs: list[str]
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class ScanRequest:
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class ScanResponse:
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class ScanDiagnostics:
+    engine_parse_ms: float
+    engine_annotate_ms: float
+    engine_total_ms: float
+    files_scanned: int
+    trees_built: int
+    total_violations: int
+    validators: list[Any]
+    fan_out_ms: float
+    total_ms: float
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class FormatRequest:
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class FormatResponse:
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class FileDiff:
+    def __init__(self, **kwargs: Any) -> None: ...

--- a/src/apme/v1/validate_pb2.pyi
+++ b/src/apme/v1/validate_pb2.pyi
@@ -1,0 +1,13 @@
+"""Stub for generated validate_pb2 (proto types)."""
+
+from typing import Any
+
+class ValidateRequest:
+    request_id: str
+    hierarchy_payload: bytes
+    scandata: bytes
+    files: list[Any]
+    def __init__(self, **kwargs: Any) -> None: ...
+
+class ValidateResponse:
+    def __init__(self, **kwargs: Any) -> None: ...

--- a/src/apme_engine/cli.py
+++ b/src/apme_engine/cli.py
@@ -5,10 +5,12 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 import grpc
 
-from apme.v1 import primary_pb2, primary_pb2_grpc
+from apme.v1 import primary_pb2_grpc
+from apme.v1.primary_pb2 import ScanDiagnostics
 from apme_engine.collection_cache import (
     get_cache_root,
     pull_galaxy_collection,
@@ -27,10 +29,10 @@ from apme_engine.validators.native import NativeValidator
 from apme_engine.validators.opa import OpaValidator
 
 
-def _sort_violations(violations: list[dict]) -> list[dict]:
+def _sort_violations(violations: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Sort by file, then line for stable output."""
 
-    def key(v):
+    def key(v: dict[str, Any]) -> tuple[str, int | float]:
         f = v.get("file") or ""
         line = v.get("line")
         if isinstance(line, (list, tuple)) and line:
@@ -40,10 +42,10 @@ def _sort_violations(violations: list[dict]) -> list[dict]:
     return sorted(violations, key=key)
 
 
-def _deduplicate_violations(violations: list[dict]) -> list[dict]:
+def _deduplicate_violations(violations: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Remove duplicate violations sharing the same (rule_id, file, line)."""
-    seen: set[tuple] = set()
-    out: list[dict] = []
+    seen: set[tuple[str, str, Any]] = set()
+    out: list[dict[str, Any]] = []
     for v in violations:
         line = v.get("line")
         if isinstance(line, (list, tuple)):
@@ -64,7 +66,7 @@ def _fmt_ms(ms: float) -> str:
     return f"{ms / 1000:.1f}s"
 
 
-def _print_diagnostics_v(diag: "primary_pb2.ScanDiagnostics"):
+def _print_diagnostics_v(diag: ScanDiagnostics) -> None:
     """Print -v level diagnostics: validator summaries + top 10 slowest rules."""
     w = sys.stderr.write
 
@@ -113,7 +115,7 @@ def _print_diagnostics_v(diag: "primary_pb2.ScanDiagnostics"):
     w("\n")
 
 
-def _print_diagnostics_vv(diag: "primary_pb2.ScanDiagnostics"):
+def _print_diagnostics_vv(diag: ScanDiagnostics) -> None:
     """Print -vv level diagnostics: full per-rule breakdown for every validator."""
     w = sys.stderr.write
 
@@ -146,7 +148,7 @@ def _print_diagnostics_vv(diag: "primary_pb2.ScanDiagnostics"):
     w(f"  Total:        {_fmt_ms(diag.total_ms)}\n\n")
 
 
-def _diag_to_dict(diag: "primary_pb2.ScanDiagnostics") -> dict:
+def _diag_to_dict(diag: ScanDiagnostics) -> dict[str, Any]:
     """Convert ScanDiagnostics proto to a JSON-serializable dict."""
     validators = []
     for vd in diag.validators:
@@ -176,7 +178,7 @@ def _diag_to_dict(diag: "primary_pb2.ScanDiagnostics") -> dict:
     }
 
 
-def _run_scan(args):
+def _run_scan(args: argparse.Namespace) -> None:
     """Run scan: engine + validators on target path, or call Primary daemon over gRPC."""
     primary_addr = getattr(args, "primary_addr", None) or os.environ.get("APME_PRIMARY_ADDRESS")
     if primary_addr:
@@ -197,13 +199,13 @@ def _run_scan(args):
             print(json.dumps({"violations": [], "hierarchy_payload": context.hierarchy_payload}))
         sys.exit(0)
 
-    validators = []
+    validators: list[tuple[str, OpaValidator | NativeValidator]] = []
     if not args.no_opa:
         validators.append(("OPA", OpaValidator(args.opa_bundle)))
     if not args.no_native:
         validators.append(("Native", NativeValidator()))
 
-    violations = []
+    violations: list[dict[str, Any]] = []
     for name, v in validators:
         result = v.run(context)
         sys.stderr.write(f"{name}: {len(result)} violation(s)\n")
@@ -221,17 +223,20 @@ def _run_scan(args):
         print(json.dumps({"violations": violations, "count": len(violations)}, indent=2))
         return
 
-    payload = context.hierarchy_payload
+    payload: dict[str, Any] = context.hierarchy_payload or {}
     print(f"Scan: {payload.get('scan_id', '')} | Violations: {len(violations)}")
-    for v in violations:
-        line = v.get("line")
+    for violation in violations:
+        line = violation.get("line")
         line_str = str(line) if line is not None else "?"
-        print(f"  [{v.get('rule_id', '')}] {v.get('file', '')}:{line_str} - {v.get('message', '')}")
+        rule_id = violation.get("rule_id", "")
+        fpath = violation.get("file", "")
+        msg = violation.get("message", "")
+        print(f"  [{rule_id}] {fpath}:{line_str} - {msg}")
     if not violations:
         print("No violations.")
 
 
-def _run_scan_grpc(args, primary_addr: str):
+def _run_scan_grpc(args: argparse.Namespace, primary_addr: str) -> None:
     """Send chunked fs to Primary daemon and print violations."""
     verbosity = getattr(args, "verbose", 0) or 0
 
@@ -247,7 +252,7 @@ def _run_scan_grpc(args, primary_addr: str):
         sys.exit(1)
 
     channel = grpc.insecure_channel(primary_addr)
-    stub = primary_pb2_grpc.PrimaryStub(channel)
+    stub = primary_pb2_grpc.PrimaryStub(channel)  # type: ignore[no-untyped-call]
     try:
         resp = stub.Scan(req, timeout=120)
     except grpc.RpcError as e:
@@ -283,7 +288,7 @@ def _run_scan_grpc(args, primary_addr: str):
         print("No violations.")
 
 
-def _run_cache(args):
+def _run_cache(args: argparse.Namespace) -> None:
     """Run a collection cache command (pull-galaxy, pull-requirements, clone-org)."""
     cache_root = get_cache_root() if args.cache_root is None else Path(args.cache_root)
 
@@ -322,7 +327,7 @@ def _run_cache(args):
         sys.exit(1)
 
 
-def _run_format(args):
+def _run_format(args: argparse.Namespace) -> None:
     """Format YAML files: normalize indentation, key order, jinja spacing, tabs."""
     target = Path(args.target).resolve()
     exclude = getattr(args, "exclude", None) or []
@@ -364,7 +369,7 @@ def _run_format(args):
         sys.stderr.write(f"\n{len(changed)} file(s) would be reformatted (use --apply to write)\n")
 
 
-def _scan_files_local(file_paths: list[str], repo_root: str, opa_bundle: str | None) -> list[dict]:
+def _scan_files_local(file_paths: list[str], repo_root: str, opa_bundle: str | None) -> list[dict[str, Any]]:
     """In-process scan: engine + OPA + native validators. Returns violation dicts."""
     from apme_engine.runner import run_scan as _run_scan
 
@@ -372,7 +377,7 @@ def _scan_files_local(file_paths: list[str], repo_root: str, opa_bundle: str | N
     if not yaml_files:
         return []
 
-    all_violations: list[dict] = []
+    all_violations: list[dict[str, Any]] = []
     for fpath in yaml_files:
         try:
             context = _run_scan(fpath, repo_root, include_scandata=True)
@@ -382,7 +387,7 @@ def _scan_files_local(file_paths: list[str], repo_root: str, opa_bundle: str | N
         if not context.hierarchy_payload:
             continue
 
-        validators = [
+        validators: list[tuple[str, OpaValidator | NativeValidator]] = [
             ("OPA", OpaValidator(opa_bundle)),
             ("Native", NativeValidator()),
         ]
@@ -392,7 +397,7 @@ def _scan_files_local(file_paths: list[str], repo_root: str, opa_bundle: str | N
     return _deduplicate_violations(_sort_violations(all_violations))
 
 
-def _run_fix(args):
+def _run_fix(args: argparse.Namespace) -> None:
     """Format → idempotency check → scan → remediate (convergence loop)."""
     target = Path(args.target).resolve()
     exclude = getattr(args, "exclude", None) or []
@@ -461,7 +466,7 @@ def _run_fix(args):
     repo_root = str(Path(__file__).resolve().parent.parent)
     opa_bundle = getattr(args, "opa_bundle", None)
 
-    def scan_fn(paths: list[str]) -> list[dict]:
+    def scan_fn(paths: list[str]) -> list[dict[str, Any]]:
         return _scan_files_local(paths, repo_root, opa_bundle)
 
     registry = build_default_registry()
@@ -493,7 +498,7 @@ def _run_fix(args):
             sys.stdout.write(p.diff)
 
 
-def _run_health_check(args):
+def _run_health_check(args: argparse.Namespace) -> None:
     """Check health of all services (Primary, Native, OPA, Ansible, Cache maintainer) via gRPC."""
     primary_addr = getattr(args, "primary_addr", None) or os.environ.get("APME_PRIMARY_ADDRESS")
     if not primary_addr:
@@ -510,7 +515,9 @@ def _run_health_check(args):
     )
 
     if getattr(args, "json", False):
-        out = {name: {k: v for k, v in r.items() if v is not None} for name, r in results.items()}
+        out: dict[str, dict[str, Any]] = {
+            name: {k: v for k, v in r.items() if v is not None} for name, r in results.items()
+        }
         print(json.dumps(out, indent=2))
         sys.exit(0 if all(r["ok"] for r in results.values()) else 1)
 
@@ -529,7 +536,7 @@ def _run_health_check(args):
     sys.exit(0 if all_ok else 1)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Run APME scan: engine + OPA and native validators; or manage collection cache.",
     )

--- a/src/apme_engine/daemon/ansible_validator_main.py
+++ b/src/apme_engine/daemon/ansible_validator_main.py
@@ -8,14 +8,14 @@ import traceback
 from apme_engine.daemon.ansible_validator_server import serve
 
 
-async def _run(listen: str):
+async def _run(listen: str) -> None:
     server = await serve(listen)
     sys.stderr.write(f"Ansible validator listening on {listen}\n")
     sys.stderr.flush()
     await server.wait_for_termination()
 
 
-def main():
+def main() -> None:
     listen = os.environ.get("APME_ANSIBLE_VALIDATOR_LISTEN", "0.0.0.0:50053")
     try:
         asyncio.run(_run(listen))

--- a/src/apme_engine/daemon/ansible_validator_server.py
+++ b/src/apme_engine/daemon/ansible_validator_server.py
@@ -11,11 +11,14 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import grpc
 import grpc.aio
 
-from apme.v1 import common_pb2, validate_pb2, validate_pb2_grpc
+from apme.v1 import validate_pb2, validate_pb2_grpc
+from apme.v1.common_pb2 import HealthResponse, RuleTiming, ValidatorDiagnostics
+from apme.v1.validate_pb2 import ValidateResponse
 from apme_engine.collection_cache.config import get_cache_root
 from apme_engine.collection_cache.venv_builder import build_venv
 from apme_engine.daemon.violation_convert import violation_dict_to_proto
@@ -43,7 +46,7 @@ def _cache_root() -> Path:
     return get_cache_root()
 
 
-def _write_chunked_fs(files: list) -> Path:
+def _write_chunked_fs(files: list[Any]) -> Path:
     """Write request.files into a temp directory; return path to that directory."""
     tmp = Path(tempfile.mkdtemp(prefix="apme_ansible_val_"))
     for f in files:
@@ -69,10 +72,10 @@ def _build_ephemeral_venv(
 
 
 def _run_ansible_validate(
-    files: list,
+    files: list[Any],
     raw_version: str,
     collection_specs: list[str],
-    hierarchy_payload: dict,
+    hierarchy_payload: dict[str, Any],
     req_id: str,
 ) -> _AnsibleResult:
     """Blocking function: build ephemeral venv, run validator, return result with timing."""
@@ -91,7 +94,7 @@ def _run_ansible_validate(
             venv_build_ms = (time.monotonic() - tv) * 1000
             sys.stderr.write(f"[req={req_id}] Ansible: venv build failed for {raw_version}: {e}\n")
             sys.stderr.flush()
-            err_viol = {
+            err_viol: dict[str, Any] = {
                 "rule_id": "L057",
                 "level": "error",
                 "message": f"Ephemeral venv build failed for {raw_version}: {e}",
@@ -128,7 +131,7 @@ def _run_ansible_validate(
         sys.stderr.write(f"[req={req_id}] Ansible error: {e}\n")
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
-        err_viol = {
+        err_viol_exc: dict[str, Any] = {
             "rule_id": "L057",
             "level": "error",
             "message": str(e),
@@ -137,7 +140,7 @@ def _run_ansible_validate(
             "path": "",
         }
         return _AnsibleResult(
-            run_result=AnsibleRunResult(violations=[err_viol]),
+            run_result=AnsibleRunResult(violations=[err_viol_exc]),
             venv_build_ms=venv_build_ms,
             ansible_core_version=raw_version,
         )
@@ -153,17 +156,17 @@ def _run_ansible_validate(
 class AnsibleValidatorServicer(validate_pb2_grpc.ValidatorServicer):
     """Async gRPC adapter: builds ephemeral venv per request, runs AnsibleValidator."""
 
-    async def Validate(self, request, context):
+    async def Validate(self, request: Any, context: Any) -> ValidateResponse:
         req_id = request.request_id or ""
         t0 = time.monotonic()
         try:
             if not request.files:
-                return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
+                return ValidateResponse(violations=[], request_id=req_id)
 
             raw_version = (request.ansible_core_version or "").strip() or DEFAULT_VERSION
             collection_specs = [s.strip() for s in (request.collection_specs or []) if s.strip()]
 
-            hierarchy_payload = {}
+            hierarchy_payload: dict[str, Any] = {}
             if request.hierarchy_payload:
                 try:
                     hierarchy_payload = json.loads(request.hierarchy_payload)
@@ -193,14 +196,14 @@ class AnsibleValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             sys.stderr.flush()
 
             rule_timings = [
-                common_pb2.RuleTiming(
+                RuleTiming(
                     rule_id=rt.rule_id,
                     elapsed_ms=rt.elapsed_ms,
                     violations=rt.violations,
                 )
                 for rt in result.run_result.rule_timings
             ]
-            diag = common_pb2.ValidatorDiagnostics(
+            diag = ValidatorDiagnostics(
                 validator_name="ansible",
                 request_id=req_id,
                 total_ms=total_ms,
@@ -224,16 +227,16 @@ class AnsibleValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             sys.stderr.write(f"[req={req_id}] Ansible error: {e}\n")
             traceback.print_exc(file=sys.stderr)
             sys.stderr.flush()
-            return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
+            return ValidateResponse(violations=[], request_id=req_id)
 
-    async def Health(self, request, context):
-        return common_pb2.HealthResponse(status="ok")
+    async def Health(self, request: Any, context: Any) -> HealthResponse:
+        return HealthResponse(status="ok")
 
 
-async def serve(listen: str = "0.0.0.0:50053"):
+async def serve(listen: str = "0.0.0.0:50053") -> Any:
     """Create, bind, and start async gRPC server with Ansible servicer."""
     server = grpc.aio.server(maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS)
-    validate_pb2_grpc.add_ValidatorServicer_to_server(AnsibleValidatorServicer(), server)
+    validate_pb2_grpc.add_ValidatorServicer_to_server(AnsibleValidatorServicer(), server)  # type: ignore[no-untyped-call]
     if ":" in listen:
         _, _, port = listen.rpartition(":")
         server.add_insecure_port(f"[::]:{port}")

--- a/src/apme_engine/daemon/cache_maintainer_main.py
+++ b/src/apme_engine/daemon/cache_maintainer_main.py
@@ -7,7 +7,7 @@ import traceback
 from apme_engine.daemon.cache_maintainer_server import serve
 
 
-def main():
+def main() -> None:
     listen = os.environ.get("APME_CACHE_MAINTAINER_LISTEN", "0.0.0.0:50052")
     try:
         server = serve(listen)

--- a/src/apme_engine/daemon/cache_maintainer_server.py
+++ b/src/apme_engine/daemon/cache_maintainer_server.py
@@ -3,10 +3,13 @@
 import os
 from concurrent import futures
 from pathlib import Path
+from typing import Any
 
 import grpc
 
-from apme.v1 import cache_pb2, cache_pb2_grpc, common_pb2
+from apme.v1 import cache_pb2_grpc
+from apme.v1.cache_pb2 import CloneOrgResponse, PullGalaxyResponse, PullRequirementsResponse
+from apme.v1.common_pb2 import HealthResponse
 from apme_engine.collection_cache.config import get_cache_root
 from apme_engine.collection_cache.manager import (
     pull_galaxy_collection,
@@ -27,36 +30,36 @@ def _cache_root() -> Path:
 class CacheMaintainerServicer(cache_pb2_grpc.CacheMaintainerServicer):
     """Implements CacheMaintainer RPCs using collection_cache manager."""
 
-    def PullGalaxy(self, request, context):
+    def PullGalaxy(self, request: Any, context: Any) -> PullGalaxyResponse:
         try:
             path = pull_galaxy_collection(
                 spec=request.spec or "",
                 cache_root=_cache_root(),
                 galaxy_server=request.galaxy_server or None,
             )
-            return cache_pb2.PullGalaxyResponse(success=True, path=str(path))
+            return PullGalaxyResponse(success=True, path=str(path))
         except Exception as e:
-            return cache_pb2.PullGalaxyResponse(success=False, error_message=str(e))
+            return PullGalaxyResponse(success=False, error_message=str(e))
 
-    def PullRequirements(self, request, context):
+    def PullRequirements(self, request: Any, context: Any) -> PullRequirementsResponse:
         try:
             req_path = (request.requirements_path or "").strip()
             if not req_path:
-                return cache_pb2.PullRequirementsResponse(success=False, error_message="requirements_path is required")
+                return PullRequirementsResponse(success=False, error_message="requirements_path is required")
             paths = pull_galaxy_requirements(
                 requirements_path=req_path,
                 cache_root=_cache_root(),
                 galaxy_server=request.galaxy_server or None,
             )
-            return cache_pb2.PullRequirementsResponse(success=True, paths=[str(p) for p in paths])
+            return PullRequirementsResponse(success=True, paths=[str(p) for p in paths])
         except Exception as e:
-            return cache_pb2.PullRequirementsResponse(success=False, error_message=str(e))
+            return PullRequirementsResponse(success=False, error_message=str(e))
 
-    def CloneOrg(self, request, context):
+    def CloneOrg(self, request: Any, context: Any) -> CloneOrgResponse:
         try:
             org = (request.org or "").strip()
             if not org:
-                return cache_pb2.CloneOrgResponse(success=False, error_message="org is required")
+                return CloneOrgResponse(success=False, error_message="org is required")
             depth = request.depth if request.depth > 0 else 1
             token = (request.token or "").strip() or None
             cache = _cache_root()
@@ -81,18 +84,18 @@ class CacheMaintainerServicer(cache_pb2_grpc.CacheMaintainerServicer):
                 finally:
                     if token and "GITHUB_TOKEN" in os.environ:
                         del os.environ["GITHUB_TOKEN"]
-            return cache_pb2.CloneOrgResponse(success=True, paths=[str(p) for p in paths])
+            return CloneOrgResponse(success=True, paths=[str(p) for p in paths])
         except Exception as e:
-            return cache_pb2.CloneOrgResponse(success=False, error_message=str(e))
+            return CloneOrgResponse(success=False, error_message=str(e))
 
-    def Health(self, request, context):
-        return common_pb2.HealthResponse(status="ok")
+    def Health(self, request: Any, context: Any) -> HealthResponse:
+        return HealthResponse(status="ok")
 
 
-def serve(listen: str = "0.0.0.0:50052"):
+def serve(listen: str = "0.0.0.0:50052") -> Any:
     """Create and return a gRPC server with CacheMaintainer servicer (caller must start it)."""
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
-    cache_pb2_grpc.add_CacheMaintainerServicer_to_server(CacheMaintainerServicer(), server)
+    cache_pb2_grpc.add_CacheMaintainerServicer_to_server(CacheMaintainerServicer(), server)  # type: ignore[no-untyped-call]
     if ":" in listen:
         _, _, port = listen.rpartition(":")
         server.add_insecure_port(f"[::]:{port}")

--- a/src/apme_engine/daemon/chunked_fs.py
+++ b/src/apme_engine/daemon/chunked_fs.py
@@ -3,7 +3,8 @@
 import os
 from pathlib import Path
 
-from apme.v1 import common_pb2, primary_pb2
+from apme.v1.common_pb2 import File
+from apme.v1.primary_pb2 import ScanOptions, ScanRequest
 
 # Skip these dirs when walking (same kind of ignores as many linters)
 SKIP_DIRS = {".git", "__pycache__", ".venv", "venv", "node_modules", ".tox", "htmlcov"}
@@ -62,7 +63,7 @@ def build_scan_request(
     project_root_name: str = "project",
     ansible_core_version: str | None = None,
     collection_specs: list[str] | None = None,
-) -> primary_pb2.ScanRequest:
+) -> ScanRequest:
     """
     Walk target_path (file or directory) and build a ScanRequest with chunked files.
     Paths in File messages are relative to the project root (target_path if dir, else parent).
@@ -98,15 +99,15 @@ def build_scan_request(
         # Skip if looks binary
         if b"\x00" in content[:8192]:
             continue
-        files.append(common_pb2.File(path=str(rel), content=content))
+        files.append(File(path=str(rel), content=content))
 
-    options = primary_pb2.ScanOptions()
+    options = ScanOptions()
     if ansible_core_version:
         options.ansible_core_version = ansible_core_version
     if collection_specs:
         options.collection_specs.extend(collection_specs)
 
-    return primary_pb2.ScanRequest(
+    return ScanRequest(
         scan_id=scan_id or "",
         project_root=project_root_name,
         files=files,

--- a/src/apme_engine/daemon/gitleaks_validator_main.py
+++ b/src/apme_engine/daemon/gitleaks_validator_main.py
@@ -8,14 +8,14 @@ import traceback
 from apme_engine.daemon.gitleaks_validator_server import serve
 
 
-async def _run(listen: str):
+async def _run(listen: str) -> None:
     server = await serve(listen)
     sys.stderr.write(f"Gitleaks validator listening on {listen}\n")
     sys.stderr.flush()
     await server.wait_for_termination()
 
 
-def main():
+def main() -> None:
     listen = os.environ.get("APME_GITLEAKS_VALIDATOR_LISTEN", "0.0.0.0:50056")
     try:
         asyncio.run(_run(listen))

--- a/src/apme_engine/daemon/gitleaks_validator_server.py
+++ b/src/apme_engine/daemon/gitleaks_validator_server.py
@@ -9,11 +9,14 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+from typing import Any
 
 import grpc
 import grpc.aio
 
-from apme.v1 import common_pb2, validate_pb2, validate_pb2_grpc
+from apme.v1 import validate_pb2_grpc
+from apme.v1.common_pb2 import HealthResponse, RuleTiming, ValidatorDiagnostics
+from apme.v1.validate_pb2 import ValidateResponse
 from apme_engine.daemon.violation_convert import violation_dict_to_proto
 from apme_engine.validators.gitleaks.scanner import GITLEAKS_BIN, run_gitleaks
 
@@ -32,7 +35,7 @@ _SCANNABLE_EXTENSIONS = (
 )
 
 
-def _run_scan(files: list) -> tuple[list[dict], int]:
+def _run_scan(files: list[Any]) -> tuple[list[dict[str, Any]], int]:
     """Blocking function: write files to temp dir, run gitleaks, return (violations, files_written)."""
     temp_dir = Path(tempfile.mkdtemp(prefix="apme_gitleaks_"))
     try:
@@ -65,12 +68,12 @@ def _get_gitleaks_version() -> str:
 class GitleaksValidatorServicer(validate_pb2_grpc.ValidatorServicer):
     """Async gRPC adapter: runs gitleaks in executor thread."""
 
-    async def Validate(self, request, context):
+    async def Validate(self, request: Any, context: Any) -> ValidateResponse:
         req_id = request.request_id or ""
         t0 = time.monotonic()
         try:
             if not request.files:
-                return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
+                return ValidateResponse(violations=[], request_id=req_id)
 
             sys.stderr.write(f"[req={req_id}] Gitleaks: scanning {len(request.files)} file(s)\n")
             sys.stderr.flush()
@@ -85,14 +88,14 @@ class GitleaksValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             sys.stderr.write(f"[req={req_id}] Gitleaks: {len(violations)} finding(s) in {total_ms:.1f}ms\n")
             sys.stderr.flush()
 
-            diag = common_pb2.ValidatorDiagnostics(
+            diag = ValidatorDiagnostics(
                 validator_name="gitleaks",
                 request_id=req_id,
                 total_ms=total_ms,
                 files_received=len(request.files),
                 violations_found=len(violations),
                 rule_timings=[
-                    common_pb2.RuleTiming(
+                    RuleTiming(
                         rule_id="gitleaks_subprocess",
                         elapsed_ms=total_ms,
                         violations=len(violations),
@@ -104,7 +107,7 @@ class GitleaksValidatorServicer(validate_pb2_grpc.ValidatorServicer):
                 },
             )
 
-            return validate_pb2.ValidateResponse(
+            return ValidateResponse(
                 violations=[violation_dict_to_proto(v) for v in violations],
                 request_id=req_id,
                 diagnostics=diag,
@@ -115,9 +118,9 @@ class GitleaksValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             sys.stderr.write(f"[req={req_id}] Gitleaks error: {e}\n")
             traceback.print_exc(file=sys.stderr)
             sys.stderr.flush()
-            return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
+            return ValidateResponse(violations=[], request_id=req_id)
 
-    async def Health(self, request, context):
+    async def Health(self, request: Any, context: Any) -> HealthResponse:
         try:
             proc = await asyncio.create_subprocess_exec(
                 GITLEAKS_BIN,
@@ -128,18 +131,18 @@ class GitleaksValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
             if proc.returncode == 0:
                 version = stdout.decode().strip()
-                return common_pb2.HealthResponse(status=f"ok (gitleaks {version})")
-            return common_pb2.HealthResponse(status=f"gitleaks exited {proc.returncode}")
+                return HealthResponse(status=f"ok (gitleaks {version})")
+            return HealthResponse(status=f"gitleaks exited {proc.returncode}")
         except FileNotFoundError:
-            return common_pb2.HealthResponse(status="gitleaks binary not found")
+            return HealthResponse(status="gitleaks binary not found")
         except Exception as e:
-            return common_pb2.HealthResponse(status=f"gitleaks health error: {e}")
+            return HealthResponse(status=f"gitleaks health error: {e}")
 
 
-async def serve(listen: str = "0.0.0.0:50056"):
+async def serve(listen: str = "0.0.0.0:50056") -> Any:
     """Create, bind, and start async gRPC server with Gitleaks servicer."""
     server = grpc.aio.server(maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS)
-    validate_pb2_grpc.add_ValidatorServicer_to_server(GitleaksValidatorServicer(), server)
+    validate_pb2_grpc.add_ValidatorServicer_to_server(GitleaksValidatorServicer(), server)  # type: ignore[no-untyped-call]
     if ":" in listen:
         _, _, port = listen.rpartition(":")
         server.add_insecure_port(f"[::]:{port}")

--- a/src/apme_engine/daemon/health_check.py
+++ b/src/apme_engine/daemon/health_check.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+from collections.abc import Callable
 from typing import Any
 
 import grpc
@@ -24,7 +25,7 @@ def _derive_addresses(primary_addr: str) -> dict[str, str]:
     }
 
 
-def check_grpc_health(addr: str, stub_factory, timeout: float = 5.0) -> dict[str, Any]:
+def check_grpc_health(addr: str, stub_factory: Callable[..., Any], timeout: float = 5.0) -> dict[str, Any]:
     """Call Health RPC on a gRPC service; return {ok, status, error, latency_ms}."""
     start = time.perf_counter()
     try:

--- a/src/apme_engine/daemon/native_validator_main.py
+++ b/src/apme_engine/daemon/native_validator_main.py
@@ -8,14 +8,14 @@ import traceback
 from apme_engine.daemon.native_validator_server import serve
 
 
-async def _run(listen: str):
+async def _run(listen: str) -> None:
     server = await serve(listen)
     sys.stderr.write(f"Native validator listening on {listen}\n")
     sys.stderr.flush()
     await server.wait_for_termination()
 
 
-def main():
+def main() -> None:
     listen = os.environ.get("APME_NATIVE_VALIDATOR_LISTEN", "0.0.0.0:50055")
     try:
         asyncio.run(_run(listen))

--- a/src/apme_engine/daemon/native_validator_server.py
+++ b/src/apme_engine/daemon/native_validator_server.py
@@ -5,12 +5,15 @@ import json
 import os
 import sys
 import time
+from typing import Any
 
 import grpc
 import grpc.aio
 import jsonpickle
 
-from apme.v1 import common_pb2, validate_pb2, validate_pb2_grpc
+from apme.v1 import validate_pb2, validate_pb2_grpc
+from apme.v1.common_pb2 import HealthResponse, RuleTiming, ValidatorDiagnostics
+from apme.v1.validate_pb2 import ValidateResponse
 from apme_engine.daemon.violation_convert import violation_dict_to_proto
 from apme_engine.validators.base import ScanContext
 from apme_engine.validators.native import NativeRunResult, NativeValidator
@@ -18,7 +21,7 @@ from apme_engine.validators.native import NativeRunResult, NativeValidator
 _MAX_CONCURRENT_RPCS = int(os.environ.get("APME_NATIVE_MAX_RPCS", "32"))
 
 
-def _run_native(hierarchy_payload: dict, scandata) -> NativeRunResult:
+def _run_native(hierarchy_payload: dict[str, Any], scandata: Any) -> NativeRunResult:
     """Blocking function: create ScanContext and run NativeValidator with timing."""
     scan_context = ScanContext(
         hierarchy_payload=hierarchy_payload,
@@ -31,11 +34,11 @@ def _run_native(hierarchy_payload: dict, scandata) -> NativeRunResult:
 class NativeValidatorServicer(validate_pb2_grpc.ValidatorServicer):
     """Async gRPC adapter: deserializes scandata, runs native rules in executor."""
 
-    async def Validate(self, request, context):
+    async def Validate(self, request: Any, context: Any) -> ValidateResponse:
         req_id = request.request_id or ""
         t0 = time.monotonic()
         try:
-            hierarchy_payload = {}
+            hierarchy_payload: dict[str, Any] = {}
             if request.hierarchy_payload:
                 try:
                     hierarchy_payload = json.loads(request.hierarchy_payload)
@@ -48,7 +51,7 @@ class NativeValidatorServicer(validate_pb2_grpc.ValidatorServicer):
                     scandata = jsonpickle.decode(request.scandata.decode("utf-8"))
                 except Exception as e:
                     sys.stderr.write(f"[req={req_id}] Native: failed to decode scandata: {e}\n")
-                    return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
+                    return ValidateResponse(violations=[], request_id=req_id)
 
             result = await asyncio.get_event_loop().run_in_executor(
                 None,
@@ -61,14 +64,14 @@ class NativeValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             sys.stderr.flush()
 
             rule_timings = [
-                common_pb2.RuleTiming(
+                RuleTiming(
                     rule_id=rt.rule_id,
                     elapsed_ms=rt.elapsed_ms,
                     violations=rt.violations,
                 )
                 for rt in result.rule_timings
             ]
-            diag = common_pb2.ValidatorDiagnostics(
+            diag = ValidatorDiagnostics(
                 validator_name="native",
                 request_id=req_id,
                 total_ms=total_ms,
@@ -88,16 +91,16 @@ class NativeValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             sys.stderr.write(f"[req={req_id}] Native error: {e}\n")
             traceback.print_exc(file=sys.stderr)
             sys.stderr.flush()
-            return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
+            return ValidateResponse(violations=[], request_id=req_id)
 
-    async def Health(self, request, context):
-        return common_pb2.HealthResponse(status="ok")
+    async def Health(self, request: Any, context: Any) -> HealthResponse:
+        return HealthResponse(status="ok")
 
 
-async def serve(listen: str = "0.0.0.0:50055"):
+async def serve(listen: str = "0.0.0.0:50055") -> Any:
     """Create, bind, and start async gRPC server with Native servicer."""
     server = grpc.aio.server(maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS)
-    validate_pb2_grpc.add_ValidatorServicer_to_server(NativeValidatorServicer(), server)
+    validate_pb2_grpc.add_ValidatorServicer_to_server(NativeValidatorServicer(), server)  # type: ignore[no-untyped-call]
     if ":" in listen:
         _, _, port = listen.rpartition(":")
         server.add_insecure_port(f"[::]:{port}")

--- a/src/apme_engine/daemon/opa_validator_main.py
+++ b/src/apme_engine/daemon/opa_validator_main.py
@@ -8,14 +8,14 @@ import traceback
 from apme_engine.daemon.opa_validator_server import serve
 
 
-async def _run(listen: str):
+async def _run(listen: str) -> None:
     server = await serve(listen)
     sys.stderr.write(f"OPA validator (gRPC wrapper) listening on {listen}\n")
     sys.stderr.flush()
     await server.wait_for_termination()
 
 
-def main():
+def main() -> None:
     listen = os.environ.get("APME_OPA_VALIDATOR_LISTEN", "0.0.0.0:50054")
     try:
         asyncio.run(_run(listen))

--- a/src/apme_engine/daemon/opa_validator_server.py
+++ b/src/apme_engine/daemon/opa_validator_server.py
@@ -4,12 +4,15 @@ import json
 import os
 import sys
 import time
+from typing import Any
 
 import grpc
 import grpc.aio
 import httpx
 
-from apme.v1 import common_pb2, validate_pb2, validate_pb2_grpc
+from apme.v1 import validate_pb2, validate_pb2_grpc
+from apme.v1.common_pb2 import HealthResponse, RuleTiming, ValidatorDiagnostics
+from apme.v1.validate_pb2 import ValidateResponse
 from apme_engine.daemon.violation_convert import violation_dict_to_proto
 
 OPA_REST_URL = os.environ.get("APME_OPA_REST_URL", "http://localhost:8181")
@@ -21,23 +24,23 @@ _MAX_CONCURRENT_RPCS = int(os.environ.get("APME_OPA_MAX_RPCS", "32"))
 class OpaValidatorServicer(validate_pb2_grpc.ValidatorServicer):
     """Async gRPC facade: translates Validate RPCs into OPA REST queries via httpx."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._client = httpx.AsyncClient(timeout=30.0)
 
-    async def Validate(self, request, context):
+    async def Validate(self, request: Any, context: Any) -> validate_pb2.ValidateResponse:
         req_id = request.request_id or ""
         t0 = time.monotonic()
-        violations: list[dict] = []
+        violations: list[dict[str, Any]] = []
         opa_query_ms = 0.0
         opa_response_size = 0
         try:
-            hierarchy_payload = {}
+            hierarchy_payload: dict[str, Any] = {}
             if request.hierarchy_payload:
                 try:
                     hierarchy_payload = json.loads(request.hierarchy_payload)
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     sys.stderr.write(f"[req={req_id}] OPA: failed to decode hierarchy_payload\n")
-                    return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
+                    return ValidateResponse(violations=[], request_id=req_id)
 
             url = f"{OPA_REST_URL}{OPA_VIOLATIONS_ENDPOINT}"
             tq = time.monotonic()
@@ -48,7 +51,7 @@ class OpaValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             if r.status_code != 200:
                 sys.stderr.write(f"[req={req_id}] OPA returned HTTP {r.status_code}\n")
                 sys.stderr.flush()
-                return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
+                return ValidateResponse(violations=[], request_id=req_id)
 
             data = r.json()
             result = data.get("result", [])
@@ -59,7 +62,7 @@ class OpaValidatorServicer(validate_pb2_grpc.ValidatorServicer):
         except Exception as e:
             sys.stderr.write(f"[req={req_id}] OPA error: {e}\n")
             sys.stderr.flush()
-            return validate_pb2.ValidateResponse(violations=[], request_id=req_id)
+            return ValidateResponse(violations=[], request_id=req_id)
 
         total_ms = (time.monotonic() - t0) * 1000
 
@@ -67,12 +70,12 @@ class OpaValidatorServicer(validate_pb2_grpc.ValidatorServicer):
 
         rule_counts = Counter(v.get("rule_id", "unknown") for v in violations)
         rule_timings = [
-            common_pb2.RuleTiming(rule_id="opa_query", elapsed_ms=opa_query_ms, violations=len(violations)),
+            RuleTiming(rule_id="opa_query", elapsed_ms=opa_query_ms, violations=len(violations)),
         ]
         for rid, count in sorted(rule_counts.items()):
-            rule_timings.append(common_pb2.RuleTiming(rule_id=rid, elapsed_ms=0.0, violations=count))
+            rule_timings.append(RuleTiming(rule_id=rid, elapsed_ms=0.0, violations=count))
 
-        diag = common_pb2.ValidatorDiagnostics(
+        diag = ValidatorDiagnostics(
             validator_name="opa",
             request_id=req_id,
             total_ms=total_ms,
@@ -85,26 +88,26 @@ class OpaValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             },
         )
 
-        return validate_pb2.ValidateResponse(
+        return ValidateResponse(
             violations=[violation_dict_to_proto(v) for v in violations],
             request_id=req_id,
             diagnostics=diag,
         )
 
-    async def Health(self, request, context):
+    async def Health(self, request: Any, context: Any) -> HealthResponse:
         try:
             r = await self._client.get(f"{OPA_REST_URL}/health")
             if r.status_code == 200:
-                return common_pb2.HealthResponse(status="ok")
-            return common_pb2.HealthResponse(status=f"opa unhealthy: HTTP {r.status_code}")
+                return HealthResponse(status="ok")
+            return HealthResponse(status=f"opa unhealthy: HTTP {r.status_code}")
         except Exception as e:
-            return common_pb2.HealthResponse(status=f"opa unreachable: {e}")
+            return HealthResponse(status=f"opa unreachable: {e}")
 
 
-async def serve(listen: str = "0.0.0.0:50054"):
+async def serve(listen: str = "0.0.0.0:50054") -> Any:
     """Create, bind, and start async gRPC server with OPA servicer."""
     server = grpc.aio.server(maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS)
-    validate_pb2_grpc.add_ValidatorServicer_to_server(OpaValidatorServicer(), server)
+    validate_pb2_grpc.add_ValidatorServicer_to_server(OpaValidatorServicer(), server)  # type: ignore[no-untyped-call]
     if ":" in listen:
         _, _, port = listen.rpartition(":")
         server.add_insecure_port(f"[::]:{port}")

--- a/src/apme_engine/daemon/primary_main.py
+++ b/src/apme_engine/daemon/primary_main.py
@@ -8,14 +8,14 @@ import traceback
 from apme_engine.daemon.primary_server import serve
 
 
-async def _run(listen: str):
+async def _run(listen: str) -> None:
     server = await serve(listen)
     sys.stderr.write(f"Primary daemon listening on {listen}\n")
     sys.stderr.flush()
     await server.wait_for_termination()
 
 
-def main():
+def main() -> None:
     listen = os.environ.get("APME_PRIMARY_LISTEN", "0.0.0.0:50051")
     try:
         asyncio.run(_run(listen))

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -11,12 +11,16 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import grpc
 import grpc.aio
 import jsonpickle
 
-from apme.v1 import common_pb2, primary_pb2, primary_pb2_grpc, validate_pb2, validate_pb2_grpc
+from apme.v1 import primary_pb2, primary_pb2_grpc, validate_pb2_grpc
+from apme.v1.common_pb2 import HealthResponse, ValidatorDiagnostics
+from apme.v1.primary_pb2 import FileDiff, FormatResponse, ScanDiagnostics, ScanResponse
+from apme.v1.validate_pb2 import ValidateRequest
 from apme_engine.daemon.violation_convert import violation_proto_to_dict
 from apme_engine.runner import run_scan
 
@@ -25,12 +29,12 @@ _MAX_CONCURRENT_RPCS = int(os.environ.get("APME_PRIMARY_MAX_RPCS", "16"))
 
 @dataclass
 class _ValidatorResult:
-    violations: list = field(default_factory=list)
-    diagnostics: common_pb2.ValidatorDiagnostics | None = None
+    violations: list[dict[str, Any]] = field(default_factory=list)
+    diagnostics: ValidatorDiagnostics | None = None
 
 
-def _sort_violations(violations: list[dict]) -> list[dict]:
-    def key(v):
+def _sort_violations(violations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def key(v: dict[str, Any]) -> tuple[str, int | float]:
         f = v.get("file") or ""
         line = v.get("line")
         if isinstance(line, (list, tuple)) and line:
@@ -42,10 +46,10 @@ def _sort_violations(violations: list[dict]) -> list[dict]:
     return sorted(violations, key=key)
 
 
-def _deduplicate_violations(violations: list[dict]) -> list[dict]:
+def _deduplicate_violations(violations: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Remove duplicate violations sharing the same (rule_id, file, line)."""
-    seen: set[tuple] = set()
-    out: list[dict] = []
+    seen: set[tuple[str, str, Any]] = set()
+    out: list[dict[str, Any]] = []
     for v in violations:
         line = v.get("line")
         if isinstance(line, (list, tuple)):
@@ -57,7 +61,7 @@ def _deduplicate_violations(violations: list[dict]) -> list[dict]:
     return out
 
 
-def _write_chunked_fs(project_root: str, files: list) -> Path:
+def _write_chunked_fs(project_root: str, files: list[Any]) -> Path:
     """Write request.files into a temp directory; return path to that directory."""
     tmp = Path(tempfile.mkdtemp(prefix="apme_primary_"))
     for f in files:
@@ -69,13 +73,13 @@ def _write_chunked_fs(project_root: str, files: list) -> Path:
 
 async def _call_validator(
     address: str,
-    request: validate_pb2.ValidateRequest,
+    request: ValidateRequest,
     timeout: int = 60,
 ) -> _ValidatorResult:
     """Call a validator over async gRPC; return violations + diagnostics."""
     req_id = request.request_id or ""
     channel = grpc.aio.insecure_channel(address)
-    stub = validate_pb2_grpc.ValidatorStub(channel)
+    stub = validate_pb2_grpc.ValidatorStub(channel)  # type: ignore[no-untyped-call]
     try:
         resp = await stub.Validate(request, timeout=timeout)
         return _ValidatorResult(
@@ -87,7 +91,7 @@ async def _call_validator(
         sys.stderr.flush()
         return _ValidatorResult()
     finally:
-        await channel.close()
+        await channel.close(grace=None)
 
 
 VALIDATOR_ENV_VARS = {
@@ -99,9 +103,9 @@ VALIDATOR_ENV_VARS = {
 
 
 class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
-    async def Scan(self, request, context):
+    async def Scan(self, request: Any, context: Any) -> primary_pb2.ScanResponse:
         scan_id = request.scan_id or str(uuid.uuid4())
-        violations: list[dict] = []
+        violations: list[dict[str, Any]] = []
         temp_dir = None
         scan_t0 = time.monotonic()
 
@@ -110,7 +114,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             sys.stderr.flush()
 
             if not request.files:
-                return primary_pb2.ScanResponse(scan_id=scan_id, violations=[])
+                return ScanResponse(scan_id=scan_id, violations=[])
 
             temp_dir = await asyncio.get_event_loop().run_in_executor(
                 None,
@@ -134,10 +138,10 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             if not context_obj.hierarchy_payload:
                 sys.stderr.write(f"[req={scan_id}] Scan: no hierarchy payload produced\n")
                 sys.stderr.flush()
-                return primary_pb2.ScanResponse(scan_id=scan_id, violations=[])
+                return ScanResponse(scan_id=scan_id, violations=[])
 
             opts = request.options if request.HasField("options") else None
-            validate_request = validate_pb2.ValidateRequest(
+            validate_request = ValidateRequest(
                 request_id=scan_id,
                 project_root=request.project_root or "",
                 files=list(request.files),
@@ -154,7 +158,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                     continue
                 tasks[name] = _call_validator(addr, validate_request)
 
-            validator_diagnostics: list[common_pb2.ValidatorDiagnostics] = []
+            validator_diagnostics: list[ValidatorDiagnostics] = []
 
             fan_out_ms = 0.0
             if tasks:
@@ -164,15 +168,16 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
 
                 counts: dict[str, int] = {}
                 for name, result in zip(tasks.keys(), results, strict=False):
-                    if isinstance(result, Exception):
+                    if isinstance(result, BaseException):
                         sys.stderr.write(f"[req={scan_id}] {name} raised: {result}\n")
                         sys.stderr.flush()
                         counts[name] = 0
                     else:
-                        counts[name] = len(result.violations)
-                        violations.extend(result.violations)
-                        if result.diagnostics:
-                            validator_diagnostics.append(result.diagnostics)
+                        res = result
+                        counts[name] = len(res.violations)
+                        violations.extend(res.violations)
+                        if res.diagnostics:
+                            validator_diagnostics.append(res.diagnostics)
 
                 parts = " ".join(f"{n.title()}={counts.get(n, 0)}" for n in VALIDATOR_ENV_VARS)
                 sys.stderr.write(f"[req={scan_id}] Scan: {parts} Total={len(violations)}\n")
@@ -185,7 +190,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
 
             total_ms = (time.monotonic() - scan_t0) * 1000
             ediag = context_obj.engine_diagnostics
-            scan_diag = primary_pb2.ScanDiagnostics(
+            scan_diag = ScanDiagnostics(
                 engine_parse_ms=ediag.parse_ms,
                 engine_annotate_ms=ediag.annotate_ms,
                 engine_total_ms=ediag.total_ms,
@@ -197,7 +202,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                 total_ms=total_ms,
             )
 
-            return primary_pb2.ScanResponse(
+            return ScanResponse(
                 violations=proto_violations,
                 scan_id=scan_id,
                 diagnostics=scan_diag,
@@ -214,13 +219,13 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                 with contextlib.suppress(OSError):
                     shutil.rmtree(temp_dir)
 
-    async def Format(self, request, context):
+    async def Format(self, request: Any, context: Any) -> FormatResponse:
         from apme_engine.formatter import format_content
 
         sys.stderr.write(f"Format: received {len(request.files)} file(s)\n")
         sys.stderr.flush()
 
-        def _do_format(files):
+        def _do_format(files: list[Any]) -> list[Any]:
             diffs = []
             for f in files:
                 if not f.path.endswith((".yml", ".yaml")):
@@ -232,7 +237,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                 result = format_content(text, filename=f.path)
                 if result.changed:
                     diffs.append(
-                        primary_pb2.FileDiff(
+                        FileDiff(
                             path=f.path,
                             original=f.content,
                             formatted=result.formatted.encode("utf-8"),
@@ -249,15 +254,15 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
 
         sys.stderr.write(f"Format: {len(diffs)} file(s) changed\n")
         sys.stderr.flush()
-        return primary_pb2.FormatResponse(diffs=diffs)
+        return FormatResponse(diffs=diffs)
 
-    async def Health(self, request, context):
-        return common_pb2.HealthResponse(status="ok")
+    async def Health(self, request: Any, context: Any) -> HealthResponse:
+        return HealthResponse(status="ok")
 
 
-async def serve(listen_address: str = "0.0.0.0:50051"):
+async def serve(listen_address: str = "0.0.0.0:50051") -> Any:
     server = grpc.aio.server(maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS)
-    primary_pb2_grpc.add_PrimaryServicer_to_server(PrimaryServicer(), server)
+    primary_pb2_grpc.add_PrimaryServicer_to_server(PrimaryServicer(), server)  # type: ignore[no-untyped-call]
     if ":" in listen_address:
         _, _, port = listen_address.rpartition(":")
         server.add_insecure_port(f"[::]:{port}")

--- a/src/apme_engine/daemon/violation_convert.py
+++ b/src/apme_engine/daemon/violation_convert.py
@@ -1,11 +1,13 @@
 """Convert between dict violations (validator output) and proto Violation."""
 
-from apme.v1 import common_pb2
+from typing import Any
+
+from apme.v1.common_pb2 import LineRange, Violation
 
 
-def violation_dict_to_proto(v: dict) -> common_pb2.Violation:
+def violation_dict_to_proto(v: dict[str, Any]) -> Violation:
     """Build a proto Violation from a dict with rule_id, level, message, file, line, path."""
-    out = common_pb2.Violation(
+    out = Violation(
         rule_id=v.get("rule_id") or "",
         level=v.get("level") or "",
         message=v.get("message") or "",
@@ -14,15 +16,15 @@ def violation_dict_to_proto(v: dict) -> common_pb2.Violation:
     )
     line = v.get("line")
     if isinstance(line, (list, tuple)) and len(line) >= 2:
-        out.line_range.CopyFrom(common_pb2.LineRange(start=int(line[0]), end=int(line[1])))
+        out.line_range.CopyFrom(LineRange(start=int(line[0]), end=int(line[1])))
     elif isinstance(line, int):
         out.line = line
     return out
 
 
-def violation_proto_to_dict(v: common_pb2.Violation) -> dict:
+def violation_proto_to_dict(v: Violation) -> dict[str, Any]:
     """Build a dict violation from proto (for CLI output)."""
-    line = v.line if v.HasField("line") else None
+    line: int | list[int] | None = v.line if v.HasField("line") else None
     if v.HasField("line_range"):
         line = [v.line_range.start, v.line_range.end]
     return {

--- a/src/apme_engine/engine/__init__.py
+++ b/src/apme_engine/engine/__init__.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import sys
+from typing import Any
 
 from .scanner import ARIScanner, Config
 
 # ARI CLI (ARICLI, RAMCLI) not imported by default to avoid pulling in heavy deps on scanner import.
-ARICLI = None
-RAMCLI = None
+ARICLI: type[Any] | None = None
+RAMCLI: type[Any] | None = None
 
 ari_actions = ["project", "playbook", "collection", "role", "taskfile"]
 ram_actions = ["ram"]
@@ -12,7 +15,7 @@ ram_actions = ["ram"]
 all_actions = ari_actions + ram_actions
 
 
-def main():
+def main() -> None:
     if len(sys.argv) == 1:
         print("Please specify one of the following operations of ari.")
         print("[operations]")
@@ -27,11 +30,15 @@ def main():
     action = sys.argv[1]
 
     if action in ari_actions:
-        cli = ARICLI()
-        cli.run()
+        from .cli import ARICLI as _ARICLI
+
+        ari_cli = _ARICLI()
+        ari_cli.run()
     elif action == "ram":
-        cli = RAMCLI()
-        cli.run()
+        from .cli.ram import RAMCLI as _RAMCLI
+
+        ram_cli = _RAMCLI()
+        ram_cli.run()
     else:
         print(f"The action {action} is not supported!", file=sys.stderr)
         sys.exit(1)

--- a/src/apme_engine/engine/analyzer.py
+++ b/src/apme_engine/engine/analyzer.py
@@ -1,16 +1,19 @@
+from __future__ import annotations
+
 import argparse
 import json
+from typing import Any, cast
 
 import apme_engine.engine.logger as logger
 from apme_engine.engine.annotators.risk_annotator_base import RiskAnnotator
 
-from .models import AnsibleRunContext, TaskCallsInTree
+from .models import AnsibleRunContext, TaskCall, TaskCallsInTree
 from .utils import load_classes_in_dir
 
-annotator_cache = []
+annotator_cache: list[Any] = []
 
 
-def load_annotators(ctx: AnsibleRunContext = None):
+def load_annotators(ctx: AnsibleRunContext | None = None) -> list[RiskAnnotator]:
     global annotator_cache
 
     if annotator_cache:
@@ -29,23 +32,25 @@ def load_annotators(ctx: AnsibleRunContext = None):
 
 
 def load_taskcalls_in_trees(path: str) -> list[TaskCallsInTree]:
-    taskcalls_in_trees = []
+    taskcalls_in_trees: list[TaskCallsInTree] = []
     try:
         with open(path) as file:
             for line in file:
-                taskcalls_in_tree = TaskCallsInTree.from_json(line)
+                taskcalls_in_tree = cast(TaskCallsInTree, TaskCallsInTree.from_json(line))
                 taskcalls_in_trees.append(taskcalls_in_tree)
     except Exception as e:
         raise ValueError(f"failed to load the json file {path} {e}") from e
     return taskcalls_in_trees
 
 
-def analyze(contexts: list[AnsibleRunContext]):
+def analyze(contexts: list[AnsibleRunContext]) -> list[AnsibleRunContext]:
     num = len(contexts)
     for i, ctx in enumerate(contexts):
         if not isinstance(ctx, AnsibleRunContext):
             continue
         for _j, t in enumerate(ctx.tasks):
+            if not isinstance(t, TaskCall):
+                continue
             annotator = None
             _annotators = load_annotators(ctx)
             for ax in _annotators:
@@ -65,7 +70,7 @@ def analyze(contexts: list[AnsibleRunContext]):
     return contexts
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         prog="analyze.py",
         description="analyze tasks",
@@ -84,7 +89,16 @@ def main():
     args = parser.parse_args()
 
     taskcalls_in_trees = load_taskcalls_in_trees(args.input)
-    taskcalls_in_trees = analyze(taskcalls_in_trees)
+    # Convert to AnsibleRunContext for analyze, then back to TaskCallsInTree for output
+    contexts = [
+        AnsibleRunContext.from_targets(targets=tct.taskcalls, root_key=tct.root_key) for tct in taskcalls_in_trees
+    ]
+    analyzed_contexts = analyze(contexts)
+    # Update taskcalls_in_trees with annotated tasks from analyzed_contexts
+    for tct, ctx in zip(taskcalls_in_trees, analyzed_contexts, strict=False):
+        for i, tc in enumerate(ctx.taskcalls):
+            if i < len(tct.taskcalls):
+                tct.taskcalls[i] = tc
 
     if args.output != "":
         lines = [json.dumps(single_tree_data) for single_tree_data in taskcalls_in_trees]

--- a/src/apme_engine/engine/annotators/annotator_base.py
+++ b/src/apme_engine/engine/annotators/annotator_base.py
@@ -1,30 +1,34 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
 
 from apme_engine.engine.models import Annotation, AnsibleRunContext, TaskCall
 
 
 class Annotator:
     type: str = ""
-    context: AnsibleRunContext = None
+    context: AnsibleRunContext | Any | None = None
 
-    def __init__(self, context: AnsibleRunContext = None):
-        if context:
+    def __init__(self, context: AnsibleRunContext | Any | None = None) -> None:
+        if context is not None:
             self.context = context
 
-    def run(self, task: TaskCall):
+    def run(self, task: TaskCall) -> Any:
         raise ValueError("this is a base class method")
 
 
 @dataclass
 class AnnotatorResult:
-    annotations: list[Annotation] = None
-    data: any = None
+    annotations: Sequence[Annotation] | None = field(default=None)
+    data: Any = None
 
-    def print(self):
+    def print(self) -> None:
         raise ValueError("this is a base class method")
 
-    def to_json(self):
+    def to_json(self) -> Any:
         raise ValueError("this is a base class method")
 
-    def error(self):
+    def error(self) -> None:
         raise ValueError("this is a base class method")

--- a/src/apme_engine/engine/annotators/ansible.builtin/apt.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/apt.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
 
 
 class AptAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.apt"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         pkg = task.args.get("name")
         if pkg is None:
             pkg = task.args.get("pkg")

--- a/src/apme_engine/engine/annotators/ansible.builtin/apt_key.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/apt_key.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, KeyConfigChangeDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, KeyConfigChangeDetail, RiskAnnotation, TaskCall
 
 
 class AptKeyAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.apt_key"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         # id = task.args.get("id")
         key = None
         if key is None:

--- a/src/apme_engine/engine/annotators/ansible.builtin/assemble.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/assemble.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class AssembleAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.assemble"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         path = task.args.get("dest")
         src = task.args.get("src")
         unsafe_writes = task.args.get("unsafe_writes")

--- a/src/apme_engine/engine/annotators/ansible.builtin/blockinfile.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/blockinfile.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class BlockinfileAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.blockinfile"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         path = task.args.get("path")
         unsafe_writes = task.args.get("unsafe_writes")
         state = task.args.get("state")

--- a/src/apme_engine/engine/annotators/ansible.builtin/dnf.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/dnf.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
 
 
 class DnfAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.dnf"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         pkg = task.args.get("name")
         allow_downgrade = task.args.get("allow_downgrade")
         validate_certs = task.args.get("validate_certs")

--- a/src/apme_engine/engine/annotators/ansible.builtin/file.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/file.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class FileAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.file"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         path = task.args.get("path")
         mode = task.args.get("mode")
         unsafe_writes = task.args.get("unsafe_writes")

--- a/src/apme_engine/engine/annotators/ansible.builtin/get_url.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/get_url.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
 
 
 class GetURLAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.get_url"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         src = task.args.get("url")
         dest = task.args.get("dest")
 

--- a/src/apme_engine/engine/annotators/ansible.builtin/git.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/git.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
 
 
 class GetURLAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.git"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         src = task.args.get("repo")
         dest = task.args.get("dest")
 

--- a/src/apme_engine/engine/annotators/ansible.builtin/lineinfile.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/lineinfile.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class LineInFileAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.lineinfile"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         path = task.args.get("path")
         mode = task.args.get("mode")
         unsafe_writes = task.args.get("unsafe_writes")

--- a/src/apme_engine/engine/annotators/ansible.builtin/pip.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/pip.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
 
 
 class PipAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.pip"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         pkg = task.args.get("name")
         if pkg is None:
             pkg = task.args.get("requirements")

--- a/src/apme_engine/engine/annotators/ansible.builtin/replace.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/replace.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class ReplaceAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.replace"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         path = task.args.get("path")
         mode = task.args.get("mode")
         unsafe_writes = task.args.get("unsafe_writes")

--- a/src/apme_engine/engine/annotators/ansible.builtin/rpm_key.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/rpm_key.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, KeyConfigChangeDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, KeyConfigChangeDetail, RiskAnnotation, TaskCall
 
 
 class RpmKeyAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.rpm_key"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         key = task.args.get("key")
         state = task.args.get("state")
 

--- a/src/apme_engine/engine/annotators/ansible.builtin/subversion.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/subversion.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
 
 
 class SubversionAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.subversion"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         src = task.args.get("repo")
         dest = task.args.get("dest")
         annotation = RiskAnnotation.init(

--- a/src/apme_engine/engine/annotators/ansible.builtin/template.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/template.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, FileChangeDetail, RiskAnnotation, TaskCall
 
 
 class TemplateAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.template"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         path = task.args.get("dest")
         src = task.args.get("src")
         mode = task.args.get("mode")

--- a/src/apme_engine/engine/annotators/ansible.builtin/unarchive.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/unarchive.py
@@ -1,7 +1,7 @@
 import contextlib
 
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, InboundTransferDetail, RiskAnnotation, TaskCall
 from apme_engine.engine.utils import parse_bool
 
 
@@ -9,27 +9,32 @@ class UnarchiveAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.unarchive"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         src = task.args.get("src")  # required
         dest = task.args.get("dest")  # required
         remote_src = task.args.get("remote_src")
 
         is_remote_src = False
-        if remote_src:
-            if isinstance(remote_src.raw, (str, bool)):
+        if remote_src is not None:
+            raw_val = getattr(remote_src, "raw", None)
+            if isinstance(raw_val, (str, bool)):
                 with contextlib.suppress(Exception):
-                    is_remote_src = parse_bool(remote_src.raw)
-            if not is_remote_src and (isinstance(remote_src.templated, (str, bool))):
+                    is_remote_src = parse_bool(raw_val)
+            templated_val = getattr(remote_src, "templated", None)
+            if not is_remote_src and isinstance(templated_val, (str, bool)):
                 with contextlib.suppress(Exception):
-                    is_remote_src = parse_bool(remote_src.templated)
+                    is_remote_src = parse_bool(templated_val)
 
         url_sep = "://"
         is_download = False
-        if is_remote_src and (url_sep in src.raw or url_sep in src.templated):
-            is_download = True
+        if src is not None and is_remote_src:
+            src_raw = getattr(src, "raw", "") or ""
+            src_templated = getattr(src, "templated", "") or ""
+            if url_sep in str(src_raw) or url_sep in str(src_templated):
+                is_download = True
 
         if not is_download:
-            return None
+            return ModuleAnnotatorResult(annotations=[])
 
         annotation = RiskAnnotation.init(
             risk_type=DefaultRiskType.INBOUND, detail=InboundTransferDetail(_src_arg=src, _dest_arg=dest)

--- a/src/apme_engine/engine/annotators/ansible.builtin/uri.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/uri.py
@@ -7,10 +7,12 @@ class URIAnnotator(ModuleAnnotator):
     enabled: bool = True
 
     def run(self, task: TaskCall) -> ModuleAnnotatorResult:
-        method = task.args.get("method")
+        method_val = task.args.get("method")
+        method = getattr(method_val, "raw", method_val) if method_val is not None else None
+        method_str = str(method) if method is not None else ""
 
         annotations = []
-        if method in ["PUT", "POST", "PATCH"]:
+        if method_str in ["PUT", "POST", "PATCH"]:
             url = task.args.get("url")
             body = task.args.get("body")
             annotation = RiskAnnotation.init(

--- a/src/apme_engine/engine/annotators/ansible.builtin/yum.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/yum.py
@@ -1,12 +1,12 @@
 from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotator, ModuleAnnotatorResult
-from apme_engine.engine.models import Annotation, DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, PackageInstallDetail, RiskAnnotation, TaskCall
 
 
 class YumAnnotator(ModuleAnnotator):
     fqcn: str = "ansible.builtin.yum"
     enabled: bool = True
 
-    def run(self, task: TaskCall) -> list[Annotation]:
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         pkg = task.args.get("name")
         allow_downgrade = task.args.get("allow_downgrade")
         validate_certs = task.args.get("validate_certs")

--- a/src/apme_engine/engine/annotators/ansible_builtin.py
+++ b/src/apme_engine/engine/annotators/ansible_builtin.py
@@ -1,3 +1,4 @@
+from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotatorResult
 from apme_engine.engine.annotators.risk_annotator_base import RiskAnnotator
 from apme_engine.engine.models import TaskCall
 
@@ -7,12 +8,12 @@ class AnsibleBuiltinRiskAnnotator(RiskAnnotator):
     enabled: bool = True
 
     def match(self, task: TaskCall) -> bool:
-        resolved_name = task.spec.resolved_name
-        return resolved_name.startswith("ansible.builtin.")
+        resolved_name = getattr(task.spec, "resolved_name", "") if task.spec else ""
+        return bool(resolved_name and str(resolved_name).startswith("ansible.builtin."))
 
     # embed "analyzed_data" field in Task
-    def run(self, task: TaskCall):
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         if not self.match(task):
-            return []
+            return ModuleAnnotatorResult(annotations=[])
 
         return self.run_module_annotators("ansible.builtin", task)

--- a/src/apme_engine/engine/annotators/risk_annotator_base.py
+++ b/src/apme_engine/engine/annotators/risk_annotator_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from apme_engine.engine.annotators.annotator_base import Annotator, AnnotatorResult
@@ -11,15 +13,15 @@ class RiskAnnotator(Annotator):
     name: str = ""
     enabled: bool = False
 
-    module_annotator_cache: dict = {}
+    module_annotator_cache: dict[str, list[ModuleAnnotator]] = {}
 
     def match(self, task: TaskCall) -> bool:
         raise ValueError("this is a base class method")
 
-    def run(self, task: TaskCall):
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
         raise ValueError("this is a base class method")
 
-    def load_module_annotators(self, dir_path: str):
+    def load_module_annotators(self, dir_path: str) -> list[ModuleAnnotator]:
         if dir_path in self.module_annotator_cache:
             return self.module_annotator_cache[dir_path]
 
@@ -34,14 +36,14 @@ class RiskAnnotator(Annotator):
 
     def run_module_annotators(self, dir_path: str, task: TaskCall) -> ModuleAnnotatorResult:
         if not dir_path:
-            return []
+            return ModuleAnnotatorResult(annotations=[])
 
-        resolved_name = task.spec.resolved_name
+        resolved_name = getattr(task.spec, "resolved_name", "") if task.spec else ""
         module_annotators = self.load_module_annotators(dir_path)
 
         # TODO: need to consider annotator precedence
 
-        annotations = []
+        annotations: list[RiskAnnotation] = []
 
         for annotator in module_annotators:
             if not isinstance(annotator, ModuleAnnotator):
@@ -56,10 +58,10 @@ class RiskAnnotator(Annotator):
                 continue
 
             if result.annotations:
-                annotations.extend(result.annotations)
+                annotations.extend(result.annotations)  # type: ignore[arg-type]
         if annotations:
             return ModuleAnnotatorResult(annotations=annotations)
-        return None
+        return ModuleAnnotatorResult(annotations=[])
 
 
 @dataclass

--- a/src/apme_engine/engine/annotators/sample_custom_annotator.py
+++ b/src/apme_engine/engine/annotators/sample_custom_annotator.py
@@ -1,6 +1,12 @@
+"""Sample custom risk annotator (example/template only)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from apme_engine.engine.annotators.module_annotator_base import ModuleAnnotatorResult
 from apme_engine.engine.annotators.risk_annotator_base import RiskAnnotator
-from apme_engine.engine.annotators.variable_resolver import VariableAnnotation
-from apme_engine.engine.models import Annotation, DefaultRiskType, RiskAnnotation, TaskCall
+from apme_engine.engine.models import DefaultRiskType, RiskAnnotation, TaskCall, VariableAnnotation
 
 
 class SampleCustomAnnotator(RiskAnnotator):
@@ -14,25 +20,27 @@ class SampleCustomAnnotator(RiskAnnotator):
         return False
 
     # extract analyzed_data from task and embed it
-    def run(self, task: TaskCall) -> list[Annotation]:
-        resolved_name = task.spec.resolved_name
-        options = task.spec.module_options
+    def run(self, task: TaskCall) -> ModuleAnnotatorResult:
+        resolved_name = getattr(task.spec, "resolved_name", "") if task.spec else ""
+        options = getattr(task.spec, "module_options", {}) if task.spec else {}
         var_annos = task.get_annotation_by_type(VariableAnnotation.type)
         var_anno = var_annos[0] if len(var_annos) > 0 else VariableAnnotation()
-        resolved_options = var_anno.resolved_module_options
+        resolved_options = getattr(var_anno, "resolved_module_options", [])
 
-        annotations = []
+        annotations: list[RiskAnnotation] = []
         # example of package_install
         if resolved_name == "sample.custom.homebrew":
-            res = RiskAnnotation(type=self.type, category=DefaultRiskType.PACKAGE_INSTALL)
-            res.data = self.homebrew(options)
+            res = RiskAnnotation(type=self.type, risk_type=DefaultRiskType.PACKAGE_INSTALL)
+            res.data = self.homebrew(options)  # type: ignore[attr-defined]
+            resolved_data: list[dict[str, Any]] = []
             for ro in resolved_options:
-                res.resolved_data.append(self.homebrew(ro))
+                resolved_data.append(self.homebrew(ro))
+            res.resolved_data = resolved_data  # type: ignore[attr-defined]
             annotations.append(res)
-        return annotations
+        return ModuleAnnotatorResult(annotations=annotations)
 
-    def homebrew(self, options):
-        data = {}
+    def homebrew(self, options: Any) -> dict[str, Any]:
+        data: dict[str, Any] = {}
         if type(options) is not dict:
             return data
         if "name" in options:

--- a/src/apme_engine/engine/annotators/variable_resolver.py
+++ b/src/apme_engine/engine/annotators/variable_resolver.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import Any
 
 from apme_engine.engine.annotators.annotator_base import Annotator, AnnotatorResult
 from apme_engine.engine.context import Context, resolve_module_options
@@ -6,6 +9,8 @@ from apme_engine.engine.keyutil import detect_type
 from apme_engine.engine.models import (
     Arguments,
     ArgumentsType,
+    CallObject,
+    Object,
     ObjectList,
     Playbook,
     Repository,
@@ -19,12 +24,13 @@ from apme_engine.engine.models import (
 
 class VariableAnnotator(Annotator):
     type: str = VariableAnnotation.type
-    context: Context = None
+    context: Context
 
-    def __init__(self, context: Context):
+    def __init__(self, context: Context) -> None:
+        super().__init__(context=context)
         self.context = context
 
-    def run(self, taskcall: TaskCall):
+    def run(self, taskcall: TaskCall) -> VariableAnnotatorResult:
         resolved = resolve_module_options(self.context, taskcall)
         resolved_module_options = resolved[0]
         resolved_variables = resolved[1]
@@ -68,7 +74,7 @@ class VariableAnnotator(Annotator):
             history.append(v)
             self.context.var_use_history[v.name] = history
 
-        m_opts = taskcall.spec.module_options
+        m_opts = getattr(taskcall.spec, "module_options", None)
         if isinstance(m_opts, list):
             args_type = ArgumentsType.LIST
         elif isinstance(m_opts, dict):
@@ -100,24 +106,25 @@ class VariableAnnotatorResult(AnnotatorResult):
     pass
 
 
-def tree_to_task_list(tree, node_objects):
-    node_dict = {}
+def tree_to_task_list(tree: Any, node_objects: ObjectList) -> list[dict[str, Any]]:
+    """Convert tree (TreeNode-like with .key, .children) to task list. tree is unused/dead."""
+    node_dict: dict[str, Object | CallObject] = {}
     for no in node_objects.items:
         node_dict[no.key] = no
 
-    def getSubTree(node):
-        tasks = []
+    def getSubTree(node: Any) -> tuple[list[dict[str, Any]], str]:
+        tasks: list[dict[str, Any]] = []
         resolved_name = ""
         no = node_dict[node.key]
         node_type = detect_type(node.key)
 
-        children_tasks = []
+        children_tasks: list[dict[str, Any]] = []
         if node_type == "module" or node_type == "role":
-            resolved_name = no.fqcn
+            resolved_name = getattr(no, "fqcn", "")
         elif node_type == "taskfile":
             resolved_name = no.key
 
-        children_per_type = {}
+        children_per_type: dict[str, list[Object | CallObject]] = {}
         for c in node.children:
             ctype = detect_type(c.key)
             if ctype in children_per_type:
@@ -157,25 +164,28 @@ def tree_to_task_list(tree, node_objects):
             resolved_name = fqcns[0] if len(fqcns) > 0 else ""
 
         if node_type == "task":
-            no.resolved_name = resolved_name
+            no.resolved_name = resolved_name  # type: ignore[union-attr]
             tasks.append(no.__dict__)
         tasks.extend(children_tasks)
         return tasks, resolved_name
 
-    tasks, _ = getSubTree(tree)
+    root = tree.items[0] if isinstance(tree, ObjectList) and tree.items else tree
+    tasks, _ = getSubTree(root)
     return tasks
 
 
 def resolve_variables(tree: ObjectList, additional: ObjectList) -> list[TaskCall]:
-    tree_root_key = tree.items[0].spec.key if len(tree.items) > 0 else ""
+    first_item = tree.items[0] if len(tree.items) > 0 else None
+    tree_root_key = getattr(getattr(first_item, "spec", None), "key", "") if first_item else ""
     inventories = get_inventories(tree_root_key, additional)
     context = Context(inventories=inventories)
-    depth_dict = {}
-    resolved_taskcalls = []
+    depth_dict: dict[str, int] = {}
+    resolved_taskcalls: list[TaskCall] = []
     for call_obj in tree.items:
         caller_depth_lvl = 0
-        if call_obj.called_from != "":
-            caller_key = call_obj.called_from
+        called_from = getattr(call_obj, "called_from", "")
+        if called_from != "":
+            caller_key = called_from
             caller_depth_lvl = depth_dict.get(caller_key, 0)
         depth_lvl = caller_depth_lvl + 1
         depth_dict[call_obj.key] = depth_lvl
@@ -190,7 +200,7 @@ def resolve_variables(tree: ObjectList, additional: ObjectList) -> list[TaskCall
     return resolved_taskcalls
 
 
-def get_inventories(tree_root_key, additional):
+def get_inventories(tree_root_key: str, additional: ObjectList) -> list[Any]:
     if tree_root_key == "":
         return []
     tree_root_type = detect_type(tree_root_key)

--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -7,7 +7,7 @@ valid_playbook_re = re.compile(r"^\s*?-?\s*?(?:hosts|include|import_playbook):\s
 
 # this method is based on awx code
 # awx/main/utils/ansible.py#L42-L64 in ansible/awx
-def could_be_playbook(fpath):
+def could_be_playbook(fpath: str) -> bool:
     basename, ext = os.path.splitext(fpath)
     if ext not in [".yml", ".yaml"]:
         return False
@@ -28,7 +28,7 @@ def could_be_playbook(fpath):
 
 # this method is based on awx code
 # awx/main/models/projects.py#L206-L217 in ansible/awx
-def search_playbooks(root_path):
+def search_playbooks(root_path: str) -> list[str]:
     results = []
     if root_path and os.path.exists(root_path):
         for dirpath, _dirnames, filenames in os.walk(root_path, followlinks=False):
@@ -43,7 +43,7 @@ def search_playbooks(root_path):
 
 # this method is based on awx code
 # awx/main/utils/ansible.py#L24-L39 in ansible/awx
-def skip_directory(relative_directory_path):
+def skip_directory(relative_directory_path: str) -> bool:
     path_elements = relative_directory_path.split(os.sep)
     # Exclude files in a roles subdirectory.
     if "roles" in path_elements:

--- a/src/apme_engine/engine/cli/__init__.py
+++ b/src/apme_engine/engine/cli/__init__.py
@@ -1,7 +1,9 @@
 import argparse
 import json
 import os
+from typing import Any
 
+from .. import logger
 from ..finder import get_yml_list, list_scan_target, update_the_yaml_target
 from ..scanner import ARIScanner, config
 from ..utils import (
@@ -11,13 +13,14 @@ from ..utils import (
     is_url,
     split_name_and_version,
 )
-from . import logger
+
+__all__ = ["ARICLI", "RAMCLI", "logger"]
 
 
 class ARICLI:
-    args = None
+    args: argparse.Namespace | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="TODO")
         parser.add_argument(
             "-s",
@@ -113,8 +116,9 @@ class ARICLI:
         args = parser.parse_args()
         self.args = args
 
-    def run(self):
+    def run(self) -> None:
         args = self.args
+        assert args is not None
         print("ARI args: ", args.target_name)
         target_name = args.target_name
         target_version = ""
@@ -206,7 +210,7 @@ class ARICLI:
             targets = list_scan_target(root_dir=target_name, task_num_threshold=task_num_threshold)
             print("Start scanning")
             total = len(targets)
-            file_list = {"playbook": [], "role": [], "taskfile": []}
+            file_list: dict[str, list[str]] = {"playbook": [], "role": [], "taskfile": []}
             for i, target_info in enumerate(targets):
                 fpath = target_info["filepath"]
                 fpath_from_root = target_info["path_from_root"]
@@ -256,8 +260,8 @@ class ARICLI:
                             for i in reversed(range(len(targets))):
                                 logger.debug("Nodes dir number: %s", i)
                                 nodes = targets[i]["nodes"]
-                                line_number_list = []
-                                mutated_yaml_list = []
+                                line_number_list: list[str] = []
+                                mutated_yaml_list: list[Any] = []
                                 target_file_path = ""
                                 temp_file_path = ""
                                 for j in range(1, len(nodes)):
@@ -296,7 +300,13 @@ class ARICLI:
                                                 mutated_yaml_list.append(mutated_yaml)
                                                 temp_file_path = target_file_path
                                             line_number = w007_rule["file"][1]
-                                            line_number_list.append(line_number)
+                                            if isinstance(line_number, (list, tuple)) and len(line_number) >= 2:
+                                                ln_str = f"{line_number[0]}-{line_number[1]}"
+                                            elif isinstance(line_number, int):
+                                                ln_str = f"{line_number}-{line_number}"
+                                            else:
+                                                ln_str = str(line_number)
+                                            line_number_list.append(ln_str)
                                             break  # w007 rule with mutated yaml is processed, breaking out of iteration
                                 try:
                                     if target_file_path == "" or not mutated_yaml_list or not line_number_list:

--- a/src/apme_engine/engine/cli/ram/__init__.py
+++ b/src/apme_engine/engine/cli/ram/__init__.py
@@ -11,9 +11,9 @@ ram_actions = ["search", "list", "diff", "generate", "update", "release"]
 
 
 class RAMCLI:
-    _cli = None
+    _cli: RAMSearchCLI | RAMListCLI | RAMDiffCLI | RAMGenerateCLI | RAMUpdateCLI | RAMReleaseCLI | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         args = sys.argv
         if len(args) > 2:
             action = args[2]
@@ -41,6 +41,6 @@ class RAMCLI:
         else:
             raise ValueError(f"An action must be specified; {ram_actions}")
 
-    def run(self):
-        if self._cli:
+    def run(self) -> None:
+        if self._cli is not None:
             self._cli.run()

--- a/src/apme_engine/engine/cli/ram/diff.py
+++ b/src/apme_engine/engine/cli/ram/diff.py
@@ -6,9 +6,9 @@ from ...utils import show_diffs
 
 
 class RAMDiffCLI:
-    args = None
+    args: argparse.Namespace | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="TODO")
         parser.add_argument("target_type", help="content type", choices={"ram"})
         parser.add_argument("action", help="action for RAM command or target_name of search action")
@@ -18,8 +18,9 @@ class RAMDiffCLI:
         args = parser.parse_args()
         self.args = args
 
-    def run(self):
+    def run(self) -> None:
         args = self.args
+        assert args is not None
         action = args.action
         if action != "diff":
             raise ValueError('RAMDiffCLI cannot be executed without "diff" action')

--- a/src/apme_engine/engine/cli/ram/generate.py
+++ b/src/apme_engine/engine/cli/ram/generate.py
@@ -4,9 +4,9 @@ from ...ram_generator import RiskAssessmentModelGenerator as RAMGenerator
 
 
 class RAMGenerateCLI:
-    args = None
+    args: argparse.Namespace | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="TODO")
         parser.add_argument("target_type", help="content type", choices={"ram"})
         parser.add_argument("action", help="action for RAM command or target_name of search action")
@@ -23,8 +23,9 @@ class RAMGenerateCLI:
         args = parser.parse_args()
         self.args = args
 
-    def run(self):
+    def run(self) -> None:
         args = self.args
+        assert args is not None
         action = args.action
         if action != "generate":
             raise ValueError('RAMGenerateCLI cannot be executed without "generate" action')

--- a/src/apme_engine/engine/cli/ram/list.py
+++ b/src/apme_engine/engine/cli/ram/list.py
@@ -6,17 +6,18 @@ from ...utils import show_all_ram_metadata
 
 
 class RAMListCLI:
-    args = None
+    args: argparse.Namespace | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="TODO")
         parser.add_argument("target_type", help="content type", choices={"ram"})
         parser.add_argument("action", help="action for RAM command or target_name of search action")
         args = parser.parse_args()
         self.args = args
 
-    def run(self):
+    def run(self) -> None:
         args = self.args
+        assert args is not None
         action = args.action
         if action != "list":
             raise ValueError('RAMListCLI cannot be executed without "list" action')

--- a/src/apme_engine/engine/cli/ram/release.py
+++ b/src/apme_engine/engine/cli/ram/release.py
@@ -5,9 +5,9 @@ from ...scanner import config
 
 
 class RAMReleaseCLI:
-    args = None
+    args: argparse.Namespace | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="TODO")
         parser.add_argument("target_type", help="content type", choices={"ram"})
         parser.add_argument("action", help="action for RAM command or target_name of search action")
@@ -15,8 +15,9 @@ class RAMReleaseCLI:
         args = parser.parse_args()
         self.args = args
 
-    def run(self):
+    def run(self) -> None:
         args = self.args
+        assert args is not None
         action = args.action
         if action != "release":
             raise ValueError('RAMReleaseCLI cannot be executed without "release" action')

--- a/src/apme_engine/engine/cli/ram/search.py
+++ b/src/apme_engine/engine/cli/ram/search.py
@@ -6,9 +6,9 @@ from ...utils import split_name_and_version
 
 
 class RAMSearchCLI:
-    args = None
+    args: argparse.Namespace | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="TODO")
         parser.add_argument("target_type", help="content type", choices={"ram"})
         parser.add_argument("action", help="action for RAM command or target_name of search action")
@@ -16,8 +16,9 @@ class RAMSearchCLI:
         args = parser.parse_args()
         self.args = args
 
-    def run(self):
+    def run(self) -> None:
         args = self.args
+        assert args is not None
         action = args.action
         target_name = args.target_name
         if action != "search":

--- a/src/apme_engine/engine/cli/ram/update.py
+++ b/src/apme_engine/engine/cli/ram/update.py
@@ -4,9 +4,9 @@ from ...ram_generator import RiskAssessmentModelGenerator as RAMGenerator
 
 
 class RAMUpdateCLI:
-    args = None
+    args: argparse.Namespace | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="TODO")
         parser.add_argument("target_type", help="content type", choices={"ram"})
         parser.add_argument("action", help="action for RAM command or target_name of search action")
@@ -15,8 +15,9 @@ class RAMUpdateCLI:
         args = parser.parse_args()
         self.args = args
 
-    def run(self):
+    def run(self) -> None:
         args = self.args
+        assert args is not None
         action = args.action
         if action != "update":
             raise ValueError('RAMUpdateCLI cannot be executed without "update" action')

--- a/src/apme_engine/engine/context.py
+++ b/src/apme_engine/engine/context.py
@@ -1,14 +1,18 @@
+from __future__ import annotations
+
 import copy
 import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, cast
 
 from .models import (
     BecomeInfo,
     CallObject,
     Collection,
     InventoryType,
+    Module,
     Object,
     Play,
     Playbook,
@@ -17,6 +21,7 @@ from .models import (
     TaskCall,
     TaskFile,
     Variable,
+    VariablePrecedence,
     VariableType,
     immutable_var_types,
 )
@@ -27,7 +32,12 @@ _special_var_value = "__ansible_special_variable__"
 variable_block_re = re.compile(r"{{[^}]+}}")
 
 
-def get_object(json_path, type, name, cache=None):
+def get_object(
+    json_path: str,
+    type: str,
+    name: str,
+    cache: dict[str, tuple[str, str]] | None = None,
+) -> Object | Role | Collection | Play | Task | TaskFile | Module | None:
     if cache is None:
         cache = {}
     json_type = ""
@@ -52,7 +62,7 @@ def get_object(json_path, type, name, cache=None):
     else:
         json_type, json_str = cached[0], cached[1]
     if json_type == "role":
-        r = Role.from_json(json_str)
+        r = cast(Role, Role.from_json(json_str))
         if type == "collection":
             raise ValueError("collection cannot be gotten in a role")
         if type == "role":
@@ -62,16 +72,16 @@ def get_object(json_path, type, name, cache=None):
         elif type == "taskfile":
             for tf in r.taskfiles:
                 if tf.defined_in == name:
-                    return tf
+                    return cast(TaskFile, tf)
         elif type == "task":
             for tf in r.taskfiles:
                 for t in tf.tasks:
                     if t.id == name:
-                        return t
+                        return cast(Task, t)
         elif type == "module":
             for m in r.modules:
                 if m.fqcn == name:
-                    return m
+                    return cast(Module, m)
         return None
     elif json_type == "collection":
         c = Collection()
@@ -81,46 +91,46 @@ def get_object(json_path, type, name, cache=None):
         if type == "role":
             for r in c.roles:
                 if r.fqcn == name:
-                    return r
+                    return cast(Role, r)
         elif type == "playbook":
             for p in c.playbooks:
                 if p.defined_in == name:
-                    return p
+                    return cast(Play, p)
         elif type == "taskfile":
             for tf in c.taskfiles:
                 if tf.defined_in == name:
-                    return tf
+                    return cast(TaskFile, tf)
             for r in c.roles:
                 for tf in r.taskfiles:
                     if tf.defined_in == name:
-                        return tf
+                        return cast(TaskFile, tf)
         elif type == "task":
             for p in c.playbooks:
                 for t in p.tasks:
                     if t.id == name:
-                        return t
+                        return cast(Task, t)
             for tf in c.taskfiles:
                 for t in tf.tasks:
                     if t.id == name:
-                        return t
+                        return cast(Task, t)
             for r in c.roles:
                 for tf in r.taskfiles:
                     for t in tf.tasks:
                         if t.id == name:
-                            return t
+                            return cast(Task, t)
         elif type == "module":
             for m in c.modules:
                 if m.fqcn == name:
-                    return m
+                    return cast(Module, m)
         return None
     return None
 
 
-def recursive_find_variable(var_name, var_dict=None):
+def recursive_find_variable(var_name: str, var_dict: dict[str, Any] | None = None) -> Any:
     if var_dict is None:
         var_dict = {}
 
-    def _visitor(vname, nname, node):
+    def _visitor(vname: str, nname: str, node: Any) -> Any:
         if nname == vname:
             return node
         if isinstance(node, dict):
@@ -138,7 +148,7 @@ def recursive_find_variable(var_name, var_dict=None):
     return _visitor(var_name, "", var_dict)
 
 
-def flatten(var_dict: dict = None, _prefix: str = ""):
+def flatten(var_dict: dict[str, Any] | None = None, _prefix: str = "") -> dict[str, Any]:
     if var_dict is None:
         var_dict = {}
     flat_vars = {}
@@ -156,27 +166,27 @@ def flatten(var_dict: dict = None, _prefix: str = ""):
 @dataclass
 class Context:
     keep_obj: bool = False
-    chain: list = field(default_factory=list)
-    variables: dict = field(default_factory=dict)
-    options: dict = field(default_factory=dict)
-    inventories: list = field(default_factory=list)
-    role_defaults: list = field(default_factory=list)
-    role_vars: list = field(default_factory=list)
-    registered_vars: list = field(default_factory=list)
-    set_facts: list = field(default_factory=list)
-    task_vars: list = field(default_factory=list)
+    chain: list[dict[str, Any]] = field(default_factory=list)
+    variables: dict[str, Any] = field(default_factory=dict)
+    options: dict[str, Any] = field(default_factory=dict)
+    inventories: list[Any] = field(default_factory=list)
+    role_defaults: list[str] = field(default_factory=list)
+    role_vars: list[str] = field(default_factory=list)
+    registered_vars: list[str] = field(default_factory=list)
+    set_facts: list[str] = field(default_factory=list)
+    task_vars: list[str] = field(default_factory=list)
 
-    become: BecomeInfo = None
-    module_defaults: dict = field(default_factory=dict)
+    become: BecomeInfo | None = None
+    module_defaults: dict[str, Any] = field(default_factory=dict)
 
-    var_set_history: dict = field(default_factory=dict)
-    var_use_history: dict = field(default_factory=dict)
+    var_set_history: dict[str, list[Variable]] = field(default_factory=dict)
+    var_use_history: dict[str, Any] = field(default_factory=dict)
 
-    _flat_vars: dict = field(default_factory=dict)
+    _flat_vars: dict[str, Any] = field(default_factory=dict)
 
-    def add(self, obj, depth_lvl=0):
-        _obj = None
-        _spec = None
+    def add(self, obj: Object | CallObject, depth_lvl: int = 0) -> None:
+        _obj: Object | CallObject | None = None
+        _spec: Object | None = None
         if isinstance(obj, Object):
             _obj = obj
             _spec = obj
@@ -253,12 +263,16 @@ class Context:
             # Module
             return
         self.options.update(_spec.options)
-        chain_node = {"key": _obj.key, "depth": depth_lvl}
+        chain_node: dict[str, Any] = {"key": _obj.key, "depth": depth_lvl}
         if self.keep_obj:
             chain_node["obj"] = _obj
         self.chain.append(chain_node)
 
-    def resolve_variable(self, var_name, resolve_history=None):
+    def resolve_variable(
+        self,
+        var_name: str,
+        resolve_history: dict[str, dict[str, Any]] | None = None,
+    ) -> tuple[Any, VariablePrecedence, dict[str, dict[str, Any]]]:
         if resolve_history is None:
             resolve_history = {}
         if var_name in resolve_history:
@@ -343,9 +357,13 @@ class Context:
 
         return None, VariableType.Unknown, _resolve_history
 
-    def resolve_single_variable(self, txt, resolve_history=None):
+    def resolve_single_variable(
+        self,
+        txt: Any,
+        resolve_history: dict[str, dict[str, Any]] | None = None,
+    ) -> tuple[Any, dict[str, dict[str, Any]]]:
         if resolve_history is None:
-            resolve_history = []
+            resolve_history = {}
         new_history = resolve_history.copy()
         if not isinstance(txt, str):
             return txt, new_history
@@ -370,7 +388,7 @@ class Context:
         else:
             return txt, new_history
 
-    def update_flat_vars(self, new_vars: dict, _prefix: str = ""):
+    def update_flat_vars(self, new_vars: dict[str, Any], _prefix: str = "") -> None:
         for k, v in new_vars.items():
             if isinstance(v, dict):
                 flat_var_name = f"{_prefix}{k}"
@@ -382,22 +400,22 @@ class Context:
                 self._flat_vars.update({flat_key: v})
         return
 
-    def chain_str(self):
-        lines = []
+    def chain_str(self) -> str:
+        lines: list[str] = []
         for chain_item in self.chain:
-            obj = chain_item.get("obj", None)
+            obj: Object | CallObject | None = chain_item.get("obj", None)
             depth = chain_item.get("depth", 0)
             indent = "  " * depth
-            obj_type = type(obj).__name__
-            obj_name = obj.name
+            obj_type = type(obj).__name__ if obj else "None"
+            obj_name = getattr(obj, "name", "") or getattr(obj, "key", "") if obj else ""
             line = f"{indent}{obj_type}: {obj_name}\n"
-            if obj_type == "Task":
-                module_name = obj.module
+            if obj_type == "Task" and obj and hasattr(obj, "module"):
+                module_name = getattr(obj, "module", "")
                 line = f"{indent}{obj_type}: {obj_name} (module: {module_name})\n"
             lines.append(line)
         return "".join(lines)
 
-    def copy(self):
+    def copy(self) -> Context:
         return Context(
             keep_obj=self.keep_obj,
             chain=copy.copy(self.chain),
@@ -411,7 +429,7 @@ class Context:
         # return copy.deepcopy(self)
 
 
-def resolved_vars_contains(resolved_vars, new_var):
+def resolved_vars_contains(resolved_vars: list[dict[str, Any]], new_var: dict[str, Any]) -> bool:
     if not isinstance(new_var, dict):
         return False
     new_var_key = new_var.get("key", "")
@@ -430,15 +448,20 @@ def resolved_vars_contains(resolved_vars, new_var):
     return False
 
 
-def resolve_module_options(context: Context, taskcall: TaskCall):
-    resolved_vars = []
-    variables_in_loop = []
-    used_variables = {}
-    if len(taskcall.spec.loop) == 0:
+def resolve_module_options(
+    context: Context, taskcall: TaskCall
+) -> tuple[list[Any], list[dict[str, Any]], dict[str, list[str]], dict[str, Any]]:
+    resolved_vars: list[dict[str, Any]] = []
+    variables_in_loop: list[dict[str, Any]] = []
+    used_variables: dict[str, Any] = {}
+    spec = taskcall.spec
+    loop: dict[str, Any] = getattr(spec, "loop", {}) or {}
+    module_options: Any = getattr(spec, "module_options", None)
+    if len(loop) == 0:
         variables_in_loop = [{}]
     else:
-        loop_key = list(taskcall.spec.loop.keys())[0]
-        loop_values = taskcall.spec.loop.get(loop_key, [])
+        loop_key = list(loop.keys())[0]
+        loop_values = loop.get(loop_key, [])
         new_var = {
             "key": loop_key,
             "value": loop_values,
@@ -540,16 +563,16 @@ def resolve_module_options(context: Context, taskcall: TaskCall):
             if loop_values:
                 raise ValueError(f"loop_values of type {type(loop_values).__name__} is not supported yet")
 
-    resolved_opts_in_loop = []
-    mutable_vars_per_mo = {}
+    resolved_opts_in_loop: list[Any] = []
+    mutable_vars_per_mo: dict[str, list[str]] = {}
     for variables in variables_in_loop:
-        resolved_opts = None
-        if isinstance(taskcall.spec.module_options, dict):
+        resolved_opts: Any = None
+        if isinstance(module_options, dict):
             resolved_opts = {}
             for (
                 module_opt_key,
                 module_opt_val,
-            ) in taskcall.spec.module_options.items():
+            ) in module_options.items():
                 if not isinstance(module_opt_val, str):
                     resolved_opts[module_opt_key] = module_opt_val
                     continue
@@ -619,10 +642,10 @@ def resolve_module_options(context: Context, taskcall: TaskCall):
                         break
                     resolved_opt_val = resolved_opt_val.replace(original_block, str(resolved_var_val))
                 resolved_opts[module_opt_key] = resolved_opt_val
-        elif isinstance(taskcall.spec.module_options, str):
-            resolved_opt_val = taskcall.spec.module_options
+        elif isinstance(module_options, str):
+            resolved_opt_val = module_options
             if variable_block_re.search(resolved_opt_val):
-                var_names = extract_variable_names(taskcall.spec.module_options)
+                var_names = extract_variable_names(module_options)
                 for var_name_dict in var_names:
                     original_block = var_name_dict.get("original", "")
                     var_name = var_name_dict.get("name", "")
@@ -680,12 +703,12 @@ def resolve_module_options(context: Context, taskcall: TaskCall):
                     resolved_opt_val = resolved_opt_val.replace(original_block, str(resolved_var_val))
             resolved_opts = resolved_opt_val
         else:
-            resolved_opts = taskcall.spec.module_options
+            resolved_opts = module_options
         resolved_opts_in_loop.append(resolved_opts)
     return resolved_opts_in_loop, resolved_vars, mutable_vars_per_mo, used_variables
 
 
-def extract_variable_names(txt):
+def extract_variable_names(txt: str) -> list[dict[str, str]]:
     if not variable_block_re.search(txt):
         return []
     found_var_blocks = variable_block_re.findall(txt)
@@ -720,8 +743,8 @@ def extract_variable_names(txt):
     return blocks
 
 
-def flatten_dict_vars(variables: dict, _prefix: str = "") -> dict:
-    flat_vars_dict = {}
+def flatten_dict_vars(variables: dict[str, Any], _prefix: str = "") -> dict[str, Any]:
+    flat_vars_dict: dict[str, Any] = {}
     for key, val in variables.items():
         var_name = f"{_prefix}{key}" if _prefix else key
         flat_vars_dict[var_name] = val

--- a/src/apme_engine/engine/dependency_dir_preparator.py
+++ b/src/apme_engine/engine/dependency_dir_preparator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import datetime
 import glob
@@ -10,6 +12,7 @@ import tarfile
 import tempfile
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
+from typing import Any
 
 import yaml
 
@@ -85,23 +88,30 @@ class DependencyDirPreparator:
     target_version: str = ""
     target_path: str = ""
     target_dependency_dir: str = ""
-    target_path_mappings: dict = field(default_factory=dict)
+    target_path_mappings: dict[str, Any] = field(default_factory=dict)
     metadata: DownloadMetadata = field(default_factory=DownloadMetadata)
     download_location: str = ""
     dependency_dir_path: str = ""
     silent: bool = False
     do_save: bool = False
-    tmp_install_dir: tempfile.TemporaryDirectory = None
+    tmp_install_dir: tempfile.TemporaryDirectory[Any] | None = None
     periodical_cleanup: bool = False
-    cleanup_queue: list = field(default_factory=list)
+    cleanup_queue: list[Any] = field(default_factory=list)
     cleanup_threshold: int = 200
 
     # -- out --
-    dependency_dirs: list = field(default_factory=list)
+    dependency_dirs: list[Any] = field(default_factory=list)
+    install_log: str = ""
+    index: dict[str, Any] = field(default_factory=dict)
 
     def prepare_dir(
-        self, root_install=True, use_ansible_path=False, is_src_installed=False, cache_enabled=False, cache_dir=""
-    ):
+        self,
+        root_install: bool = True,
+        use_ansible_path: bool = False,
+        is_src_installed: bool = False,
+        cache_enabled: bool = False,
+        cache_dir: str = "",
+    ) -> list[Any]:
         logger.debug("setup base dirs")
         self.setup_dirs(cache_enabled, cache_dir)
         logger.debug("prepare target dir")
@@ -125,7 +135,7 @@ class DependencyDirPreparator:
             self.prepare_dependency_dir(dependencies, cache_enabled, cache_dir)
         return self.dependency_dirs
 
-    def setup_dirs(self, cache_enabled=False, cache_dir=""):
+    def setup_dirs(self, cache_enabled: bool = False, cache_dir: str = "") -> None:
         self.download_location = os.path.join(self.root_dir, "archives")
         self.dependency_dir_path = self.root_dir
         # check download_location
@@ -139,7 +149,13 @@ class DependencyDirPreparator:
             os.makedirs(self.dependency_dir_path)
         return
 
-    def prepare_root_dir(self, root_install=True, is_src_installed=False, cache_enabled=False, cache_dir=""):
+    def prepare_root_dir(
+        self,
+        root_install: bool = True,
+        is_src_installed: bool = False,
+        cache_enabled: bool = False,
+        cache_dir: str = "",
+    ) -> None:
         # install root
         if is_src_installed:
             pass
@@ -186,7 +202,9 @@ class DependencyDirPreparator:
                     self.metadata.hash = hash
         return
 
-    def prepare_dependency_dir(self, dependencies, cache_enabled=False, cache_dir=""):
+    def prepare_dependency_dir(
+        self, dependencies: dict[str, Any], cache_enabled: bool = False, cache_dir: str = ""
+    ) -> None:
         col_dependencies = dependencies.get("dependencies", {}).get("collections", [])
         role_dependencies = dependencies.get("dependencies", {}).get("roles", [])
 
@@ -230,7 +248,8 @@ class DependencyDirPreparator:
                         logger.debug(f"found cache data {targz_file}")
                         metadata_file = os.path.join(targz_file.rsplit("/", 1)[0], download_metadata_file)
                         md = self.find_target_metadata(LoadType.COLLECTION, metadata_file, col_name)
-                        downloaded_dep.metadata = md
+                        if md is not None:
+                            downloaded_dep.metadata = md
                     else:
                         # if no cache data, download
                         logger.debug("cache data not found")
@@ -241,8 +260,8 @@ class DependencyDirPreparator:
                         metadata = self.extract_collections_metadata(install_msg, cache_location)
                         metadata_file = self.export_data(metadata, cache_location, download_metadata_file)
                         md = self.find_target_metadata(LoadType.COLLECTION, metadata_file, col_name)
-                        downloaded_dep.metadata = md
-                        if md:
+                        if md is not None:
+                            downloaded_dep.metadata = md
                             targz_file = md.download_src_path
                     # install collection from tar.gz
                     self.install_galaxy_collection_from_targz(targz_file, sub_dependency_dir_path)
@@ -358,14 +377,18 @@ class DependencyDirPreparator:
                         if os.path.exists(install_dir):
                             install_dir = os.path.dirname(install_dir)
                         install_msg, install_err = install_galaxy_target(
-                            name, LoadType.ROLE, install_dir, self.source_repository, target_version
+                            name,
+                            LoadType.ROLE,
+                            install_dir,
+                            self.source_repository,
+                            target_version=target_version if target_version is not None else "",
                         )
                         logger.debug(f"role install msg: {install_msg}")
                         logger.debug(f"role install msg err: {install_err}")
-                        metadata = self.extract_roles_metadata(install_msg)
-                        if not metadata:
+                        metadata_val: dict[str, list[dict[str, Any]]] | None = self.extract_roles_metadata(install_msg)
+                        if not metadata_val:
                             raise ValueError(f"failed to install {LoadType.ROLE} {name}")
-                        metadata_file = self.export_data(metadata, download_meta_dir_path, download_metadata_file)
+                        metadata_file = self.export_data(metadata_val, download_meta_dir_path, download_metadata_file)
                         md = self.find_target_metadata(LoadType.ROLE, metadata_file, name)
                         # save cache
                         if not os.path.exists(cache_dir_path):
@@ -397,11 +420,11 @@ class DependencyDirPreparator:
                     )
                     logger.debug(f"role install msg: {install_msg}")
                     logger.debug(f"role install msg err: {install_err}")
-                    metadata = self.extract_roles_metadata(install_msg)
-                    if not metadata:
+                    metadata_val = self.extract_roles_metadata(install_msg)
+                    if not metadata_val:
                         raise ValueError(f"failed to install {LoadType.ROLE} {name}")
                     sub_download_location = os.path.join(self.download_location, "role", name)
-                    metadata_file = self.export_data(metadata, sub_download_location, download_metadata_file)
+                    metadata_file = self.export_data(metadata_val, sub_download_location, download_metadata_file)
                     md = self.find_target_metadata(LoadType.ROLE, metadata_file, name)
                     if md is not None:
                         downloaded_dep.metadata = md
@@ -409,16 +432,17 @@ class DependencyDirPreparator:
                 self.dependency_dirs.append(asdict(downloaded_dep))
         return
 
-    def src_install(self):
+    def src_install(self) -> None:
         try:
             self.setup_tmp_dir()
-            self.root_install(self.tmp_install_dir)
+            if self.tmp_install_dir is not None:
+                self.root_install(self.tmp_install_dir)
         finally:
             self.clean_tmp_dir()
         return
 
-    def root_install(self, tmp_src_dir):
-        tmp_src_dir = os.path.join(self.tmp_install_dir.name, "src")
+    def root_install(self, tmp_install_dir: tempfile.TemporaryDirectory[Any]) -> None:
+        tmp_src_dir = os.path.join(tmp_install_dir.name, "src")
         if not os.path.exists(tmp_src_dir):
             os.makedirs(tmp_src_dir)
 
@@ -452,11 +476,12 @@ class DependencyDirPreparator:
                 metadata = self.extract_collections_metadata(install_msg, sub_download_location)
                 metadata_file = self.export_data(metadata, sub_download_location, download_metadata_file)
                 md = self.find_target_metadata(LoadType.COLLECTION, metadata_file, self.target_name)
-            if md:
+            if md is not None:
                 self.install_galaxy_collection_from_reqfile(md.requirements_file, tmp_src_dir)
             dst_src_dir = self.target_path_mappings["src"]
             dependency_dir = tmp_src_dir
-            self.metadata = md
+            if md is not None:
+                self.metadata = md
         elif self.target_type == LoadType.ROLE:
             install_msg = ""
             sub_download_location = os.path.join(self.download_location, "roles", self.target_name)
@@ -479,10 +504,10 @@ class DependencyDirPreparator:
                 )
                 logger.debug(f"role install msg: {install_msg}")
                 logger.debug(f"role install msg err: {install_err}")
-                metadata = self.extract_roles_metadata(install_msg)
-                if not metadata:
+                role_metadata: dict[str, list[dict[str, Any]]] | None = self.extract_roles_metadata(install_msg)
+                if not role_metadata:
                     raise ValueError(f"failed to install {self.target_type} {self.target_name}")
-                metadata_file = self.export_data(metadata, metafile_location, download_metadata_file)
+                metadata_file = self.export_data(role_metadata, metafile_location, download_metadata_file)
                 md = self.find_target_metadata(LoadType.ROLE, metadata_file, self.target_name)
                 # save cache
                 if not os.path.exists(sub_download_location):
@@ -529,15 +554,15 @@ class DependencyDirPreparator:
         self.dependency_dirs = self.dependnecy_dirs(metadata_file, self.target_type, self.target_name)
         return
 
-    def set_index(self, path):
+    def set_index(self, path: str) -> None:
         if not self.silent:
             print("crawl content")
         dep_type = LoadType.UNKNOWN
-        target_path_list = []
+        target_path_list: list[str] = []
         if os.path.isfile(path):
             # need further check?
             dep_type = LoadType.PLAYBOOK
-            target_path_list.append = [path]
+            target_path_list.append(path)
         elif os.path.exists(os.path.join(path, collection_manifest_json)):
             dep_type = LoadType.COLLECTION
             target_path_list = [path]
@@ -554,10 +579,10 @@ class DependencyDirPreparator:
             logger.error("this target type is not supported")
             sys.exit(1)
 
-        list = []
+        dep_list: list[dict[str, Any]] = []
         for target_path in target_path_list:
             ext_name = get_target_name(dep_type, target_path)
-            list.append(
+            dep_list.append(
                 {
                     "name": ext_name,
                     "type": dep_type,
@@ -565,13 +590,19 @@ class DependencyDirPreparator:
             )
 
         index_data = {
-            "dependencies": list,
+            "dependencies": dep_list,
             "path_mappings": self.target_path_mappings,
         }
 
         self.index = index_data
 
-    def download_galaxy_collection(self, target, output_dir, version="", source_repository=""):
+    def download_galaxy_collection(
+        self,
+        target: str,
+        output_dir: str,
+        version: str = "",
+        source_repository: str = "",
+    ) -> str:
         server_option = ""
         if source_repository:
             server_option = f"--server {source_repository}"
@@ -594,7 +625,9 @@ class DependencyDirPreparator:
         logger.debug(f"STDOUT: {install_msg}")
         return install_msg
 
-    def download_galaxy_collection_from_reqfile(self, requirements, output_dir, source_repository=""):
+    def download_galaxy_collection_from_reqfile(
+        self, requirements: str, output_dir: str, source_repository: str = ""
+    ) -> None:
         server_option = ""
         if source_repository:
             server_option = f"--server {source_repository}"
@@ -609,7 +642,7 @@ class DependencyDirPreparator:
         logger.debug(f"STDOUT: {install_msg}")
         # return proc.stdout
 
-    def install_galaxy_collection_from_targz(self, tarfile, output_dir):
+    def install_galaxy_collection_from_targz(self, tarfile: str, output_dir: str) -> None:
         logger.debug(f"install collection from {tarfile}")
         proc = subprocess.run(
             f"ansible-galaxy collection install {tarfile} -p {output_dir}",
@@ -622,7 +655,7 @@ class DependencyDirPreparator:
         logger.debug(f"STDOUT: {install_msg}")
         # return proc.stdout
 
-    def install_galaxy_collection_from_reqfile(self, requirements, output_dir):
+    def install_galaxy_collection_from_reqfile(self, requirements: str, output_dir: str) -> None:
         if not os.path.isfile(requirements):
             # get requirements file from archives dir under current root_dir
             child_dir_path = requirements.split("archives")[-1]
@@ -647,7 +680,7 @@ class DependencyDirPreparator:
         logger.debug(f"STDOUT: {install_msg}")
         # return proc.stdout
 
-    def is_download_file_exist(self, type, target, dir):
+    def is_download_file_exist(self, type: str, target: str, dir: str) -> tuple[bool, str]:
         is_exist = False
         filename = ""
         download_metadata_files = glob.glob(f"{dir}/{type}/{target}/**/{download_metadata_file}", recursive=True)
@@ -667,7 +700,7 @@ class DependencyDirPreparator:
                         filename = file
         return is_exist, filename
 
-    def install_galaxy_role_from_reqfile(self, file, output_dir):
+    def install_galaxy_role_from_reqfile(self, file: str, output_dir: str) -> None:
         proc = subprocess.run(
             f"ansible-galaxy role install -r {file} -p {output_dir}",
             shell=True,
@@ -678,7 +711,7 @@ class DependencyDirPreparator:
         install_msg = proc.stdout
         logger.debug(f"STDOUT: {install_msg}")
 
-    def extract_collections_metadata(self, log_message, download_location):
+    def extract_collections_metadata(self, log_message: str, download_location: str) -> dict[str, list[dict[str, Any]]]:
         # -- log message
         # Downloading collection 'community.rabbitmq:1.2.3' to
         # Downloading https://galaxy.ansible.com/download/ansible-posix-1.4.0.tar.gz to ...
@@ -724,7 +757,7 @@ class DependencyDirPreparator:
         result = {"collections": metadata_list}
         return result
 
-    def extract_roles_metadata(self, log_message):
+    def extract_roles_metadata(self, log_message: str) -> dict[str, list[dict[str, Any]]] | None:
         # - downloading role from https://github.com/rhythmictech/ansible-role-awscli/archive/1.0.3.tar.gz
         # - extracting rhythmictech.awscli to /private/tmp/role-test/rhythmictech.awscli
         url = ""
@@ -760,7 +793,7 @@ class DependencyDirPreparator:
         result = {"roles": metadata_list}
         return result
 
-    def find_target_metadata(self, type, metadata_file, target):
+    def find_target_metadata(self, type: str, metadata_file: str, target: str) -> DownloadMetadata | None:
         if not os.path.isfile(metadata_file):
             # get metadata file from archives dir under current root_dir
             child_dir_path = metadata_file.split("archives")[-1]
@@ -785,8 +818,8 @@ class DependencyDirPreparator:
         logger.warning(f"metadata not found: {target}")
         return None
 
-    def existing_dependency_dir_loader(self, dependency_type, dependency_dir_path):
-        search_dirs = []
+    def existing_dependency_dir_loader(self, dependency_type: str, dependency_dir_path: str) -> list[dict[str, Any]]:
+        search_dirs: list[dict[str, Any]] = []
         if dependency_type == LoadType.COLLECTION:
             base_dir = dependency_dir_path
             if os.path.exists(os.path.join(dependency_dir_path, "ansible_collections")):
@@ -799,31 +832,30 @@ class DependencyDirPreparator:
                 ]
                 search_dirs.extend(colls)
 
-        dependency_dirs = []
+        dependency_dirs: list[dict[str, Any]] = []
         for dep_info in search_dirs:
-            downloaded_dep = {"dir": "", "metadata": {}}
-            downloaded_dep["dir"] = dep_info["path"]
-            # meta data
-            downloaded_dep["metadata"]["type"] = LoadType.COLLECTION
-            downloaded_dep["metadata"]["name"] = dep_info["name"]
+            metadata: dict[str, Any] = {"type": LoadType.COLLECTION, "name": dep_info["name"]}
+            downloaded_dep: dict[str, Any] = {"dir": dep_info["path"], "metadata": metadata}
             dependency_dirs.append(downloaded_dep)
         return dependency_dirs
 
-    def __save_install_log(self):
+    def __save_install_log(self) -> None:
+        if self.tmp_install_dir is None:
+            return
         tmpdir = self.tmp_install_dir.name
         tmp_install_log = os.path.join(tmpdir, "install.log")
         with open(tmp_install_log, "w") as f:
             f.write(self.install_log)
 
-    def __save_index(self):
-        index_location = self.__path_mappings["index"]
+    def __save_index(self) -> None:
+        index_location = self.target_path_mappings["index"]
         index_dir = os.path.dirname(os.path.abspath(index_location))
         if not os.path.exists(index_dir):
             os.makedirs(index_dir)
         with open(index_location, "w") as f:
             json.dump(self.index, f, indent=2)
 
-    def move_src(self, src, dst):
+    def move_src(self, src: str, dst: str) -> None:
         if src == "" or not os.path.exists(src) or not os.path.isdir(src):
             raise ValueError(f"src {src} is not directory")
         if dst == "" or ".." in dst:
@@ -850,13 +882,13 @@ class DependencyDirPreparator:
             raise ValueError(proc.stderr + "\ndirs: " + ", ".join(dirs)) from exc
         return
 
-    def setup_tmp_dir(self):
+    def setup_tmp_dir(self) -> None:
         if self.tmp_install_dir is None or not os.path.exists(self.tmp_install_dir.name):
             self.tmp_install_dir = tempfile.TemporaryDirectory()
             if self.periodical_cleanup:
                 self.cleanup_queue.append(deepcopy(self.tmp_install_dir))
 
-    def clean_tmp_dir(self):
+    def clean_tmp_dir(self) -> None:
         if self.tmp_install_dir is not None and os.path.exists(self.tmp_install_dir.name):
             if self.periodical_cleanup:
                 if len(self.cleanup_queue) > self.cleanup_threshold:
@@ -868,7 +900,7 @@ class DependencyDirPreparator:
                 self.tmp_install_dir.cleanup()
                 self.tmp_install_dir = None
 
-    def export_data(self, data, dir, filename):
+    def export_data(self, data: dict[str, Any], dir: str, filename: str) -> str:
         if not os.path.exists(dir):
             os.makedirs(dir)
         file = os.path.join(dir, filename)
@@ -877,7 +909,7 @@ class DependencyDirPreparator:
             json.dump(data, f)
         return file
 
-    def get_metafile_in_target(self, type, filepath):
+    def get_metafile_in_target(self, type: str, filepath: str) -> tuple[str, str]:
         metafile_path = ""
         files_path = ""
         if type == LoadType.COLLECTION:
@@ -887,13 +919,15 @@ class DependencyDirPreparator:
                     if info.name.endswith(collection_manifest_json):
                         f = tar.extractfile(info)
                         metafile_path = filepath.replace(".tar.gz", f"-{collection_manifest_json}")
-                        with open(metafile_path, "wb") as c:
-                            c.write(f.read())
+                        if f is not None:
+                            with open(metafile_path, "wb") as c:
+                                c.write(f.read())
                     if info.name.endswith(collection_files_json):
                         f = tar.extractfile(info)
                         files_path = filepath.replace(".tar.gz", f"-{collection_files_json}")
-                        with open(files_path, "wb") as c:
-                            c.write(f.read())
+                        if f is not None:
+                            with open(files_path, "wb") as c:
+                                c.write(f.read())
         elif type == LoadType.ROLE:
             # get meta/main.yml path
             role_meta_files = safe_glob(
@@ -907,7 +941,7 @@ class DependencyDirPreparator:
                 metafile_path = role_meta_files[0]
         return metafile_path, files_path
 
-    def update_metadata(self, type, metadata_file, target, key, value):
+    def update_metadata(self, type: str, metadata_file: str, target: str, key: str, value: Any) -> None:
         with open(metadata_file) as f:
             metadata = json.load(f)
         if type == LoadType.COLLECTION:
@@ -932,7 +966,7 @@ class DependencyDirPreparator:
                     json.dump(metadata, f)
         return
 
-    def update_role_download_src(self, metadata_file, dst_src_dir):
+    def update_role_download_src(self, metadata_file: str, dst_src_dir: str) -> None:
         with open(metadata_file) as f:
             metadata = json.load(f)
         metadata_list = metadata.get("roles", [])
@@ -953,7 +987,7 @@ class DependencyDirPreparator:
             json.dump(metadata, f)
         return
 
-    def get_author(self, type, metafile_path):
+    def get_author(self, type: str, metafile_path: str) -> str:
         if not os.path.exists(metafile_path):
             metafile_path = f"{self.root_dir}/{metafile_path}"
             if not os.path.exists(metafile_path):
@@ -967,11 +1001,14 @@ class DependencyDirPreparator:
         elif type == LoadType.ROLE:
             with open(metafile_path) as f:
                 metadata = yaml.safe_load(f)
+            if metadata is None:
+                return ""
             author = metadata.get("galaxy_info", {}).get("author", "")
-            return author
+            return str(author) if author is not None else ""
+        return ""
 
-    def dependnecy_dirs(self, metadata_file, target_type, target_name):
-        dependency_dirs = []
+    def dependnecy_dirs(self, metadata_file: str, target_type: str, target_name: str) -> list[dict[str, Any]]:
+        dependency_dirs: list[dict[str, Any]] = []
         if not os.path.isfile(metadata_file):
             # get metadata file from archives dir under current root_dir
             child_dir_path = metadata_file.split("archives")[-1]
@@ -1009,12 +1046,12 @@ class DependencyDirPreparator:
         return dependency_dirs
 
 
-def find_ext_dependencies(path):
+def find_ext_dependencies(path: str) -> tuple[str, list[str]]:
     collection_meta_files = safe_glob(os.path.join(path, "**", collection_manifest_json), recursive=True)
     if len(collection_meta_files) > 0:
         collection_path_list = [trim_suffix(f, ["/" + collection_manifest_json]) for f in collection_meta_files]
         collection_path_list = remove_subdirectories(collection_path_list)
-        return LoadType.COLLECTION, collection_path_list
+        return (LoadType.COLLECTION, collection_path_list)
     role_meta_files = safe_glob(
         [
             os.path.join(path, "**", role_meta_main_yml),
@@ -1027,5 +1064,5 @@ def find_ext_dependencies(path):
             trim_suffix(f, ["/" + role_meta_main_yml, "/" + role_meta_main_yaml]) for f in role_meta_files
         ]
         role_path_list = remove_subdirectories(role_path_list)
-        return LoadType.ROLE, role_path_list
-    return LoadType.UNKNOWN, []
+        return (LoadType.ROLE, role_path_list)
+    return (LoadType.UNKNOWN, [])

--- a/src/apme_engine/engine/dependency_finder.py
+++ b/src/apme_engine/engine/dependency_finder.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import json
 import os
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -21,8 +24,13 @@ github_workflows_dir = ".github/workflows"
 ansible_home = os.getenv("ANSIBLE_HOME", "~/.ansible")
 
 
-def find_dependency(type, target, dependency_dir, use_ansible_path=False):
-    dependencies = {"dependencies": {}, "type": "", "file": ""}
+def find_dependency(
+    type: str,
+    target: str,
+    dependency_dir: str,
+    use_ansible_path: bool = False,
+) -> dict[str, Any]:
+    dependencies: dict[str, Any] = {"dependencies": {}, "type": "", "file": ""}
     logger.debug("search dependency")
     if dependency_dir:
         requirements, paths, metadata = load_existing_dependency_dir(dependency_dir)
@@ -53,27 +61,31 @@ def find_dependency(type, target, dependency_dir, use_ansible_path=False):
 
     if use_ansible_path and dependencies["dependencies"]:
         ansible_dir = Path(ansible_home).expanduser()
-        paths, metadata = search_ansible_dir(dependencies["dependencies"], str(ansible_dir))
-        if paths:
-            dependencies["paths"] = paths
-        if metadata:
-            dependencies["metadata"] = metadata
+        deps = dependencies["dependencies"]
+        if isinstance(deps, dict):
+            paths, metadata = search_ansible_dir(deps, str(ansible_dir))
+            if paths:
+                dependencies["paths"] = paths
+            if metadata:
+                dependencies["metadata"] = metadata
 
     return dependencies
 
 
-def search_ansible_dir(dependencies: dict, ansible_dir: str):
+def search_ansible_dir(
+    dependencies: dict[str, Any], ansible_dir: str
+) -> tuple[dict[str, dict[str, str]], dict[str, dict[str, Any]]]:
     if not dependencies:
         return {}, {}
     if not isinstance(dependencies, dict):
         return {}, {}
 
-    paths = {
+    paths: dict[str, dict[str, str]] = {
         "roles": {},
         "collections": {},
     }
 
-    metadata = {
+    metadata: dict[str, dict[str, Any]] = {
         "roles": {},
         "collections": {},
     }
@@ -128,7 +140,7 @@ def search_ansible_dir(dependencies: dict, ansible_dir: str):
     return paths, metadata
 
 
-def find_role_dependency(target):
+def find_role_dependency(target: str) -> tuple[dict[str, Any], str]:
     requirements = {}
     if not os.path.exists(target):
         raise ValueError(f"Invalid target dir: {target}")
@@ -187,7 +199,7 @@ def find_role_dependency(target):
     return requirements, main_yaml
 
 
-def find_collection_dependency(target):
+def find_collection_dependency(target: str) -> tuple[dict[str, Any], str]:
     requirements = {}
     # collection dir installed by ansible-galaxy command
     manifest_json_files = safe_glob(os.path.join(target, "**", collection_manifest_json), recursive=True)
@@ -208,7 +220,7 @@ def find_collection_dependency(target):
     return requirements, manifest_json
 
 
-def find_project_dependency(target):
+def find_project_dependency(target: str) -> tuple[dict[str, Any], str]:
     if os.path.exists(target):
         coll_req = os.path.join(target, collection_manifest_json)
         role_req1 = os.path.join(target, role_meta_main_yaml)
@@ -226,7 +238,7 @@ def find_project_dependency(target):
         raise ValueError(f"Invalid target dir: {target}")
 
 
-def load_requirements(path):
+def load_requirements(path: str) -> tuple[dict[str, Any], str]:
     requirements = {}
     yaml_path = ""
     # project dir
@@ -263,7 +275,7 @@ def load_requirements(path):
     return requirements, yaml_path
 
 
-def is_galaxy_yml(path):
+def is_galaxy_yml(path: str) -> bool:
     if not os.path.exists(path):
         return False
 
@@ -280,7 +292,7 @@ def is_galaxy_yml(path):
     return bool("name" in metadata and "namespace" in metadata)
 
 
-def load_dependency_from_galaxy(path):
+def load_dependency_from_galaxy(path: str) -> tuple[dict[str, Any], str]:
     requirements = {}
     yaml_path = ""
     galaxy_yml_files = safe_glob(os.path.join(path, "**", galaxy_yml), recursive=True)
@@ -300,7 +312,13 @@ def load_dependency_from_galaxy(path):
     return requirements, yaml_path
 
 
-def load_existing_dependency_dir(dependency_dir):
+def load_existing_dependency_dir(
+    dependency_dir: str,
+) -> tuple[
+    dict[str, list[str]],
+    dict[str, dict[str, str]],
+    dict[str, dict[str, Any]],
+]:
     # role_meta_files = safe_glob(
     #     [
     #         os.path.join(dependency_dir, "**", role_meta_main_yml),
@@ -310,15 +328,15 @@ def load_existing_dependency_dir(dependency_dir):
     # )
     collection_meta_files = safe_glob(os.path.join(dependency_dir, "**", collection_manifest_json), recursive=True)
     collection_meta_files = [fpath for fpath in collection_meta_files if github_workflows_dir not in fpath]
-    requirements = {
+    requirements: dict[str, list[str]] = {
         "roles": [],
         "collections": [],
     }
-    paths = {
+    paths: dict[str, dict[str, str]] = {
         "roles": {},
         "collections": {},
     }
-    metadata = {
+    metadata: dict[str, dict[str, Any]] = {
         "roles": {},
         "collections": {},
     }
@@ -351,7 +369,7 @@ def load_existing_dependency_dir(dependency_dir):
     return requirements, paths, metadata
 
 
-def install_github_target(target, output_dir):
+def install_github_target(target: str, output_dir: str) -> str:
     proc = subprocess.run(
         f"git clone {target} {output_dir}",
         shell=True,
@@ -364,7 +382,7 @@ def install_github_target(target, output_dir):
     return proc.stdout
 
 
-def format_dependency_info(dependencies):
+def format_dependency_info(dependencies: dict[str, Any]) -> list[dict[str, Any]]:
     results = []
     for k, v in dependencies.items():
         results.append({"name": k, "version": v})

--- a/src/apme_engine/engine/finder.py
+++ b/src/apme_engine/engine/finder.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import json
 import os
 import re
 import traceback
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -11,11 +15,10 @@ from .yaml_utils import FormattedYAML
 
 try:
     # if `libyaml` is available, use C based loader for performance
-    import _yaml  # noqa: F401
+    import _yaml  # type: ignore[import-not-found]  # noqa: F401
     from yaml import CSafeLoader as Loader
 except Exception:
-    # otherwise, use Python based loader
-    from yaml import SafeLoader as Loader
+    from yaml import SafeLoader as Loader  # type: ignore[assignment]
 import contextlib
 
 from . import logger
@@ -38,9 +41,9 @@ github_workflows_dir = ".github/workflows"
 
 
 class Singleton(type):
-    _instances = {}
+    _instances: dict[type[Any], Any] = {}
 
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls: type[Any], *args: Any, **kwargs: Any) -> Any:
         if cls not in cls._instances:
             cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
@@ -48,27 +51,27 @@ class Singleton(type):
 
 @dataclass(frozen=True)
 class TaskKeywordSet(metaclass=Singleton):
-    task_keywords: set
+    task_keywords: set[str] = field(default_factory=set)
 
 
 @dataclass(frozen=True)
 class BuiltinModuleSet(metaclass=Singleton):
-    builtin_modules: set
+    builtin_modules: set[str] = field(default_factory=set)
 
 
 p = Path(__file__).resolve().parent
 with open(p / "task_keywords.txt") as f:
-    TaskKeywordSet(set(f.read().splitlines()))
+    TaskKeywordSet(task_keywords=set(f.read().splitlines()))
 
 with open(p / "builtin-modules.txt") as f:
-    BuiltinModuleSet(set(f.read().splitlines()))
+    BuiltinModuleSet(builtin_modules=set(f.read().splitlines()))
 
 
-def get_builtin_module_names():
+def get_builtin_module_names() -> set[str]:
     return BuiltinModuleSet().builtin_modules
 
 
-def find_module_name(data_block):
+def find_module_name(data_block: dict[str, Any]) -> str:
     keys = [k for k in data_block]
     task_keywords = TaskKeywordSet().task_keywords
     builtin_modules = BuiltinModuleSet().builtin_modules
@@ -103,11 +106,11 @@ def find_module_name(data_block):
 
 
 def get_task_blocks(
-    fpath="",
-    yaml_str="",
-    task_dict_list=None,
-    jsonpath_prefix="",
-):
+    fpath: str = "",
+    yaml_str: str = "",
+    task_dict_list: list[dict[str, Any]] | None = None,
+    jsonpath_prefix: str = "",
+) -> tuple[list[tuple[dict[str, Any], str]] | None, str | None]:
     d = None
     yaml_lines = ""
     if yaml_str:
@@ -153,7 +156,11 @@ def get_task_blocks(
 #         - some_module2
 #         - some_module3
 #
-def flatten_block_tasks(task_dict, jsonpath_prefix="", module_defaults=None):
+def flatten_block_tasks(
+    task_dict: dict[str, Any] | None,
+    jsonpath_prefix: str = "",
+    module_defaults: dict[str, Any] | None = None,
+) -> list[tuple[dict[str, Any], str]]:
     if module_defaults is None:
         module_defaults = {}
     if task_dict is None:
@@ -210,7 +217,7 @@ def flatten_block_tasks(task_dict, jsonpath_prefix="", module_defaults=None):
 
 def identify_lines_with_jsonpath(
     fpath: str = "", yaml_str: str = "", jsonpath: str = ""
-) -> tuple[str, tuple[int, int]]:
+) -> tuple[str | None, tuple[int, int] | None]:
     if not jsonpath:
         return None, None
 
@@ -259,8 +266,8 @@ def identify_lines_with_jsonpath(
     return current_lines, line_num_tuple
 
 
-def find_child_yaml_block(yaml_str: str, key: str = "", line_num_offset: int = -1) -> list:
-    skip_condition_funcs = [
+def find_child_yaml_block(yaml_str: str, key: str = "", line_num_offset: int = -1) -> list[tuple[str, tuple[int, int]]]:
+    skip_condition_funcs: list[Callable[[str], bool]] = [
         # for YAML separator
         lambda x: x.strip() == "---",
         # for empty line
@@ -269,16 +276,16 @@ def find_child_yaml_block(yaml_str: str, key: str = "", line_num_offset: int = -
         lambda x: x.strip().startswith("#"),
     ]
 
-    def match_condition_func(x):
+    def match_condition_func(x: str) -> bool:
         if key:
             return x.strip().startswith(f"{key}:")
         else:
             return x.strip().startswith("- ")
 
-    def is_yaml_end_separator(x):
+    def is_yaml_end_separator(x: str) -> bool:
         return x.strip() == "..."
 
-    def get_indent_level(x):
+    def get_indent_level(x: str) -> int:
         return len(x) - len(x.lstrip())
 
     top_level_indent = 100
@@ -297,9 +304,9 @@ def find_child_yaml_block(yaml_str: str, key: str = "", line_num_offset: int = -
     if top_level_indent == 100:
         return []
 
-    blocks = []
-    line_buffer = []
-    isolated_line_buffer = []
+    blocks: list[tuple[str, tuple[int, int]]] = []
+    line_buffer: list[str] = []
+    isolated_line_buffer: list[str] = []
     buffer_begin = -1
     if key:
         for i, line in enumerate(yaml_str.splitlines()):
@@ -376,7 +383,7 @@ def find_child_yaml_block(yaml_str: str, key: str = "", line_num_offset: int = -
     return blocks
 
 
-def search_module_files(path, module_dir_paths=None):
+def search_module_files(path: str, module_dir_paths: list[str] | None = None) -> list[str]:
     if module_dir_paths is None:
         module_dir_paths = []
     file_list = []
@@ -408,7 +415,7 @@ def search_module_files(path, module_dir_paths=None):
     return file_list
 
 
-def find_module_dirs(role_root_dir):
+def find_module_dirs(role_root_dir: str) -> list[str]:
     module_dirs = []
     for module_dir_pattern in module_dir_patterns:
         moddir = os.path.join(role_root_dir, module_dir_pattern)
@@ -417,7 +424,7 @@ def find_module_dirs(role_root_dir):
     return module_dirs
 
 
-def search_taskfiles_for_playbooks(path, taskfile_dir_paths: list = None):
+def search_taskfiles_for_playbooks(path: str, taskfile_dir_paths: list[str] | None = None) -> list[str]:
     # must copy the input here; otherwise, the added items are kept forever
     if taskfile_dir_paths is None:
         taskfile_dir_paths = []
@@ -448,16 +455,15 @@ def search_taskfiles_for_playbooks(path, taskfile_dir_paths: list = None):
     return candidates
 
 
-def search_inventory_files(path):
+def search_inventory_files(path: str) -> list[str]:
     inventory_file_patterns = [
         os.path.join(path, "**/group_vars", "*"),
         os.path.join(path, "**/host_vars", "*"),
     ]
-    files = safe_glob(patterns=inventory_file_patterns, recursive=True)
-    return files
+    return safe_glob(patterns=inventory_file_patterns, recursive=True)
 
 
-def find_best_repo_root_path(path):
+def find_best_repo_root_path(path: str) -> str:
     base_path = path
 
     manifest_json_path = os.path.join(base_path, "MANIFEST.json")
@@ -511,10 +517,10 @@ def find_best_repo_root_path(path):
             if len(candidate) < len(root_path):
                 root_path = candidate
 
-    return root_path
+    return str(root_path)
 
 
-def find_collection_name_of_repo(path):
+def find_collection_name_of_repo(path: str) -> str:
     galaxy_yml_pattern = os.path.join(path, "**/galaxy.yml")
     manifest_json_pattern = os.path.join(path, "**/MANIFEST.json")
     found_metadata_files = safe_glob([galaxy_yml_pattern, manifest_json_pattern], recursive=True)
@@ -549,25 +555,23 @@ def find_collection_name_of_repo(path):
                     logger.debug(f"failed to load this json file to read MANIFEST.json; {e.args[0]}")
         if my_collection_info is None:
             return ""
-        namespace = my_collection_info.get("namespace", "")
-        name = my_collection_info.get("name", "")
+        namespace = str(my_collection_info.get("namespace", ""))
+        name = str(my_collection_info.get("name", ""))
         my_collection_name = f"{namespace}.{name}"
-    return my_collection_name
+    return str(my_collection_name)
 
 
-def find_all_ymls(root_dir: str):
+def find_all_ymls(root_dir: str) -> list[str]:
     patterns = [os.path.join(root_dir, "**", "*.ya?ml")]
-    ymls = safe_glob(patterns)
-    return ymls
+    return safe_glob(patterns)
 
 
-def find_all_files(root_dir: str):
+def find_all_files(root_dir: str) -> list[str]:
     patterns = [os.path.join(root_dir, "**", "*")]
-    files = safe_glob(patterns, type="file")
-    return files
+    return safe_glob(patterns, type=["file"])
 
 
-def _get_body_data(body: str = "", data: list = None, fpath: str = ""):
+def _get_body_data(body: str = "", data: list[Any] | None = None, fpath: str = "") -> tuple[str, Any, str]:
     if fpath and not body and not data:
         try:
             with open(fpath) as file:
@@ -581,7 +585,7 @@ def _get_body_data(body: str = "", data: list = None, fpath: str = ""):
     return body, data, fpath
 
 
-def could_be_playbook_detail(body: str = "", data: list = None, fpath: str = ""):
+def could_be_playbook_detail(body: str = "", data: list[Any] | None = None, fpath: str = "") -> bool:
     body, data, fpath = _get_body_data(body, data, fpath)
 
     if not body:
@@ -605,7 +609,7 @@ def could_be_playbook_detail(body: str = "", data: list = None, fpath: str = "")
     return bool("import_playbook" in data[0] or "ansible.builtin.import_playbook" in data[0])
 
 
-def could_be_taskfile(body: str = "", data: list = None, fpath: str = ""):
+def could_be_taskfile(body: str = "", data: list[Any] | None = None, fpath: str = "") -> bool:
     body, data, fpath = _get_body_data(body, data, fpath)
 
     if not body:
@@ -635,7 +639,7 @@ def could_be_taskfile(body: str = "", data: list = None, fpath: str = ""):
 # this function is only for empty files
 # if a target file has some contents, it should be checked with
 # some dedicated functions like `could_be_taskfile()`.
-def label_empty_file_by_path(fpath: str):
+def label_empty_file_by_path(fpath: str) -> str:
     taskfile_dir = ["/tasks/", "/handlers/"]
     for t_d in taskfile_dir:
         if t_d in fpath:
@@ -649,7 +653,7 @@ def label_empty_file_by_path(fpath: str):
     return ""
 
 
-def get_role_info_from_path(fpath: str):
+def get_role_info_from_path(fpath: str) -> tuple[str, str]:
     patterns = [
         "/roles/",
         "/tests/integration/targets/",
@@ -709,22 +713,22 @@ def get_role_info_from_path(fpath: str):
 
 
 # TODO: implement this
-def get_project_info_for_file(fpath, root_dir):
+def get_project_info_for_file(fpath: str, root_dir: str) -> tuple[str, str]:
     return os.path.basename(root_dir), root_dir
 
 
-def is_meta_yml(yml_path):
+def is_meta_yml(yml_path: str) -> bool:
     parts = yml_path.split("/")
     return bool(len(parts) > 2 and parts[-2] == "meta")
 
 
-def is_vars_yml(yml_path):
+def is_vars_yml(yml_path: str) -> bool:
     parts = yml_path.split("/")
     return bool(len(parts) > 2 and parts[-2] in ["vars", "defaults"])
 
 
-def count_top_level_element(yml_body: str = ""):
-    def _is_skip_line(line: str):
+def count_top_level_element(yml_body: str = "") -> int:
+    def _is_skip_line(line: str) -> bool:
         # skip empty line
         if not line.strip():
             return True
@@ -762,7 +766,9 @@ def count_top_level_element(yml_body: str = ""):
     return count
 
 
-def label_yml_file(yml_path: str = "", yml_body: str = "", task_num_thresh: int = 50):
+def label_yml_file(
+    yml_path: str = "", yml_body: str = "", task_num_thresh: int = 50
+) -> tuple[str, int, dict[str, str] | None]:
     body = ""
     data = None
     error = None
@@ -816,7 +822,9 @@ def label_yml_file(yml_path: str = "", yml_body: str = "", task_num_thresh: int 
     return label, name_count, None
 
 
-def get_yml_label(file_path, root_path, task_num_threshold: int = -1):
+def get_yml_label(
+    file_path: str, root_path: str, task_num_threshold: int = -1
+) -> tuple[str, dict[str, Any] | None, dict[str, Any] | None]:
     relative_path = file_path.replace(root_path, "")
     if relative_path[-1] == "/":
         relative_path = relative_path[:-1]
@@ -839,7 +847,7 @@ def get_yml_label(file_path, root_path, task_num_threshold: int = -1):
     return label, role_info, project_info
 
 
-def get_yml_list(root_dir: str, task_num_threshold: int = -1):
+def get_yml_list(root_dir: str, task_num_threshold: int = -1) -> list[dict[str, Any]]:
     found_ymls = find_all_ymls(root_dir)
     all_files = []
     for yml_path in found_ymls:
@@ -849,11 +857,11 @@ def get_yml_list(root_dir: str, task_num_threshold: int = -1):
         if not project_info:
             project_info = {}
         if role_info:
-            if role_info["path"] and not role_info["path"].startswith(root_dir):
+            if role_info.get("path") and not str(role_info.get("path", "")).startswith(root_dir):
                 role_info["path"] = os.path.join(root_dir, role_info["path"])
-            role_info["is_external_dependency"] = "." in role_info["name"]
-        in_role = bool(role_info)
-        in_project = bool(project_info)
+            role_info["is_external_dependency"] = "." in role_info.get("name", "")
+        in_role: bool = bool(role_info)
+        in_project: bool = bool(project_info)
         all_files.append(
             {
                 "filepath": yml_path,
@@ -868,7 +876,7 @@ def get_yml_list(root_dir: str, task_num_threshold: int = -1):
     return all_files
 
 
-def list_scan_target(root_dir: str, task_num_threshold: int = -1):
+def list_scan_target(root_dir: str, task_num_threshold: int = -1) -> list[dict[str, Any]]:
     yml_list = get_yml_list(root_dir=root_dir, task_num_threshold=task_num_threshold)
     known_roles = set()
     all_targets = []
@@ -903,7 +911,7 @@ def list_scan_target(root_dir: str, task_num_threshold: int = -1):
     return all_targets
 
 
-def update_line_with_space(new_line_content, old_line_content, leading_spaces=0):
+def update_line_with_space(new_line_content: str, old_line_content: str, leading_spaces: int = 0) -> str:
     """
     Returns the line of the input lines with mutation, having spaces
     exactly same as input yaml lines
@@ -914,7 +922,7 @@ def update_line_with_space(new_line_content, old_line_content, leading_spaces=0)
     return " " * leading_spaces + new_line_content
 
 
-def populate_new_data_list(data, line_number_list):
+def populate_new_data_list(data: str, line_number_list: list[str]) -> list[str]:
     """
     Function to check diff in line between the
     first mutated results, and then copy the in
@@ -928,7 +936,7 @@ def populate_new_data_list(data, line_number_list):
     return temp_data[0 : input_line_number - 1]
 
 
-def check_and_add_diff_lines(start_line, stop_line, lines, data_copy):
+def check_and_add_diff_lines(start_line: int, stop_line: int, lines: list[str], data_copy: list[str]) -> None:
     """
     Function to check diff in line between the mutated results,
     and then copy the in between lines to mutated data lines
@@ -940,7 +948,9 @@ def check_and_add_diff_lines(start_line, stop_line, lines, data_copy):
         data_copy.append(line)
 
 
-def check_diff_and_copy_olddata_to_newdata(line_number_list, lines, new_data):
+def check_diff_and_copy_olddata_to_newdata(
+    line_number_list: list[str], lines: list[str], new_data: list[str]
+) -> list[str]:
     """
     Function to find the old lines which weren't mutated by ARI rules,
     it need to be copied to new content as is
@@ -952,9 +962,10 @@ def check_diff_and_copy_olddata_to_newdata(line_number_list, lines, new_data):
             for i in range(new_content_last_line, len(lines)):
                 new_data.append(lines[i])
         return new_data
+    return new_data
 
 
-def update_and_append_new_line(new_line, old_line, leading_spaces, data_copy):
+def update_and_append_new_line(new_line: str, old_line: str, leading_spaces: int, data_copy: list[str]) -> str:
     """
     Function to get the leading space for the new ARI mutated line, with
     its equivaltent old line with space similar to the old line
@@ -964,7 +975,7 @@ def update_and_append_new_line(new_line, old_line, leading_spaces, data_copy):
     return ""
 
 
-def update_the_yaml_target(file_path, line_number_list, new_content_list):
+def update_the_yaml_target(file_path: str, line_number_list: list[str], new_content_list: list[str]) -> None:
     try:
         # Read the original YAML file
         with open(file_path) as file:
@@ -974,7 +985,7 @@ def update_the_yaml_target(file_path, line_number_list, new_content_list):
         )
         data_copy = populate_new_data_list(data, line_number_list)
         stop_line_number = 0
-        new_lines = []
+        new_lines: list[str] = []
         for iter in range(len(line_number_list)):
             line_number = line_number_list[iter]
             new_content = new_content_list[iter]
@@ -998,7 +1009,7 @@ def update_the_yaml_target(file_path, line_number_list, new_content_list):
             end = stop_line_number - 1
             data_copy.append("\n")
             for i in range(start, end):
-                line_number = i
+                line_idx = i
                 if len(lines) == i:
                     break
                 try:
@@ -1006,17 +1017,17 @@ def update_the_yaml_target(file_path, line_number_list, new_content_list):
                     new_line_content = new_lines.pop(0)
                 except IndexError:
                     break
-                if 0 <= line_number < len(lines):
+                if 0 <= line_idx < len(lines):
                     # Preserve the original indentation
-                    old_line_content = lines[line_number]
+                    old_line_content = lines[line_idx]
                     if "---" in old_line_content:
                         continue
                     if new_line_content in old_line_content:
-                        leading_spaces = len(lines[line_number]) - len(lines[line_number].lstrip())
+                        leading_spaces = len(lines[line_idx]) - len(lines[line_idx].lstrip())
                         temp_content.append(new_line_content)
                         new_line_content = new_line_content.lstrip(" ")
-                        lines[line_number] = " " * leading_spaces + new_line_content
-                        data_copy.append(lines[line_number])
+                        lines[line_idx] = " " * leading_spaces + new_line_content
+                        data_copy.append(lines[line_idx])
                     else:
                         new_line_key = new_line_content.split(":")
                         new_key = new_line_key[0].strip(" ")
@@ -1055,7 +1066,7 @@ def update_the_yaml_target(file_path, line_number_list, new_content_list):
                         if new_line_content:
                             data_copy.append(new_line_content)
                 else:
-                    return IndexError("Line number out of range.")
+                    raise IndexError("Line number out of range.")
         # check for diff b/w new content and old contents,
         # and copy the old content that's not updated by ARI mutation
         data_copy = check_diff_and_copy_olddata_to_newdata(line_number_list, lines, data_copy)
@@ -1071,3 +1082,4 @@ def update_the_yaml_target(file_path, line_number_list, new_content_list):
         logger.warning(
             "YAML LINES: ARI fix update yaml by lines failed for file: '%s', with error: '%s'", file_path, ex
         )
+        return

--- a/src/apme_engine/engine/findings.py
+++ b/src/apme_engine/engine/findings.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import os
 from copy import deepcopy
 from dataclasses import dataclass, field
+from typing import Any
 
 import jsonpickle
 
@@ -13,27 +16,27 @@ from .utils import (
 
 @dataclass
 class Findings:
-    metadata: dict = field(default_factory=dict)
-    dependencies: list = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    dependencies: list[Any] = field(default_factory=list)
 
-    root_definitions: dict = field(default_factory=dict)
-    ext_definitions: dict = field(default_factory=dict)
-    extra_requirements: list = field(default_factory=list)
-    resolve_failures: dict = field(default_factory=dict)
+    root_definitions: dict[str, Any] = field(default_factory=dict)
+    ext_definitions: dict[str, Any] = field(default_factory=dict)
+    extra_requirements: list[Any] = field(default_factory=list)
+    resolve_failures: dict[str, Any] = field(default_factory=dict)
 
-    prm: dict = field(default_factory=dict)
-    report: dict = field(default_factory=dict)
+    prm: dict[str, Any] = field(default_factory=dict)
+    report: dict[str, Any] = field(default_factory=dict)
 
     summary_txt: str = ""
     scan_time: str = ""
 
-    def simple(self):
+    def simple(self) -> dict[str, Any]:
         d = self.report.copy()
         d["metadata"] = self.metadata
         d["dependencies"] = self.dependencies
         return d
 
-    def dump(self, fpath=""):
+    def dump(self, fpath: str = "") -> str:
         f = deepcopy(self)
         # omit report and summary_txt when the findings are saved
         # to reduce unnecessary file write
@@ -48,10 +51,10 @@ class Findings:
             finally:
                 unlock_file(lock)
                 remove_lock_file(lock)
-        return json_str
+        return str(json_str)
 
-    def save_rule_result(self, fpath=""):
-        json_str = jsonpickle.encode(self.report.get("ari_result", {}), make_refs=False, unpicklable=False)
+    def save_rule_result(self, fpath: str = "") -> str:
+        json_str: str = jsonpickle.encode(self.report.get("ari_result", {}), make_refs=False, unpicklable=False)
         if fpath:
             rule_result_dir = os.path.dirname(fpath)
             if not os.path.exists(rule_result_dir):
@@ -61,9 +64,9 @@ class Findings:
         return json_str
 
     @staticmethod
-    def load(fpath="", json_str=""):
+    def load(fpath: str = "", json_str: str = "") -> Findings:
         if fpath:
             with open(fpath) as file:
                 json_str = file.read()
-        findings = jsonpickle.decode(json_str)
+        findings: Findings = jsonpickle.decode(json_str)
         return findings

--- a/src/apme_engine/engine/key_test.py
+++ b/src/apme_engine/engine/key_test.py
@@ -1,6 +1,6 @@
 import json
 
-from keyutil import get_obj_info_by_key
+from apme_engine.engine.keyutil import get_obj_info_by_key
 
 if __name__ == "__main__":
     keys = [

--- a/src/apme_engine/engine/keyutil.py
+++ b/src/apme_engine/engine/keyutil.py
@@ -1,26 +1,30 @@
+from __future__ import annotations
+
 import os
+from typing import Any
 
 key_delimiter = ":"
 object_delimiter = "#"
 
 
 class Key:
-    def __init__(self, str):
-        self.key = str
+    def __init__(self, key_str: str) -> None:
+        self.key = key_str
 
-    def detect_type(self):
+    def detect_type(self) -> str:
         return self.key.split(" ")[0]
 
     # convert key to tree root name
-    def to_name(self):
+    def to_name(self) -> str | None:
         _type = self.detect_type()
         if _type == "playbook":
             return os.path.basename(self.key.split(key_delimiter)[-1])
         elif _type == "role":
             return self.key.split(key_delimiter)[-1]
+        return None
 
 
-def make_global_key_prefix(collection, role):
+def make_global_key_prefix(collection: str, role: str) -> str:
     key_prefix = ""
     if collection != "":
         key_prefix = f"collection{key_delimiter}{collection}{object_delimiter}"
@@ -29,11 +33,11 @@ def make_global_key_prefix(collection, role):
     return key_prefix
 
 
-def detect_type(key=""):
+def detect_type(key: str = "") -> str:
     return key.split(" ")[0]
 
 
-def set_play_key(obj, parent_key="", parent_local_key=""):
+def set_play_key(obj: Any, parent_key: str = "", parent_local_key: str = "") -> None:
     type_str = obj.type
     index_info = f"[{obj.index}]"
     _parent_key = parent_key.split(" ")[-1]
@@ -44,7 +48,7 @@ def set_play_key(obj, parent_key="", parent_local_key=""):
     obj.local_key = local_key
 
 
-def set_role_key(obj):
+def set_role_key(obj: Any) -> None:
     global_key_prefix = make_global_key_prefix(obj.collection, "")
     global_key = f"{obj.type} {global_key_prefix}{obj.type}{key_delimiter}{obj.fqcn}"
     local_key = f"{obj.type} {obj.type}{key_delimiter}{obj.defined_in}"
@@ -52,7 +56,7 @@ def set_role_key(obj):
     obj.local_key = local_key
 
 
-def set_module_key(obj):
+def set_module_key(obj: Any) -> None:
     global_key_prefix = make_global_key_prefix(obj.collection, obj.role)
     global_key = f"{obj.type} {global_key_prefix}{obj.type}{key_delimiter}{obj.fqcn}"
     local_key = f"{obj.type} {obj.type}{key_delimiter}{obj.defined_in}"
@@ -60,14 +64,14 @@ def set_module_key(obj):
     obj.local_key = local_key
 
 
-def set_collection_key(obj):
+def set_collection_key(obj: Any) -> None:
     global_key = f"{obj.type} {obj.type}{key_delimiter}{obj.name}"
     local_key = global_key
     obj.key = global_key
     obj.local_key = local_key
 
 
-def get_obj_type(key):
+def get_obj_type(key: str) -> str | None:
     idx0 = key.find(" ")
     obj_type = key[:idx0]
     if obj_type in [
@@ -85,8 +89,8 @@ def get_obj_type(key):
         return None
 
 
-def get_obj_info_by_key(key):
-    info = {}
+def get_obj_info_by_key(key: str) -> dict[str, Any]:
+    info: dict[str, Any] = {}
     info["key"] = key
     skip = False
 
@@ -163,7 +167,7 @@ def get_obj_info_by_key(key):
     return info
 
 
-def set_task_key(obj, parent_key="", parent_local_key=""):
+def set_task_key(obj: Any, parent_key: str = "", parent_local_key: str = "") -> None:
     index_info = f"[{obj.index}]"
     _parent_key = parent_key.split(" ")[-1]
     _parent_local_key = parent_local_key.split(" ")[-1]
@@ -173,7 +177,7 @@ def set_task_key(obj, parent_key="", parent_local_key=""):
     obj.local_key = local_key
 
 
-def set_taskfile_key(obj):
+def set_taskfile_key(obj: Any) -> None:
     global_key_prefix = make_global_key_prefix(obj.collection, obj.role)
     global_key = f"{obj.type} {global_key_prefix}{obj.type}{key_delimiter}{obj.defined_in}"
     local_key = f"{obj.type} {obj.type}{key_delimiter}{obj.defined_in}"
@@ -181,7 +185,7 @@ def set_taskfile_key(obj):
     obj.local_key = local_key
 
 
-def set_playbook_key(obj):
+def set_playbook_key(obj: Any) -> None:
     global_key_prefix = make_global_key_prefix(obj.collection, obj.role)
     global_key = f"{obj.type} {global_key_prefix}{obj.type}{key_delimiter}{obj.defined_in}"
     local_key = f"{obj.type} {obj.type}{key_delimiter}{obj.defined_in}"
@@ -189,20 +193,20 @@ def set_playbook_key(obj):
     obj.local_key = local_key
 
 
-def set_repository_key(obj):
+def set_repository_key(obj: Any) -> None:
     global_key = f"{obj.type} {obj.type}{key_delimiter}{obj.name}"
     local_key = global_key
     obj.key = global_key
     obj.local_key = local_key
 
 
-def set_call_object_key(cls_name: str, spec_key: str, caller_key: str):
+def set_call_object_key(cls_name: str, spec_key: str, caller_key: str) -> str:
     parts = spec_key.split(" ", 1)
     caller_only = caller_key.split(" FROM ")[0]
     return f"{cls_name} {parts[1]} FROM {caller_only}"
 
 
-def make_imported_taskfile_key(caller_key, path):
+def make_imported_taskfile_key(caller_key: str, path: str) -> str:
     caller_key_payload = caller_key.split(" ")[-1]
     parts = caller_key_payload.split(object_delimiter)
     parent = ""
@@ -213,7 +217,7 @@ def make_imported_taskfile_key(caller_key, path):
     return key
 
 
-def set_file_key(obj):
+def set_file_key(obj: Any) -> None:
     global_key_prefix = make_global_key_prefix(obj.collection, obj.role)
     global_key = f"{obj.type} {global_key_prefix}{obj.type}{key_delimiter}{obj.defined_in}"
     local_key = f"{obj.type} {obj.type}{key_delimiter}{obj.defined_in}"

--- a/src/apme_engine/engine/loader.py
+++ b/src/apme_engine/engine/loader.py
@@ -12,7 +12,7 @@ role_meta_main_yaml = "meta/main.yaml"
 
 
 # remove a dir which is a sub directory of another dir in the list
-def remove_subdirectories(dir_list):
+def remove_subdirectories(dir_list: list[str]) -> list[str]:
     sorted_dir_list = sorted(dir_list)
     new_dir_list = []
     for i, dir in enumerate(sorted_dir_list):
@@ -22,7 +22,7 @@ def remove_subdirectories(dir_list):
     return new_dir_list
 
 
-def trim_suffix(txt, suffix_patterns=None):
+def trim_suffix(txt: str, suffix_patterns: str | list[str] | None = None) -> str:
     if suffix_patterns is None:
         suffix_patterns = []
     if isinstance(suffix_patterns, str):
@@ -35,7 +35,7 @@ def trim_suffix(txt, suffix_patterns=None):
     return txt
 
 
-def get_loader_version():
+def get_loader_version() -> str:
     version = ""
     with contextlib.suppress(Exception):
         version = _pkg_version("apme-engine")
@@ -50,7 +50,7 @@ def get_loader_version():
     return version
 
 
-def get_target_name(target_type, target_path):
+def get_target_name(target_type: str, target_path: str) -> str:
     target_name = ""
     if target_type == LoadType.PROJECT:
         project_name = os.path.normpath(target_path).split("/")[-1]
@@ -71,8 +71,10 @@ def get_target_name(target_type, target_path):
     return target_name
 
 
-def filepath_to_target_name(filepath):
-    return filepath.translate(str.maketrans({" ": "___", "/": "---", ".": "_dot_"}))
+def filepath_to_target_name(filepath: str) -> str:
+    return filepath.translate(
+        str.maketrans({" ": "___", "/": "---", ".": "_dot_"})  # type: ignore[arg-type]
+    )
 
 
 # if __name__ == "__main__":

--- a/src/apme_engine/engine/logger.py
+++ b/src/apme_engine/engine/logger.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import logging
 import sys
+from typing import Any
 
-_logger = None
+_logger: logging.Logger | None = None
 
 log_level_map = {
     "error": logging.ERROR,
@@ -11,7 +14,7 @@ log_level_map = {
 }
 
 
-def set_logger_channel(channel: str = ""):
+def set_logger_channel(channel: str = "") -> None:
     global _logger
     _logger = logging.getLogger(channel)
     handler = logging.StreamHandler(sys.stdout)
@@ -21,27 +24,33 @@ def set_logger_channel(channel: str = ""):
     _logger.addHandler(handler)
 
 
-def set_log_level(level_str: str = "info"):
+def set_log_level(level_str: str = "info") -> None:
     global _logger
     level = log_level_map.get(level_str.lower())
-    _logger.setLevel(level)
+    if _logger is not None and level is not None:
+        _logger.setLevel(level)
 
 
-def exception(*args, **kwargs):
-    _logger.exception(*args, **kwargs)
+def exception(*args: object, **kwargs: Any) -> None:
+    if _logger is not None:
+        _logger.exception(*args, **kwargs)
 
 
-def error(*args, **kwargs):
-    _logger.error(*args, **kwargs)
+def error(*args: object, **kwargs: Any) -> None:
+    if _logger is not None:
+        _logger.error(*args, **kwargs)
 
 
-def warning(*args, **kwargs):
-    _logger.warning(*args, **kwargs)
+def warning(*args: object, **kwargs: Any) -> None:
+    if _logger is not None:
+        _logger.warning(*args, **kwargs)
 
 
-def info(*args, **kwargs):
-    _logger.info(*args, **kwargs)
+def info(*args: object, **kwargs: Any) -> None:
+    if _logger is not None:
+        _logger.info(*args, **kwargs)
 
 
-def debug(*args, **kwargs):
-    _logger.debug(*args, **kwargs)
+def debug(*args: object, **kwargs: Any) -> None:
+    if _logger is not None:
+        _logger.debug(*args, **kwargs)

--- a/src/apme_engine/engine/model_loader.py
+++ b/src/apme_engine/engine/model_loader.py
@@ -1,18 +1,20 @@
+from __future__ import annotations
+
 import datetime
 import json
 import os
 import re
 import traceback
+from typing import Any, cast
 
 import yaml
 
 try:
     # if `libyaml` is available, use C based loader for performance
-    import _yaml  # noqa: F401
+    import _yaml  # type: ignore[import-not-found]  # noqa: F401
     from yaml import CSafeLoader as Loader
 except Exception:
-    # otherwise, use Python based loader
-    from yaml import SafeLoader as Loader
+    from yaml import SafeLoader as Loader  # type: ignore[assignment]
 
 import contextlib
 
@@ -38,6 +40,7 @@ from .models import (
     File,
     Inventory,
     InventoryType,
+    Load,
     LoadType,
     Module,
     ModuleArgument,
@@ -92,20 +95,20 @@ loop_task_option_names = [
 
 
 def load_repository(
-    path="",
-    installed_collections_path="",
-    installed_roles_path="",
-    my_collection_name="",
-    basedir="",
-    target_playbook_path="",
-    target_taskfile_path="",
-    use_ansible_doc=True,
-    skip_playbook_format_error=True,
-    skip_task_format_error=True,
-    include_test_contents=False,
-    yaml_label_list=None,
-    load_children=True,
-):
+    path: str = "",
+    installed_collections_path: str = "",
+    installed_roles_path: str = "",
+    my_collection_name: str = "",
+    basedir: str = "",
+    target_playbook_path: str = "",
+    target_taskfile_path: str = "",
+    use_ansible_doc: bool = True,
+    skip_playbook_format_error: bool = True,
+    skip_task_format_error: bool = True,
+    include_test_contents: bool = False,
+    yaml_label_list: list[tuple[str, str, Any]] | None = None,
+    load_children: bool = True,
+) -> Repository:
     repoObj = Repository()
 
     repo_path = ""
@@ -124,7 +127,7 @@ def load_repository(
             repo_path = path
 
     # if `path` and `repo_path` are different, update yaml_label_list
-    if repo_to_root and yaml_label_list:
+    if repo_to_root and yaml_label_list is not None:
         yaml_label_list = [
             (os.path.normpath(os.path.join(repo_to_root, fpath)), label, role_info)
             for (fpath, label, role_info) in yaml_label_list
@@ -221,7 +224,7 @@ def load_repository(
     return repoObj
 
 
-def load_installed_collections(installed_collections_path):
+def load_installed_collections(installed_collections_path: str) -> list[Collection]:
     search_path = installed_collections_path
     if installed_collections_path == "" or not os.path.exists(search_path):
         return []
@@ -246,7 +249,7 @@ def load_installed_collections(installed_collections_path):
     return collections
 
 
-def load_inventory(path, basedir=""):
+def load_inventory(path: str, basedir: str = "") -> Inventory:
     invObj = Inventory()
     fullpath = ""
     if os.path.exists(path) and path != "" and path != ".":
@@ -297,7 +300,7 @@ def load_inventory(path, basedir=""):
     return invObj
 
 
-def load_inventories(path, basedir=""):
+def load_inventories(path: str, basedir: str = "") -> list[Inventory]:
     if not os.path.exists(path):
         return []
     inventories = []
@@ -314,15 +317,15 @@ def load_inventories(path, basedir=""):
 
 # TODO: need more-detailed labels like `vars`? (currently use the passed one as is)
 def load_file(
-    path,
-    basedir="",
-    label="",
-    body="",
-    error="",
-    read=True,
-    role_name="",
-    collection_name="",
-):
+    path: str,
+    basedir: str = "",
+    label: str = "",
+    body: str = "",
+    error: str = "",
+    read: bool = True,
+    role_name: str = "",
+    collection_name: str = "",
+) -> File:
     fullpath = os.path.join(basedir, path)
     if not os.path.exists(fullpath) and path and os.path.exists(path):
         fullpath = path
@@ -382,11 +385,18 @@ def load_file(
 # e.g. variable files, jinja2 templates and non-ansible files
 # TODO: support loading without pre-computed yaml_label_list
 # TODO: support non-YAML files
-def load_files(path, basedir="", yaml_label_list=None, role_name="", collection_name="", load_children=True):
+def load_files(
+    path: str,
+    basedir: str = "",
+    yaml_label_list: list[tuple[str, str, Any]] | None = None,
+    role_name: str = "",
+    collection_name: str = "",
+    load_children: bool = True,
+) -> list[File | str]:
     if not yaml_label_list:
         return []
 
-    files = []
+    files: list[File | str] = []
     for fpath, label, _role_info in yaml_label_list:
         if not fpath:
             continue
@@ -404,17 +414,17 @@ def load_files(path, basedir="", yaml_label_list=None, role_name="", collection_
 
 
 def load_play(
-    path,
-    index,
-    play_block_dict,
-    role_name="",
-    collection_name="",
-    parent_key="",
-    parent_local_key="",
-    yaml_lines="",
-    basedir="",
-    skip_task_format_error=True,
-):
+    path: str,
+    index: int,
+    play_block_dict: Any,
+    role_name: str = "",
+    collection_name: str = "",
+    parent_key: str = "",
+    parent_local_key: str = "",
+    yaml_lines: str = "",
+    basedir: str = "",
+    skip_task_format_error: bool = True,
+) -> Play:
     pbObj = Play()
     if play_block_dict is None:
         raise ValueError("play block dict is required to load Play")
@@ -459,12 +469,14 @@ def load_play(
     keys = [k for k in data_block if k not in tasks_keys]
     keys.extend(tasks_keys)
     task_count = 0
-    task_loading = {
+    task_errors: list[BaseException] = []
+    task_loading: dict[str, Any] = {
         "total": 0,
         "success": 0,
         "failure": 0,
-        "errors": [],
+        "errors": task_errors,
     }
+    err: BaseException | None = None
     for k in keys:
         if k not in data_block:
             continue
@@ -482,7 +494,7 @@ def load_play(
             for task_dict, task_jsonpath in task_blocks:
                 task_loading["total"] += 1
                 i = task_count
-                error = None
+                err = None
                 try:
                     t = load_task(
                         path=path,
@@ -505,7 +517,7 @@ def load_play(
                         if t.line_num_in_file and len(t.line_num_in_file) == 2:
                             last_task_line_num = t.line_num_in_file[1]
                 except TaskFormatError as exc:
-                    error = exc
+                    err = exc
                     if skip_task_format_error:
                         logger.debug(f"this task is wrong format; skip the task in {path}, index: {i}; skip this")
                     else:
@@ -513,13 +525,13 @@ def load_play(
                             f"this task is wrong format; skip the task in {path}, index: {{i}}"
                         ) from exc
                 except Exception as exc:
-                    error = exc
+                    err = exc
                     logger.exception(f"error while loading the task at {path} (index={i})")
                 finally:
                     task_count += 1
-                    if error:
+                    if err is not None:
                         task_loading["failure"] += 1
-                        task_loading["errors"].append(error)
+                        task_loading["errors"].append(err)
         elif k == "tasks":
             if not isinstance(v, list):
                 continue
@@ -531,7 +543,7 @@ def load_play(
             for task_dict, task_jsonpath in task_blocks:
                 i = task_count
                 task_loading["total"] += 1
-                error = None
+                err = None
                 try:
                     t = load_task(
                         path=path,
@@ -554,7 +566,7 @@ def load_play(
                         if t.line_num_in_file and len(t.line_num_in_file) == 2:
                             last_task_line_num = t.line_num_in_file[1]
                 except TaskFormatError as exc:
-                    error = exc
+                    err = exc
                     if skip_task_format_error:
                         logger.debug(f"this task is wrong format; skip the task in {path}, index: {i}; skip this")
                     else:
@@ -562,13 +574,13 @@ def load_play(
                             f"this task is wrong format; skip the task in {path}, index: {{i}}"
                         ) from exc
                 except Exception as exc:
-                    error = exc
+                    err = exc
                     logger.exception(f"error while loading the task at {path} (index={i})")
                 finally:
                     task_count += 1
-                    if error:
+                    if err is not None:
                         task_loading["failure"] += 1
-                        task_loading["errors"].append(error)
+                        task_loading["errors"].append(err)
         elif k == "post_tasks":
             if not isinstance(v, list):
                 continue
@@ -580,7 +592,7 @@ def load_play(
             for task_dict, task_jsonpath in task_blocks:
                 i = task_count
                 task_loading["total"] += 1
-                error = None
+                err = None
                 try:
                     t = load_task(
                         path=path,
@@ -603,7 +615,7 @@ def load_play(
                         if t.line_num_in_file and len(t.line_num_in_file) == 2:
                             last_task_line_num = t.line_num_in_file[1]
                 except TaskFormatError as exc:
-                    error = exc
+                    err = exc
                     if skip_task_format_error:
                         logger.debug(f"this task is wrong format; skip the task in {path}, index: {i}; skip this")
                     else:
@@ -611,13 +623,13 @@ def load_play(
                             f"this task is wrong format; skip the task in {path}, index: {{i}}"
                         ) from exc
                 except Exception as exc:
-                    error = exc
+                    err = exc
                     logger.exception(f"error while loading the task at {path} (index={i})")
                 finally:
                     task_count += 1
-                    if error:
+                    if err is not None:
                         task_loading["failure"] += 1
-                        task_loading["errors"].append(error)
+                        task_loading["errors"].append(err)
         elif k == "handlers":
             if not isinstance(v, list):
                 continue
@@ -629,7 +641,7 @@ def load_play(
             for task_dict, task_jsonpath in task_blocks:
                 i = task_count
                 task_loading["total"] += 1
-                error = None
+                err = None
                 try:
                     t = load_task(
                         path=path,
@@ -652,7 +664,7 @@ def load_play(
                         if t.line_num_in_file and len(t.line_num_in_file) == 2:
                             last_task_line_num = t.line_num_in_file[1]
                 except TaskFormatError as exc:
-                    error = exc
+                    err = exc
                     if skip_task_format_error:
                         logger.debug(f"this task is wrong format; skip the task in {path}, index: {i}; skip this")
                     else:
@@ -660,19 +672,19 @@ def load_play(
                             f"this task is wrong format; skip the task in {path}, index: {{i}}"
                         ) from exc
                 except Exception as exc:
-                    error = exc
+                    err = exc
                     logger.exception(f"error while loading the task at {path} (index={i})")
                 finally:
                     task_count += 1
-                    if error:
+                    if err is not None:
                         task_loading["failure"] += 1
-                        task_loading["errors"].append(error)
+                        task_loading["errors"].append(err)
         elif k == "roles":
             if not isinstance(v, list):
                 continue
             for i, r_block in enumerate(v):
                 r_name = ""
-                role_options = {}
+                role_options: dict[str, Any] = {}
                 if isinstance(r_block, dict):
                     r_name = r_block.get("role", "")
                     role_options = {}
@@ -730,7 +742,8 @@ def load_play(
     pbObj.vars_files = vars_files
     pbObj.module_defaults = module_defaults
     pbObj.options = play_options
-    pbObj.become = BecomeInfo.from_options(play_options)
+    _become = BecomeInfo.from_options(play_options)
+    pbObj.become = _become if _become is not None else BecomeInfo()
     pbObj.collections_in_play = collections_in_play
     pbObj.task_loading = task_loading
 
@@ -738,17 +751,17 @@ def load_play(
 
 
 def load_roleinplay(
-    name,
-    options,
-    defined_in,
-    role_index,
-    play_index,
-    role_name="",
-    collection_name="",
-    collections_in_play=None,
-    playbook_yaml="",
-    basedir="",
-):
+    name: str,
+    options: dict[str, Any],
+    defined_in: str,
+    role_index: int,
+    play_index: int,
+    role_name: str = "",
+    collection_name: str = "",
+    collections_in_play: list[str] | None = None,
+    playbook_yaml: str = "",
+    basedir: str = "",
+) -> RoleInPlay:
     if collections_in_play is None:
         collections_in_play = []
     ripObj = RoleInPlay()
@@ -772,14 +785,14 @@ def load_roleinplay(
 
 
 def load_playbook(
-    path="",
-    yaml_str="",
-    role_name="",
-    collection_name="",
-    basedir="",
-    skip_playbook_format_error=True,
-    skip_task_format_error=True,
-):
+    path: str = "",
+    yaml_str: str = "",
+    role_name: str = "",
+    collection_name: str = "",
+    basedir: str = "",
+    skip_playbook_format_error: bool = True,
+    skip_task_format_error: bool = True,
+) -> Playbook:
     pbObj = Playbook()
     fullpath = ""
     if yaml_str:
@@ -861,14 +874,14 @@ def load_playbook(
 
 
 def load_playbooks(
-    path,
-    basedir="",
-    skip_playbook_format_error=True,
-    skip_task_format_error=True,
-    include_test_contents=False,
-    yaml_label_list=None,
-    load_children=True,
-):
+    path: str,
+    basedir: str = "",
+    skip_playbook_format_error: bool = True,
+    skip_task_format_error: bool = True,
+    include_test_contents: bool = False,
+    yaml_label_list: list[tuple[str, str, Any]] | None = None,
+    load_children: bool = True,
+) -> list[Playbook | str]:
     if path == "":
         return []
     patterns = [
@@ -878,8 +891,8 @@ def load_playbooks(
     if include_test_contents:
         patterns.append(os.path.join(path, "tests/**/*.ya?ml"))
         patterns.append(os.path.join(path, "molecule/**/*.ya?ml"))
-    candidates = safe_glob(patterns, recursive=True)
-    candidates = [(c, False) for c in candidates]
+    glob_results = safe_glob(patterns, recursive=True)
+    candidates_list: list[tuple[str, bool]] = [(c, False) for c in glob_results]
 
     # add files if yaml_label_list is given
     if yaml_label_list:
@@ -892,14 +905,14 @@ def load_playbooks(
                 _fpath = fpath
                 if not _fpath.startswith(basedir):
                     _fpath = os.path.join(basedir, fpath)
-                if _fpath not in candidates:
-                    candidates.append((_fpath, True))
+                if not any(c[0] == _fpath for c in candidates_list):
+                    candidates_list.append((_fpath, True))
 
-    playbooks = []
+    playbooks: list[Playbook | str] = []
     playbook_names = []
-    candidates = sorted(candidates, key=lambda x: x[0])
-    loaded = set()
-    for fpath, from_list in candidates:
+    candidates_list = sorted(candidates_list, key=lambda x: x[0])
+    loaded: set[str] = set()
+    for fpath, from_list in candidates_list:
         if fpath in loaded:
             continue
 
@@ -938,22 +951,22 @@ def load_playbooks(
                     playbook_names.append(p.defined_in)
                 loaded.add(fpath)
     if not load_children:
-        playbooks = sorted(playbooks)
+        playbooks = sorted(playbooks)  # type: ignore[type-var]
     return playbooks
 
 
 def load_role(
-    path,
-    name="",
-    collection_name="",
-    module_dir_paths=None,
-    basedir="",
-    use_ansible_doc=True,
-    skip_playbook_format_error=True,
-    skip_task_format_error=True,
-    include_test_contents=False,
-    load_children=True,
-):
+    path: str,
+    name: str = "",
+    collection_name: str = "",
+    module_dir_paths: list[str] | None = None,
+    basedir: str = "",
+    use_ansible_doc: bool = True,
+    skip_playbook_format_error: bool = True,
+    skip_task_format_error: bool = True,
+    include_test_contents: bool = False,
+    load_children: bool = True,
+) -> Role:
     if module_dir_paths is None:
         module_dir_paths = []
     roleObj = Role()
@@ -1073,13 +1086,13 @@ def load_role(
                     logger.debug(f"failed to load this yaml file to read variables; {e.args[0]}")
         roleObj.variables = variables
 
-    modules = []
+    modules: list[Module | str] = []
     module_files = search_module_files(fullpath, module_dir_paths)
 
     if not load_children:
         use_ansible_doc = False
 
-    module_specs = {}
+    module_specs: dict[str, Any] = {}
     if use_ansible_doc:
         module_specs = get_module_specs_by_ansible_doc(
             module_files=module_files,
@@ -1100,12 +1113,13 @@ def load_role(
             )
         except Exception:
             logger.exception(f"error while loading the module at {module_file_path}")
-        if load_children:
-            modules.append(m)
-        else:
-            modules.append(m.defined_in)
+        if m is not None:
+            if load_children:
+                modules.append(m)
+            else:
+                modules.append(m.defined_in)
     if not load_children:
-        modules = sorted(modules)
+        modules = sorted(modules)  # type: ignore[type-var]
     roleObj.modules = modules
 
     patterns = [tasks_dir_path + "/**/*.ya?ml"]
@@ -1116,7 +1130,7 @@ def load_role(
         patterns.extend([tests_dir_path + "/**/*.ya?ml"])
     task_yaml_files = safe_glob(patterns, recursive=True)
 
-    taskfiles = []
+    taskfiles: list[TaskFile | str] = []
     for task_yaml_path in task_yaml_files:
         tf = None
         if not could_be_taskfile(fpath=task_yaml_path):
@@ -1145,14 +1159,14 @@ def load_role(
         else:
             taskfiles.append(tf.defined_in)
     if not load_children:
-        taskfiles = sorted(taskfiles)
+        taskfiles = sorted(taskfiles)  # type: ignore[type-var]
     roleObj.taskfiles = taskfiles
 
     if os.path.exists(handlers_dir_path):
         handler_patterns = [handlers_dir_path + "/**/*.ya?ml"]
         handler_files = safe_glob(handler_patterns, recursive=True)
 
-        handlers = []
+        handlers: list[TaskFile | str] = []
         for handler_yaml_path in handler_files:
             tf = None
             try:
@@ -1177,22 +1191,22 @@ def load_role(
             else:
                 handlers.append(tf.defined_in)
         if not load_children:
-            handlers = sorted(handlers)
+            handlers = sorted(handlers)  # type: ignore[type-var]
         roleObj.handlers = handlers
 
     return roleObj
 
 
 def load_roles(
-    path,
-    basedir="",
-    use_ansible_doc=True,
-    skip_playbook_format_error=True,
-    skip_task_format_error=True,
-    include_test_contents=False,
-    yaml_label_list=None,
-    load_children=True,
-):
+    path: str,
+    basedir: str = "",
+    use_ansible_doc: bool = True,
+    skip_playbook_format_error: bool = True,
+    skip_task_format_error: bool = True,
+    include_test_contents: bool = False,
+    yaml_label_list: list[tuple[str, str, Any]] | None = None,
+    load_children: bool = True,
+) -> list[Role | str]:
     if path == "":
         return []
     roles_patterns = ["roles", "playbooks/roles", "playbook/roles"]
@@ -1209,7 +1223,7 @@ def load_roles(
         if found_roles:
             roles_dir_path = found_roles[0]
 
-    def is_role_dir(found_dirs: list) -> bool:
+    def is_role_dir(found_dirs: list[str]) -> bool:
         # From ansible role doc
         # if none of the following dirs are found, we don't treat it as a role dir
         role_dir_patterns = set(
@@ -1267,7 +1281,7 @@ def load_roles(
     if not role_dirs:
         return []
 
-    roles = []
+    roles: list[Role | str] = []
     for role_dir in role_dirs:
         try:
             r = load_role(
@@ -1285,11 +1299,11 @@ def load_roles(
         else:
             roles.append(r.defined_in)
     if not load_children:
-        roles = sorted(roles)
+        roles = sorted(roles)  # type: ignore[type-var]
     return roles
 
 
-def load_requirements(path):
+def load_requirements(path: str) -> dict[str, Any]:
     requirements = {}
     requirements_yml_path = os.path.join(path, "requirements.yml")
     if os.path.exists(requirements_yml_path):
@@ -1301,7 +1315,7 @@ def load_requirements(path):
     return requirements
 
 
-def load_installed_roles(installed_roles_path):
+def load_installed_roles(installed_roles_path: str) -> list[Role]:
     search_path = installed_roles_path
     if installed_roles_path == "" or not os.path.exists(search_path):
         return []
@@ -1336,8 +1350,13 @@ def load_installed_roles(installed_roles_path):
 
 
 def load_module(
-    module_file_path, collection_name="", role_name="", basedir="", use_ansible_doc=True, module_specs=None
-):
+    module_file_path: str,
+    collection_name: str = "",
+    role_name: str = "",
+    basedir: str = "",
+    use_ansible_doc: bool = True,
+    module_specs: dict[str, Any] | None = None,
+) -> Module:
     if module_specs is None:
         module_specs = {}
     moduleObj = Module()
@@ -1403,27 +1422,31 @@ def load_module(
                 arg_spec = arg_specs[arg_name]
                 if not isinstance(arg_spec, dict):
                     continue
-                arg_value_type = get_class_by_arg_type(arg_spec.get("type", None))
+                _arg_type = arg_spec.get("type")
+                arg_value_type = get_class_by_arg_type(str(_arg_type) if _arg_type is not None else "")
                 arg_value_type_str = ""
                 if arg_value_type:
                     arg_value_type_str = arg_value_type.__name__
 
-                arg_elements_type = get_class_by_arg_type(arg_spec.get("elements", None))
+                _arg_elements = arg_spec.get("elements")
+                arg_elements_type = get_class_by_arg_type(str(_arg_elements) if _arg_elements is not None else "")
                 arg_elements_type_str = ""
                 if arg_elements_type:
                     arg_elements_type_str = arg_elements_type.__name__
-                required = None
+                required: bool | None = None
                 with contextlib.suppress(Exception):
                     required = parse_bool(arg_spec.get("required", "false"))
+                _choices = arg_spec.get("choices")
+                _aliases = arg_spec.get("aliases")
                 arg = ModuleArgument(
                     name=arg_name,
                     type=arg_value_type_str,
                     elements=arg_elements_type_str,
-                    required=required,
+                    required=required if required is not None else False,
                     description=arg_spec.get("description", ""),
-                    default=arg_spec.get("default", None),
-                    choices=arg_spec.get("choices", None),
-                    aliases=arg_spec.get("aliases", None),
+                    default=arg_spec.get("default"),
+                    choices=_choices if isinstance(_choices, list) else [],
+                    aliases=_aliases if isinstance(_aliases, list) else [],
                 )
                 arguments.append(arg)
     moduleObj.documentation = doc_yaml
@@ -1436,17 +1459,17 @@ def load_module(
 
 
 builtin_modules_file_name = "ansible_builtin_modules.json"
-builtin_modules = {}
+builtin_modules: dict[str, Module] = {}
 
 
-def load_builtin_modules():
+def load_builtin_modules() -> dict[str, Module]:
     global builtin_modules
     if builtin_modules:
         return builtin_modules
     base_path = os.path.dirname(__file__)
     data_path = os.path.join(base_path, builtin_modules_file_name)
     module_list = ObjectList.from_json(fpath=data_path)
-    builtin_modules = {m.name: m for m in module_list.items}
+    builtin_modules = {m.name: m for m in module_list.items if isinstance(m, Module)}
     return builtin_modules
 
 
@@ -1454,7 +1477,14 @@ def load_builtin_modules():
 # https://docs.ansible.com/ansible/2.8/user_guide/playbooks_best_practices.html
 # however, it is often defined in `plugins/modules` directory,
 # so we search both the directories
-def load_modules(path, basedir="", collection_name="", module_dir_paths=None, use_ansible_doc=True, load_children=True):
+def load_modules(
+    path: str,
+    basedir: str = "",
+    collection_name: str = "",
+    module_dir_paths: list[str] | None = None,
+    use_ansible_doc: bool = True,
+    load_children: bool = True,
+) -> list[Module | str]:
     if module_dir_paths is None:
         module_dir_paths = []
     if path == "":
@@ -1477,7 +1507,7 @@ def load_modules(path, basedir="", collection_name="", module_dir_paths=None, us
             search_path=path,
         )
 
-    modules = []
+    modules: list[Module | str] = []
     for module_file_path in module_files:
         m = None
         try:
@@ -1490,30 +1520,31 @@ def load_modules(path, basedir="", collection_name="", module_dir_paths=None, us
             )
         except Exception:
             logger.exception(f"error while loading the module at {module_file_path}")
-        if load_children:
-            modules.append(m)
-        else:
-            modules.append(m.defined_in)
+        if m is not None:
+            if load_children:
+                modules.append(m)
+            else:
+                modules.append(m.defined_in)
     if not load_children:
-        modules = sorted(modules)
+        modules = sorted(modules)  # type: ignore[type-var]
     return modules
 
 
 def load_task(
-    path,
-    index,
-    task_block_dict,
-    task_jsonpath="",
-    role_name="",
-    collection_name="",
-    collections_in_play=None,
-    play_index=-1,
-    parent_key="",
-    parent_local_key="",
-    yaml_lines="",
-    previous_task_line=-1,
-    basedir="",
-):
+    path: str,
+    index: int,
+    task_block_dict: dict[str, Any],
+    task_jsonpath: str = "",
+    role_name: str = "",
+    collection_name: str = "",
+    collections_in_play: list[str] | None = None,
+    play_index: int = -1,
+    parent_key: str = "",
+    parent_local_key: str = "",
+    yaml_lines: str = "",
+    previous_task_line: int = -1,
+    basedir: str = "",
+) -> Task:
     if collections_in_play is None:
         collections_in_play = []
     taskObj = Task()
@@ -1539,8 +1570,8 @@ def load_task(
     task_name = ""
     module_name = find_module_name(task_block_dict)
     module_short_name = module_name.split(".")[-1]
-    task_options = {}
-    module_options = {}
+    task_options: dict[str, Any] = {}
+    module_options: dict[str, Any] | str = {}
     for k, v in data_block.items():
         if k == "name":
             task_name = v
@@ -1551,10 +1582,12 @@ def load_task(
             if isinstance(_opt, str):
                 module_options = _opt.lstrip(module_name).lstrip(" ")
             elif isinstance(_opt, dict):
+                _mod_opts: dict[str, Any] = {}
                 for mk, mv in _opt.items():
                     if mk == "module":
                         continue
-                    module_options[mk] = mv
+                    _mod_opts[mk] = mv
+                module_options = _mod_opts
             task_options.update({k: v})
         else:
             task_options.update({k: v})
@@ -1679,12 +1712,19 @@ def load_task(
     taskObj.set_facts = set_facts
     taskObj.loop = loop_info
     taskObj.module = module_name
-    taskObj.module_options = module_options
+    taskObj.module_options = module_options if isinstance(module_options, dict) else {"_raw": module_options}
 
     return taskObj
 
 
-def load_taskfile(path, yaml_str="", role_name="", collection_name="", basedir="", skip_task_format_error=True):
+def load_taskfile(
+    path: str,
+    yaml_str: str = "",
+    role_name: str = "",
+    collection_name: str = "",
+    basedir: str = "",
+    skip_task_format_error: bool = True,
+) -> TaskFile:
     tfObj = TaskFile()
     fullpath = ""
     if yaml_str:
@@ -1715,18 +1755,20 @@ def load_taskfile(path, yaml_str="", role_name="", collection_name="", basedir="
 
     if yaml_str and not yaml_lines:
         yaml_lines = yaml_str
-    tfObj.yaml_lines = yaml_lines
+    tfObj.yaml_lines = yaml_lines or ""
 
     if task_dicts is None:
         return tfObj
-    tasks = []
-    task_loading = {
+    tasks: list[Task] = []
+    task_errors_tf: list[BaseException] = []
+    task_loading: dict[str, Any] = {
         "total": 0,
         "success": 0,
         "failure": 0,
-        "errors": [],
+        "errors": task_errors_tf,
     }
-    last_task_line_num = -1
+    last_task_line_num: int = -1
+    error: BaseException | None = None
     for i, (t_dict, t_jsonpath) in enumerate(task_dicts):
         task_loading["total"] += 1
         error = None
@@ -1738,7 +1780,7 @@ def load_taskfile(path, yaml_str="", role_name="", collection_name="", basedir="
                 t_jsonpath,
                 role_name,
                 collection_name,
-                yaml_lines=yaml_lines,
+                yaml_lines=yaml_lines or "",
                 parent_key=tfObj.key,
                 parent_local_key=tfObj.local_key,
                 previous_task_line=last_task_line_num,
@@ -1760,7 +1802,7 @@ def load_taskfile(path, yaml_str="", role_name="", collection_name="", basedir="
             error = exc
             logger.exception(f"error while loading the task at {fullpath}, index: {i}")
         finally:
-            if error:
+            if error is not None:
                 task_loading["failure"] += 1
                 task_loading["errors"].append(error)
     tfObj.tasks = tasks
@@ -1771,7 +1813,12 @@ def load_taskfile(path, yaml_str="", role_name="", collection_name="", basedir="
 
 # playbooks possibly include/import task files around the playbook file
 # we search this type of isolated taskfile in `playbooks` and `tasks` dir
-def load_taskfiles(path, basedir="", yaml_label_list=None, load_children=True):
+def load_taskfiles(
+    path: str,
+    basedir: str = "",
+    yaml_label_list: list[tuple[str, str, Any]] | None = None,
+    load_children: bool = True,
+) -> list[TaskFile | str]:
     if not os.path.exists(path):
         return []
 
@@ -1794,30 +1841,32 @@ def load_taskfiles(path, basedir="", yaml_label_list=None, load_children=True):
     if len(taskfile_paths) == 0:
         return []
 
-    taskfiles = []
+    taskfiles: list[TaskFile | str] = []
     for taskfile_path in taskfile_paths:
         try:
             tf = load_taskfile(taskfile_path, basedir=basedir)
         except Exception:
             logger.exception(f"error while loading the task file at {taskfile_path}")
-        if load_children:
-            taskfiles.append(tf)
-        else:
-            taskfiles.append(tf.defined_in)
+            tf = None
+        if tf is not None:
+            if load_children:
+                taskfiles.append(tf)
+            else:
+                taskfiles.append(tf.defined_in)
     if not load_children:
-        taskfiles = sorted(taskfiles)
+        taskfiles = sorted(taskfiles)  # type: ignore[type-var]
     return taskfiles
 
 
 def load_collection(
-    collection_dir,
-    basedir="",
-    use_ansible_doc=True,
-    skip_playbook_format_error=True,
-    skip_task_format_error=True,
-    include_test_contents=False,
-    load_children=True,
-):
+    collection_dir: str,
+    basedir: str = "",
+    use_ansible_doc: bool = True,
+    skip_playbook_format_error: bool = True,
+    skip_task_format_error: bool = True,
+    include_test_contents: bool = False,
+    load_children: bool = True,
+) -> Collection:
     colObj = Collection()
     fullpath = ""
     if os.path.exists(collection_dir):
@@ -1885,19 +1934,20 @@ def load_collection(
 
     taskfile_paths = search_taskfiles_for_playbooks(fullpath)
     if len(taskfile_paths) > 0:
-        taskfiles = []
+        taskfiles: list[TaskFile | str] = []
         for taskfile_path in taskfile_paths:
             try:
                 tf = load_taskfile(taskfile_path, basedir=basedir)
             except Exception:
                 logger.exception(f"error while loading the task file at {taskfile_path}")
-                continue
-            if load_children:
-                taskfiles.append(tf)
-            else:
-                taskfiles.append(tf.defined_in)
+                tf = None
+            if tf is not None:
+                if load_children:
+                    taskfiles.append(tf)
+                else:
+                    taskfiles.append(tf.defined_in)
         if not load_children:
-            taskfiles = sorted(taskfiles)
+            taskfiles = sorted(taskfiles)  # type: ignore[type-var]
         colObj.taskfiles = taskfiles
 
     roles = load_roles(
@@ -1910,7 +1960,7 @@ def load_collection(
 
     module_files = search_module_files(fullpath)
 
-    modules = []
+    modules: list[Module | str] = []
     if not load_children:
         use_ansible_doc = False
 
@@ -1935,12 +1985,13 @@ def load_collection(
         except Exception:
             logger.exception(f"error while loading the module at {f}")
             continue
-        if load_children:
-            modules.append(m)
-        else:
-            modules.append(m.defined_in)
+        if m is not None:
+            if load_children:
+                modules.append(m)
+            else:
+                modules.append(m.defined_in)
     if not load_children:
-        modules = sorted(modules)
+        modules = sorted(modules)  # type: ignore[type-var]
     colObj.name = collection_name
     path = collection_dir
     if basedir != "" and path.startswith(basedir):
@@ -1953,10 +2004,10 @@ def load_collection(
     return colObj
 
 
-def load_object(loadObj):
+def load_object(loadObj: Load) -> None:
     target_type = loadObj.target_type
     path = loadObj.path
-    obj = None
+    obj: Collection | Role | Playbook | Repository | TaskFile | None = None
     if target_type == LoadType.COLLECTION:
         obj = load_collection(
             collection_dir=path, basedir=path, include_test_contents=loadObj.include_test_contents, load_children=False
@@ -2004,47 +2055,47 @@ def load_object(loadObj):
                 path=basedir, basedir=basedir, target_taskfile_path=target_taskfile_path, load_children=False
             )
     elif target_type == LoadType.PROJECT:
+        _yaml_labels = loadObj.yaml_label_list
         obj = load_repository(
             path=path,
             basedir=path,
             include_test_contents=loadObj.include_test_contents,
-            yaml_label_list=loadObj.yaml_label_list,
+            yaml_label_list=cast(list[tuple[str, str, Any]] | None, _yaml_labels if _yaml_labels else None),
             load_children=False,
         )
 
-    if hasattr(obj, "roles"):
-        loadObj.roles = obj.roles
-    if hasattr(obj, "playbooks"):
-        loadObj.playbooks = obj.playbooks
-    if hasattr(obj, "taskfiles"):
-        loadObj.taskfiles = obj.taskfiles
-    if hasattr(obj, "handlers"):
-        current = loadObj.taskfiles
-        if not current:
-            current = []
-        loadObj.taskfiles = current + obj.handlers
-    if hasattr(obj, "modules"):
-        loadObj.modules = obj.modules
-    if hasattr(obj, "files"):
-        loadObj.files = obj.files
+    if obj is not None:
+        if hasattr(obj, "roles"):
+            loadObj.roles = getattr(obj, "roles", [])
+        if hasattr(obj, "playbooks"):
+            loadObj.playbooks = getattr(obj, "playbooks", [])
+        if hasattr(obj, "taskfiles"):
+            loadObj.taskfiles = getattr(obj, "taskfiles", [])
+        if hasattr(obj, "handlers"):
+            current = loadObj.taskfiles or []
+            loadObj.taskfiles = current + getattr(obj, "handlers", [])
+        if hasattr(obj, "modules"):
+            loadObj.modules = getattr(obj, "modules", [])
+        if hasattr(obj, "files"):
+            loadObj.files = getattr(obj, "files", [])
 
-    if target_type == LoadType.ROLE:
+    if target_type == LoadType.ROLE and isinstance(obj, Role):
         loadObj.roles = [obj.defined_in]
-    elif target_type == LoadType.PLAYBOOK and loadObj.playbook_only:
+    elif target_type == LoadType.PLAYBOOK and loadObj.playbook_only and isinstance(obj, Playbook):
         loadObj.playbooks = [obj.defined_in]
-    elif target_type == LoadType.TASKFILE and loadObj.taskfile_only:
+    elif target_type == LoadType.TASKFILE and loadObj.taskfile_only and isinstance(obj, TaskFile):
         loadObj.taskfiles = [obj.defined_in]
 
     loadObj.timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")
 
 
-def find_playbook_role_module(path, use_ansible_doc=True):
+def find_playbook_role_module(path: str, use_ansible_doc: bool = True) -> tuple[list[Any], list[Any], list[Any]]:
     playbooks = load_playbooks(path, basedir=path, load_children=False)
     root_role = None
     with contextlib.suppress(Exception):
         root_role = load_role(path, basedir=path, use_ansible_doc=use_ansible_doc, load_children=False)
     sub_roles = load_roles(path, basedir=path, use_ansible_doc=use_ansible_doc, load_children=False)
-    roles = []
+    roles: list[str | Role] = []
     if root_role and root_role.metadata:
         roles.append(".")
     if len(sub_roles) > 0:

--- a/src/apme_engine/engine/models.py
+++ b/src/apme_engine/engine/models.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import builtins
 import contextlib
 import json
 import os
@@ -5,6 +8,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, cast
 
 import jsonpickle
 from rapidfuzz.distance import Levenshtein
@@ -48,22 +52,23 @@ class FatalRuleResultError(Exception):
 
 
 class JSONSerializable:
-    def dump(self):
+    def dump(self) -> str:
         return self.to_json()
 
-    def to_json(self):
-        return jsonpickle.encode(self, make_refs=False)
+    def to_json(self) -> str:
+        return str(jsonpickle.encode(self, make_refs=False))
 
     @classmethod
-    def from_json(cls, json_str):
+    def from_json(cls: type[JSONSerializable], json_str: str) -> JSONSerializable:
         instance = cls()
-        loaded = jsonpickle.decode(json_str)
-        instance.__dict__.update(loaded.__dict__)
+        loaded: Any = jsonpickle.decode(json_str)
+        if hasattr(loaded, "__dict__"):
+            instance.__dict__.update(loaded.__dict__)
         return instance
 
 
 class Resolvable:
-    def resolve(self, resolver):
+    def resolve(self, resolver: Any) -> None:
         if not hasattr(resolver, "apply"):
             raise ValueError("this resolver does not have apply() method")
         if not callable(resolver.apply):
@@ -87,7 +92,7 @@ class Resolvable:
         return
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> list[Any] | None:
         raise NotImplementedError
 
 
@@ -112,15 +117,15 @@ class Load(JSONSerializable):
     taskfile_only: bool = False
     base_dir: str = ""
     include_test_contents: bool = False
-    yaml_label_list: list = field(default_factory=list)
+    yaml_label_list: list[str] = field(default_factory=list)
     timestamp: str = ""
 
     # the following variables are list of paths; not object
-    roles: list = field(default_factory=list)
-    playbooks: list = field(default_factory=list)
-    taskfiles: list = field(default_factory=list)
-    modules: list = field(default_factory=list)
-    files: list = field(default_factory=list)
+    roles: list[str] = field(default_factory=list)
+    playbooks: list[str] = field(default_factory=list)
+    taskfiles: list[str] = field(default_factory=list)
+    modules: list[str] = field(default_factory=list)
+    files: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -131,74 +136,73 @@ class Object(JSONSerializable):
 
 @dataclass
 class ObjectList(JSONSerializable):
-    items: list = field(default_factory=list)
-    _dict: dict = field(default_factory=dict)
+    items: list[Object | CallObject] = field(default_factory=list)
+    _dict: dict[str, Object | CallObject] = field(default_factory=dict)
 
-    def dump(self, fpath=""):
+    def dump(self, fpath: str = "") -> str:
         return self.to_json(fpath=fpath)
 
-    def to_json(self, fpath=""):
-        lines = [jsonpickle.encode(obj, make_refs=False) for obj in self.items]
+    def to_json(self, fpath: str = "") -> str:
+        lines: list[str] = [jsonpickle.encode(obj, make_refs=False) for obj in self.items]
         json_str = "\n".join(lines)
         if fpath != "":
             Path(fpath).write_text(json_str)
         return json_str
 
-    def to_one_line_json(self):
-        return jsonpickle.encode(self.items, make_refs=False)
+    def to_one_line_json(self) -> str:
+        return str(jsonpickle.encode(self.items, make_refs=False))
 
     @classmethod
-    def from_json(cls, json_str="", fpath=""):
+    def from_json(cls: type[ObjectList], json_str: str = "", fpath: str = "") -> ObjectList:
         instance = cls()
         if fpath != "":
             json_str = Path(fpath).read_text()
-        lines = json_str.splitlines()
-        items = [jsonpickle.decode(obj_str) for obj_str in lines]
-        instance.items = items
+        lines: list[str] = json_str.splitlines()
+        items: list[Any] = [jsonpickle.decode(obj_str) for obj_str in lines]
+        instance.items = [cast(Object, obj) for obj in items]
         instance._update_dict()
         return instance
 
-    def add(self, obj, update_dict=True):
+    def add(self, obj: Object | CallObject, update_dict: bool = True) -> None:
         self.items.append(obj)
         if update_dict:
             self._add_dict_item(obj)
         return
 
-    def merge(self, obj_list):
+    def merge(self, obj_list: ObjectList) -> None:
         if not isinstance(obj_list, ObjectList):
             raise ValueError(f"obj_list must be an instance of ObjectList, but got {type(obj_list).__name__}")
         self.items.extend(obj_list.items)
         self._update_dict()
         return
 
-    def find_by_attr(self, key, val):
+    def find_by_attr(self, key: str, val: Any) -> list[Object | CallObject]:
         found = [obj for obj in self.items if obj.__dict__.get(key, None) == val]
         return found
 
-    def find_by_type(self, type):
-        return [obj for obj in self.items if hasattr(obj, "type") and obj.type == type]
+    def find_by_type(self, type_name: str) -> list[Object | CallObject]:
+        return [obj for obj in self.items if hasattr(obj, "type") and obj.type == type_name]
 
-    def find_by_key(self, key):
+    def find_by_key(self, key: str) -> Object | CallObject | None:
         return self._dict.get(key, None)
 
-    def contains(self, key="", obj=None):
+    def contains(self, key: str = "", obj: Object | None = None) -> bool:
         if obj is not None:
             key = obj.key
         return self.find_by_key(key) is not None
 
-    def update_dict(self):
+    def update_dict(self) -> None:
         self._update_dict()
 
-    def _update_dict(self):
+    def _update_dict(self) -> None:
         for obj in self.items:
             self._dict[obj.key] = obj
-        return
 
-    def _add_dict_item(self, obj):
+    def _add_dict_item(self, obj: Object | CallObject) -> None:
         self._dict[obj.key] = obj
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> list[Object | CallObject]:
         return self.items
 
 
@@ -212,7 +216,7 @@ class CallObject(JSONSerializable):
     node_id: str = ""
 
     @classmethod
-    def from_spec(cls, spec, caller, index):
+    def from_spec(cls: builtins.type[CallObject], spec: Object, caller: CallObject | None, index: int) -> CallObject:
         instance = cls()
         instance.spec = spec
         caller_key = "None"
@@ -243,11 +247,20 @@ class RunTargetType:
 @dataclass
 class RunTarget:
     type: str = ""
+    spec: Object = field(default_factory=Object)  # from CallObject in subclasses
+    key: str = ""
+    annotations: list[Annotation] = field(default_factory=list)
 
-    def file_info(self):
-        file = self.spec.defined_in
-        lines = None
+    def file_info(self) -> tuple[str, str | None]:
+        file = getattr(self.spec, "defined_in", "") if self.spec else ""
+        lines: str | None = None
         return file, lines
+
+    def has_annotation_by_condition(self, cond: AnnotationCondition) -> bool:
+        return False
+
+    def get_annotation_by_condition(self, cond: AnnotationCondition) -> Annotation | RiskAnnotation | None:
+        return None
 
 
 @dataclass
@@ -256,13 +269,13 @@ class RunTargetList:
 
     _i: int = 0
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.items)
 
-    def __iter__(self):
+    def __iter__(self) -> RunTargetList:
         return self
 
-    def __next__(self):
+    def __next__(self) -> RunTarget:
         if self._i == len(self.items):
             self._i = 0
             raise StopIteration()
@@ -270,7 +283,7 @@ class RunTargetList:
         self._i += 1
         return item
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: int) -> RunTarget:
         return self.items[i]
 
 
@@ -284,37 +297,37 @@ class File:
     collection: str = ""
 
     body: str = ""
-    data: any = None
+    data: Any = None
     encrypted: bool = False
     error: str = ""
     label: str = ""
     defined_in: str = ""
 
-    annotations: dict = field(default_factory=dict)
+    annotations: dict[str, Any] = field(default_factory=dict)
 
-    def set_key(self):
+    def set_key(self) -> None:
         set_file_key(self)
 
-    def children_to_key(self):
+    def children_to_key(self) -> File:
         return self
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> None:
         return None
 
 
 @dataclass
 class ModuleArgument:
     name: str = ""
-    type: str = None
-    elements: str = None
-    default: any = None
+    type: str | None = None
+    elements: str | None = None
+    default: Any = None
     required: bool = False
     description: str = ""
-    choices: list = field(default_factory=list)
-    aliases: list = field(default_factory=list)
+    choices: list[Any] = field(default_factory=list)
+    aliases: list[str] = field(default_factory=list)
 
-    def available_keys(self):
+    def available_keys(self) -> list[str]:
         keys = [self.name]
         if self.aliases:
             keys.extend(self.aliases)
@@ -332,21 +345,21 @@ class Module(Object, Resolvable):
     role: str = ""
     documentation: str = ""
     examples: str = ""
-    arguments: list = field(default_factory=list)
+    arguments: list[Any] = field(default_factory=list)
     defined_in: str = ""
     builtin: bool = False
-    used_in: list = field(default_factory=list)  # resolved later
+    used_in: list[Any] = field(default_factory=list)  # resolved later
 
-    annotations: dict = field(default_factory=dict)
+    annotations: dict[str, Any] = field(default_factory=dict)
 
-    def set_key(self):
+    def set_key(self) -> None:
         set_module_key(self)
 
-    def children_to_key(self):
+    def children_to_key(self) -> Module:
         return self
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> None:
         return None
 
 
@@ -362,25 +375,25 @@ class Collection(Object, Resolvable):
     path: str = ""
     key: str = ""
     local_key: str = ""
-    metadata: dict = field(default_factory=dict)
-    meta_runtime: dict = field(default_factory=dict)
-    files: dict = field(default_factory=dict)
-    playbooks: list = field(default_factory=list)
-    taskfiles: list = field(default_factory=list)
-    roles: list = field(default_factory=list)
-    modules: list = field(default_factory=list)
-    dependency: dict = field(default_factory=dict)
-    requirements: dict = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    meta_runtime: dict[str, Any] = field(default_factory=dict)
+    files: dict[str, Any] = field(default_factory=dict)
+    playbooks: list[Any] = field(default_factory=list)
+    taskfiles: list[Any] = field(default_factory=list)
+    roles: list[Any] = field(default_factory=list)
+    modules: list[Any] = field(default_factory=list)
+    dependency: dict[str, Any] = field(default_factory=dict)
+    requirements: dict[str, Any] = field(default_factory=dict)
 
-    annotations: dict = field(default_factory=dict)
+    annotations: dict[str, Any] = field(default_factory=dict)
 
-    variables: dict = field(default_factory=dict)
-    options: dict = field(default_factory=dict)
+    variables: dict[str, Any] = field(default_factory=dict)
+    options: dict[str, Any] = field(default_factory=dict)
 
-    def set_key(self):
+    def set_key(self) -> None:
         set_collection_key(self)
 
-    def children_to_key(self):
+    def children_to_key(self) -> Collection:
         module_keys = [m.key if isinstance(m, Module) else m for m in self.modules]
         self.modules = sorted(module_keys)
 
@@ -395,7 +408,7 @@ class Collection(Object, Resolvable):
         return self
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> list[Any]:
         return self.playbooks + self.taskfiles + self.roles + self.modules
 
 
@@ -407,7 +420,7 @@ class CollectionCall(CallObject, Resolvable):
 @dataclass
 class TaskCallsInTree(JSONSerializable):
     root_key: str = ""
-    taskcalls: list = field(default_factory=list)
+    taskcalls: list[Any] = field(default_factory=list)
 
 
 @dataclass
@@ -415,28 +428,34 @@ class VariablePrecedence:
     name: str = ""
     order: int = -1
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.name
 
     def __eq__(self, __o: object) -> bool:
+        if not isinstance(__o, VariablePrecedence):
+            return NotImplemented
         return self.order == __o.order
 
     def __ne__(self, __o: object) -> bool:
         return not self.__eq__(__o)
 
-    def __lt__(self, __o: object):
+    def __lt__(self, __o: object) -> bool:
+        if not isinstance(__o, VariablePrecedence):
+            return NotImplemented
         return self.order < __o.order
 
-    def __le__(self, __o: object):
+    def __le__(self, __o: object) -> bool:
+        if not isinstance(__o, VariablePrecedence):
+            return NotImplemented
         return self.__lt__(__o) or self.__eq__(__o)
 
-    def __gt__(self, __o: object):
+    def __gt__(self, __o: object) -> bool:
         return not self.__le__(__o)
 
-    def __ge__(self, __o: object):
+    def __ge__(self, __o: object) -> bool:
         return not self.__lt__(__o)
 
 
@@ -483,30 +502,30 @@ immutable_var_types = [VariableType.LoopVars]
 @dataclass
 class Variable:
     name: str = ""
-    value: any = None
-    type: VariableType = None
-    elements: list = field(default_factory=list)
-    setter: any = None
-    used_in: any = None
+    value: Any = None
+    type: VariablePrecedence | None = None
+    elements: list[Any] = field(default_factory=list)
+    setter: Any = None
+    used_in: Any = None
 
     @property
-    def is_mutable(self):
-        return self.type not in immutable_var_types
+    def is_mutable(self) -> bool:
+        return self.type not in immutable_var_types if self.type else True
 
 
 @dataclass
 class VariableDict:
-    _dict: dict = field(default_factory=dict)
+    _dict: dict[str, list[Variable]] = field(default_factory=dict)
 
     @staticmethod
-    def print_table(data: dict):
+    def print_table(data: dict[str, list[Variable]]) -> str:
         d = VariableDict(_dict=data)
         table = []
         type_labels = []
         found_type_label_names = []
         for v_list in d._dict.values():
             for v in v_list:
-                if v.type.name in found_type_label_names:
+                if not v.type or v.type.name in found_type_label_names:
                     continue
                 type_labels.append(v.type)
                 found_type_label_names.append(v.type.name)
@@ -526,7 +545,7 @@ class VariableDict:
                 type_label = t.name.upper()
                 row[type_label] = value
             table.append(row)
-        return tabulate(table, headers="keys")
+        return str(tabulate(table, headers="keys"))
 
 
 class ArgumentsType:
@@ -537,31 +556,32 @@ class ArgumentsType:
 
 @dataclass
 class Arguments:
-    type: ArgumentsType = ""
-    raw: any = None
+    type: str = ArgumentsType.SIMPLE
+    raw: Any = None
     vars: list[Variable] = field(default_factory=list)
     resolved: bool = False
-    templated: any = None
+    templated: Any = None
     is_mutable: bool = False
 
-    def get(self, key: str = ""):
-        sub_raw = None
-        sub_templated = None
+    def get(self, key: str = "") -> Arguments | None:
+        sub_raw: Any = None
+        sub_templated: Any = None
         if key == "":
             sub_raw = self.raw
             sub_templated = self.templated
         else:
             if isinstance(self.raw, dict):
                 sub_raw = self.raw.get(key, None)
-                if self.templated:
-                    sub_templated = self.templated[0].get(key, None)
+                if self.templated and isinstance(self.templated, (list, tuple)):
+                    first: Any = self.templated[0]
+                    sub_templated = first.get(key, None) if isinstance(first, dict) else self.templated
             else:
                 sub_raw = self.raw
                 sub_templated = self.templated
         if not sub_raw:
             return None
 
-        _vars = []
+        _vars: list[Variable] = []
         sub_type = ArgumentsType.SIMPLE
         if isinstance(sub_raw, str):
             for v in self.vars:
@@ -599,31 +619,31 @@ class Location:
     value: str = ""
     vars: list[Variable] = field(default_factory=list)
 
-    _args: Arguments = None
+    _args: Arguments | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self._args:
-            self.value = self._args.raw
+            self.value = str(self._args.raw) if self._args.raw is not None else ""
             self.vars = self._args.vars
 
     @property
-    def is_mutable(self):
+    def is_mutable(self) -> bool:
         return len(self.vars) > 0
 
     @property
-    def is_empty(self):
+    def is_empty(self) -> bool:
         return not self.type and not self.value
 
-    def is_inside(self, loc):
+    def is_inside(self, loc: Location) -> bool:
         if not isinstance(loc, Location):
             raise ValueError(f"is_inside() expect Location but given {type(loc)}")
         return loc.contains(self)
 
-    def contains(self, target, any=False, all=True):
+    def contains(self, target: Location | list[Location], any_mode: bool = False, all_mode: bool = True) -> bool:
         if isinstance(target, list):
-            if any:
+            if any_mode:
                 return self.contains_any(target_list=target)
-            elif all:
+            elif all_mode:
                 return self.contains_all(target_list=target)
             else:
                 raise ValueError('contains() must be run in either "any" or "all" mode')
@@ -636,10 +656,10 @@ class Location:
         target_path = target.value
         return bool(target_path.startswith(my_path))
 
-    def contains_any(self, target_list):
+    def contains_any(self, target_list: list[Location]) -> bool:
         return any(self.contains(target) for target in target_list)
 
-    def contains_all(self, target_list):
+    def contains_all(self, target_list: list[Location]) -> bool:
         count = 0
         for target in target_list:
             if self.contains(target):
@@ -653,15 +673,15 @@ class AnnotationDetail:
 
 @dataclass
 class NetworkTransferDetail(AnnotationDetail):
-    src: Location = None
-    dest: Location = None
+    src: Location | None = None
+    dest: Location | None = None
     is_mutable_src: bool = False
     is_mutable_dest: bool = False
 
-    _src_arg: Arguments = None
-    _dest_arg: Arguments = None
+    _src_arg: Arguments | None = None
+    _dest_arg: Arguments | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self._src_arg:
             self.src = Location(_args=self._src_arg)
             if self._src_arg.is_mutable:
@@ -675,30 +695,30 @@ class NetworkTransferDetail(AnnotationDetail):
 
 @dataclass
 class InboundTransferDetail(NetworkTransferDetail):
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__post_init__()
 
 
 @dataclass
 class OutboundTransferDetail(NetworkTransferDetail):
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__post_init__()
 
 
 @dataclass
 class PackageInstallDetail(AnnotationDetail):
-    pkg: any = ""
-    version: any = ""
+    pkg: Any = ""
+    version: Any = ""
     is_mutable_pkg: bool = False
     disable_validate_certs: bool = False
     allow_downgrade: bool = False
 
-    _pkg_arg: Arguments = None
-    _version_arg: Arguments = None
-    _allow_downgrade_arg: Arguments = None
-    _validate_certs_arg: Arguments = None
+    _pkg_arg: Arguments | None = None
+    _version_arg: Arguments | None = None
+    _allow_downgrade_arg: Arguments | None = None
+    _validate_certs_arg: Arguments | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self._pkg_arg:
             self.pkg = self._pkg_arg.raw
             if self._pkg_arg.is_mutable:
@@ -715,12 +735,12 @@ class PackageInstallDetail(AnnotationDetail):
 class KeyConfigChangeDetail(AnnotationDetail):
     is_deletion: bool = False
     is_mutable_key: bool = False
-    key: str = ""
+    key: Any = ""
 
-    _key_arg: Arguments = None
-    _state_arg: Arguments = None
+    _key_arg: Arguments | None = None
+    _state_arg: Arguments | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self._key_arg:
             self.key = self._key_arg.vars
             if self._key_arg and self._key_arg.is_mutable:
@@ -731,21 +751,21 @@ class KeyConfigChangeDetail(AnnotationDetail):
 
 @dataclass
 class FileChangeDetail(AnnotationDetail):
-    path: Location = None
-    src: Location = None
+    path: Location | None = None
+    src: Location | None = None
     is_mutable_path: bool = False
     is_mutable_src: bool = False
     is_unsafe_write: bool = False
     is_deletion: bool = False
     is_insecure_permissions: bool = False
 
-    _path_arg: Arguments = None
-    _src_arg: Arguments = None
-    _mode_arg: Arguments = None
-    _state_arg: Arguments = None
-    _unsafe_write_arg: Arguments = None
+    _path_arg: Arguments | None = None
+    _src_arg: Arguments | None = None
+    _mode_arg: Arguments | None = None
+    _state_arg: Arguments | None = None
+    _unsafe_write_arg: Arguments | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self._mode_arg and self._mode_arg.raw in ["1777", "0777"]:
             self.is_insecure_permissions = True
         if self._state_arg and self._state_arg.raw == "absent":
@@ -762,27 +782,29 @@ class FileChangeDetail(AnnotationDetail):
             self.is_unsafe_write = True
 
 
-execution_programs: list = ["sh", "bash", "zsh", "fish", "ash", "python*", "java*", "node*"]
-non_execution_programs: list = ["tar", "gunzip", "unzip", "mv", "cp"]
+execution_programs: list[str] = ["sh", "bash", "zsh", "fish", "ash", "python*", "java*", "node*"]
+non_execution_programs: list[str] = ["tar", "gunzip", "unzip", "mv", "cp"]
 
 
 @dataclass
 class CommandExecDetail(AnnotationDetail):
-    command: Arguments = None
+    command: Arguments | None = None
     exec_files: list[Location] = field(default_factory=list)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.exec_files = self.extract_exec_files()
 
-    def extract_exec_files(self):
-        cmd_str = ""
+    def extract_exec_files(self) -> list[Location]:
+        cmd_str: str | list[str] | dict[str, Any] = ""
         if self.command:
-            cmd_str = self.command.raw
+            cmd_str = self.command.raw or ""
         if isinstance(cmd_str, list):
-            cmd_str = " ".join(cmd_str)
-        if isinstance(cmd_str, dict):
-            cmd_str = cmd_str.get("cmd", "")
-        lines = cmd_str.splitlines()
+            cmd_str = " ".join(str(x) for x in cmd_str)
+        elif isinstance(cmd_str, dict):
+            cmd_str = str(cmd_str.get("cmd", ""))
+        elif not isinstance(cmd_str, str):
+            cmd_str = str(cmd_str) if cmd_str else ""
+        lines: list[str] = cmd_str.splitlines()
         exec_files = []
         for line in lines:
             parts = []
@@ -817,7 +839,7 @@ class CommandExecDetail(AnnotationDetail):
                 if found_program is None:
                     found_program = p
                     break
-            if found_program:
+            if found_program and self.command:
                 exec_file_name = found_program
                 related_vars = [v for v in self.command.vars if v.name in exec_file_name]
                 location_type = LocationType.FILE
@@ -830,7 +852,7 @@ class CommandExecDetail(AnnotationDetail):
         return exec_files
 
 
-def _convert_to_bool(a: any):
+def _convert_to_bool(a: Any) -> bool | None:
     if type(a) is bool:
         return bool(a)
     if type(a) is str:
@@ -841,7 +863,7 @@ def _convert_to_bool(a: any):
 @dataclass
 class Annotation(JSONSerializable):
     key: str = ""
-    value: any = None
+    value: Any = None
 
     rule_id: str = ""
 
@@ -852,7 +874,7 @@ class Annotation(JSONSerializable):
 @dataclass
 class VariableAnnotation(Annotation):
     type: str = "variable_annotation"
-    option_value: Arguments = field(default_factory=Arguments)
+    option_value: Arguments = field(default_factory=lambda: Arguments())
 
 
 class RiskType:
@@ -875,14 +897,18 @@ class DefaultRiskType(RiskType):
 @dataclass
 class RiskAnnotation(Annotation, NetworkTransferDetail, CommandExecDetail):
     type: str = "risk_annotation"
-    risk_type: RiskType = ""
+    risk_type: str | RiskType = ""
 
     @classmethod
-    def init(cls, risk_type: RiskType, detail: AnnotationDetail):
+    def init(
+        cls: builtins.type[RiskAnnotation],
+        risk_type: str | RiskType,
+        detail: AnnotationDetail,
+    ) -> RiskAnnotation:
         anno = cls()
         anno.risk_type = risk_type
         # Walk MRO to collect annotations from all parent classes of the detail
-        all_attrs: dict = {}
+        all_attrs: dict[str, Any] = {}
         for klass in reversed(type(detail).__mro__):
             all_attrs.update(getattr(klass, "__annotations__", {}))
         for attr_name in all_attrs:
@@ -892,44 +918,44 @@ class RiskAnnotation(Annotation, NetworkTransferDetail, CommandExecDetail):
             setattr(anno, attr_name, val)
         return anno
 
-    def equal_to(self, anno):
+    def equal_to(self, anno: RiskAnnotation) -> bool:
         if self.type != anno.type:
             return False
         if self.risk_type != anno.risk_type:
             return False
         self_dict = self.__dict__
         anno_dict = anno.__dict__
-        return equal(self_dict, anno_dict)
+        return bool(equal(self_dict, anno_dict))
 
 
 @dataclass
 class FindCondition:
-    def check(self, anno: RiskAnnotation):
+    def check(self, anno: RiskAnnotation) -> bool:
         raise NotImplementedError
 
 
 @dataclass
 class AnnotationCondition:
-    type: RiskType = ""
-    attr_conditions: list = field(default_factory=list)
+    type: str | RiskType = ""
+    attr_conditions: list[tuple[str, Any]] = field(default_factory=list)
 
-    def risk_type(self, risk_type: RiskType):
+    def risk_type(self, risk_type: str | RiskType) -> AnnotationCondition:
         self.type = risk_type
         return self
 
-    def attr(self, key: str, val: any):
+    def attr(self, key: str, val: Any) -> AnnotationCondition:
         self.attr_conditions.append((key, val))
         return self
 
 
 @dataclass
 class AttributeCondition(FindCondition):
-    attr: str = None
-    result: any = None
+    attr: str | None = None
+    result: Any = None
 
-    def check(self, anno: RiskAnnotation):
-        if self.attr and hasattr(anno.detail, self.attr):
-            anno_value = getattr(anno.detail, self.attr)
+    def check(self, anno: RiskAnnotation) -> bool:
+        if self.attr and hasattr(anno, self.attr):
+            anno_value = getattr(anno, self.attr, None)
             if anno_value == self.result:
                 return True
             if self.result is None and isinstance(anno_value, bool) and anno_value:
@@ -939,13 +965,14 @@ class AttributeCondition(FindCondition):
 
 @dataclass
 class FunctionCondition(FindCondition):
-    func: Callable = None
-    args: list[any] = None
-    result: any = None
+    func: Callable[..., Any] | None = None
+    args: dict[str, Any] | list[Any] | None = None
+    result: Any = None
 
-    def check(self, anno: RiskAnnotation):
-        if self.func and callable(self.func):
-            result = self.func(anno, **self.args)
+    def check(self, anno: RiskAnnotation) -> bool:
+        if self.func is not None and callable(self.func):
+            kwargs: dict[str, Any] = self.args if isinstance(self.args, dict) else {}
+            result = self.func(anno, **kwargs)
             if result == self.result:
                 return True
         return False
@@ -957,10 +984,10 @@ class RiskAnnotationList:
 
     _i: int = 0
 
-    def __iter__(self):
+    def __iter__(self) -> RiskAnnotationList:
         return self
 
-    def __next__(self):
+    def __next__(self) -> RiskAnnotation:
         if self._i == len(self.items):
             self._i = 0
             raise StopIteration()
@@ -968,20 +995,24 @@ class RiskAnnotationList:
         self._i += 1
         return anno
 
-    def after(self, anno: RiskAnnotation):
+    def after(self, anno: RiskAnnotation) -> RiskAnnotationList:
         return get_annotations_after(self, anno)
 
-    def filter(self, risk_type: RiskType = ""):
+    def filter(self, risk_type: str | RiskType = "") -> RiskAnnotationList:
         current = self
         if risk_type:
             current = filter_annotations_by_type(current, risk_type)
         return current
 
-    def find(self, risk_type: RiskType = "", condition: FindCondition | list[FindCondition] = None):
+    def find(
+        self,
+        risk_type: str | RiskType = "",
+        condition: FindCondition | list[FindCondition] | None = None,
+    ) -> RiskAnnotationList:
         return search_risk_annotations(self, risk_type, condition)
 
 
-def get_annotations_after(anno_list: RiskAnnotationList, anno: RiskAnnotation):
+def get_annotations_after(anno_list: RiskAnnotationList, anno: RiskAnnotation) -> RiskAnnotationList:
     sub_list = []
     found = False
     for anno_i in anno_list:
@@ -994,17 +1025,19 @@ def get_annotations_after(anno_list: RiskAnnotationList, anno: RiskAnnotation):
     return RiskAnnotationList(sub_list)
 
 
-def filter_annotations_by_type(anno_list: RiskAnnotationList, risk_type: RiskType):
-    sub_list = []
+def filter_annotations_by_type(anno_list: RiskAnnotationList, risk_type: str | RiskType) -> RiskAnnotationList:
+    sub_list: list[RiskAnnotation] = []
     for anno_i in anno_list:
         if anno_i.risk_type == risk_type:
             sub_list.append(anno_i)
-    return sub_list
+    return RiskAnnotationList(sub_list)
 
 
 def search_risk_annotations(
-    anno_list: RiskAnnotationList, risk_type: RiskType = "", condition: FindCondition | list[FindCondition] = None
-):
+    anno_list: RiskAnnotationList,
+    risk_type: str | RiskType = "",
+    condition: FindCondition | list[FindCondition] | None = None,
+) -> RiskAnnotationList:
     matched = []
     for risk_anno in anno_list:
         if not isinstance(risk_anno, RiskAnnotation):
@@ -1036,7 +1069,7 @@ class BecomeInfo:
     flags: str = ""
 
     @staticmethod
-    def from_options(options: dict):
+    def from_options(options: dict[str, Any]) -> BecomeInfo | None:
         if "become" in options:
             become = options.get("become", "")
             enabled = False
@@ -1052,7 +1085,7 @@ class BecomeInfo:
 @dataclass
 class Task(Object, Resolvable):
     type: str = "task"
-    name: str = ""
+    name: str | None = ""
     module: str = ""
     index: int = -1
     play_index: int = -1
@@ -1061,46 +1094,46 @@ class Task(Object, Resolvable):
     local_key: str = ""
     role: str = ""
     collection: str = ""
-    become: BecomeInfo = None
-    variables: dict = field(default_factory=dict)
-    module_defaults: dict = field(default_factory=dict)
-    registered_variables: dict = field(default_factory=dict)
-    set_facts: dict = field(default_factory=dict)
-    loop: dict = field(default_factory=dict)
-    options: dict = field(default_factory=dict)
-    module_options: dict = field(default_factory=dict)
+    become: BecomeInfo | None = None
+    variables: dict[str, Any] = field(default_factory=dict)
+    module_defaults: dict[str, Any] = field(default_factory=dict)
+    registered_variables: dict[str, Any] = field(default_factory=dict)
+    set_facts: dict[str, Any] = field(default_factory=dict)
+    loop: dict[str, Any] = field(default_factory=dict)
+    options: dict[str, Any] = field(default_factory=dict)
+    module_options: dict[str, Any] = field(default_factory=dict)
     executable: str = ""
     executable_type: str = ""
-    collections_in_play: list = field(default_factory=list)
+    collections_in_play: list[str] = field(default_factory=list)
 
     yaml_lines: str = ""
-    line_num_in_file: list = field(default_factory=list)  # [begin, end]
+    line_num_in_file: list[int] = field(default_factory=list)  # [begin, end]
     jsonpath: str = ""
 
     # FQCN for Module and Role. Or a file path for TaskFile.  resolved later
     resolved_name: str = ""
     # candidates of resovled_name
-    possible_candidates: list = field(default_factory=list)
+    possible_candidates: list[Any] = field(default_factory=list)
 
     # embed these data when module/role/taskfile are resolved
-    module_info: dict = field(default_factory=dict)
-    include_info: dict = field(default_factory=dict)
+    module_info: dict[str, Any] = field(default_factory=dict)
+    include_info: dict[str, Any] = field(default_factory=dict)
 
     def set_yaml_lines(
         self,
-        fullpath="",
-        yaml_lines="",
-        task_name="",
-        module_name="",
-        module_options=None,
-        task_options=None,
-        previous_task_line=-1,
-        jsonpath="",
-    ):
+        fullpath: str = "",
+        yaml_lines: str = "",
+        task_name: str = "",
+        module_name: str = "",
+        module_options: Any = None,
+        task_options: Any = None,
+        previous_task_line: int = -1,
+        jsonpath: str = "",
+    ) -> None:
         if not task_name and not module_options:
             return
 
-        lines = []
+        lines: list[str] = []
         lines = yaml_lines.splitlines() if yaml_lines else Path(fullpath).read_text().splitlines()
 
         if jsonpath:
@@ -1158,7 +1191,7 @@ class Task(Object, Resolvable):
             best_line_num_in_file = candidate_blocks[0][1]
         else:
             # reconstruct yaml from the task data to calculate similarity (edit distance) later
-            reconstructed_data = [{}]
+            reconstructed_data: list[dict[str, Any]] = [{}]
             if task_name:
                 reconstructed_data[0]["name"] = task_name
             reconstructed_data[0][module_name] = module_options
@@ -1173,7 +1206,7 @@ class Task(Object, Resolvable):
             # find best match by edit distance
             if reconstructed_yaml:
 
-                def remove_comment_lines(s):
+                def remove_comment_lines(s: str) -> str:
                     lines = s.splitlines()
                     updated = []
                     for line in lines:
@@ -1182,10 +1215,10 @@ class Task(Object, Resolvable):
                         updated.append(line)
                     return "\n".join(updated)
 
-                def calc_dist(s1, s2):
+                def calc_dist(s1: str, s2: str) -> int:
                     us1 = remove_comment_lines(s1)
                     us2 = remove_comment_lines(s2)
-                    dist = Levenshtein.distance(us1, us2)
+                    dist = int(Levenshtein.distance(us1, us2))
                     return dist
 
                 r = reconstructed_yaml
@@ -1202,7 +1235,7 @@ class Task(Object, Resolvable):
         self.line_num_in_file = best_line_num_in_file
         return
 
-    def _find_task_block(self, yaml_lines: list, start_line_num: int):
+    def _find_task_block(self, yaml_lines: list[str], start_line_num: int) -> tuple[str | None, list[int] | None]:
         if not yaml_lines:
             return None, None
 
@@ -1276,15 +1309,15 @@ class Task(Object, Resolvable):
         if begin_line_num < 0 or end_line_num > len(lines) or begin_line_num > end_line_num:
             return None, None
 
-        yaml_lines = "\n".join(lines[begin_line_num : end_line_num + 1])
+        result_yaml = "\n".join(lines[begin_line_num : end_line_num + 1])
         line_num_in_file = [begin_line_num + 1, end_line_num + 1]
-        return yaml_lines, line_num_in_file
+        return result_yaml, line_num_in_file
 
     # this keeps original contents like comments, indentation
     # and quotes for string as much as possible
-    def yaml(self, original_module="", use_yaml_lines=True):
-        task_data_wrapper = None
-        task_data = None
+    def yaml(self, original_module: str = "", use_yaml_lines: bool = True) -> str:
+        task_data_wrapper: list[dict[str, Any]] | None = None
+        task_data: dict[str, Any] | None = None
         if use_yaml_lines:
             try:
                 task_data_wrapper = ariyaml.load(self.yaml_lines)
@@ -1346,18 +1379,19 @@ class Task(Object, Resolvable):
                 recursive_copy_dict(self.module_options, new_la_opt)
                 options_without_name["local_action"] = new_la_opt
             recursive_copy_dict(options_without_name, current_to)
-        if len(task_data_wrapper) == 0:
-            task_data_wrapper.append(current_to)
+        wrapper = task_data_wrapper if task_data_wrapper is not None else []
+        if len(wrapper) == 0:
+            wrapper.append(current_to)
         else:
-            task_data_wrapper[0] = current_to
-        new_yaml = ariyaml.dump(task_data_wrapper)
+            wrapper[0] = current_to
+        new_yaml = str(ariyaml.dump(wrapper))
         return new_yaml
 
     # this makes a yaml from task contents such as spec.module,
     # spec.options, spec.module_options in a fixed format
     # NOTE: this will lose comments and indentations in the original YAML
-    def formatted_yaml(self):
-        task_data = {}
+    def formatted_yaml(self) -> str:
+        task_data: dict[str, Any] = {}
         if self.name:
             task_data["name"] = self.name
         if self.module:
@@ -1366,11 +1400,11 @@ class Task(Object, Resolvable):
             if key == "name":
                 continue
             task_data[key] = val
-        task_data = self.str2double_quoted_scalar(task_data)
+        task_data = cast(dict[str, Any], self.str2double_quoted_scalar(task_data))
         data = [task_data]
-        return ariyaml.dump(data)
+        return str(ariyaml.dump(data))
 
-    def str2double_quoted_scalar(self, v):
+    def str2double_quoted_scalar(self, v: Any) -> Any:
         if isinstance(v, dict):
             for key, val in v.items():
                 new_val = self.str2double_quoted_scalar(val)
@@ -1385,41 +1419,41 @@ class Task(Object, Resolvable):
             pass
         return v
 
-    def set_key(self, parent_key="", parent_local_key=""):
+    def set_key(self, parent_key: str = "", parent_local_key: str = "") -> None:
         set_task_key(self, parent_key, parent_local_key)
 
-    def children_to_key(self):
+    def children_to_key(self) -> Task:
         return self
 
     @property
-    def defined_vars(self):
+    def defined_vars(self) -> dict[str, Any]:
         d_vars = self.variables
         d_vars.update(self.registered_variables)
         d_vars.update(self.set_facts)
         return d_vars
 
     @property
-    def tags(self):
+    def tags(self) -> Any:
         return self.options.get("tags", None)
 
     @property
-    def when(self):
+    def when(self) -> Any:
         return self.options.get("when", None)
 
     @property
-    def action(self):
+    def action(self) -> str:
         return self.executable
 
     @property
-    def resolved_action(self):
+    def resolved_action(self) -> str:
         return self.resolved_name
 
     @property
-    def line_number(self):
+    def line_number(self) -> list[int]:
         return self.line_num_in_file
 
     @property
-    def id(self):
+    def id(self) -> str:
         return json.dumps(
             {
                 "path": self.defined_in,
@@ -1429,172 +1463,188 @@ class Task(Object, Resolvable):
         )
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> None:
         return None
 
 
 @dataclass
 class MutableContent:
     _yaml: str = ""
-    _task_spec: Task = None
+    _task_spec: Task | None = None
+
+    def _require_task_spec(self) -> Task:
+        if self._task_spec is None:
+            raise ValueError("MutableContent has no task spec")
+        return self._task_spec
 
     @staticmethod
-    def from_task_spec(task_spec):
+    def from_task_spec(task_spec: Task) -> MutableContent:
         mc = MutableContent(
             _yaml=task_spec.yaml_lines,
             _task_spec=deepcopy(task_spec),
         )
         return mc
 
-    def set_task_name(self, task_name: str):
+    def set_task_name(self, task_name: str) -> MutableContent:
         # if `name` is None or empty string, Task.yaml() won't output the field
-        self._task_spec.name = task_name
-        self._yaml = self._task_spec.yaml()
-        self._task_spec.yaml_lines = self._yaml
+        spec = self._require_task_spec()
+        spec.name = task_name
+        self._yaml = spec.yaml()
+        spec.yaml_lines = self._yaml
         return self
 
-    def get_task_name(self):
-        return self._task_spec.name
+    def get_task_name(self) -> str | None:
+        return self._task_spec.name if self._task_spec else None
 
-    def omit_task_name(self):
+    def omit_task_name(self) -> MutableContent:
         # if `name` is None or empty string, Task.yaml() won't output the field
-        self._task_spec.name = None
-        self._yaml = self._task_spec.yaml()
-        self._task_spec.yaml_lines = self._yaml
+        spec = self._require_task_spec()
+        spec.name = None
+        self._yaml = spec.yaml()
+        spec.yaml_lines = self._yaml
         return self
 
-    def set_module_name(self, module_name):
-        original_module = deepcopy(self._task_spec.module)
-        self._task_spec.module = module_name
-        self._yaml = self._task_spec.yaml(original_module=original_module)
-        self._task_spec.yaml_lines = self._yaml
+    def set_module_name(self, module_name: str) -> MutableContent:
+        spec = self._require_task_spec()
+        original_module = deepcopy(spec.module)
+        spec.module = module_name
+        self._yaml = spec.yaml(original_module=original_module)
+        spec.yaml_lines = self._yaml
         return self
 
-    def replace_key(self, old_key: str, new_key: str):
-        if old_key in self._task_spec.options:
-            value = self._task_spec.options[old_key]
-            self._task_spec.options.pop(old_key)
-            self._task_spec.options[new_key] = value
-        self._yaml = self._task_spec.yaml()
-        self._task_spec.yaml_lines = self._yaml
+    def replace_key(self, old_key: str, new_key: str) -> MutableContent:
+        spec = self._require_task_spec()
+        if old_key in spec.options:
+            value = spec.options[old_key]
+            spec.options.pop(old_key)
+            spec.options[new_key] = value
+        self._yaml = spec.yaml()
+        spec.yaml_lines = self._yaml
         return self
 
-    def replace_value(self, old_value: str, new_value: str):
+    def replace_value(self, old_value: str, new_value: str) -> MutableContent:
+        spec = self._require_task_spec()
         original_new_value = deepcopy(new_value)
         need_restore = False
         keys_to_be_restored = []
         if isinstance(new_value, str):
             new_value = DoubleQuotedScalarString(new_value)
             need_restore = True
-        for k, v in self._task_spec.options.items():
+        for k, v in spec.options.items():
             if type(v).__name__ != type(old_value).__name__:
                 continue
             if v != old_value:
                 continue
-            self._task_spec.options[k] = new_value
+            spec.options[k] = new_value
             keys_to_be_restored.append(k)
-        self._yaml = self._task_spec.yaml()
-        self._task_spec.yaml_lines = self._yaml
+        self._yaml = spec.yaml()
+        spec.yaml_lines = self._yaml
         if need_restore:
-            for k, _ in self._task_spec.options.items():
+            for k, _ in spec.options.items():
                 if k in keys_to_be_restored:
-                    self._task_spec.options[k] = original_new_value
+                    spec.options[k] = original_new_value
         return self
 
-    def remove_key(self, key):
-        if key in self._task_spec.options:
-            self._task_spec.options.pop(key)
-        self._yaml = self._task_spec.yaml()
-        self._task_spec.yaml_lines = self._yaml
+    def remove_key(self, key: str) -> MutableContent:
+        spec = self._require_task_spec()
+        if key in spec.options:
+            spec.options.pop(key)
+        self._yaml = spec.yaml()
+        spec.yaml_lines = self._yaml
         return self
 
-    def set_new_module_arg_key(self, key, value):
+    def set_new_module_arg_key(self, key: str, value: Any) -> MutableContent:
+        spec = self._require_task_spec()
         original_value = deepcopy(value)
         need_restore = False
         if isinstance(value, str):
             value = DoubleQuotedScalarString(value)
             need_restore = True
-        self._task_spec.module_options[key] = value
-        self._yaml = self._task_spec.yaml()
-        self._task_spec.yaml_lines = self._yaml
+        spec.module_options[key] = value
+        self._yaml = spec.yaml()
+        spec.yaml_lines = self._yaml
         if need_restore:
-            self._task_spec.module_options[key] = original_value
+            spec.module_options[key] = original_value
         return self
 
-    def remove_module_arg_key(self, key):
-        if key in self._task_spec.module_options:
-            self._task_spec.module_options.pop(key)
-        self._yaml = self._task_spec.yaml()
-        self._task_spec.yaml_lines = self._yaml
+    def remove_module_arg_key(self, key: str) -> MutableContent:
+        spec = self._require_task_spec()
+        if key in spec.module_options:
+            spec.module_options.pop(key)
+        self._yaml = spec.yaml()
+        spec.yaml_lines = self._yaml
         return self
 
-    def replace_module_arg_key(self, old_key: str, new_key: str):
-        if old_key in self._task_spec.module_options:
-            value = self._task_spec.module_options[old_key]
-            self._task_spec.module_options.pop(old_key)
-            self._task_spec.module_options[new_key] = value
-        self._yaml = self._task_spec.yaml()
-        self._task_spec.yaml_lines = self._yaml
+    def replace_module_arg_key(self, old_key: str, new_key: str) -> MutableContent:
+        spec = self._require_task_spec()
+        if old_key in spec.module_options:
+            value = spec.module_options[old_key]
+            spec.module_options.pop(old_key)
+            spec.module_options[new_key] = value
+        self._yaml = spec.yaml()
+        spec.yaml_lines = self._yaml
         return self
 
-    def replace_module_arg_value(self, key: str = "", old_value: any = None, new_value: any = None):
+    def replace_module_arg_value(self, key: str = "", old_value: Any = None, new_value: Any = None) -> MutableContent:
+        spec = self._require_task_spec()
         original_new_value = deepcopy(new_value)
         need_restore = False
         keys_to_be_restored = []
         if isinstance(new_value, str):
             new_value = DoubleQuotedScalarString(new_value)
             need_restore = True
-        for k in self._task_spec.module_options:
+        for k in spec.module_options:
             # if `key` is specified, skip other keys
             if key and k != key:
                 continue
-            value = self._task_spec.module_options[k]
+            value = spec.module_options[k]
             if type(value).__name__ == type(old_value).__name__ and value == old_value:
-                self._task_spec.module_options[k] = new_value
+                spec.module_options[k] = new_value
                 keys_to_be_restored.append(k)
-        self._yaml = self._task_spec.yaml()
-        self._task_spec.yaml_lines = self._yaml
+        self._yaml = spec.yaml()
+        spec.yaml_lines = self._yaml
         if need_restore:
-            for k in self._task_spec.module_options:
+            for k in spec.module_options:
                 if k in keys_to_be_restored:
-                    self._task_spec.module_options[k] = original_new_value
+                    spec.module_options[k] = original_new_value
         return self
 
-    def replace_with_dict(self, new_dict: dict):
-        # import this here to avoid circular import
+    def replace_with_dict(self, new_dict: dict[str, Any]) -> MutableContent:
+        spec = self._require_task_spec()
         from .model_loader import load_task
 
         yaml_lines = ariyaml.dump([new_dict])
         new_task = load_task(
-            path=self._task_spec.defined_in,
-            index=self._task_spec.index,
+            path=spec.defined_in,
+            index=spec.index,
             task_block_dict=new_dict,
-            task_jsonpath=self._task_spec.jsonpath,
-            role_name=self._task_spec.role,
-            collection_name=self._task_spec.collection,
-            collections_in_play=self._task_spec.collections_in_play,
-            play_index=self._task_spec.play_index,
+            task_jsonpath=spec.jsonpath,
+            role_name=spec.role,
+            collection_name=spec.collection,
+            collections_in_play=spec.collections_in_play,
+            play_index=spec.play_index,
             yaml_lines=yaml_lines,
         )
         self._yaml = yaml_lines
         self._task_spec = new_task
         return self
 
-    def replace_module_arg_with_dict(self, new_dict: dict):
-        self._task_spec.module_options = new_dict
-        self._yaml = self._task_spec.yaml()
+    def replace_module_arg_with_dict(self, new_dict: dict[str, Any]) -> MutableContent:
+        spec = self._require_task_spec()
+        spec.module_options = new_dict
+        self._yaml = spec.yaml()
         return self
 
     # this keeps original contents like comments, indentation
     # and quotes for string as much as possible
-    def yaml(self):
+    def yaml(self) -> str:
         return self._yaml
 
     # this makes a yaml from task contents such as spec.module,
     # spec.options, spec.module_options in a fixed format
     # NOTE: this will lose comments and indentations in the original YAML
-    def formatted_yaml(self):
-        return self._task_spec.formatted_yaml()
+    def formatted_yaml(self) -> str:
+        return self._require_task_spec().formatted_yaml()
 
 
 @dataclass
@@ -1604,19 +1654,19 @@ class TaskCall(CallObject, RunTarget):
     # any Annotators in "annotators" dir can add them to this object
     annotations: list[Annotation] = field(default_factory=list)
     args: Arguments = field(default_factory=Arguments)
-    variable_set: dict = field(default_factory=dict)
-    variable_use: dict = field(default_factory=dict)
-    become: BecomeInfo = None
-    module_defaults: dict = field(default_factory=dict)
+    variable_set: dict[str, Any] = field(default_factory=dict)
+    variable_use: dict[str, Any] = field(default_factory=dict)
+    become: BecomeInfo | None = None
+    module_defaults: dict[str, Any] = field(default_factory=dict)
 
-    module: Module = None
-    content: MutableContent = None
+    module: Module | None = None
+    content: MutableContent | None = None
 
-    def get_annotation_by_type(self, type_str=""):
+    def get_annotation_by_type(self, type_str: str = "") -> list[Annotation]:
         matched = [an for an in self.annotations if an.type == type_str]
         return matched
 
-    def get_annotation_by_type_and_attr(self, type_str="", key="", val=None):
+    def get_annotation_by_type_and_attr(self, type_str: str = "", key: str = "", val: Any = None) -> list[Annotation]:
         matched = [
             an
             for an in self.annotations
@@ -1624,7 +1674,7 @@ class TaskCall(CallObject, RunTarget):
         ]
         return matched
 
-    def set_annotation(self, key: str, value: any, rule_id: str):
+    def set_annotation(self, key: str, value: Any, rule_id: str) -> None:
         end_to_set = False
         for an in self.annotations:
             if not hasattr(an, "key"):
@@ -1637,7 +1687,7 @@ class TaskCall(CallObject, RunTarget):
             self.annotations.append(Annotation(key=key, value=value, rule_id=rule_id))
         return
 
-    def get_annotation(self, key: str, __default: any = None, rule_id: str = ""):
+    def get_annotation(self, key: str, __default: Any = None, rule_id: str = "") -> Any:
         value = __default
         for an in self.annotations:
             if not hasattr(an, "key"):
@@ -1649,14 +1699,14 @@ class TaskCall(CallObject, RunTarget):
                 break
         return value
 
-    def has_annotation_by_condition(self, cond: AnnotationCondition):
+    def has_annotation_by_condition(self, cond: AnnotationCondition) -> bool:
         anno = self.get_annotation_by_condition(cond)
         return bool(anno)
 
-    def get_annotation_by_condition(self, cond: AnnotationCondition):
-        _annotations = self.annotations
+    def get_annotation_by_condition(self, cond: AnnotationCondition) -> Annotation | RiskAnnotation | None:
+        _annotations: list[Annotation] = list(self.annotations)
         if cond.type:
-            _annotations = [an for an in _annotations if an.type == RiskAnnotation.type and an.risk_type == cond.type]
+            _annotations = [an for an in _annotations if isinstance(an, RiskAnnotation) and an.risk_type == cond.type]
         if cond.attr_conditions:
             for key, val in cond.attr_conditions:
                 _annotations = [an for an in _annotations if hasattr(an, key) and getattr(an, key) == val]
@@ -1664,53 +1714,53 @@ class TaskCall(CallObject, RunTarget):
             return _annotations[0]
         return None
 
-    def file_info(self):
-        file = self.spec.defined_in
+    def file_info(self) -> tuple[str, str]:
+        file = self.spec.defined_in  # type: ignore[attr-defined]
         lines = "?"
-        if len(self.spec.line_number) == 2:
-            l_num = self.spec.line_number
+        if len(self.spec.line_number) == 2:  # type: ignore[attr-defined]
+            l_num = self.spec.line_number  # type: ignore[attr-defined]
             lines = f"L{l_num[0]}-{l_num[1]}"
         return file, lines
 
     @property
-    def resolved_name(self):
-        return self.spec.resolved_name
+    def resolved_name(self) -> str:
+        return getattr(self.spec, "resolved_name", "") if self.spec else ""
 
     @property
-    def resolved_action(self):
+    def resolved_action(self) -> str:
         return self.resolved_name
 
     @property
-    def action_type(self):
-        return self.spec.executable_type
+    def action_type(self) -> str:
+        return getattr(self.spec, "executable_type", "") if self.spec else ""
 
 
 @dataclass
 class AnsibleRunContext:
     sequence: RunTargetList = field(default_factory=RunTargetList)
     root_key: str = ""
-    parent: Object = None
-    ram_client: any = None
-    scan_metadata: dict = field(default_factory=dict)
+    parent: Object | None = None
+    ram_client: Any = None
+    scan_metadata: dict[str, Any] = field(default_factory=dict)
 
     # used by rule check
-    current: RunTarget = None
+    current: RunTarget | None = None
     _i: int = 0
 
     # used if ram generate / other data generation by loop
     last_item: bool = False
 
     # TODO: implement the following attributes
-    vars: any = None
-    host_info: any = None
+    vars: Any = None
+    host_info: Any = None
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.sequence)
 
-    def __iter__(self):
+    def __iter__(self) -> AnsibleRunContext:
         return self
 
-    def __next__(self):
+    def __next__(self) -> RunTarget:
         if self._i == len(self.sequence):
             self._i = 0
             self.current = None
@@ -1720,24 +1770,29 @@ class AnsibleRunContext:
         self._i += 1
         return t
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: int) -> RunTarget:
         return self.sequence[i]
 
     @staticmethod
     def from_tree(
-        tree: ObjectList, parent: Object = None, last_item: bool = False, ram_client=None, scan_metadata=None
-    ):
+        tree: ObjectList,
+        parent: Object | None = None,
+        last_item: bool = False,
+        ram_client: Any = None,
+        scan_metadata: dict[str, Any] | None = None,
+    ) -> AnsibleRunContext:
         if not tree:
-            return AnsibleRunContext(parent=parent, last_item=last_item)
+            return AnsibleRunContext(parent=parent, last_item=last_item, scan_metadata=scan_metadata or {})
         if len(tree.items) == 0:
-            return AnsibleRunContext(parent=parent, last_item=last_item)
-
-        root_key = tree.items[0].spec.key
-        sequence_items = []
+            return AnsibleRunContext(parent=parent, last_item=last_item, scan_metadata=scan_metadata or {})
+        scan_metadata = scan_metadata or {}
+        first_item = tree.items[0]
+        spec = getattr(first_item, "spec", None)
+        root_key = getattr(spec, "key", getattr(first_item, "key", "")) if spec else getattr(first_item, "key", "")
+        sequence_items: list[RunTarget] = []
         for item in tree.items:
-            if not isinstance(item, RunTarget):
-                continue
-            sequence_items.append(item)
+            if isinstance(item, RunTarget):
+                sequence_items.append(cast(RunTarget, item))
         tl = RunTargetList(items=sequence_items)
         return AnsibleRunContext(
             sequence=tl,
@@ -1752,13 +1807,16 @@ class AnsibleRunContext:
     def from_targets(
         targets: list[RunTarget],
         root_key: str = "",
-        parent: Object = None,
+        parent: Object | None = None,
         last_item: bool = False,
-        ram_client=None,
-        scan_metadata=None,
-    ):
+        ram_client: Any = None,
+        scan_metadata: dict[str, Any] | None = None,
+    ) -> AnsibleRunContext:
         if not root_key and len(targets) > 0:
-            root_key = targets[0].spec.key
+            root_key = (
+                getattr(targets[0].spec, "key", "") if hasattr(targets[0], "spec") else getattr(targets[0], "key", "")
+            )
+        scan_metadata = scan_metadata or {}
         tl = RunTargetList(items=targets)
         return AnsibleRunContext(
             sequence=tl,
@@ -1769,13 +1827,13 @@ class AnsibleRunContext:
             scan_metadata=scan_metadata,
         )
 
-    def find(self, target: RunTarget):
+    def find(self, target: RunTarget) -> RunTarget | None:
         for t in self.sequence:
             if t.key == target.key:
                 return t
         return None
 
-    def before(self, target: RunTarget):
+    def before(self, target: RunTarget) -> AnsibleRunContext:
         targets = []
         for rt in self.sequence:
             if rt.key == target.key:
@@ -1790,7 +1848,7 @@ class AnsibleRunContext:
             scan_metadata=self.scan_metadata,
         )
 
-    def search(self, cond: AnnotationCondition):
+    def search(self, cond: AnnotationCondition) -> AnsibleRunContext:
         targets = [t for t in self.sequence if t.type == RunTargetType.Task and t.has_annotation_by_condition(cond)]
         return AnsibleRunContext.from_targets(
             targets,
@@ -1801,12 +1859,12 @@ class AnsibleRunContext:
             scan_metadata=self.scan_metadata,
         )
 
-    def is_end(self, target: RunTarget):
+    def is_end(self, target: RunTarget) -> bool:
         if len(self) == 0:
             return False
         return target.key == self.sequence[-1].key
 
-    def is_last_task(self, target: RunTarget):
+    def is_last_task(self, target: RunTarget) -> bool:
         if len(self) == 0:
             return False
         taskcalls = self.taskcalls
@@ -1814,12 +1872,12 @@ class AnsibleRunContext:
             return False
         return target.key == taskcalls[-1].key
 
-    def is_begin(self, target: RunTarget):
+    def is_begin(self, target: RunTarget) -> bool:
         if len(self) == 0:
             return False
         return target.key == self.sequence[0].key
 
-    def copy(self):
+    def copy(self) -> AnsibleRunContext:
         return AnsibleRunContext.from_targets(
             targets=self.sequence.items,
             root_key=self.root_key,
@@ -1830,24 +1888,27 @@ class AnsibleRunContext:
         )
 
     @property
-    def info(self):
+    def info(self) -> dict[str, Any]:
         if not self.root_key:
             return {}
-        return get_obj_info_by_key(self.root_key)
+        info: dict[str, Any] = dict(get_obj_info_by_key(self.root_key))
+        return info
 
     @property
-    def taskcalls(self):
+    def taskcalls(self) -> list[RunTarget]:
         return [t for t in self.sequence if t.type == RunTargetType.Task]
 
     @property
-    def tasks(self):
+    def tasks(self) -> list[RunTarget]:
         return self.taskcalls
 
     @property
-    def annotations(self):
-        anno_list = []
+    def annotations(self) -> RiskAnnotationList:
+        anno_list: list[RiskAnnotation] = []
         for tc in self.taskcalls:
-            anno_list.extend(tc.annotations)
+            for a in tc.annotations:
+                if isinstance(a, RiskAnnotation):
+                    anno_list.append(a)
         return RiskAnnotationList(anno_list)
 
 
@@ -1858,7 +1919,7 @@ class TaskFile(Object, Resolvable):
     defined_in: str = ""
     key: str = ""
     local_key: str = ""
-    tasks: list = field(default_factory=list)
+    tasks: list[Any] = field(default_factory=list)
     # role name of this task file
     # this might be empty because a task file can be defined out of roles
     role: str = ""
@@ -1866,26 +1927,26 @@ class TaskFile(Object, Resolvable):
 
     yaml_lines: str = ""
 
-    used_in: list = field(default_factory=list)  # resolved later
+    used_in: list[Any] = field(default_factory=list)  # resolved later
 
-    annotations: dict = field(default_factory=dict)
+    annotations: dict[str, Any] = field(default_factory=dict)
 
-    variables: dict = field(default_factory=dict)
-    module_defaults: dict = field(default_factory=dict)
-    options: dict = field(default_factory=dict)
+    variables: dict[str, Any] = field(default_factory=dict)
+    module_defaults: dict[str, Any] = field(default_factory=dict)
+    options: dict[str, Any] = field(default_factory=dict)
 
-    task_loading: dict = field(default_factory=dict)
+    task_loading: dict[str, Any] = field(default_factory=dict)
 
-    def set_key(self):
+    def set_key(self) -> None:
         set_taskfile_key(self)
 
-    def children_to_key(self):
+    def children_to_key(self) -> TaskFile:
         task_keys = [t.key if isinstance(t, Task) else t for t in self.tasks]
         self.tasks = task_keys
         return self
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> list[Any]:
         return self.tasks
 
 
@@ -1902,31 +1963,31 @@ class Role(Object, Resolvable):
     key: str = ""
     local_key: str = ""
     fqcn: str = ""
-    metadata: dict = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
     collection: str = ""
-    playbooks: list = field(default_factory=list)
+    playbooks: list[Any] = field(default_factory=list)
     # 1 role can have multiple task yamls
-    taskfiles: list = field(default_factory=list)
-    handlers: list = field(default_factory=list)
+    taskfiles: list[Any] = field(default_factory=list)
+    handlers: list[Any] = field(default_factory=list)
     # roles/xxxx/library/zzzz.py can be called as module zzzz
-    modules: list = field(default_factory=list)
-    dependency: dict = field(default_factory=dict)
-    requirements: dict = field(default_factory=dict)
+    modules: list[Any] = field(default_factory=list)
+    dependency: dict[str, Any] = field(default_factory=dict)
+    requirements: dict[str, Any] = field(default_factory=dict)
 
     source: str = ""  # collection/scm repo/galaxy
 
-    annotations: dict = field(default_factory=dict)
+    annotations: dict[str, Any] = field(default_factory=dict)
 
-    default_variables: dict = field(default_factory=dict)
-    variables: dict = field(default_factory=dict)
+    default_variables: dict[str, Any] = field(default_factory=dict)
+    variables: dict[str, Any] = field(default_factory=dict)
     # key: loop_var (default "item"), value: list/dict of item value
-    loop: dict = field(default_factory=dict)
-    options: dict = field(default_factory=dict)
+    loop: dict[str, Any] = field(default_factory=dict)
+    options: dict[str, Any] = field(default_factory=dict)
 
-    def set_key(self):
+    def set_key(self) -> None:
         set_role_key(self)
 
-    def children_to_key(self):
+    def children_to_key(self) -> Role:
         module_keys = [m.key if isinstance(m, Module) else m for m in self.modules]
         self.modules = sorted(module_keys)
 
@@ -1938,7 +1999,7 @@ class Role(Object, Resolvable):
         return self
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> list[Any]:
         return self.taskfiles + self.modules
 
 
@@ -1951,7 +2012,7 @@ class RoleCall(CallObject, RunTarget):
 class RoleInPlay(Object, Resolvable):
     type: str = "roleinplay"
     name: str = ""
-    options: dict = field(default_factory=dict)
+    options: dict[str, Any] = field(default_factory=dict)
     defined_in: str = ""
     role_index: int = -1
     play_index: int = -1
@@ -1961,16 +2022,16 @@ class RoleInPlay(Object, Resolvable):
 
     resolved_name: str = ""  # resolved later
     # candidates of resovled_name
-    possible_candidates: list = field(default_factory=list)
+    possible_candidates: list[Any] = field(default_factory=list)
 
-    annotations: dict = field(default_factory=dict)
-    collections_in_play: list = field(default_factory=list)
+    annotations: dict[str, Any] = field(default_factory=dict)
+    collections_in_play: list[Any] = field(default_factory=list)
 
     # embed this data when role is resolved
-    role_info: dict = field(default_factory=dict)
+    role_info: dict[str, Any] = field(default_factory=dict)
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> None:
         return None
 
 
@@ -1992,27 +2053,27 @@ class Play(Object, Resolvable):
     collection: str = ""
     import_module: str = ""
     import_playbook: str = ""
-    pre_tasks: list = field(default_factory=list)
-    tasks: list = field(default_factory=list)
-    post_tasks: list = field(default_factory=list)
-    handlers: list = field(default_factory=list)
+    pre_tasks: list[Any] = field(default_factory=list)
+    tasks: list[Any] = field(default_factory=list)
+    post_tasks: list[Any] = field(default_factory=list)
+    handlers: list[Any] = field(default_factory=list)
     # not actual Role, but RoleInPlay defined in this playbook
-    roles: list = field(default_factory=list)
-    module_defaults: dict = field(default_factory=dict)
-    options: dict = field(default_factory=dict)
-    collections_in_play: list = field(default_factory=list)
-    become: BecomeInfo = None
-    variables: dict = field(default_factory=dict)
-    vars_files: list = field(default_factory=list)
+    roles: list[Any] = field(default_factory=list)
+    module_defaults: dict[str, Any] = field(default_factory=dict)
+    options: dict[str, Any] = field(default_factory=dict)
+    collections_in_play: list[Any] = field(default_factory=list)
+    become: BecomeInfo | None = None
+    variables: dict[str, Any] = field(default_factory=dict)
+    vars_files: list[Any] = field(default_factory=list)
 
     jsonpath: str = ""
 
-    task_loading: dict = field(default_factory=dict)
+    task_loading: dict[str, Any] = field(default_factory=dict)
 
-    def set_key(self, parent_key="", parent_local_key=""):
+    def set_key(self, parent_key: str = "", parent_local_key: str = "") -> None:
         set_play_key(self, parent_key, parent_local_key)
 
-    def children_to_key(self):
+    def children_to_key(self) -> Play:
         pre_task_keys = [t.key if isinstance(t, Task) else t for t in self.pre_tasks]
         self.pre_tasks = pre_task_keys
 
@@ -2027,11 +2088,11 @@ class Play(Object, Resolvable):
         return self
 
     @property
-    def id(self):
+    def id(self) -> str:
         return json.dumps({"path": self.defined_in, "index": self.index})
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> list[Any]:
         return self.pre_tasks + self.tasks + self.roles
 
 
@@ -2053,29 +2114,28 @@ class Playbook(Object, Resolvable):
     role: str = ""
     collection: str = ""
 
-    plays: list = field(default_factory=list)
+    plays: list[Any] = field(default_factory=list)
 
-    used_in: list = field(default_factory=list)  # resolved later
+    used_in: list[Any] = field(default_factory=list)  # resolved later
 
-    annotations: dict = field(default_factory=dict)
+    annotations: dict[str, Any] = field(default_factory=dict)
 
-    variables: dict = field(default_factory=dict)
-    options: dict = field(default_factory=dict)
+    variables: dict[str, Any] = field(default_factory=dict)
+    options: dict[str, Any] = field(default_factory=dict)
 
-    def set_key(self):
+    def set_key(self) -> None:
         set_playbook_key(self)
 
-    def children_to_key(self):
+    def children_to_key(self) -> Playbook:
         play_keys = [play.key if isinstance(play, Play) else play for play in self.plays]
         self.plays = play_keys
         return self
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> list[Any]:
         if "plays" in self.__dict__:
             return self.plays
-        else:
-            return self.roles + self.tasks
+        return getattr(self, "roles", []) + getattr(self, "tasks", [])
 
 
 @dataclass
@@ -2097,7 +2157,7 @@ class Inventory(JSONSerializable):
     inventory_type: str = ""
     group_name: str = ""
     host_name: str = ""
-    variables: dict = field(default_factory=dict)
+    variables: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -2111,8 +2171,8 @@ class Repository(Object, Resolvable):
     # if set, this repository is a collection repository
     my_collection_name: str = ""
 
-    playbooks: list = field(default_factory=list)
-    roles: list = field(default_factory=list)
+    playbooks: list[Any] = field(default_factory=list)
+    roles: list[Any] = field(default_factory=list)
 
     # for playbook scan
     target_playbook_path: str = ""
@@ -2120,28 +2180,28 @@ class Repository(Object, Resolvable):
     # for taskfile scan
     target_taskfile_path: str = ""
 
-    requirements: dict = field(default_factory=dict)
+    requirements: dict[str, Any] = field(default_factory=dict)
 
     installed_collections_path: str = ""
-    installed_collections: list = field(default_factory=list)
+    installed_collections: list[Any] = field(default_factory=list)
 
     installed_roles_path: str = ""
-    installed_roles: list = field(default_factory=list)
-    modules: list = field(default_factory=list)
-    taskfiles: list = field(default_factory=list)
+    installed_roles: list[Any] = field(default_factory=list)
+    modules: list[Any] = field(default_factory=list)
+    taskfiles: list[Any] = field(default_factory=list)
 
-    inventories: list = field(default_factory=list)
+    inventories: list[Any] = field(default_factory=list)
 
-    files: list = field(default_factory=list)
+    files: list[Any] = field(default_factory=list)
 
     version: str = ""
 
-    annotations: dict = field(default_factory=dict)
+    annotations: dict[str, Any] = field(default_factory=dict)
 
-    def set_key(self):
+    def set_key(self) -> None:
         set_repository_key(self)
 
-    def children_to_key(self):
+    def children_to_key(self) -> Repository:
         module_keys = [m.key if isinstance(m, Module) else m for m in self.modules]
         self.modules = sorted(module_keys)
 
@@ -2156,7 +2216,7 @@ class Repository(Object, Resolvable):
         return self
 
     @property
-    def resolver_targets(self):
+    def resolver_targets(self) -> list[Any]:
         return self.playbooks + self.roles + self.modules + self.installed_roles + self.installed_collections
 
 
@@ -2165,7 +2225,7 @@ class RepositoryCall(CallObject):
     type: str = "repositorycall"
 
 
-def call_obj_from_spec(spec: Object, caller: CallObject, index: int = 0):
+def call_obj_from_spec(spec: Object, caller: CallObject | None, index: int = 0) -> CallObject | None:
     if isinstance(spec, Repository):
         return RepositoryCall.from_spec(spec, caller, index)
     elif isinstance(spec, Playbook):
@@ -2179,7 +2239,7 @@ def call_obj_from_spec(spec: Object, caller: CallObject, index: int = 0):
     elif isinstance(spec, TaskFile):
         return TaskFileCall.from_spec(spec, caller, index)
     elif isinstance(spec, Task):
-        taskcall = TaskCall.from_spec(spec, caller, index)
+        taskcall = cast(TaskCall, TaskCall.from_spec(spec, caller, index))
         taskcall.content = MutableContent.from_task_spec(task_spec=spec)
         return taskcall
     elif isinstance(spec, Module):
@@ -2194,17 +2254,17 @@ class GalaxyArtifact(Repository):
     type: str = ""  # Role or Collection
 
     # make it easier to search a module
-    module_dict: dict = field(default_factory=dict)
+    module_dict: dict[str, Any] = field(default_factory=dict)
     # make it easier to search a task
-    task_dict: dict = field(default_factory=dict)
+    task_dict: dict[str, Any] = field(default_factory=dict)
     # make it easier to search a taskfile
-    taskfile_dict: dict = field(default_factory=dict)
+    taskfile_dict: dict[str, Any] = field(default_factory=dict)
     # make it easier to search a role
-    role_dict: dict = field(default_factory=dict)
+    role_dict: dict[str, Any] = field(default_factory=dict)
     # make it easier to search a playbook
-    playbook_dict: dict = field(default_factory=dict)
+    playbook_dict: dict[str, Any] = field(default_factory=dict)
     # make it easier to search a collection
-    collection_dict: dict = field(default_factory=dict)
+    collection_dict: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -2218,7 +2278,7 @@ class ModuleMetadata:
     deprecated: bool = False
 
     @staticmethod
-    def from_module(m: Module, metadata: dict):
+    def from_module(m: Module, metadata: dict[str, Any]) -> ModuleMetadata:
         mm = ModuleMetadata()
         for key in mm.__dict__:
             if hasattr(m, key):
@@ -2232,7 +2292,7 @@ class ModuleMetadata:
         return mm
 
     @staticmethod
-    def from_routing(dst: str, metadata: dict):
+    def from_routing(dst: str, metadata: dict[str, Any]) -> ModuleMetadata:
         mm = ModuleMetadata()
         mm.fqcn = dst
         mm.type = metadata.get("type", "")
@@ -2243,7 +2303,7 @@ class ModuleMetadata:
         return mm
 
     @staticmethod
-    def from_dict(d: dict):
+    def from_dict(d: dict[str, Any]) -> ModuleMetadata:
         mm = ModuleMetadata()
         mm.fqcn = d.get("fqcn", "")
         mm.type = d.get("type", "")
@@ -2252,7 +2312,7 @@ class ModuleMetadata:
         mm.hash = d.get("hash", "")
         return mm
 
-    def __eq__(self, mm):
+    def __eq__(self, mm: object) -> bool:
         if not isinstance(mm, ModuleMetadata):
             return False
         return (
@@ -2273,7 +2333,7 @@ class RoleMetadata:
     hash: str = ""
 
     @staticmethod
-    def from_role(r: Role, metadata: dict):
+    def from_role(r: Role, metadata: dict[str, Any]) -> RoleMetadata:
         rm = RoleMetadata()
         for key in rm.__dict__:
             if hasattr(r, key):
@@ -2287,7 +2347,7 @@ class RoleMetadata:
         return rm
 
     @staticmethod
-    def from_dict(d: dict):
+    def from_dict(d: dict[str, Any]) -> RoleMetadata:
         rm = RoleMetadata()
         rm.fqcn = d.get("fqcn", "")
         rm.type = d.get("type", "")
@@ -2296,8 +2356,8 @@ class RoleMetadata:
         rm.hash = d.get("hash", "")
         return rm
 
-    def __eq__(self, rm):
-        if not isinstance(rm, ModuleMetadata):
+    def __eq__(self, rm: object) -> bool:
+        if not isinstance(rm, RoleMetadata):
             return False
         return (
             self.fqcn == rm.fqcn
@@ -2317,7 +2377,7 @@ class TaskFileMetadata:
     hash: str = ""
 
     @staticmethod
-    def from_taskfile(tf: TaskFile, metadata: dict):
+    def from_taskfile(tf: TaskFile, metadata: dict[str, Any]) -> TaskFileMetadata:
         tfm = TaskFileMetadata()
         for key in tfm.__dict__:
             if hasattr(tf, key):
@@ -2331,8 +2391,8 @@ class TaskFileMetadata:
         return tfm
 
     @staticmethod
-    def from_dict(d: dict):
-        tfm = RoleMetadata()
+    def from_dict(d: dict[str, Any]) -> TaskFileMetadata:
+        tfm = TaskFileMetadata()
         tfm.key = d.get("key", "")
         tfm.type = d.get("type", "")
         tfm.name = d.get("name", "")
@@ -2340,7 +2400,7 @@ class TaskFileMetadata:
         tfm.hash = d.get("hash", "")
         return tfm
 
-    def __eq__(self, tfm):
+    def __eq__(self, tfm: object) -> bool:
         if not isinstance(tfm, TaskFileMetadata):
             return False
         return (
@@ -2355,14 +2415,16 @@ class TaskFileMetadata:
 @dataclass
 class ActionGroupMetadata:
     group_name: str = ""
-    group_modules: list = field(default_factory=list)
+    group_modules: list[Any] = field(default_factory=list)
     type: str = ""
     name: str = ""
     version: str = ""
     hash: str = ""
 
     @staticmethod
-    def from_action_group(group_name: str, group_modules: list, metadata: dict):
+    def from_action_group(
+        group_name: str, group_modules: list[Any], metadata: dict[str, Any]
+    ) -> ActionGroupMetadata | None:
         if not group_name:
             return None
 
@@ -2379,17 +2441,17 @@ class ActionGroupMetadata:
         return agm
 
     @staticmethod
-    def from_dict(d: dict):
+    def from_dict(d: dict[str, Any]) -> ActionGroupMetadata:
         agm = ActionGroupMetadata()
         agm.group_name = d.get("group_name", "")
-        agm.group_modules = d.get("group_modules", "")
+        agm.group_modules = d.get("group_modules", [])
         agm.type = d.get("type", "")
         agm.name = d.get("name", "")
         agm.version = d.get("version", "")
         agm.hash = d.get("hash", "")
         return agm
 
-    def __eq__(self, agm):
+    def __eq__(self, agm: object) -> bool:
         if not isinstance(agm, ActionGroupMetadata):
             return False
         return (
@@ -2442,39 +2504,40 @@ class RuleMetadata:
     version: str = ""
     commit_id: str = ""
     severity: str = ""
-    tags: tuple = ()
+    tags: tuple[str, ...] = ()
 
 
 @dataclass
 class SpecMutation:
-    key: str = None
-    changes: list = field(default_factory=list)
+    key: str | None = None
+    changes: list[Any] = field(default_factory=list)
     object: Object = field(default_factory=Object)
     rule: RuleMetadata = field(default_factory=RuleMetadata)
 
 
 @dataclass
 class RuleResult:
-    rule: RuleMetadata = None
+    rule: RuleMetadata | None = None
 
     verdict: bool = False
-    detail: dict = None
-    file: tuple = None
-    error: str = None
+    detail: dict[str, Any] | None = None
+    file: tuple[Any, ...] | None = None
+    error: str | None = None
 
     matched: bool = False
-    duration: float = None
+    duration: float | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.verdict:
             self.verdict = True
         else:
             self.verdict = False
 
-    def set_value(self, key: str, value: any):
-        self.detail[key] = value
+    def set_value(self, key: str, value: Any) -> None:
+        if self.detail is not None:
+            self.detail[key] = value
 
-    def get_detail(self):
+    def get_detail(self) -> dict[str, Any] | None:
         return self.detail
 
 
@@ -2491,7 +2554,7 @@ class Rule(RuleMetadata):
     # if there are any spec mutations, re-run the scan later with the mutated spec
     spec_mutation: bool = False
 
-    def __post_init__(self, rule_id: str = "", description: str = ""):
+    def __post_init__(self, rule_id: str = "", description: str = "") -> None:
         if rule_id:
             self.rule_id = rule_id
         if description:
@@ -2506,10 +2569,10 @@ class Rule(RuleMetadata):
     def match(self, ctx: AnsibleRunContext) -> bool:
         raise ValueError("this is a base class method")
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         raise ValueError("this is a base class method")
 
-    def print(self, result: RuleResult):
+    def print(self, result: RuleResult) -> str:
         output = (
             f"ruleID={self.rule_id}, severity={self.severity}, description={self.description}, result={result.verdict}"
         )
@@ -2520,15 +2583,15 @@ class Rule(RuleMetadata):
             output += f", detail={result.detail}"
         return output
 
-    def to_json(self, result: RuleResult):
-        return json.dumps(result.detail)
+    def to_json(self, result: RuleResult) -> str:
+        return str(json.dumps(result.detail))
 
-    def error(self, result: RuleResult):
+    def error(self, result: RuleResult) -> str | None:
         if result.error:
             return result.error
         return None
 
-    def get_metadata(self):
+    def get_metadata(self) -> RuleMetadata:
         return RuleMetadata(
             rule_id=self.rule_id,
             description=self.description,
@@ -2542,25 +2605,25 @@ class Rule(RuleMetadata):
 
 @dataclass
 class NodeResult(JSONSerializable):
-    node: RunTarget = None
+    node: RunTarget | dict[str, Any] | None = None
     rules: list[RuleResult] = field(default_factory=list)
 
-    def results(self):
+    def results(self) -> list[RuleResult]:
         return self.rules
 
-    def find_result(self, rule_id: str):
-        filtered = [r for r in self.rules if r.rule.rule_id == rule_id]
+    def find_result(self, rule_id: str) -> RuleResult | None:
+        filtered = [r for r in self.rules if r.rule and r.rule.rule_id == rule_id]
         if not filtered:
             return None
         return filtered[0]
 
     def search_results(
         self,
-        rule_id: str | list = None,
-        tag: str | list = None,
-        matched: bool = None,
-        verdict: bool = None,
-    ):
+        rule_id: str | list[Any] | None = None,
+        tag: str | list[Any] | None = None,
+        matched: bool | None = None,
+        verdict: bool | None = None,
+    ) -> list[RuleResult]:
         if not rule_id and not tag:
             return self.rules
 
@@ -2571,15 +2634,15 @@ class NodeResult(JSONSerializable):
                 target_rule_ids = [rule_id]
             elif isinstance(rule_id, list):
                 target_rule_ids = rule_id
-            filtered = [r for r in filtered if r.rule.rule_id in target_rule_ids]
+            filtered = [r for r in filtered if r.rule and r.rule.rule_id in target_rule_ids]
 
         if tag:
-            target_tags = []
+            target_tags: list[Any] = []
             if isinstance(tag, str):
                 target_tags = [tag]
             elif isinstance(tag, list):
                 target_tags = tag
-            filtered = [r for r in filtered for t in r.rule.tags if t in target_tags]
+            filtered = [r for r in filtered if r.rule is not None and any(t in target_tags for t in r.rule.tags)]
 
         if matched is not None:
             filtered = [r for r in filtered if r.matched == matched]
@@ -2596,66 +2659,66 @@ class TargetResult(JSONSerializable):
     target_name: str = ""
     nodes: list[NodeResult] = field(default_factory=list)
 
-    def applied_rules(self):
-        results = []
+    def applied_rules(self) -> list[RuleResult]:
+        results: list[RuleResult] = []
         for n in self.nodes:
             matched_rules = n.search_results(matched=True)
             if matched_rules:
-                results.extend()
+                results.extend(matched_rules)
         return results
 
-    def matched_rules(self):
-        results = []
+    def matched_rules(self) -> list[RuleResult]:
+        results: list[RuleResult] = []
         for n in self.nodes:
             matched_rules = n.search_results(verdict=True)
             if matched_rules:
-                results.extend()
+                results.extend(matched_rules)
         return results
 
-    def tasks(self):
+    def tasks(self) -> TargetResult:
         return self._filter(TaskCall)
 
-    def task(self, name):
-        return self._find_by_name(name=name, type=TaskCall)
+    def task(self, name: str) -> NodeResult | None:
+        return self._find_by_name(name=name, target_type=TaskCall)
 
-    def roles(self):
+    def roles(self) -> TargetResult:
         return self._filter(RoleCall)
 
-    def role(self, name):
-        return self._find_by_name(name=name, type=RoleCall)
+    def role(self, name: str) -> NodeResult | None:
+        return self._find_by_name(name=name, target_type=RoleCall)
 
-    def playbooks(self):
+    def playbooks(self) -> TargetResult:
         return self._filter(PlaybookCall)
 
-    def playbook(self, name):
-        return self._find_by_name(name=name, type=PlaybookCall)
+    def playbook(self, name: str) -> NodeResult | None:
+        return self._find_by_name(name=name, target_type=PlaybookCall)
 
-    def plays(self):
+    def plays(self) -> TargetResult:
         return self._filter(PlayCall)
 
-    def play(self, name):
-        return self._find_by_name(name=name, type=PlayCall)
+    def play(self, name: str) -> NodeResult | None:
+        return self._find_by_name(name=name, target_type=PlayCall)
 
-    def taskfiles(self):
+    def taskfiles(self) -> TargetResult:
         return self._filter(TaskFileCall)
 
-    def taskfile(self, name):
-        return self._find_by_name(name=name, type=TaskFileCall)
+    def taskfile(self, name: str) -> NodeResult | None:
+        return self._find_by_name(name=name, target_type=TaskFileCall)
 
-    def _find_by_name(self, name, type: type = None):
+    def _find_by_name(self, name: str, target_type: type[RunTarget] | None = None) -> NodeResult | None:
         nodes = deepcopy(self.nodes)
-        if type:
-            type_only_result = self._filter(type)
+        if target_type:
+            type_only_result = self._filter(target_type)
             if not type_only_result:
                 return None
             nodes = type_only_result.nodes
-        filtered_nodes = [nr for nr in nodes if nr.node.spec.name == name]
+        filtered_nodes = [nr for nr in nodes if nr.node and getattr(getattr(nr.node, "spec", None), "name", "") == name]
         if not filtered_nodes:
             return None
         return filtered_nodes[0]
 
-    def _filter(self, type):
-        filtered_nodes = [nr for nr in self.nodes if isinstance(nr.node, type)]
+    def _filter(self, target_type: type[RunTarget]) -> TargetResult:
+        filtered_nodes = [nr for nr in self.nodes if isinstance(nr.node, target_type)]
         return TargetResult(target_type=self.target_type, target_name=self.target_name, nodes=filtered_nodes)
 
 
@@ -2663,10 +2726,10 @@ class TargetResult(JSONSerializable):
 class ARIResult(JSONSerializable):
     targets: list[TargetResult] = field(default_factory=list)
 
-    def playbooks(self):
+    def playbooks(self) -> ARIResult:
         return self._filter("playbook")
 
-    def playbook(self, name="", path="", yaml_str=""):
+    def playbook(self, name: str = "", path: str = "", yaml_str: str = "") -> TargetResult | None:
         if name:
             return self._find_by_name(name)
 
@@ -2680,16 +2743,16 @@ class ARIResult(JSONSerializable):
 
         return None
 
-    def roles(self):
+    def roles(self) -> ARIResult:
         return self._filter("role")
 
-    def role(self, name):
+    def role(self, name: str) -> TargetResult | None:
         return self._find_by_name(name=name, type_str="role")
 
-    def taskfiles(self):
+    def taskfiles(self) -> ARIResult:
         return self._filter("taskfile")
 
-    def taskfile(self, name="", path="", yaml_str=""):
+    def taskfile(self, name: str = "", path: str = "", yaml_str: str = "") -> TargetResult | None:
         if name:
             return self._find_by_name(name=name, type_str="taskfile")
 
@@ -2703,7 +2766,9 @@ class ARIResult(JSONSerializable):
 
         return None
 
-    def find_target(self, name="", path="", yaml_str="", target_type=""):
+    def find_target(
+        self, name: str = "", path: str = "", yaml_str: str = "", target_type: str = ""
+    ) -> TargetResult | None:
         if name:
             return self._find_by_name(name=name, type_str=target_type)
 
@@ -2717,7 +2782,7 @@ class ARIResult(JSONSerializable):
 
         return None
 
-    def _find_by_name(self, name, type_str=""):
+    def _find_by_name(self, name: str, type_str: str = "") -> TargetResult | None:
         targets = deepcopy(self.targets)
         if type_str:
             type_only_result = self._filter(type_str)
@@ -2729,7 +2794,7 @@ class ARIResult(JSONSerializable):
             return None
         return filtered_targets[0]
 
-    def _find_by_yaml_str(self, yaml_str, type_str):
+    def _find_by_yaml_str(self, yaml_str: str, type_str: str) -> TargetResult | None:
         type_only_result = self._filter(type_str)
         if not type_only_result:
             return None
@@ -2737,13 +2802,13 @@ class ARIResult(JSONSerializable):
             tr
             for tr in type_only_result.targets
             if tr.nodes
-            and hasattr(tr.nodes[0].node.spec, "yaml_lines")
-            and tr.nodes[0].node.spec.yaml_lines == yaml_str
+            and tr.nodes[0].node
+            and getattr(getattr(tr.nodes[0].node, "spec", None), "yaml_lines", "") == yaml_str
         ]
         if not filtered_targets:
             return None
         return filtered_targets[0]
 
-    def _filter(self, type_str):
+    def _filter(self, type_str: str) -> ARIResult:
         filtered_targets = [tr for tr in self.targets if tr.target_type == type_str]
         return ARIResult(targets=filtered_targets)

--- a/src/apme_engine/engine/parser.py
+++ b/src/apme_engine/engine/parser.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import copy
 import os
 from pathlib import Path
+from typing import Any, cast
 
 from . import logger
 from .model_loader import (
@@ -35,25 +38,34 @@ from .utils import (
 
 class Parser:
     def __init__(
-        self, do_save=False, use_ansible_doc=True, skip_playbook_format_error=True, skip_task_format_error=True
-    ):
+        self,
+        do_save: bool = False,
+        use_ansible_doc: bool = True,
+        skip_playbook_format_error: bool = True,
+        skip_task_format_error: bool = True,
+    ) -> None:
         self.do_save = do_save
         self.use_ansible_doc = use_ansible_doc
         self.skip_playbook_format_error = skip_playbook_format_error
         self.skip_task_format_error = skip_task_format_error
 
-    def run(self, load_data=None, load_json_path="", collection_name_of_project=""):
-        ld = Load()
+    def run(
+        self,
+        load_data: Load | None = None,
+        load_json_path: str = "",
+        collection_name_of_project: str = "",
+    ) -> Any:
+        ld: Load = Load()
         if load_data is not None:
             ld = load_data
         elif load_json_path != "":
             if not os.path.exists(load_json_path):
                 raise ValueError(f"file not found: {load_json_path}")
-            ld = Load.from_json(Path(load_json_path).read_text())
+            ld = cast(Load, Load.from_json(Path(load_json_path).read_text()))
 
         collection_name = ""
         role_name = ""
-        obj = None
+        obj: Any = None
         if ld.target_type == LoadType.COLLECTION:
             collection_name = ld.target_name
             try:
@@ -109,7 +121,7 @@ class Parser:
                     skip_playbook_format_error=self.skip_playbook_format_error,
                     skip_task_format_error=self.skip_task_format_error,
                     include_test_contents=ld.include_test_contents,
-                    yaml_label_list=ld.yaml_label_list,
+                    yaml_label_list=cast("list[tuple[str, str, Any]] | None", ld.yaml_label_list),
                 )
             except PlaybookFormatError:
                 if not self.skip_playbook_format_error:
@@ -207,7 +219,7 @@ class Parser:
         else:
             raise ValueError(f"unsupported type: {ld.target_type}")
 
-        mappings = {
+        mappings: dict[str, list[Any]] = {
             "roles": [],
             "taskfiles": [],
             "modules": [],
@@ -301,8 +313,9 @@ class Parser:
             except Exception as e:
                 logger.debug(f"failed to load a playbook: {e}")
                 continue
-            playbooks.append(p)
-            mappings["playbooks"].append([playbook_path, p.key])
+            if p is not None:
+                playbooks.append(p)
+                mappings["playbooks"].append([playbook_path, p.key])
 
         plays = [play for p in playbooks for play in p.plays]
 
@@ -339,8 +352,9 @@ class Parser:
             except Exception as e:
                 logger.debug(f"failed to load a module: {e}")
                 continue
-            modules.append(m)
-            mappings["modules"].append([module_path, m.key])
+            if m is not None:
+                modules.append(m)
+                mappings["modules"].append([module_path, m.key])
 
         files = []
         for file_path in ld.files:
@@ -348,7 +362,8 @@ class Parser:
             try:
                 label = "others"
                 if ld.yaml_label_list:
-                    for _fpath, _label, _ in ld.yaml_label_list:
+                    yaml_labels = cast(list[tuple[str, str, Any]], ld.yaml_label_list)
+                    for _fpath, _label, _ in yaml_labels:
                         if _fpath == file_path:
                             label = _label
                 f = load_file(
@@ -361,8 +376,9 @@ class Parser:
             except Exception as e:
                 logger.debug(f"failed to load a file: {e}")
                 continue
-            files.append(f)
-            mappings["files"].append([file_path, f.key])
+            if f is not None:
+                files.append(f)
+                mappings["files"].append([file_path, f.key])
 
         logger.debug(f"roles: {len(roles)}")
         logger.debug(f"taskfiles: {len(taskfiles)}")
@@ -385,10 +401,10 @@ class Parser:
         elif ld.target_type == LoadType.PROJECT:
             projects = [obj]
 
-        if len(collections) > 0:
-            collections = [c.children_to_key() for c in collections]
-        if len(projects) > 0:
-            projects = [p.children_to_key() for p in projects]
+        if len(collections) > 0 and obj is not None:
+            collections = [obj.children_to_key()]
+        if len(projects) > 0 and obj is not None:
+            projects = [obj.children_to_key()]
         if len(roles) > 0:
             roles = [r.children_to_key() for r in roles]
         if len(taskfiles) > 0:
@@ -426,7 +442,7 @@ class Parser:
         return definitions, ld
 
     @classmethod
-    def restore_definition_objects(cls, input_dir):
+    def restore_definition_objects(cls: type[Any], input_dir: str) -> tuple[dict[str, Any], Load]:
         collections = _load_object_list(Collection, os.path.join(input_dir, "collections.json"))
 
         # TODO: only repository?
@@ -455,15 +471,14 @@ class Parser:
             "tasks": tasks,
         }
 
-        ld = Load()
         mapping_path = os.path.join(input_dir, "mappings.json")
         if not os.path.exists(mapping_path):
             raise ValueError(f"file not found: {mapping_path}")
-        ld = Load.from_json(Path(mapping_path).read_text())
+        ld = cast(Load, Load.from_json(Path(mapping_path).read_text()))
         return definitions, ld
 
     @classmethod
-    def dump_definition_objects(cls, output_dir, definitions, ld):
+    def dump_definition_objects(cls: type[Any], output_dir: str, definitions: dict[str, Any], ld: Load) -> None:
         collections = definitions.get("collections", [])
         if len(collections) > 0:
             _dump_object_list(collections, os.path.join(output_dir, "collections.json"))
@@ -499,7 +514,7 @@ class Parser:
         Path(mapping_path).write_text(ld.dump())
 
 
-def _dump_object_list(obj_list, output_path):
+def _dump_object_list(obj_list: list[Any], output_path: str) -> None:
     tmp_obj_list = copy.deepcopy(obj_list)
     lines = []
     for i in range(len(tmp_obj_list)):
@@ -508,7 +523,7 @@ def _dump_object_list(obj_list, output_path):
     return
 
 
-def _load_object_list(cls, input_path):
+def _load_object_list(cls: type[Any], input_path: str) -> list[Any]:
     obj_list = []
     if os.path.exists(input_path):
         with open(input_path) as f:
@@ -518,7 +533,7 @@ def _load_object_list(cls, input_path):
     return obj_list
 
 
-def load_name2target_name(path):
+def load_name2target_name(path: str) -> str:
     filename = os.path.basename(path)
     parts = os.path.splitext(filename)
     prefix = "load-"

--- a/src/apme_engine/engine/ram_generator.py
+++ b/src/apme_engine/engine/ram_generator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import json
 import os
@@ -11,27 +13,27 @@ from .scanner import ARIScanner, config
 
 
 class RiskAssessmentModelGenerator:
-    _queue: list = []
-    _resume: int = -1
-    _update: bool = False
-
-    start: float = None
+    _queue: list[tuple[str, str]]
+    _resume: int
+    _update: bool
+    _scanner: ARIScanner
+    start: float | None = None
 
     def __init__(
         self,
-        target_list=None,
-        resume=-1,
-        update=False,
-        parallel=True,
-        download_only=False,
-        include_test_contents=False,
-        out_dir=None,
-        no_module_spec=False,
-        no_retry=False,
-    ):
+        target_list: list[tuple[str, str]] | None = None,
+        resume: int = -1,
+        update: bool = False,
+        parallel: bool = True,
+        download_only: bool = False,
+        include_test_contents: bool = False,
+        out_dir: str | None = None,
+        no_module_spec: bool = False,
+        no_retry: bool = False,
+    ) -> None:
         if target_list is None:
             target_list = []
-        self._queue = target_list
+        self._queue = list(target_list)
         self._resume = resume
         self._update = update
         self._parallel = parallel
@@ -60,7 +62,7 @@ class RiskAssessmentModelGenerator:
             write_ram=write_ram,
         )
 
-    def run(self):
+    def run(self) -> None:
         num = len(self._queue)
         resume_str = f"(resume from {self._resume})" if self._resume > 0 else ""
         print(f"Start scanning {num} targets {resume_str}")
@@ -91,8 +93,9 @@ class RiskAssessmentModelGenerator:
             for i, num, _type, _name in input_list:
                 self.scan(i, num, _type, _name)
 
-    def scan(self, i, num, type, name):
-        elapsed = round(time.time() - self.start, 2)
+    def scan(self, i: int, num: int, type: str, name: str) -> None:
+        start_val = self.start if self.start is not None else time.time()
+        elapsed = round(time.time() - start_val, 2)
         start_of_this_scan = time.time()
         thread_id = threading.get_native_id()
         print(f"[{i + 1}/{num}] start {type} {name} ({elapsed} sec. elapsed) (thread: {thread_id})")
@@ -109,6 +112,7 @@ class RiskAssessmentModelGenerator:
             out_dir = None
             if self._out_dir_base:
                 out_dir = os.path.join(self._out_dir_base, type, name)
+            out_dir_str = out_dir if out_dir else ""
             self._scanner.evaluate(
                 type=type,
                 name=name,
@@ -116,7 +120,7 @@ class RiskAssessmentModelGenerator:
                 download_only=self._download_only,
                 include_test_contents=self._include_test_contents,
                 use_src_cache=use_src_cache,
-                out_dir=out_dir,
+                out_dir=out_dir_str,
             )
         except Exception:
             error = traceback.format_exc()
@@ -128,7 +132,7 @@ class RiskAssessmentModelGenerator:
         if elapsed_for_this_scan > 60:
             print(f"WARNING: It took {elapsed_for_this_scan} sec. to process [{i + 1}/{num}] {type} {name}")
 
-    def save_ram_log(self, type, name, fail):
+    def save_ram_log(self, type: str, name: str, fail: bool) -> None:
         out_dir = os.path.join(self._scanner.root_dir, "log", type, name)
         path = os.path.join(out_dir, "ram_log.json")
 
@@ -149,7 +153,7 @@ class RiskAssessmentModelGenerator:
             json.dump(logs, file)
         return
 
-    def skip_scan(self, type, name) -> bool:
+    def skip_scan(self, type: str, name: str) -> bool:
         skip = False
         path = os.path.join(self._scanner.root_dir, "log", type, name, "ram_log.json")
         if not os.path.exists(path):

--- a/src/apme_engine/engine/risk_assessment_model.py
+++ b/src/apme_engine/engine/risk_assessment_model.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import json
 import os
 import tarfile
 from dataclasses import dataclass, field
+from typing import Any, cast
 
 import jsonpickle
 
@@ -42,28 +45,28 @@ action_group_index_name = "action_group_index.json"
 class RAMClient:
     root_dir: str = ""
 
-    findings_json_list_cache: list = field(default_factory=list)
+    findings_json_list_cache: list[str] = field(default_factory=list)
 
-    findings_cache: dict = field(default_factory=dict)
-    findings_search_cache: dict = field(default_factory=dict)
+    findings_cache: dict[str, Any] = field(default_factory=dict)
+    findings_search_cache: dict[str, Any] = field(default_factory=dict)
 
-    module_search_cache: dict = field(default_factory=dict)
-    role_search_cache: dict = field(default_factory=dict)
-    taskfile_search_cache: dict = field(default_factory=dict)
-    task_search_cache: dict = field(default_factory=dict)
+    module_search_cache: dict[str, Any] = field(default_factory=dict)
+    role_search_cache: dict[str, Any] = field(default_factory=dict)
+    taskfile_search_cache: dict[str, Any] = field(default_factory=dict)
+    task_search_cache: dict[str, Any] = field(default_factory=dict)
 
-    builtin_modules_cache: dict = field(default_factory=dict)
+    builtin_modules_cache: dict[str, Any] = field(default_factory=dict)
 
-    module_index: dict = field(default_factory=dict)
-    role_index: dict = field(default_factory=dict)
-    taskfile_index: dict = field(default_factory=dict)
+    module_index: dict[str, Any] = field(default_factory=dict)
+    role_index: dict[str, Any] = field(default_factory=dict)
+    taskfile_index: dict[str, Any] = field(default_factory=dict)
 
     # used for grouped module_defaults such as `group/aws`
-    action_group_index: dict = field(default_factory=dict)
+    action_group_index: dict[str, Any] = field(default_factory=dict)
 
     max_cache_size: int = 200
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         module_index_path = os.path.join(self.root_dir, "indices", module_index_name)
         if os.path.exists(module_index_path):
             with open(module_index_path) as file:
@@ -84,7 +87,7 @@ class RAMClient:
             with open(action_group_index_path) as file:
                 self.action_group_index = json.load(file)
 
-    def clear_old_cache(self):
+    def clear_old_cache(self) -> None:
         size = self.max_cache_size
         self._remove_old_item(self.findings_cache, size)
         self._remove_old_item(self.findings_search_cache, size)
@@ -94,7 +97,7 @@ class RAMClient:
         self._remove_old_item(self.task_search_cache, size)
         return
 
-    def _remove_old_item(self, data: dict, size: int):
+    def _remove_old_item(self, data: dict[str, Any], size: int) -> None:
         if len(data) <= size:
             return
         num = len(data) - size
@@ -103,7 +106,7 @@ class RAMClient:
             data.pop(oldest_key)
         return
 
-    def register(self, findings: Findings):
+    def register(self, findings: Findings) -> None:
         metadata = findings.metadata
 
         type = metadata.get("type", "")
@@ -116,13 +119,13 @@ class RAMClient:
 
         self.clear_old_cache()
 
-    def register_indices_to_ram(self, findings: Findings, include_test_contents: bool = False):
+    def register_indices_to_ram(self, findings: Findings, include_test_contents: bool = False) -> None:
         self.register_module_index_to_ram(findings=findings, include_test_contents=include_test_contents)
         self.register_role_index_to_ram(findings=findings, include_test_contents=include_test_contents)
         self.register_taskfile_index_to_ram(findings=findings, include_test_contents=include_test_contents)
         self.register_action_group_index_to_ram(findings=findings)
 
-    def register_module_index_to_ram(self, findings: Findings, include_test_contents: bool = False):
+    def register_module_index_to_ram(self, findings: Findings, include_test_contents: bool = False) -> None:
         new_data_found = False
         modules = self.load_module_index()
         for module in findings.root_definitions.get("definitions", {}).get("modules", []):
@@ -178,7 +181,7 @@ class RAMClient:
             self.save_module_index(modules)
         return
 
-    def register_role_index_to_ram(self, findings: Findings, include_test_contents: bool = False):
+    def register_role_index_to_ram(self, findings: Findings, include_test_contents: bool = False) -> None:
         new_data_found = False
         roles = self.load_role_index()
         for role in findings.root_definitions.get("definitions", {}).get("roles", []):
@@ -208,7 +211,7 @@ class RAMClient:
             self.save_role_index(roles)
         return
 
-    def register_taskfile_index_to_ram(self, findings: Findings, include_test_contents: bool = False):
+    def register_taskfile_index_to_ram(self, findings: Findings, include_test_contents: bool = False) -> None:
         new_data_found = False
         taskfiles = self.load_taskfile_index()
         for taskfile in findings.root_definitions.get("definitions", {}).get("taskfiles", []):
@@ -238,7 +241,7 @@ class RAMClient:
             self.save_taskfile_index(taskfiles)
         return
 
-    def register_action_group_index_to_ram(self, findings: Findings, include_test_contents: bool = False):
+    def register_action_group_index_to_ram(self, findings: Findings, include_test_contents: bool = False) -> None:
         new_data_found = False
         action_groups = self.load_action_group_index()
 
@@ -291,7 +294,7 @@ class RAMClient:
             self.save_action_group_index(action_groups)
         return
 
-    def make_findings_dir_path(self, type, name, version, hash):
+    def make_findings_dir_path(self, type: str, name: str, version: str, hash: str) -> str:
         type_root = type + "s"
         dir_name = name
         if type in [LoadType.PROJECT, LoadType.PLAYBOOK, LoadType.TASKFILE]:
@@ -301,7 +304,9 @@ class RAMClient:
         out_dir = os.path.join(self.root_dir, type_root, "findings", dir_name, ver_str, hash_str)
         return out_dir
 
-    def load_metadata_from_findings(self, type, name, version, hash="*"):
+    def load_metadata_from_findings(
+        self, type: str, name: str, version: str, hash: str = "*"
+    ) -> tuple[bool, dict[str, Any] | None, list[Any] | None]:
         findings = self.search_findings(name, version, type)
         if not findings:
             return False, None, None
@@ -309,14 +314,16 @@ class RAMClient:
             return False, None, None
         return True, findings.metadata, findings.dependencies
 
-    def load_definitions_from_findings(self, type, name, version, hash, allow_unresolved=False):
+    def load_definitions_from_findings(
+        self, type: str, name: str, version: str, hash: str, allow_unresolved: bool = False
+    ) -> tuple[bool, dict[str, Any], dict[str, Any]]:
         findings_dir = self.make_findings_dir_path(type, name, version, hash)
         findings_path = os.path.join(findings_dir, "findings.json")
         loaded = False
         definitions = {}
         mappings = {}
         if os.path.exists(findings_path):
-            findings = Findings.load(fpath=findings_path)
+            findings = cast(Findings | None, Findings.load(fpath=findings_path))
             # use RAM only if no unresolved dependency
             # (RAM should be fully-resolved specs as much as possible)
             if findings and (len(findings.extra_requirements) == 0 or allow_unresolved):
@@ -326,7 +333,7 @@ class RAMClient:
                     loaded = True
         return loaded, definitions, mappings
 
-    def search_builtin_module(self, name, used_in=""):
+    def search_builtin_module(self, name: str, used_in: str = "") -> list[dict[str, Any]]:
         builtin_modules = {}
         if self.builtin_modules_cache:
             builtin_modules = self.builtin_modules_cache
@@ -355,7 +362,7 @@ class RAMClient:
             )
         return matched_modules
 
-    def load_from_indice(self, short_name, meta, used_in=""):
+    def load_from_indice(self, short_name: str, meta: dict[str, Any], used_in: str = "") -> dict[str, Any]:
         _type = meta.get("type", "")
         _name = meta.get("name", "")
         collection = ""
@@ -387,13 +394,19 @@ class RAMClient:
         return m_wrapper
 
     def search_module(
-        self, name, exact_match=False, max_match=-1, collection_name="", collection_version="", used_in=""
-    ):
+        self,
+        name: str,
+        exact_match: bool = False,
+        max_match: int = -1,
+        collection_name: str = "",
+        collection_version: str = "",
+        used_in: str = "",
+    ) -> list[dict[str, Any]]:
         if max_match == 0:
             return []
         args_str = json.dumps([name, exact_match, max_match, collection_name, collection_version])
         if args_str in self.module_search_cache:
-            return self.module_search_cache[args_str]
+            return cast(list[dict[str, Any]], self.module_search_cache[args_str])
 
         # check if the module is builtin
         matched_builtin_modules = self.search_builtin_module(name, used_in)
@@ -426,8 +439,8 @@ class RAMClient:
                 non_deprecated_cands = [idx for idx in self.module_index[short_name] if not idx["deprecated"]]
                 found_index = non_deprecated_cands[0] if non_deprecated_cands else self.module_index[short_name][0]
 
-        modules_json_list = []
-        if from_indices:
+        modules_json_list: list[str] = []
+        if from_indices and found_index is not None:
             _type = found_index.get("type", "")
             _name = found_index.get("name", "")
             _version = found_index.get("version", "")
@@ -450,7 +463,7 @@ class RAMClient:
             if findings_json in self.findings_cache:
                 modules = self.findings_cache[findings_json].get("modules", [])
             else:
-                f = Findings.load(fpath=findings_json)
+                f = cast(Findings | None, Findings.load(fpath=findings_json))
                 if not isinstance(f, Findings):
                     continue
                 definitions = f.root_definitions.get("definitions", {})
@@ -489,12 +502,14 @@ class RAMClient:
         self.module_search_cache[args_str] = matched_modules
         return matched_modules
 
-    def search_role(self, name, exact_match=False, max_match=-1, used_in=""):
+    def search_role(
+        self, name: str, exact_match: bool = False, max_match: int = -1, used_in: str = ""
+    ) -> list[dict[str, Any]]:
         if max_match == 0:
             return []
         args_str = json.dumps([name, exact_match, max_match])
         if args_str in self.role_search_cache:
-            return self.role_search_cache[args_str]
+            return cast(list[dict[str, Any]], self.role_search_cache[args_str])
 
         from_indices = False
         found_index = None
@@ -502,8 +517,8 @@ class RAMClient:
             from_indices = True
             found_index = self.role_index[name][0]
 
-        roles_json_list = []
-        if from_indices:
+        roles_json_list: list[str] = []
+        if from_indices and found_index is not None:
             _type = found_index.get("type", "")
             _name = found_index.get("name", "")
             _version = found_index.get("version", "")
@@ -526,7 +541,7 @@ class RAMClient:
             if findings_json in self.findings_cache:
                 roles = self.findings_cache[findings_json].get("roles", [])
             else:
-                f = Findings.load(fpath=findings_json)
+                f = cast(Findings | None, Findings.load(fpath=findings_json))
                 if not isinstance(f, Findings):
                     continue
                 definitions = f.root_definitions.get("definitions", {})
@@ -582,7 +597,7 @@ class RAMClient:
         self.role_search_cache[args_str] = matched_roles
         return matched_roles
 
-    def make_taskfile_key_candidates(self, name, from_path, from_key):
+    def make_taskfile_key_candidates(self, name: str, from_path: str, from_key: str) -> list[str]:
         key_candidates = []
         taskfile_ref = name
         if from_path:
@@ -598,7 +613,15 @@ class RAMClient:
 
         return key_candidates
 
-    def search_taskfile(self, name, from_path="", from_key="", max_match=-1, is_key=False, used_in=""):
+    def search_taskfile(
+        self,
+        name: str,
+        from_path: str = "",
+        from_key: str = "",
+        max_match: int = -1,
+        is_key: bool = False,
+        used_in: str = "",
+    ) -> list[dict[str, Any]]:
         if max_match == 0:
             return []
 
@@ -608,13 +631,14 @@ class RAMClient:
 
         args_str = json.dumps([name, from_path, from_key, max_match, is_key])
         if args_str in self.taskfile_search_cache:
-            return self.taskfile_search_cache[args_str]
+            return cast(list[dict[str, Any]], self.taskfile_search_cache[args_str])
 
         from_indices = False
-        found_index = None
+        found_index: dict[str, Any] | None = None
         found_key = ""
-        taskfile_key_candidates = []
-        taskfile_key_candidates = [name] if is_key else self.make_taskfile_key_candidates(name, from_path, from_key)
+        taskfile_key_candidates: list[str] = (
+            [name] if is_key else self.make_taskfile_key_candidates(name, from_path, from_key)
+        )
         for taskfile_key in taskfile_key_candidates:
             if taskfile_key in self.taskfile_index and self.taskfile_index[taskfile_key]:
                 from_indices = True
@@ -622,9 +646,9 @@ class RAMClient:
                 found_key = taskfile_key
                 break
 
-        taskfiles_json_list = []
-        content_info = None
-        if from_indices:
+        taskfiles_json_list: list[str] = []
+        content_info: dict[str, Any] | None = None
+        if from_indices and found_index is not None:
             _type = found_index.get("type", "")
             _name = found_index.get("name", "")
             _version = found_index.get("version", "")
@@ -648,7 +672,7 @@ class RAMClient:
             if findings_json in self.findings_cache:
                 taskfiles = self.findings_cache[findings_json].get("taskfiles", [])
             else:
-                f = Findings.load(fpath=findings_json)
+                f = cast(Findings | None, Findings.load(fpath=findings_json))
                 if not isinstance(f, Findings):
                     continue
                 definitions = f.root_definitions.get("definitions", {})
@@ -704,7 +728,15 @@ class RAMClient:
                 break
         return matched_taskfiles
 
-    def search_task(self, name, exact_match=False, max_match=-1, is_key=False, content_info=None, used_in=""):
+    def search_task(
+        self,
+        name: str,
+        exact_match: bool = False,
+        max_match: int = -1,
+        is_key: bool = False,
+        content_info: dict[str, Any] | None = None,
+        used_in: str = "",
+    ) -> list[dict[str, Any]]:
         if max_match == 0:
             return []
         # search task in RAM must be done for a specific content (collection/role)
@@ -714,15 +746,15 @@ class RAMClient:
 
         args_str = json.dumps([name, exact_match, max_match, is_key, content_info])
         if args_str in self.task_search_cache:
-            return self.task_search_cache[args_str]
+            return cast(list[dict[str, Any]], self.task_search_cache[args_str])
 
-        tasks_json_list = []
-        _type = content_info.get("type", "")
+        tasks_json_list: list[str] = []
+        _type = content_info.get("type", "") if content_info else ""
         if _type:
             _type = _type + "s"
-        _name = content_info.get("name", "")
-        _version = content_info.get("version", "")
-        _hash = content_info.get("hash", "")
+        _name = content_info.get("name", "") if content_info else ""
+        _version = content_info.get("version", "") if content_info else ""
+        _hash = content_info.get("hash", "") if content_info else ""
         findings_path = os.path.join(self.root_dir, _type, "findings", _name, _version, _hash, "findings.json")
         if os.path.exists(findings_path):
             tasks_json_list.append(findings_path)
@@ -734,7 +766,7 @@ class RAMClient:
             if findings_json in self.findings_cache:
                 tasks = self.findings_cache[findings_json].get("tasks", [])
             else:
-                f = Findings.load(fpath=findings_json)
+                f = cast(Findings | None, Findings.load(fpath=findings_json))
                 if not isinstance(f, Findings):
                     continue
                 definitions = f.root_definitions.get("definitions", {})
@@ -801,7 +833,7 @@ class RAMClient:
         self.task_search_cache[args_str] = matched_tasks
         return matched_tasks
 
-    def search_action_group(self, name, max_match=-1):
+    def search_action_group(self, name: str, max_match: int = -1) -> list[Any]:
         if max_match == 0:
             return []
 
@@ -813,7 +845,7 @@ class RAMClient:
             found_groups = found_groups[:max_match]
         return found_groups
 
-    def get_object_by_key(self, obj_key: str):
+    def get_object_by_key(self, obj_key: str) -> dict[str, Any] | None:
         obj_info = get_obj_info_by_key(obj_key)
         obj_type = obj_info.get("type", "")
         parent_name = obj_info.get("parent_name", "")
@@ -848,7 +880,7 @@ class RAMClient:
                 }
         return matched_obj
 
-    def init_findings_json_list_cache(self):
+    def init_findings_json_list_cache(self) -> None:
         search_patterns = os.path.join(self.root_dir, "collections", "findings", "*", "*", "*", "findings.json")
         findings_json_list_coll = safe_glob(search_patterns)
         findings_json_list_coll = sort_by_version(findings_json_list_coll)
@@ -858,7 +890,7 @@ class RAMClient:
         findings_json_list = findings_json_list_coll + findings_json_list_role
         self.findings_json_list_cache = findings_json_list
 
-    def list_all_ram_metadata(self):
+    def list_all_ram_metadata(self) -> list[dict[str, str]]:
         if not self.findings_json_list_cache:
             self.init_findings_json_list_cache()
         findings_json_list = self.findings_json_list_cache
@@ -877,12 +909,17 @@ class RAMClient:
             )
         return metadata_list
 
-    def search_findings(self, target_name, target_version, target_type=None):
+    def search_findings(
+        self,
+        target_name: str,
+        target_version: str,
+        target_type: str | None = None,
+    ) -> Findings | None:
         if not self.findings_json_list_cache:
             self.init_findings_json_list_cache()
         args_str = json.dumps([target_name, target_version, target_type])
         if args_str in self.findings_search_cache:
-            return self.findings_search_cache[args_str]
+            return cast(Findings | None, self.findings_search_cache[args_str])
 
         if not target_name:
             raise ValueError("target name must be specified for searching RAM data")
@@ -921,16 +958,16 @@ class RAMClient:
         self.findings_search_cache[args_str] = findings
         return findings
 
-    def load_findings(self, path: str):
+    def load_findings(self, path: str) -> Findings | None:
         basename = os.path.basename(path)
         dir_path = path
         if basename == "findings.json":
             dir_path = os.path.dirname(path)
 
-        findings = Findings.load(fpath=os.path.join(dir_path, "findings.json"))
+        findings = cast(Findings | None, Findings.load(fpath=os.path.join(dir_path, "findings.json")))
         return findings
 
-    def save_findings(self, findings: Findings, out_dir: str):
+    def save_findings(self, findings: Findings, out_dir: str) -> None:
         if out_dir == "":
             raise ValueError("output dir must be a non-empty value")
 
@@ -939,7 +976,7 @@ class RAMClient:
 
         findings.dump(fpath=os.path.join(out_dir, "findings.json"))
 
-    def save_index(self, index_objects, filename):
+    def save_index(self, index_objects: Any, filename: str) -> None:
         out_dir = os.path.join(self.root_dir, "indices")
         if not os.path.exists(out_dir):
             os.makedirs(out_dir, exist_ok=True)
@@ -953,7 +990,7 @@ class RAMClient:
             unlock_file(lock)
             remove_lock_file(lock)
 
-    def load_index(self, filename=""):
+    def load_index(self, filename: str = "") -> dict[str, Any]:
         path = os.path.join(self.root_dir, "indices", filename)
         index_objects = {}
         if os.path.exists(path):
@@ -961,31 +998,31 @@ class RAMClient:
                 index_objects = json.load(file)
         return index_objects
 
-    def save_module_index(self, modules):
+    def save_module_index(self, modules: dict[str, Any]) -> None:
         return self.save_index(modules, module_index_name)
 
-    def load_module_index(self):
+    def load_module_index(self) -> dict[str, Any]:
         return self.load_index(module_index_name)
 
-    def save_role_index(self, roles):
+    def save_role_index(self, roles: dict[str, Any]) -> None:
         return self.save_index(roles, role_index_name)
 
-    def load_role_index(self):
+    def load_role_index(self) -> dict[str, Any]:
         return self.load_index(role_index_name)
 
-    def save_taskfile_index(self, taskfiles):
+    def save_taskfile_index(self, taskfiles: dict[str, Any]) -> None:
         return self.save_index(taskfiles, taskfile_index_name)
 
-    def load_taskfile_index(self):
+    def load_taskfile_index(self) -> dict[str, Any]:
         return self.load_index(taskfile_index_name)
 
-    def save_action_group_index(self, action_groups):
+    def save_action_group_index(self, action_groups: dict[str, Any]) -> None:
         return self.save_index(action_groups, action_group_index_name)
 
-    def load_action_group_index(self):
+    def load_action_group_index(self) -> dict[str, Any]:
         return self.load_index(action_group_index_name)
 
-    def save_error(self, error: str, out_dir: str):
+    def save_error(self, error: str, out_dir: str) -> None:
         if out_dir == "":
             raise ValueError("output dir must be a non-empty value")
 
@@ -995,7 +1032,7 @@ class RAMClient:
         with open(os.path.join(out_dir, "error.log"), "w") as file:
             file.write(error)
 
-    def diff(self, target_name, version1, version2):
+    def diff(self, target_name: str, version1: str, version2: str) -> list[dict[str, str]]:
         findings1 = self.search_findings(target_name=target_name, target_version=version1)
         if not findings1:
             raise ValueError(f"{target_name}:{version1} is not found in RAM")
@@ -1020,9 +1057,10 @@ class RAMClient:
         if not files2:
             raise ValueError(f"Files data of {target_name}:{version2} is not recorded")
 
-        return diff_files_data(files1, files2)
+        result: list[dict[str, str]] = diff_files_data(files1, files2)
+        return result
 
-    def release(self, outfile):
+    def release(self, outfile: str) -> None:
         indices = os.path.join(self.root_dir, "indices")
         collection_findings = os.path.join(self.root_dir, "collections", "findings")
         role_findings = os.path.join(self.root_dir, "roles", "findings")
@@ -1036,17 +1074,17 @@ class RAMClient:
 
 
 # newer version comes earlier, so version num should be sorted in a reversed order
-def _path_to_reversed_version_num(path):
+def _path_to_reversed_version_num(path: str) -> float:
     version = path.split("/findings/")[-1].split("/")[1]
-    return -1 * version_to_num(version)
+    return float(-1 * version_to_num(version))
 
 
-def _path_to_collection_name(path):
+def _path_to_collection_name(path: str) -> str:
     collection = path.split("/findings/")[-1].split("/")[0]
     return collection
 
 
 # the latest known version comes first
 # `unknown` is the last
-def sort_by_version(path_list):
+def sort_by_version(path_list: list[str]) -> list[str]:
     return sorted(path_list, key=lambda x: (_path_to_collection_name(x), _path_to_reversed_version_num(x)))

--- a/src/apme_engine/engine/risk_detector.py
+++ b/src/apme_engine/engine/risk_detector.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import argparse
 import contextlib
 import json
 import os
 import time
 import traceback
+from typing import Any
 
 from . import logger
 from .analyzer import load_taskcalls_in_trees
@@ -25,11 +28,11 @@ from .utils import load_classes_in_dir
 rule_versions_filename = "rule_versions.json"
 
 
-def key2name(key: str):
+def key2name(key: str) -> str:
     return key.split(key_delimiter)[-1]
 
 
-def load_rule_versions_file(filepath: str):
+def load_rule_versions_file(filepath: str) -> dict[str, Any]:
     if not os.path.exists(filepath):
         return {}
 
@@ -50,8 +53,11 @@ def load_rule_versions_file(filepath: str):
 
 
 def load_rules(
-    rules_dir: str = "", rule_id_list: list = None, fail_on_error: bool = False, exclude_rule_ids: list = None
-):
+    rules_dir: str = "",
+    rule_id_list: list[str] | None = None,
+    fail_on_error: bool = False,
+    exclude_rule_ids: list[str] | None = None,
+) -> list[Rule]:
     if rule_id_list is None:
         rule_id_list = []
     if not rules_dir:
@@ -96,7 +102,7 @@ def load_rules(
     # sort by `rules` configuration for ARIScanner
     if rule_id_list:
 
-        def index(_list, x):
+        def index(_list: list[str], x: Rule) -> int:
             if x.rule_id in _list:
                 return _list.index(x.rule_id)
             else:
@@ -110,7 +116,7 @@ def load_rules(
     return _rules
 
 
-def make_subject_str(playbook_num: int, role_num: int):
+def make_subject_str(playbook_num: int, role_num: int) -> str:
     subject = ""
     if playbook_num > 0 and role_num > 0:
         subject = "playbooks/roles"
@@ -124,23 +130,25 @@ def make_subject_str(playbook_num: int, role_num: int):
 def detect(
     contexts: list[AnsibleRunContext],
     rules_dir: str = "",
-    rules: list = None,
-    rules_cache: list = None,
+    rules: list[Rule] | None = None,
+    rules_cache: list[Rule] | None = None,
     save_only_rule_result: bool = False,
-    exclude_rule_ids: list = None,
-):
+    exclude_rule_ids: list[str] | None = None,
+) -> tuple[dict[str, Any], list[Rule]]:
     if rules_cache is None:
         rules_cache = []
     if rules is None:
         rules = []
-    loaded_rules = []
-    loaded_rules = rules_cache or load_rules(rules_dir, rules, False, exclude_rule_ids=exclude_rule_ids or [])
+    rule_ids: list[str] | None = [r.rule_id for r in rules] if rules else None
+    loaded_rules: list[Rule] = rules_cache or load_rules(
+        rules_dir, rule_ids, False, exclude_rule_ids=exclude_rule_ids or []
+    )
 
     playbook_count = {"total": 0, "risk_found": 0}
     role_count = {"total": 0, "risk_found": 0}
 
-    data_report = {"summary": {}, "details": [], "ari_result": None}
-    role_to_playbook_mappings = {}
+    data_report: dict[str, Any] = {"summary": {}, "details": [], "ari_result": None}
+    role_to_playbook_mappings: dict[str, list[str]] = {}
 
     ari_result = ARIResult()
     spec_mutations = {}
@@ -162,7 +170,8 @@ def detect(
             playbook_count["total"] += 1
 
             for task in ctx.taskcalls:
-                parts = task.spec.defined_in.split("/")
+                defined_in = getattr(task.spec, "defined_in", "") if task.spec else ""
+                parts = defined_in.split("/")
                 if parts[0] == "roles":
                     role_name = parts[1]
                     _mappings = role_to_playbook_mappings.get(role_name, [])
@@ -181,7 +190,7 @@ def detect(
                 rule_id = rule.rule_id
                 start_time = time.time()
                 r_result = RuleResult(file=t.file_info(), rule=rule.get_metadata())
-                detail = {}
+                detail: dict[str, Any] = {}
                 try:
                     matched = rule.match(ctx)
                     if matched:
@@ -190,13 +199,13 @@ def detect(
                             r_result = tmp_result
                         r_result.matched = matched
                     r_result.duration = round((time.time() - start_time) * 1000, 6)
-                    detail = r_result.get_detail()
+                    detail = r_result.get_detail() or {}
                     fatal = detail.get("fatal", False) if detail else False
                     if fatal:
                         error = r_result.error or "unknown error"
                         error = f"ARI rule evaluation threw fatal exception: RuleID={rule_id}, error={error}"
                         raise FatalRuleResultError(error)
-                    if rule.spec_mutation and isinstance(detail, dict):
+                    if rule.spec_mutation:
                         s_mutations = detail.get("spec_mutations", [])
                         for s_mutation in s_mutations:
                             if not isinstance(s_mutation, SpecMutation):
@@ -208,8 +217,8 @@ def detect(
                     exc = traceback.format_exc()
                     r_result.error = f"failed to execute the rule `{rule.rule_id}`: {exc}"
                 n_result.rules.append(r_result)
-            # remove node details
-            if save_only_rule_result:
+            # remove node details (replace node with summary dict when save_only_rule_result)
+            if save_only_rule_result and n_result.node is not None and isinstance(n_result.node, RunTarget):
                 n_result.node = omit_node_details(n_result.node)
             t_result.nodes.append(n_result)
         ari_result.targets.append(t_result)
@@ -220,16 +229,16 @@ def detect(
     return data_report, loaded_rules
 
 
-def omit_node_details(node: RunTarget):
+def omit_node_details(node: RunTarget) -> dict[str, Any]:
     spec = None
     if node.spec:
         spec = {
-            "type": node.spec.type,
-            "name": node.spec.name,
-            "defined_in": node.spec.defined_in,
+            "type": getattr(node.spec, "type", ""),
+            "name": getattr(node.spec, "name", ""),
+            "defined_in": getattr(node.spec, "defined_in", ""),
         }
-        if isinstance(node, TaskCall):
-            spec["line_num_in_file"] = (node.spec.line_num_in_file,)
+        if isinstance(node, TaskCall) and node.spec:
+            spec["line_num_in_file"] = (getattr(node.spec, "line_num_in_file", 0),)
     summary = {
         "type": node.type,
         "spec": spec,
@@ -237,7 +246,7 @@ def omit_node_details(node: RunTarget):
     return summary
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         prog="risk_detector.py",
         description="Detect risks from tasks by checking rules",
@@ -257,8 +266,16 @@ def main():
     args = parser.parse_args()
 
     tasks_in_trees = load_taskcalls_in_trees(args.input)
-
-    detect(tasks_in_trees)
+    # Convert TaskCallsInTree to AnsibleRunContext for detect()
+    contexts: list[AnsibleRunContext] = []
+    for tct in tasks_in_trees:
+        ctx = AnsibleRunContext.from_targets(
+            targets=tct.taskcalls,
+            root_key=tct.root_key,
+        )
+        contexts.append(ctx)
+    if contexts:
+        detect(contexts)
 
 
 if __name__ == "__main__":

--- a/src/apme_engine/engine/safe_glob.py
+++ b/src/apme_engine/engine/safe_glob.py
@@ -1,11 +1,20 @@
+from __future__ import annotations
+
 import os
 import re
 import sys
+from typing import Any
 
 
 # glob.glob() may cause infinite loop when there is symlink loop
 # safe_glob() support the case by `followlink=False` option as default
-def safe_glob(patterns, root_dir="", recursive=True, type=None, followlinks=False):
+def safe_glob(
+    patterns: str | list[str],
+    root_dir: str = "",
+    recursive: bool = True,
+    type: list[str] | None = None,
+    followlinks: bool = False,
+) -> list[str]:
     if type is None:
         type = ["file", "dir"]
     pattern_list = []
@@ -75,15 +84,17 @@ def safe_glob(patterns, root_dir="", recursive=True, type=None, followlinks=Fals
     return matched_files
 
 
-def pattern_match(pattern, fpath):
+def pattern_match(pattern: str, fpath: str) -> Any:
     pattern = pattern.replace("**/", "<ANY>")
     pattern = pattern.replace("*", "[^/]*")
     pattern = pattern.replace("<ANY>", ".*")
     regex_pattern = rf"^{pattern}$"
-    return re.match(regex_pattern, fpath)
+    result = re.match(regex_pattern, fpath)
+    return result
 
 
 if __name__ == "__main__":
-    dir, pattern = sys.argv[1], sys.argv[2]
-    found = safe_glob(dir, [pattern], recursive=False)
+    root_dir: str = sys.argv[1]
+    pattern = sys.argv[2]
+    found = safe_glob(pattern, root_dir=root_dir, recursive=False)
     print(found)

--- a/src/apme_engine/engine/scanner.py
+++ b/src/apme_engine/engine/scanner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import datetime
 import json
@@ -6,6 +8,7 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import jsonpickle
 import yaml
@@ -51,7 +54,7 @@ default_config_path = ARI_CONFIG_PATH or os.path.expanduser("~/.ari/config")
 default_data_dir = os.path.join("/tmp", "ari-data")
 default_rules_dir = os.path.join(os.path.dirname(__file__), "rules")
 default_log_level = "info"
-default_rules = []
+default_rules: list[Any] = []
 default_disable_default_rules = False
 default_logger_key = "ari"
 
@@ -64,12 +67,12 @@ class Config:
     rules_dir: str = ""
     logger_key: str = ""
     log_level: str = ""
-    rules: list = field(default_factory=list)
+    rules: list[Any] = field(default_factory=list)
     disable_default_rules: bool = False
 
-    _data: dict = field(default_factory=dict)
+    _data: dict[str, Any] = field(default_factory=dict)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not self.path:
             self.path = default_config_path
         config_data = {}
@@ -104,12 +107,17 @@ class Config:
             self.rules = self._get_single_config("ARI_RULES", "rules", default_rules, "list", ",")
 
     def _get_single_config(
-        self, env_key: str = "", yaml_key: str = "", __default: any = None, __type=None, separator=""
-    ):
+        self,
+        env_key: str = "",
+        yaml_key: str = "",
+        __default: Any = None,
+        __type: Any = None,
+        separator: str = "",
+    ) -> Any:
         if env_key in os.environ:
-            _from_env = os.environ.get(env_key, None)
+            _from_env: Any = os.environ.get(env_key, None)
             if _from_env and __type and __type == "list":
-                _from_env = _from_env.split(separator)
+                _from_env = _from_env.split(separator) if isinstance(_from_env, str) else _from_env
             return _from_env
         elif yaml_key in self._data:
             _from_file = self._data.get(yaml_key, None)
@@ -142,36 +150,36 @@ class SingleScan:
     name: str = ""
     collection_name: str = ""
     role_name: str = ""
-    target_playbook_name: str = None
+    target_playbook_name: str | None = None
     playbook_yaml: str = ""
     playbook_only: bool = False
-    target_taskfile_name: str = None
+    target_taskfile_name: str | None = None
     taskfile_yaml: str = ""
     taskfile_only: bool = False
 
-    skip_playbook_format_error: bool = (True,)
-    skip_task_format_error: bool = (True,)
+    skip_playbook_format_error: bool = True
+    skip_task_format_error: bool = True
 
     install_log: str = ""
-    tmp_install_dir: tempfile.TemporaryDirectory = None
+    tmp_install_dir: tempfile.TemporaryDirectory[Any] | None = None
 
-    index: dict = field(default_factory=dict)
+    index: dict[str, Any] = field(default_factory=dict)
 
-    root_definitions: dict = field(default_factory=dict)
-    ext_definitions: dict = field(default_factory=dict)
+    root_definitions: dict[str, Any] = field(default_factory=dict)
+    ext_definitions: dict[str, Any] = field(default_factory=dict)
 
     target_object: Object = field(default_factory=Object)
 
-    trees: list = field(default_factory=list)
+    trees: list[Any] = field(default_factory=list)
     # for inventory object
     additional: ObjectList = field(default_factory=ObjectList)
 
-    taskcalls_in_trees: list = field(default_factory=list)
-    contexts: list = field(default_factory=list)
+    taskcalls_in_trees: list[Any] = field(default_factory=list)
+    contexts: list[Any] = field(default_factory=list)
 
-    data_report: dict = field(default_factory=dict)
+    data_report: dict[str, Any] = field(default_factory=dict)
 
-    __path_mappings: dict = field(default_factory=dict)
+    __path_mappings: dict[str, Any] = field(default_factory=dict)
 
     install_dependencies: bool = False
     use_ansible_path: bool = False
@@ -179,10 +187,10 @@ class SingleScan:
     dependency_dir: str = ""
     base_dir: str = ""
     target_path: str = ""
-    loaded_dependency_dirs: list = field(default_factory=list)
+    loaded_dependency_dirs: Any = field(default_factory=list)
     use_src_cache: bool = True
 
-    prm: dict = field(default_factory=dict)
+    prm: dict[str, Any] = field(default_factory=dict)
 
     download_url: str = ""
     version: str = ""
@@ -193,33 +201,33 @@ class SingleScan:
 
     include_test_contents: bool = False
     load_all_taskfiles: bool = False
-    yaml_label_list: list = field(default_factory=list)
+    yaml_label_list: list[Any] = field(default_factory=list)
 
     save_only_rule_result: bool = False
 
-    extra_requirements: list = field(default_factory=list)
-    resolve_failures: dict = field(default_factory=dict)
+    extra_requirements: list[Any] = field(default_factory=list)
+    resolve_failures: dict[str, Any] = field(default_factory=dict)
 
-    findings: Findings = None
-    result: ARIResult = None
+    findings: Findings | None = None
+    result: ARIResult | None = None
 
     # OPA input: hierarchy + annotations (set by build_hierarchy_payload when native rules are disabled)
-    hierarchy_payload: dict = field(default_factory=dict)
+    hierarchy_payload: dict[str, Any] = field(default_factory=dict)
 
     # the following are set by ARIScanner
     root_dir: str = ""
     rules_dir: str = ""
-    rules: list = field(default_factory=list)
-    rules_cache: list = field(default_factory=list)
+    rules: list[Any] = field(default_factory=list)
+    rules_cache: list[Any] = field(default_factory=list)
     persist_dependency_cache: bool = False
-    spec_mutations_from_previous_scan: dict = field(default_factory=dict)
-    spec_mutations: dict = field(default_factory=dict)
+    spec_mutations_from_previous_scan: dict[str, Any] = field(default_factory=dict)
+    spec_mutations: dict[str, Any] = field(default_factory=dict)
     use_ansible_doc: bool = True
     do_save: bool = False
     silent: bool = False
-    _parser: Parser = None
+    _parser: Parser | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.type == LoadType.COLLECTION or self.type == LoadType.ROLE:
             type_root = self.type + "s"
             target_name = self.name
@@ -320,7 +328,7 @@ class SingleScan:
                 self.name = "__in_memory__"
                 self.target_taskfile_name = self.name
 
-    def make_target_path(self, typ, target_name, dep_dir=""):
+    def make_target_path(self, typ: str, target_name: str, dep_dir: str = "") -> str:
         target_path = ""
 
         if dep_dir:
@@ -357,14 +365,14 @@ class SingleScan:
                 target_path = target_name
         return target_path
 
-    def get_src_root(self):
-        return self.__path_mappings["src"]
+    def get_src_root(self) -> str:
+        return str(self.__path_mappings["src"])
 
-    def is_src_installed(self):
+    def is_src_installed(self) -> bool:
         index_location = self.__path_mappings["index"]
         return os.path.exists(index_location)
 
-    def _prepare_dependencies(self, root_install=True):
+    def _prepare_dependencies(self, root_install: bool = True) -> tuple[str, Any]:
         # Install the target if needed
         target_path = self.make_target_path(self.type, self.name)
 
@@ -399,7 +407,7 @@ class SingleScan:
 
         return target_path, dep_dirs
 
-    def create_load_file(self, target_type, target_name, target_path):
+    def create_load_file(self, target_type: str, target_name: str, target_path: str) -> Load:
         loader_version = get_loader_version()
 
         if not os.path.exists(target_path) and not self.playbook_yaml and not self.taskfile_yaml:
@@ -425,7 +433,7 @@ class SingleScan:
         load_object(ld)
         return ld
 
-    def get_definition_path(self, ext_type, ext_name):
+    def get_definition_path(self, ext_type: str, ext_name: str) -> str:
         target_path = ""
         if ext_type == LoadType.ROLE:
             target_path = os.path.join(
@@ -441,7 +449,7 @@ class SingleScan:
             raise ValueError("Invalid ext_type")
         return target_path
 
-    def load_definition_ext(self, target_type, target_name, target_path):
+    def load_definition_ext(self, target_type: str, target_name: str, target_path: str) -> None:
         ld = self.create_load_file(target_type, target_name, target_path)
         use_cache = True
         output_dir = self.get_definition_path(ld.target_type, ld.target_name)
@@ -450,6 +458,8 @@ class SingleScan:
                 logger.debug(f"use cache from {output_dir}")
             definitions, mappings = Parser.restore_definition_objects(output_dir)
         else:
+            if self._parser is None:
+                raise ValueError("Parser not initialized")
             definitions, mappings = self._parser.run(load_data=ld)
             if self.do_save:
                 if output_dir == "":
@@ -465,7 +475,7 @@ class SingleScan:
         }
         return
 
-    def _set_load_root(self, target_path=""):
+    def _set_load_root(self, target_path: str = "") -> Load | None:
         root_load_data = None
         if self.type in [LoadType.ROLE, LoadType.COLLECTION]:
             ext_type = self.type
@@ -480,7 +490,7 @@ class SingleScan:
             root_load_data = self.create_load_file(self.type, self.name, target_path)
         return root_load_data
 
-    def get_source_path(self, ext_type, ext_name, is_ext_for_project=False):
+    def get_source_path(self, ext_type: str, ext_name: str, is_ext_for_project: bool = False) -> str:
         base_dir = ""
         if is_ext_for_project:
             base_dir = self.__path_mappings["dependencies"]
@@ -505,10 +515,12 @@ class SingleScan:
             raise ValueError("Invalid ext_type")
         return target_path
 
-    def load_definitions_root(self, target_path=""):
+    def load_definitions_root(self, target_path: str = "") -> None:
         output_dir = self.__path_mappings["root_definitions"]
         root_load = self._set_load_root(target_path=target_path)
 
+        if self._parser is None:
+            raise ValueError("Parser not initialized")
         definitions, mappings = self._parser.run(load_data=root_load, collection_name_of_project=self.collection_name)
         if self.do_save:
             if output_dir == "":
@@ -522,7 +534,7 @@ class SingleScan:
             "mappings": mappings,
         }
 
-    def apply_spec_mutations(self):
+    def apply_spec_mutations(self) -> None:
         if not self.spec_mutations_from_previous_scan:
             return
         # overwrite the loaded object with the mutated object in spec mutations
@@ -535,7 +547,7 @@ class SingleScan:
                     self.root_definitions["definitions"][type_name][i] = mutated_spec
         return
 
-    def set_target_object(self):
+    def set_target_object(self) -> None:
         type_name = self.type + "s"
         obj_list = self.root_definitions.get("definitions", {}).get(type_name, [])
         if len(obj_list) == 0:
@@ -551,7 +563,7 @@ class SingleScan:
                     break
         return
 
-    def construct_trees(self, ram_client=None):
+    def construct_trees(self, ram_client: RAMClient | None = None) -> None:
         trees, additional, extra_requirements, resolve_failures = tree(
             self.root_definitions,
             self.ext_definitions,
@@ -595,7 +607,7 @@ class SingleScan:
                     logger.info("  tree file saved")
         return
 
-    def resolve_variables(self, ram_client=None):
+    def resolve_variables(self, ram_client: RAMClient | None = None) -> None:
         taskcalls_in_trees = resolve(self.trees, self.additional)
         self.taskcalls_in_trees = taskcalls_in_trees
 
@@ -625,7 +637,7 @@ class SingleScan:
             Path(tasks_in_t_path).write_text("\n".join(tasks_in_t_lines))
         return
 
-    def annotate(self):
+    def annotate(self) -> None:
         contexts = analyze(self.contexts)
         self.contexts = contexts
 
@@ -641,7 +653,7 @@ class SingleScan:
 
         return
 
-    def _node_to_dict(self, node):
+    def _node_to_dict(self, node: Any) -> dict[str, Any]:
         """Serialize a RunTarget (playcall, rolecall, taskcall, etc.) to a JSON-serializable dict for OPA input."""
         d = {"type": getattr(node, "type", ""), "key": getattr(node, "key", "")}
         spec = getattr(node, "spec", None)
@@ -698,7 +710,7 @@ class SingleScan:
                     d["module_options"] = {str(k): self._json_safe(v) for k, v in mo.items()}
         return d
 
-    def _opts_for_opa(self, opts, keys):
+    def _opts_for_opa(self, opts: dict[str, Any], keys: list[str]) -> dict[str, Any]:
         """Return a JSON-serializable subset of opts for OPA (only listed keys that exist)."""
         out = {}
         for k in keys:
@@ -709,7 +721,7 @@ class SingleScan:
                 out[k] = self._json_safe(v)
         return out
 
-    def _json_safe(self, v):
+    def _json_safe(self, v: Any) -> Any:
         """Coerce value to a JSON-serializable form."""
         if v is None:
             return None
@@ -721,7 +733,7 @@ class SingleScan:
             return {str(k): self._json_safe(x) for k, x in v.items()}
         return str(v)
 
-    def _location_to_dict(self, loc) -> dict | None:
+    def _location_to_dict(self, loc: Any) -> dict[str, Any] | None:
         """Serialize a Location to a JSON-safe dict for OPA."""
         if loc is None or getattr(loc, "is_empty", False):
             return None
@@ -731,7 +743,7 @@ class SingleScan:
             "is_mutable": getattr(loc, "is_mutable", False),
         }
 
-    def _annotation_to_dict(self, an) -> dict:
+    def _annotation_to_dict(self, an: Any) -> dict[str, Any]:
         """Serialize a full Annotation (including RiskAnnotation detail) for OPA input."""
         from .models import Location, RiskAnnotation
 
@@ -791,11 +803,11 @@ class SingleScan:
         if config_key and d.get("key") != config_key:
             d["config_key"] = self._json_safe(config_key)
         if getattr(an, "is_mutable_key", None) is not None:
-            d["is_mutable_key"] = bool(an.is_mutable_key)
+            d["is_mutable_key"] = bool(getattr(an, "is_mutable_key", False))
 
         return d
 
-    def build_hierarchy_payload(self, scan_id: str = ""):
+    def build_hierarchy_payload(self, scan_id: str = "") -> dict[str, Any]:
         """Build OPA input: hierarchy (collection/role/playbook/play/task) + annotations. No native rules."""
         if not scan_id:
             scan_id = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M%S")
@@ -826,7 +838,7 @@ class SingleScan:
         }
         return self.hierarchy_payload
 
-    def apply_rules(self):
+    def apply_rules(self) -> None:
         # Engine-only mode: no native ARI rules; build hierarchy+annotations for OPA.
         self.build_hierarchy_payload()
         target_name = self.name
@@ -858,34 +870,34 @@ class SingleScan:
         self.result = None
         return
 
-    def add_time_records(self, time_records: dict):
+    def add_time_records(self, time_records: dict[str, Any]) -> None:
         if self.findings:
             self.findings.metadata["time_records"] = time_records
         return
 
-    def count_definitions(self):
+    def count_definitions(self) -> tuple[int, dict[str, int], dict[str, int]]:
         dep_num = len(self.loaded_dependency_dirs)
-        ext_counts = {}
+        ext_counts: dict[str, int] = {}
         for _, _defs in self.ext_definitions.items():
             for key, val in _defs.get("definitions", {}).items():
                 _current = ext_counts.get(key, 0)
                 _current += len(val)
                 ext_counts[key] = _current
-        root_counts = {}
+        root_counts: dict[str, int] = {}
         for key, val in self.root_definitions.get("definitions", {}).items():
             _current = root_counts.get(key, 0)
             _current += len(val)
             root_counts[key] = _current
         return dep_num, ext_counts, root_counts
 
-    def set_metadata(self, metadata: dict, dependencies: dict):
+    def set_metadata(self, metadata: dict[str, Any], dependencies: Any) -> None:
         self.target_path = self.make_target_path(self.type, self.name)
         self.version = metadata.get("version", "")
         self.hash = metadata.get("hash", "")
         self.download_url = metadata.get("download_url", "")
         self.loaded_dependency_dirs = dependencies
 
-    def set_metadata_findings(self):
+    def set_metadata_findings(self) -> None:
         target_name = self.name
         if self.collection_name:
             target_name = self.collection_name
@@ -905,7 +917,7 @@ class SingleScan:
             dependencies=dependencies,
         )
 
-    def load_index(self):
+    def load_index(self) -> None:
         index_location = self.__path_mappings["index"]
         with open(index_location) as f:
             self.index = json.load(f)
@@ -913,36 +925,36 @@ class SingleScan:
 
 @dataclass
 class ARIScanner:
-    config: Config = None
+    config: Config | None = None
 
     root_dir: str = ""
     rules_dir: str = ""
-    rules: list = field(default_factory=list)
-    rules_cache: list = field(default_factory=list)
+    rules: list[Any] = field(default_factory=list)
+    rules_cache: list[Any] = field(default_factory=list)
 
-    ram_client: RAMClient = None
+    ram_client: RAMClient | None = None
     read_ram: bool = True
     read_ram_for_dependency: bool = True
     write_ram: bool = False
 
     persist_dependency_cache: bool = False
 
-    skip_playbook_format_error: bool = (True,)
-    skip_task_format_error: bool = (True,)
+    skip_playbook_format_error: bool = True
+    skip_task_format_error: bool = True
 
     use_ansible_doc: bool = True
 
     do_save: bool = False
-    _parser: Parser = None
+    _parser: Parser | None = None
 
     show_all: bool = False
     pretty: bool = False
     silent: bool = False
     output_format: str = ""
 
-    _current: SingleScan = None
+    _current: SingleScan | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not self.config:
             self.config = config
 
@@ -991,12 +1003,12 @@ class ARIScanner:
         include_test_contents: bool = False,
         load_all_taskfiles: bool = False,
         save_only_rule_result: bool = False,
-        yaml_label_list: list = None,
+        yaml_label_list: list[Any] | None = None,
         objects: bool = False,
         out_dir: str = "",
-        spec_mutations_from_previous_scan: dict = None,
-    ):
-        time_records = {}
+        spec_mutations_from_previous_scan: dict[str, Any] | None = None,
+    ) -> Any:
+        time_records: dict[str, Any] = {}
         self.record_begin(time_records, "scandata_init")
 
         if not name and path:
@@ -1034,14 +1046,14 @@ class ARIScanner:
             include_test_contents=include_test_contents,
             load_all_taskfiles=load_all_taskfiles,
             save_only_rule_result=save_only_rule_result,
-            yaml_label_list=yaml_label_list,
+            yaml_label_list=yaml_label_list or [],
             out_dir=out_dir,
             root_dir=self.root_dir,
             rules_dir=self.rules_dir,
             rules=self.rules,
             rules_cache=self.rules_cache,
             persist_dependency_cache=self.persist_dependency_cache,
-            spec_mutations_from_previous_scan=spec_mutations_from_previous_scan,
+            spec_mutations_from_previous_scan=spec_mutations_from_previous_scan or {},
             use_ansible_doc=self.use_ansible_doc,
             do_save=self.do_save,
             silent=self.silent,
@@ -1173,7 +1185,8 @@ class ARIScanner:
                             load_only=True,
                         )
                         dep_scandata = dep_scanner.get_last_scandata()
-                        scandata.ext_definitions[key] = dep_scandata.root_definitions
+                        if dep_scandata is not None:
+                            scandata.ext_definitions[key] = dep_scandata.root_definitions
                         dep_loaded = True
 
             self.record_end(time_records, "dependency_load")
@@ -1270,12 +1283,17 @@ class ARIScanner:
             # print("root definitions:", root_counts)
 
         # save RAM data
-        if self.write_ram and scandata.type not in [LoadType.PLAYBOOK, LoadType.TASKFILE, LoadType.PROJECT]:
-            self.register_findings_to_ram(scandata.findings)
-            self.register_indices_to_ram(scandata.findings, include_test_contents)
+        findings = scandata.findings
+        if (
+            self.write_ram
+            and scandata.type not in [LoadType.PLAYBOOK, LoadType.TASKFILE, LoadType.PROJECT]
+            and findings is not None
+        ):
+            self.register_findings_to_ram(findings)
+            self.register_indices_to_ram(findings, include_test_contents)
 
-        if scandata.out_dir is not None and scandata.out_dir != "":
-            self.save_rule_result(scandata.findings, scandata.out_dir)
+        if scandata.out_dir is not None and scandata.out_dir != "" and findings is not None:
+            self.save_rule_result(findings, scandata.out_dir)
             if not self.silent:
                 print(f"The rule result is saved at {scandata.out_dir}")
 
@@ -1284,13 +1302,13 @@ class ARIScanner:
                 if not self.silent:
                     print(f"The objects is saved at {scandata.out_dir}")
 
-        if not self.silent:
-            summary = summarize_findings(scandata.findings, self.show_all)
+        if not self.silent and findings is not None:
+            summary = summarize_findings(findings, self.show_all)
             print(summary)
 
-        if self.pretty:
+        if self.pretty and findings is not None:
             data_str = ""
-            data = json.loads(jsonpickle.encode(scandata.findings.simple(), make_refs=False))
+            data = json.loads(jsonpickle.encode(findings.simple(), make_refs=False))
             if self.output_format.lower() == "json":
                 data_str = json.dumps(data, indent=2)
             elif self.output_format.lower() == "yaml":
@@ -1340,13 +1358,19 @@ class ARIScanner:
                     spec_mutations_from_previous_scan=scandata.spec_mutations,
                 )
 
-        return scandata.findings.report.get("ari_result", None)
+        return findings.report.get("ari_result", None) if findings is not None else None
 
-    def load_metadata_from_ram(self, type, name, version):
+    def load_metadata_from_ram(self, type: str, name: str, version: str) -> tuple[bool, Any, Any]:
+        if self.ram_client is None:
+            return False, None, None
         loaded, metadata, dependencies = self.ram_client.load_metadata_from_findings(type, name, version)
         return loaded, metadata, dependencies
 
-    def load_definitions_from_ram(self, type, name, version, hash, allow_unresolved=False):
+    def load_definitions_from_ram(
+        self, type: str, name: str, version: str, hash: str, allow_unresolved: bool = False
+    ) -> tuple[bool, dict[str, Any]]:
+        if self.ram_client is None:
+            return False, {}
         loaded, definitions, mappings = self.ram_client.load_definitions_from_findings(
             type, name, version, hash, allow_unresolved
         )
@@ -1358,16 +1382,19 @@ class ARIScanner:
             }
         return loaded, definitions_dict
 
-    def register_findings_to_ram(self, findings: Findings):
-        self.ram_client.register(findings)
+    def register_findings_to_ram(self, findings: Findings) -> None:
+        if self.ram_client is not None:
+            self.ram_client.register(findings)
 
-    def register_indices_to_ram(self, findings: Findings, include_test_contents: bool = False):
-        self.ram_client.register_indices_to_ram(findings, include_test_contents)
+    def register_indices_to_ram(self, findings: Findings, include_test_contents: bool = False) -> None:
+        if self.ram_client is not None:
+            self.ram_client.register_indices_to_ram(findings, include_test_contents)
 
-    def save_findings(self, findings: Findings, out_dir: str):
-        self.ram_client.save_findings(findings, out_dir)
+    def save_findings(self, findings: Findings, out_dir: str) -> None:
+        if self.ram_client is not None:
+            self.ram_client.save_findings(findings, out_dir)
 
-    def save_rule_result(self, findings: Findings, out_dir: str):
+    def save_rule_result(self, findings: Findings, out_dir: str) -> None:
         if out_dir == "":
             raise ValueError("output dir must be a non-empty value")
 
@@ -1376,7 +1403,7 @@ class ARIScanner:
 
         findings.save_rule_result(fpath=os.path.join(out_dir, "rule_result.json"))
 
-    def save_definitions(self, definitions: dict, out_dir: str):
+    def save_definitions(self, definitions: dict[str, Any], out_dir: str) -> None:
         if out_dir == "":
             raise ValueError("output dir must be a non-empty value")
 
@@ -1388,25 +1415,26 @@ class ARIScanner:
         with open(fpath, "w") as file:
             file.write(objects_json_str)
 
-    def get_last_scandata(self):
+    def get_last_scandata(self) -> SingleScan | None:
         return self._current
 
-    def save_error(self, error: str, out_dir: str = ""):
-        if out_dir == "":
-            type = self._current.type
-            name = self._current.name
-            version = self._current.version
-            hash = self._current.hash
-            out_dir = self.ram_client.make_findings_dir_path(type, name, version, hash)
-        self.ram_client.save_error(error, out_dir)
+    def save_error(self, error: str, out_dir: str = "") -> None:
+        if out_dir == "" and self._current is not None and self.ram_client is not None:
+            _type = self._current.type
+            _name = self._current.name
+            _version = self._current.version
+            _hash = self._current.hash
+            out_dir = self.ram_client.make_findings_dir_path(_type, _name, _version, _hash)
+        if self.ram_client is not None:
+            self.ram_client.save_error(error, out_dir)
 
-    def record_begin(self, time_records: dict, record_name: str):
+    def record_begin(self, time_records: dict[str, Any], record_name: str) -> None:
         time_records[record_name] = {}
         time_records[record_name]["begin"] = datetime.datetime.now(datetime.timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%S.%f"
         )
 
-    def record_end(self, time_records: dict, record_name: str):
+    def record_end(self, time_records: dict[str, Any], record_name: str) -> None:
         end = datetime.datetime.now(datetime.timezone.utc)
         end = end.replace(tzinfo=None)
         time_records[record_name]["end"] = end.strftime("%Y-%m-%dT%H:%M:%S.%f")
@@ -1416,13 +1444,13 @@ class ARIScanner:
 
 
 def tree(
-    root_definitions,
-    ext_definitions,
-    ram_client=None,
-    target_playbook_path=None,
-    target_taskfile_path=None,
-    load_all_taskfiles=False,
-):
+    root_definitions: dict[str, Any],
+    ext_definitions: dict[str, Any],
+    ram_client: RAMClient | None = None,
+    target_playbook_path: str | None = None,
+    target_taskfile_path: str | None = None,
+    load_all_taskfiles: bool = False,
+) -> tuple[list[Any], Any, list[Any], dict[str, Any]]:
     tl = TreeLoader(
         root_definitions, ext_definitions, ram_client, target_playbook_path, target_taskfile_path, load_all_taskfiles
     )
@@ -1439,14 +1467,16 @@ def tree(
     )
 
 
-def resolve(trees, additional):
+def resolve(trees: list[Any], additional: Any) -> list[TaskCallsInTree]:
     taskcalls_in_trees = []
     for i, tree in enumerate(trees):
         if not isinstance(tree, ObjectList):
             continue
         if len(tree.items) == 0:
             continue
-        root_key = tree.items[0].spec.key
+        first_item = tree.items[0]
+        spec = getattr(first_item, "spec", None)
+        root_key = spec.key if spec is not None else getattr(first_item, "key", "")
         logger.debug(f"[{i + 1}/{len(trees)}] {root_key}")
         taskcalls = resolve_variables(tree, additional)
         d = TaskCallsInTree(

--- a/src/apme_engine/engine/tree.py
+++ b/src/apme_engine/engine/tree.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import json
 import os
 import re
 from copy import deepcopy
 from dataclasses import dataclass, field
+from typing import Any, cast
 
 from . import logger
 from .keyutil import detect_type, key_delimiter, object_delimiter
@@ -11,6 +14,8 @@ from .models import (
     CallObject,
     ExecutableType,
     LoadType,
+    Module,
+    Object,
     ObjectList,
     Play,
     Playbook,
@@ -40,14 +45,14 @@ class TreeNode:
     key: str = ""
 
     # children is a list of TreeNode
-    children: list = field(default_factory=list)
+    children: list[TreeNode] = field(default_factory=list)
 
-    definition: dict = field(default_factory=dict)
+    definition: dict[str, Any] = field(default_factory=dict)
 
     # load a list of (src, dst) as a tree structure
     # which is composed of multiple TreeNode
     @staticmethod
-    def load(graph=None):
+    def load(graph: list[tuple[str | None, str]] | None = None) -> TreeNode:
         if graph is None:
             graph = []
         root_key_cands = [pair[1] for pair in graph if pair[0] is None]
@@ -62,7 +67,7 @@ class TreeNode:
         return tree
 
     # output list of (src, dst) to stdout or file
-    def dump(self, path=""):
+    def dump(self, path: str = "") -> None:
         src_dst_array = self.to_graph()
         if path == "":
             print(json.dumps(src_dst_array, indent=2))
@@ -71,23 +76,23 @@ class TreeNode:
             with open(path, "w") as file:
                 file.write(tree_json)
 
-    def to_str(self):
+    def to_str(self) -> str:
         src_dst_array = self.to_graph()
         return json.dumps(src_dst_array)
 
     # return list of (src, dst)
-    def to_graph(self):
+    def to_graph(self) -> list[tuple[str | None, str]]:
         return self.recursive_graph_dump(None, self)
 
     # return list of dst keys
-    def to_keys(self):
+    def to_keys(self) -> list[str]:
         return [p[1] for p in self.to_graph()]
 
     # reutrn list of TreeNodes that are under this TreeNode
-    def to_list(self):
+    def to_list(self) -> list[TreeNode]:
         return self.recursive_convert_to_list(self)
 
-    def recursive_convert_to_list(self, node, nodelist=None):
+    def recursive_convert_to_list(self, node: TreeNode, nodelist: list[TreeNode] | None = None) -> list[TreeNode]:
         if nodelist is None:
             nodelist = []
         current = [pair for pair in nodelist]
@@ -96,7 +101,12 @@ class TreeNode:
             current = self.recursive_convert_to_list(child_node, current)
         return current
 
-    def recursive_tree_load(self, node_key, src_dst_array, parent_keys=None):
+    def recursive_tree_load(
+        self,
+        node_key: str,
+        src_dst_array: list[tuple[str | None, str]],
+        parent_keys: set[str] | None = None,
+    ) -> tuple[TreeNode, set[str]]:
         if parent_keys is None:
             parent_keys = set()
         n = TreeNode(key=node_key)
@@ -114,7 +124,12 @@ class TreeNode:
                 new_parent_keys = new_parent_keys.union(sub_parent_keys)
         return n, new_parent_keys
 
-    def recursive_graph_dump(self, parent_node, node, src_dst_array=None):
+    def recursive_graph_dump(
+        self,
+        parent_node: TreeNode | None,
+        node: TreeNode,
+        src_dst_array: list[tuple[str | None, str]] | None = None,
+    ) -> list[tuple[str | None, str]]:
         if src_dst_array is None:
             src_dst_array = []
         current = [pair for pair in src_dst_array]
@@ -130,36 +145,40 @@ class TreeNode:
 
     # return a list of (src, dst) which ends with the "end_key"
     # this could return multiple paths
-    def path_to_root(self, end_key):
+    def path_to_root(self, end_key: str) -> list[TreeNode]:
         path_array = self.search_branch_to_key(end_key, self)
-        path_array = [nodelist2branch(nodelist) for nodelist in path_array]
-        return path_array
+        return [nodelist2branch(nodelist) for nodelist in path_array]
 
-    def search_branch_to_key(self, search_key, node, ancestors=None):
+    def search_branch_to_key(
+        self,
+        search_key: str,
+        node: TreeNode,
+        ancestors: list[TreeNode] | None = None,
+    ) -> list[list[TreeNode]]:
         if ancestors is None:
             ancestors = []
         current = [n for n in ancestors]
-        found = []
+        found: list[list[TreeNode]] = []
         if node.key == search_key:
-            found = current + [node]
+            found.append(current + [node])
         for child_node in node.children:
             found_in_child = self.search_branch_to_key(search_key, child_node, current + [node])
             found.extend(found_in_child)
         return found
 
-    def copy(self):
+    def copy(self) -> TreeNode:
         return deepcopy(self)
 
     @property
-    def is_empty(self):
+    def is_empty(self) -> bool:
         return self.key == "" and len(self.children) == 0
 
     @property
-    def has_definition(self):
+    def has_definition(self) -> bool:
         return len(self.definition) == 0
 
 
-def nodelist2branch(nodelist):
+def nodelist2branch(nodelist: list[TreeNode]) -> TreeNode:
     if len(nodelist) == 0:
         return TreeNode()
     t = nodelist[0].copy()
@@ -172,7 +191,7 @@ def nodelist2branch(nodelist):
     return t
 
 
-def load_single_definition(defs: dict, key: str):
+def load_single_definition(defs: dict[str, Any], key: str) -> ObjectList:
     obj_list = ObjectList()
     items = defs.get(key, [])
     for item in items:
@@ -180,7 +199,7 @@ def load_single_definition(defs: dict, key: str):
     return obj_list
 
 
-def load_definitions(defs: dict, types: list):
+def load_definitions(defs: dict[str, Any], types: list[str]) -> list[ObjectList]:
     def_list = []
     for type_key in types:
         objs_per_type = load_single_definition(defs, type_key)
@@ -188,10 +207,10 @@ def load_definitions(defs: dict, types: list):
     return def_list
 
 
-def load_all_definitions(definitions: dict):
-    _definitions = {}
+def load_all_definitions(definitions: dict[str, Any]) -> dict[str, ObjectList]:
+    _definitions: dict[str, Any] = {}
     _definitions = {"root": definitions} if "mappings" in definitions else definitions
-    loaded = {}
+    loaded: dict[str, ObjectList] = {}
     types = ["collections", "roles", "taskfiles", "modules", "playbooks", "plays", "tasks"]
     for type_key in types:
         loaded[type_key] = ObjectList()
@@ -205,8 +224,8 @@ def load_all_definitions(definitions: dict):
     return loaded
 
 
-def make_dicts(root_definitions, ext_definitions):
-    definitions = {
+def make_dicts(root_definitions: dict[str, Any], ext_definitions: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    definitions: dict[str, ObjectList] = {
         "roles": ObjectList(),
         "modules": ObjectList(),
         "taskfiles": ObjectList(),
@@ -215,7 +234,7 @@ def make_dicts(root_definitions, ext_definitions):
     for type_key in definitions:
         definitions[type_key].merge(root_definitions.get(type_key, ObjectList()))
         definitions[type_key].merge(ext_definitions.get(type_key, ObjectList()))
-    dicts = {k: {} for k in definitions}
+    dicts: dict[str, dict[str, Any]] = {k: {} for k in definitions}
     for type_key, obj_list in definitions.items():
         for obj in obj_list.items:
             obj_dict_key = obj.fqcn if hasattr(obj, "fqcn") else obj.key
@@ -225,7 +244,11 @@ def make_dicts(root_definitions, ext_definitions):
     return dicts
 
 
-def load_module_redirects(root_definitions, ext_definitions, module_dict=None):
+def load_module_redirects(
+    root_definitions: dict[str, Any],
+    ext_definitions: dict[str, Any],
+    module_dict: dict[str, Any] | None = None,
+) -> dict[str, str]:
     if module_dict is None:
         module_dict = {}
     collection_list = root_definitions.get("collections", ObjectList())
@@ -246,7 +269,7 @@ def load_module_redirects(root_definitions, ext_definitions, module_dict=None):
     return redirects
 
 
-def resolve(obj, dicts):
+def resolve(obj: Task | Play, dicts: dict[str, dict[str, Any]]) -> tuple[Task | Play, bool]:
     failed = False
     if isinstance(obj, Task):
         task = obj
@@ -281,7 +304,11 @@ def resolve(obj, dicts):
     return obj, failed
 
 
-def resolve_module(module_name, module_dict=None, module_redirects=None):
+def resolve_module(
+    module_name: str,
+    module_dict: dict[str, Any] | None = None,
+    module_redirects: dict[str, str] | None = None,
+) -> str:
     if module_redirects is None:
         module_redirects = {}
     if module_dict is None:
@@ -301,7 +328,12 @@ def resolve_module(module_name, module_dict=None, module_redirects=None):
     return module_key
 
 
-def resolve_role(role_name, role_dict=None, my_collection_name="", collections_in_play=None):
+def resolve_role(
+    role_name: str,
+    role_dict: dict[str, Any] | None = None,
+    my_collection_name: str = "",
+    collections_in_play: list[str] | None = None,
+) -> str:
     if collections_in_play is None:
         collections_in_play = []
     if role_dict is None:
@@ -335,7 +367,11 @@ def resolve_role(role_name, role_dict=None, my_collection_name="", collections_i
     return role_key
 
 
-def resolve_taskfile(taskfile_ref, taskfile_dict=None, task_key=""):
+def resolve_taskfile(
+    taskfile_ref: str,
+    taskfile_dict: dict[str, Any] | None = None,
+    task_key: str = "",
+) -> str:
     if taskfile_dict is None:
         taskfile_dict = {}
     type_prefix = "task "
@@ -357,7 +393,7 @@ def resolve_taskfile(taskfile_ref, taskfile_dict=None, task_key=""):
         taskfile_key = f"taskfile {parent_key}taskfile{key_delimiter}{fpath}"
         found_tf = taskfile_dict.get(taskfile_key)
         if found_tf is not None:
-            return found_tf.key
+            return str(found_tf.key)
 
     task_dir = os.path.dirname(task_defined_path)
     fpath = os.path.join(task_dir, taskfile_ref)
@@ -368,12 +404,16 @@ def resolve_taskfile(taskfile_ref, taskfile_dict=None, task_key=""):
     taskfile_key = f"taskfile {parent_key}taskfile{key_delimiter}{fpath}"
     found_tf = taskfile_dict.get(taskfile_key)
     if found_tf is not None:
-        return found_tf.key
+        return str(found_tf.key)
 
     return ""
 
 
-def resolve_playbook(playbook_ref, playbook_dict=None, play_key=""):
+def resolve_playbook(
+    playbook_ref: str,
+    playbook_dict: dict[str, Any] | None = None,
+    play_key: str = "",
+) -> str:
     if playbook_dict is None:
         playbook_dict = {}
     type_prefix = "play "
@@ -394,11 +434,11 @@ def resolve_playbook(playbook_ref, playbook_dict=None, play_key=""):
     playbook_key = f"playbook {parent_key}playbook{key_delimiter}{fpath}"
     found_playbook = playbook_dict.get(playbook_key)
     if found_playbook is not None:
-        return found_playbook.key
+        return str(found_playbook.key)
     return ""
 
 
-def init_builtin_modules():
+def init_builtin_modules() -> list[Any]:
     builtin_module_dict = load_builtin_modules()
     modules = list(builtin_module_dict.values())
     return modules
@@ -407,14 +447,14 @@ def init_builtin_modules():
 class TreeLoader:
     def __init__(
         self,
-        root_definitions,
-        ext_definitions,
-        ram_client=None,
-        target_playbook_path=None,
-        target_taskfile_path=None,
-        load_all_taskfiles=False,
-    ):
-        self.ram_client: RAMClient = ram_client
+        root_definitions: dict[str, Any],
+        ext_definitions: dict[str, Any],
+        ram_client: RAMClient | None = None,
+        target_playbook_path: str | None = None,
+        target_taskfile_path: str | None = None,
+        load_all_taskfiles: bool = False,
+    ) -> None:
+        self.ram_client: RAMClient | None = ram_client
 
         self.org_root_definitions = root_definitions
         self.org_ext_definitions = ext_definitions
@@ -431,9 +471,10 @@ class TreeLoader:
 
         # use mappings just to get tree tops (playbook/role)
         # we don't load any files by this mappings here
-        self.load_and_mapping = root_definitions.get("mappings", None)
-        self.playbook_mappings = self.load_and_mapping.playbooks
-        self.role_mappings = self.load_and_mapping.roles
+        self.load_and_mapping = root_definitions.get("mappings")
+        load_mapping = self.load_and_mapping
+        self.playbook_mappings = load_mapping.playbooks if load_mapping else []
+        self.role_mappings = load_mapping.roles if load_mapping else []
         self.taskfile_mappings = []
 
         # role can have child playbooks (mostly for test)
@@ -442,7 +483,7 @@ class TreeLoader:
             for mapping in self.role_mappings:
                 role_key = mapping[1]
                 role = self.get_object(role_key, False)
-                if not role:
+                if not role or not isinstance(role, Role):
                     continue
                 playbook_keys = role.playbooks
                 playbook_mappings_in_role = [(None, p_key) for p_key in playbook_keys]
@@ -458,15 +499,15 @@ class TreeLoader:
             for mapping in self.role_mappings:
                 role_key = mapping[1]
                 role = self.get_object(role_key, False)
-                if not role:
+                if not role or not isinstance(role, Role):
                     continue
                 taskfile_keys = role.taskfiles
                 taskfile_mappings_in_role = [(None, tf_key) for tf_key in taskfile_keys]
                 self.taskfile_mappings.extend(taskfile_mappings_in_role)
-            self.taskfile_mappings.extend(self.load_and_mapping.taskfiles)
+            self.taskfile_mappings.extend(load_mapping.taskfiles if load_mapping else [])
         # or, if the scan is for a single taskfile, ARI just scans it
         elif target_taskfile_path:
-            self.taskfile_mappings = self.load_and_mapping.taskfiles
+            self.taskfile_mappings = load_mapping.taskfiles if load_mapping else []
             self.taskfile_mappings = [tf for tf in self.taskfile_mappings if tf[0] == target_taskfile_path]
             self.playbook_mappings = []
             self.role_mappings = []
@@ -477,29 +518,29 @@ class TreeLoader:
         self.target_playbook_path = target_playbook_path
         self.load_all_taskfiles = load_all_taskfiles
 
-        self.module_resolve_cache = {}
-        self.role_resolve_cache = {}
-        self.taskfile_resolve_cache = {}
+        self.module_resolve_cache: dict[str, str] = {}
+        self.role_resolve_cache: dict[str, str] = {}
+        self.taskfile_resolve_cache: dict[str, str] = {}
 
-        self.resolved_module_from_ram = {}
-        self.resolved_role_from_ram = {}
-        self.resolved_taskfile_from_ram = {}
+        self.resolved_module_from_ram: dict[str, tuple[str, str]] = {}
+        self.resolved_role_from_ram: dict[str, tuple[str, str]] = {}
+        self.resolved_taskfile_from_ram: dict[str, tuple[str, str]] = {}
 
-        self.extra_requirements = []
-        self.extra_requirement_obj_set = set()
+        self.extra_requirements: list[dict[str, Any]] = []
+        self.extra_requirement_obj_set: set[str] = set()
 
-        self.trees = []
+        self.trees: list[ObjectList] = []
 
-        self.resolve_failures = {
+        self.resolve_failures: dict[str, dict[str, int]] = {
             "module": {},
             "taskfile": {},
             "role": {},
         }
         return
 
-    def run(self):
+    def run(self) -> tuple[list[ObjectList], ObjectList]:
         additional_objects = ObjectList()
-        if self.load_and_mapping.target_type == LoadType.PROJECT:
+        if self.load_and_mapping and self.load_and_mapping.target_type == LoadType.PROJECT:
             p_defs = self.org_root_definitions.get("definitions", {}).get("projects", [])
             if len(p_defs) > 0:
                 additional_objects.add(p_defs[0])
@@ -545,7 +586,14 @@ class TreeLoader:
             self.trees.append(tree_objects)
         return self.trees, additional_objects
 
-    def _recursive_get_calls(self, key, caller=None, handover=None, index=0, history=None):
+    def _recursive_get_calls(
+        self,
+        key: str,
+        caller: CallObject | None = None,
+        handover: dict[str, Any] | None = None,
+        index: int = 0,
+        history: list[str] | None = None,
+    ) -> ObjectList:
         if history is None:
             history = []
         if handover is None:
@@ -556,10 +604,15 @@ class TreeLoader:
             return obj_list
         if key in history:
             return obj_list
+        spec_obj = obj.spec if isinstance(obj, CallObject) else obj
         _history = []
         if history:
             _history = [h for h in history]
-        call_obj = call_obj_from_spec(spec=obj, caller=caller, index=index)
+        call_obj = call_obj_from_spec(
+            spec=spec_obj,
+            caller=caller,
+            index=index,
+        )
         if call_obj is not None:
             obj_list.add(call_obj, update_dict=False)
             _history.append(key)
@@ -581,75 +634,91 @@ class TreeLoader:
             )
             if isinstance(call_obj, TaskCall):
                 taskcall = call_obj
+                task_spec = cast(Task, taskcall.spec)
                 if len(child_objects.items) > 0:
-                    c_obj = child_objects.items[0]
-                    if taskcall.spec.executable_type == ExecutableType.MODULE_TYPE:
-                        taskcall.module = c_obj.spec
+                    c_obj = cast(CallObject, child_objects.items[0])
+                    if task_spec.executable_type == ExecutableType.MODULE_TYPE:
+                        mod_spec = cast(Module, c_obj.spec)
+                        taskcall.module = mod_spec
                         if c_key in from_ram:
                             req_info = from_ram[c_key]
-                            taskcall.spec.possible_candidates = [(c_obj.spec.fqcn, req_info)]
+                            task_spec.possible_candidates = [(mod_spec.fqcn, req_info)]
                         else:
-                            taskcall.spec.resolved_name = c_obj.spec.fqcn
-                        taskcall.spec.module_info = {
-                            "collection": c_obj.spec.collection,
-                            "short_name": c_obj.spec.name,
-                            "fqcn": c_obj.spec.fqcn,
-                            "key": c_obj.spec.key,
+                            task_spec.resolved_name = mod_spec.fqcn
+                        task_spec.module_info = {
+                            "collection": mod_spec.collection,
+                            "short_name": mod_spec.name,
+                            "fqcn": mod_spec.fqcn,
+                            "key": mod_spec.key,
                         }
-                    elif taskcall.spec.executable_type == ExecutableType.ROLE_TYPE:
+                    elif task_spec.executable_type == ExecutableType.ROLE_TYPE:
+                        role_spec = cast(Role, c_obj.spec)
                         if c_key in from_ram:
                             req_info = from_ram[c_key]
-                            taskcall.spec.possible_candidates = [(c_obj.spec.fqcn, req_info)]
+                            task_spec.possible_candidates = [(role_spec.fqcn, req_info)]
                         else:
-                            taskcall.spec.resolved_name = c_obj.spec.fqcn
-                        taskcall.spec.include_info = {
+                            task_spec.resolved_name = role_spec.fqcn
+                        task_spec.include_info = {
                             "type": "role",
-                            "fqcn": c_obj.spec.fqcn,
-                            "path": c_obj.spec.defined_in,
-                            "key": c_obj.spec.key,
+                            "fqcn": role_spec.fqcn,
+                            "path": role_spec.defined_in,
+                            "key": role_spec.key,
                         }
-                    elif taskcall.spec.executable_type == ExecutableType.TASKFILE_TYPE:
+                    elif task_spec.executable_type == ExecutableType.TASKFILE_TYPE:
+                        tf_spec = cast(TaskFile, c_obj.spec)
                         if c_key in from_ram:
                             req_info = from_ram[c_key]
-                            taskcall.spec.possible_candidates = [(c_obj.spec.key, req_info)]
+                            task_spec.possible_candidates = [(tf_spec.key, req_info)]
                         else:
-                            taskcall.spec.resolved_name = c_obj.spec.key
-                        taskcall.spec.include_info = {
+                            task_spec.resolved_name = tf_spec.key
+                        task_spec.include_info = {
                             "type": "taskfile",
-                            "path": c_obj.spec.defined_in,
-                            "key": c_obj.spec.key,
+                            "path": tf_spec.defined_in,
+                            "key": tf_spec.key,
                         }
                 elif loop_found and loop_obj:
-                    if taskcall.spec.executable_type == ExecutableType.ROLE_TYPE:
-                        taskcall.spec.include_info = {
+                    loop_spec = loop_obj.spec if isinstance(loop_obj, CallObject) else loop_obj
+                    if task_spec.executable_type == ExecutableType.ROLE_TYPE:
+                        task_spec.include_info = {
                             "type": "role",
-                            "path": loop_obj.defined_in,
-                            "key": loop_obj.key,
+                            "path": getattr(loop_spec, "defined_in", ""),
+                            "key": getattr(loop_spec, "key", ""),
                         }
-                    elif taskcall.spec.executable_type == ExecutableType.TASKFILE_TYPE:
-                        taskcall.spec.include_info = {
+                    elif task_spec.executable_type == ExecutableType.TASKFILE_TYPE:
+                        task_spec.include_info = {
                             "type": "taskfile",
-                            "path": loop_obj.defined_in,
-                            "key": loop_obj.key,
+                            "path": getattr(loop_spec, "defined_in", ""),
+                            "key": getattr(loop_spec, "key", ""),
                         }
             elif isinstance(call_obj, PlayCall):
                 playcall = call_obj
                 if len(child_objects.items) > 0 and "roles_info" in handover:
-                    c_obj = child_objects.items[0]
-                    if isinstance(c_obj, RoleCall):
-                        for rip in playcall.spec.roles:
-                            resolved_key = handover["roles_info"].get(rip.key, "")
-                            if resolved_key and resolved_key == c_obj.spec.key:
-                                rip.role_info = {
-                                    "fqcn": c_obj.spec.fqcn,
-                                    "path": c_obj.spec.defined_in,
-                                    "key": c_obj.spec.key,
-                                }
-            for c_obj in child_objects.items:
-                obj_list.add(c_obj)
+                    first_child = child_objects.items[0]
+                    if isinstance(first_child, RoleCall):
+                        role_spec = cast(Role, first_child.spec)
+                        play_spec = playcall.spec
+                        if isinstance(play_spec, Play):
+                            for rip in play_spec.roles:
+                                if not isinstance(rip, RoleInPlay):
+                                    continue
+                                resolved_key = handover["roles_info"].get(rip.key, "")
+                                if resolved_key and resolved_key == role_spec.key:
+                                    rip.role_info = {
+                                        "fqcn": role_spec.fqcn,
+                                        "path": role_spec.defined_in,
+                                        "key": role_spec.key,
+                                    }
+            for child_obj in child_objects.items:
+                obj_list.add(child_obj)
         return obj_list
 
-    def _recursive_make_graph(self, key, graph, _objects, caller=None):
+    def _recursive_make_graph(
+        self,
+        key: str,
+        graph: list[list[str | None]],
+        _objects: ObjectList,
+        caller: CallObject | None = None,
+    ) -> list[list[str | None]]:
         current_graph = [g for g in graph]
         # if this key is already in the graph src, no need to trace children
         key_in_graph_src = [g for g in current_graph if g[0] == key]
@@ -659,13 +728,17 @@ class TreeLoader:
         obj = self.get_object(key)
         if obj is None:
             return current_graph
-        call_obj = call_obj_from_spec(spec=obj, caller=caller)
+        spec_obj = obj.spec if isinstance(obj, CallObject) else obj
+        call_obj = call_obj_from_spec(
+            spec=spec_obj,
+            caller=caller,
+        )
         if call_obj is not None:
             caller_key = None if caller is None else caller.key
             my_key = call_obj.key
             current_graph.append([caller_key, my_key])
             _objects.add(call_obj, update_dict=False)
-        children_keys = self._get_children_keys(obj)
+        children_keys, _, _ = self._get_children_keys(obj)
         for c_key in children_keys:
             updated_graph = self._recursive_make_graph(
                 c_key,
@@ -677,7 +750,7 @@ class TreeLoader:
         return current_graph
 
     # get definition object from root/ext definitions
-    def get_object(self, obj_key, search_ram=False):
+    def get_object(self, obj_key: str, search_ram: bool = False) -> Object | CallObject | None:
         obj_type = detect_type(obj_key)
         if obj_type == "":
             raise ValueError(f'failed to detect object type from key "{obj_key}"')
@@ -693,26 +766,31 @@ class TreeLoader:
 
         if search_ram and self.ram_client:
             matched_obj = self.ram_client.get_object_by_key(obj_key)
-            obj = matched_obj.get("object", None)
+            if matched_obj is not None:
+                obj = matched_obj.get("object", None)
             if obj is not None:
-                return obj
+                return cast(Object | CallObject, obj)
 
         return None
 
-    def add_builtin_modules(self):
+    def add_builtin_modules(self) -> None:
         builtin_module_dict = load_builtin_modules()
         builtin_modules = list(builtin_module_dict.values())
-        obj_list = ObjectList(items=builtin_modules)
+        obj_list = ObjectList(items=[cast(Object | CallObject, m) for m in builtin_modules])
         self.ext_definitions["modules"].merge(obj_list)
 
-    def _get_children_keys(self, obj, handover_from_upper_node=None):
+    def _get_children_keys(
+        self,
+        obj: Object | CallObject,
+        handover_from_upper_node: dict[str, Any] | None = None,
+    ) -> tuple[list[str], dict[str, str], dict[str, Any]]:
         if handover_from_upper_node is None:
             handover_from_upper_node = {}
         if isinstance(obj, CallObject):
-            return self._get_children_keys(obj.spec)
+            return self._get_children_keys(obj.spec, handover_from_upper_node)
         children_keys = []
         from_ram = {}
-        handover = {}
+        handover: dict[str, Any] = {}
         if isinstance(obj, Playbook):
             children_keys = obj.plays
         elif isinstance(obj, Play):
@@ -958,8 +1036,8 @@ class TreeLoader:
                 children_keys.append(resolved_key)
         return children_keys, from_ram, handover
 
-    def node_objects(self, tree):
-        loaded = {}
+    def node_objects(self, tree: TreeNode) -> ObjectList:
+        loaded: dict[str, Object | CallObject] = {}
         obj_list = ObjectList()
         for k in tree.to_keys():
             if k in loaded:
@@ -974,12 +1052,12 @@ class TreeLoader:
         return obj_list
 
 
-def is_templated(txt):
+def is_templated(txt: str) -> bool:
     return "{{" in txt
 
 
 # TODO: need to use variable manager
-def render_template(txt, variable_manager=None):
+def render_template(txt: str, variable_manager: Any = None) -> str:
     regex = r'[\'"]([^\'"]+\.ya?ml)[\'"]'
     matched = re.search(regex, txt)
     if matched:
@@ -993,7 +1071,7 @@ def render_template(txt, variable_manager=None):
     return txt
 
 
-def dump_node_objects(obj_list, path=""):
+def dump_node_objects(obj_list: ObjectList, path: str = "") -> None:
     if path == "":
         lines = obj_list.dump()
         for line in lines:
@@ -1003,5 +1081,6 @@ def dump_node_objects(obj_list, path=""):
         obj_list.dump(fpath=path)
 
 
-def key_to_file_name(prefix, key):
-    return prefix + "___" + key.translate(str.maketrans({" ": "___", "/": "---", ".": "_dot_"})) + ".json"
+def key_to_file_name(prefix: str, key: str) -> str:
+    trans_table = str.maketrans({" ": "___", "/": "---", ".": "_dot_"})
+    return prefix + "___" + key.translate(trans_table) + ".json"

--- a/src/apme_engine/engine/utils.py
+++ b/src/apme_engine/engine/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import codecs
 import hashlib
 import json
@@ -7,6 +9,7 @@ import traceback
 from copy import deepcopy
 from importlib.util import module_from_spec, spec_from_file_location
 from inspect import isclass
+from typing import Any
 
 import requests
 import yaml
@@ -20,16 +23,20 @@ bool_values_false = frozenset(("n", "no", "off", "0", "false", "f", 0, 0.0, Fals
 bool_values = bool_values_true.union(bool_values_false)
 
 
-def lock_file(fpath, timeout=10):
+def get_lock_file_name(fpath: str) -> str:
+    return fpath + ".lock"
+
+
+def lock_file(fpath: str | None, timeout: int = 10) -> FileLock | None:
     if not fpath:
-        return
+        return None
     lockfile = get_lock_file_name(fpath)
     lock = FileLock(lockfile, timeout=timeout)
     lock.acquire()
     return lock
 
 
-def unlock_file(lock):
+def unlock_file(lock: Any) -> None:
     if not lock:
         return
     if not isinstance(lock, FileLock):
@@ -37,7 +44,7 @@ def unlock_file(lock):
     lock.release()
 
 
-def remove_lock_file(lock):
+def remove_lock_file(lock: FileLock | None) -> None:
     if not lock:
         return
     if not isinstance(lock, FileLock):
@@ -50,11 +57,13 @@ def remove_lock_file(lock):
     os.remove(lockfile)
 
 
-def get_lock_file_name(fpath):
-    return fpath + ".lock"
-
-
-def install_galaxy_target(target, target_type, output_dir, source_repository="", target_version=""):
+def install_galaxy_target(
+    target: str,
+    target_type: str,
+    output_dir: str,
+    source_repository: str = "",
+    target_version: str = "",
+) -> tuple[str, str]:
     server_option = ""
     if source_repository:
         server_option = f"--server {source_repository}"
@@ -75,7 +84,7 @@ def install_galaxy_target(target, target_type, output_dir, source_repository="",
     return proc.stdout, proc.stderr
 
 
-def install_github_target(target, output_dir):
+def install_github_target(target: str, output_dir: str) -> str:
     proc = subprocess.run(
         f"git clone {target} {output_dir}",
         shell=True,
@@ -86,7 +95,7 @@ def install_github_target(target, output_dir):
     return proc.stdout
 
 
-def get_download_metadata(typ: str, install_msg: str):
+def get_download_metadata(typ: str, install_msg: str) -> tuple[str, str, str]:
     download_url = ""
     version = ""
     if typ == "collection":
@@ -101,13 +110,15 @@ def get_download_metadata(typ: str, install_msg: str):
                 download_url = line.split(" ")[-1]
                 version = download_url.split("/")[-1].replace(".tar.gz", "")
                 break
-    hash = ""
+    hash_val = ""
     if download_url != "":
-        hash = get_hash_of_url(download_url)
-    return download_url, version, hash
+        hash_val = get_hash_of_url(download_url)
+    return download_url, version, hash_val
 
 
-def get_installed_metadata(type, name, path, dep_dir=None):
+def get_installed_metadata(type: str, name: str, path: str, dep_dir: str | None = None) -> tuple[str, str]:
+    download_url: str
+    version: str
     if dep_dir:
         dep_dir_alt = os.path.join(dep_dir, "ansible_collections")
         if os.path.exists(dep_dir_alt):
@@ -143,7 +154,7 @@ def get_installed_metadata(type, name, path, dep_dir=None):
     return download_url, version
 
 
-def get_collection_metadata(path: str):
+def get_collection_metadata(path: str) -> dict[str, Any] | None:
     if not os.path.exists(path):
         return None
     manifest_json_path = os.path.join(path, "MANIFEST.json")
@@ -154,7 +165,7 @@ def get_collection_metadata(path: str):
     return meta
 
 
-def get_role_metadata(path: str):
+def get_role_metadata(path: str) -> dict[str, Any] | None:
     if not os.path.exists(path):
         return None
     meta_main_yml_path = os.path.join(path, "meta", "main.yml")
@@ -165,24 +176,24 @@ def get_role_metadata(path: str):
     return meta
 
 
-def escape_url(url: str):
+def escape_url(url: str) -> str:
     base_url = url.split("?")[0]
     replaced = base_url.replace("://", "__").replace("/", "_")
     return replaced
 
 
-def escape_local_path(path: str):
+def escape_local_path(path: str) -> str:
     replaced = path.replace("/", "__")
     return replaced
 
 
-def get_hash_of_url(url: str):
+def get_hash_of_url(url: str) -> str:
     response = requests.get(url)
     hash = hashlib.sha256(response.content).hexdigest()
     return hash
 
 
-def split_name_and_version(target_name):
+def split_name_and_version(target_name: str) -> tuple[str, str]:
     name = target_name
     version = ""
     if ":" in target_name:
@@ -192,7 +203,7 @@ def split_name_and_version(target_name):
     return name, version
 
 
-def split_target_playbook_fullpath(fullpath: str):
+def split_target_playbook_fullpath(fullpath: str) -> tuple[str, str]:
     basedir = os.path.dirname(fullpath)
     if "/playbooks/" in fullpath:
         basedir = fullpath.split("/playbooks/")[0]
@@ -202,7 +213,7 @@ def split_target_playbook_fullpath(fullpath: str):
     return basedir, target_playbook_path
 
 
-def split_target_taskfile_fullpath(fullpath: str):
+def split_target_taskfile_fullpath(fullpath: str) -> tuple[str, str]:
     basedir = os.path.dirname(fullpath)
     if "/roles/" in fullpath:
         basedir = fullpath.split("/roles/")[0]
@@ -214,13 +225,13 @@ def split_target_taskfile_fullpath(fullpath: str):
     return basedir, target_taskfile_path
 
 
-def version_to_num(ver: str):
+def version_to_num(ver: str) -> float:
     if ver == "unknown":
-        return 0
+        return 0.0
     # version string can be 1.2.3-abcdxyz
     ver_num_part = ver.split("-")[0]
     parts = ver_num_part.split(".")
-    num = 0
+    num: float = 0.0
     if len(parts) >= 1 and parts[0].isnumeric():
         num += float(parts[0])
     if len(parts) >= 2 and parts[1].isnumeric():
@@ -230,26 +241,25 @@ def version_to_num(ver: str):
     return num
 
 
-def is_url(txt: str):
+def is_url(txt: str) -> bool:
     return "://" in txt
 
 
-def is_local_path(txt: str):
+def is_local_path(txt: str) -> bool:
     if is_url(txt):
         return False
     if "/" in txt:
         return True
-    if os.path.exists(txt):
-        return True
+    return bool(os.path.exists(txt))
 
 
-def indent(multi_line_txt, level=0):
+def indent(multi_line_txt: str, level: int = 0) -> str:
     lines = multi_line_txt.splitlines()
     lines = [" " * level + line for line in lines if line.replace(" ", "") != ""]
     return "\n".join(lines)
 
 
-def report_to_display(data_report: dict):
+def report_to_display(data_report: dict[str, Any]) -> str:
     playbook_num_total = data_report["summary"].get("playbooks", {}).get("total", 0)
     # playbook_num_risk_found = data_report["summary"].get("playbooks", {}).get("risk_found", 0)
     role_num_total = data_report["summary"].get("roles", {}).get("total", 0)
@@ -297,7 +307,7 @@ def report_to_display(data_report: dict):
     return output_txt
 
 
-def summarize_findings(findings, show_all: bool = False):
+def summarize_findings(findings: Any, show_all: bool = False) -> str:
     metadata = findings.metadata
     dependencies = findings.dependencies
     report = findings.report
@@ -307,8 +317,13 @@ def summarize_findings(findings, show_all: bool = False):
 
 
 def summarize_findings_data(
-    metadata, dependencies, report, resolve_failures, extra_requirements, show_all: bool = False
-):
+    metadata: dict[str, Any],
+    dependencies: list[Any],
+    report: dict[str, Any],
+    resolve_failures: dict[str, Any],
+    extra_requirements: list[Any],
+    show_all: bool = False,
+) -> str:
     target_name = metadata.get("name", "")
     output_lines = []
 
@@ -365,7 +380,7 @@ def summarize_findings_data(
     if len(extra_requirements) > 0:
         unresolved_modules = []
         unresolved_roles = []
-        suggestion = {}
+        suggestion: dict[str, dict[str, list[str]]] = {}
         for ext_req in extra_requirements:
             if ext_req.get("type", "") not in ["role", "module"]:
                 continue
@@ -465,14 +480,14 @@ def summarize_findings_data(
     return output
 
 
-def show_all_ram_metadata(ram_meta_list):
+def show_all_ram_metadata(ram_meta_list: list[dict[str, Any]]) -> None:
     table = [("NAME", "VERSION", "HASH")]
     for meta in ram_meta_list:
         table.append((meta["name"], meta["version"], meta["hash"]))
     print(tabulate(table))
 
 
-def diff_files_data(files1, files2):
+def diff_files_data(files1: dict[str, Any], files2: dict[str, Any]) -> list[dict[str, str]]:
     files_dict1 = {}
     for finfo in files1.get("files", []):
         ftype = finfo.get("ftype", "")
@@ -526,16 +541,22 @@ def diff_files_data(files1, files2):
     return diffs
 
 
-def show_diffs(diffs):
+def show_diffs(diffs: list[dict[str, str]]) -> None:
     table = [("NAME", "DIFF_TYPE")]
     for d in diffs:
         table.append((d["filepath"], d["type"]))
     print(tabulate(table))
 
 
-def get_module_specs_by_ansible_doc(module_files: str, fqcn_prefix: str, search_path: str):
+def get_module_specs_by_ansible_doc(
+    module_files: list[str] | str,
+    fqcn_prefix: str,
+    search_path: str,
+) -> dict[str, dict[str, Any]]:
     if not module_files:
         return {}
+    if isinstance(module_files, str):
+        module_files = [module_files]
 
     if search_path and fqcn_prefix:
         parent_path_pattern = "/" + fqcn_prefix.replace(".", "/")
@@ -569,7 +590,7 @@ def get_module_specs_by_ansible_doc(module_files: str, fqcn_prefix: str, search_
     )
     if proc.stderr and not proc.stdout:
         logger.debug(f"error while getting the documentation for modules `{fqcn_list_str}`: {proc.stderr}")
-        return ""
+        return {}
     wrapper_dict = json.loads(proc.stdout)
     specs = {}
     for fqcn in wrapper_dict:
@@ -583,7 +604,7 @@ def get_module_specs_by_ansible_doc(module_files: str, fqcn_prefix: str, search_
     return specs
 
 
-def get_documentation_in_module_file(fpath: str):
+def get_documentation_in_module_file(fpath: str) -> str:
     if not fpath:
         return ""
     if not os.path.exists(fpath):
@@ -620,7 +641,7 @@ def get_documentation_in_module_file(fpath: str):
     return "\n".join(doc_lines)
 
 
-def get_class_by_arg_type(arg_type: str):
+def get_class_by_arg_type(arg_type: str) -> type[Any] | None:
     if not isinstance(arg_type, str):
         return None
 
@@ -633,7 +654,7 @@ def get_class_by_arg_type(arg_type: str):
         "float": float,
         # ARI handles `path` as a string
         "path": str,
-        "raw": any,
+        "raw": Any,
         # TODO: check actual types of the following
         "jsonarg": str,
         "json": str,
@@ -648,8 +669,12 @@ def get_class_by_arg_type(arg_type: str):
 
 
 def load_classes_in_dir(
-    dir_path: str, target_class: type, base_dir: str = "", only_subclass: bool = True, fail_on_error: bool = False
-):
+    dir_path: str,
+    target_class: type[Any],
+    base_dir: str = "",
+    only_subclass: bool = True,
+    fail_on_error: bool = False,
+) -> tuple[list[type[Any]], list[str]]:
     search_path = dir_path
     found = False
     if os.path.exists(search_path):
@@ -671,6 +696,8 @@ def load_classes_in_dir(
         try:
             short_module_name = os.path.basename(s)[:-3]
             spec = spec_from_file_location(short_module_name, s)
+            if spec is None or spec.loader is None:
+                continue
             mod = module_from_spec(spec)
             spec.loader.exec_module(mod)
             for k in mod.__dict__:
@@ -694,19 +721,19 @@ def load_classes_in_dir(
     return classes, errors
 
 
-def equal(a: any, b: any):
+def equal(a: Any, b: Any) -> bool:
     type_a = type(a)
     type_b = type(b)
     if type_a != type_b:
         return False
-    if type_a is dict:
+    if type_a is dict and isinstance(a, dict) and isinstance(b, dict):
         all_keys = list(a.keys()) + list(b.keys())
         for key in all_keys:
             val_a = a.get(key, None)
             val_b = b.get(key, None)
             if not equal(val_a, val_b):
                 return False
-    elif type_a is list:
+    elif type_a is list and isinstance(a, list) and isinstance(b, list):
         if len(a) != len(b):
             return False
         for i in range(len(a)):
@@ -723,7 +750,7 @@ def equal(a: any, b: any):
     return True
 
 
-def recursive_copy_dict(src, dst):
+def recursive_copy_dict(src: dict[str, Any], dst: dict[str, Any]) -> None:
     if not isinstance(src, dict):
         raise ValueError(f"only dict input is allowed, but got {type(src)}")
 
@@ -739,12 +766,12 @@ def recursive_copy_dict(src, dst):
     return
 
 
-def is_test_object(path: str):
+def is_test_object(path: str) -> bool:
     return path.startswith("tests/integration/") or path.startswith("molecule/")
 
 
-def parse_bool(value: any):
-    value_str = None
+def parse_bool(value: Any) -> bool:
+    value_str: str | None = None
     use_value_str = False
     if isinstance(value, bool):
         return value

--- a/src/apme_engine/engine/yaml.py
+++ b/src/apme_engine/engine/yaml.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import io
 from contextvars import ContextVar
+from typing import Any
 
 from ruamel.yaml import YAML
 from ruamel.yaml.emitter import EmitterError
@@ -7,7 +10,7 @@ from ruamel.yaml.emitter import EmitterError
 _yaml: ContextVar[YAML] = ContextVar("yaml")
 
 
-def _set_yaml(force=False):
+def _set_yaml(force: bool = False) -> None:
     if not _yaml.get(None) or force:
         yaml = YAML(typ="rt", pure=True)
         yaml.default_flow_style = False
@@ -17,7 +20,7 @@ def _set_yaml(force=False):
         _yaml.set(yaml)
 
 
-def config(**kwargs):
+def config(**kwargs: Any) -> None:
     _set_yaml()
     yaml = _yaml.get()
     for key, value in kwargs.items():
@@ -25,14 +28,14 @@ def config(**kwargs):
     _yaml.set(yaml)
 
 
-def indent(**kwargs):
+def indent(**kwargs: Any) -> None:
     _set_yaml()
     yaml = _yaml.get()
     yaml.indent(**kwargs)
     _yaml.set(yaml)
 
 
-def load(stream: any):
+def load(stream: Any) -> Any:
     _set_yaml()
     yaml = _yaml.get()
     return yaml.load(stream)
@@ -41,7 +44,7 @@ def load(stream: any):
 # `ruamel.yaml` has a bug around multi-threading, and its YAML() instance could be broken
 # while concurrent dump() operation. So we try retrying if the specific error occurs.
 # Bug details: https://sourceforge.net/p/ruamel-yaml/tickets/367/
-def dump(data: any):
+def dump(data: Any) -> str:
     _set_yaml()
     retry = 2
     err = None
@@ -64,4 +67,4 @@ def dump(data: any):
                 raise err
         else:
             break
-    return result
+    return str(result) if result is not None else ""

--- a/src/apme_engine/engine/yaml_utils.py
+++ b/src/apme_engine/engine/yaml_utils.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from ruamel.yaml.representer import RoundTripRepresenter
 
 
-class OctalIntYAML11(ScalarInt):
+class OctalIntYAML11(ScalarInt):  # type: ignore[misc]
     """OctalInt representation for YAML 1.1."""
 
     # tell mypy that ScalarInt has these attributes
@@ -57,7 +57,7 @@ class OctalIntYAML11(ScalarInt):
         )
 
 
-class CustomConstructor(RoundTripConstructor):
+class CustomConstructor(RoundTripConstructor):  # type: ignore[misc]
     """Custom YAML constructor that preserves Octal formatting in YAML 1.1."""
 
     def construct_yaml_int(self, node: ScalarNode) -> Any:
@@ -104,7 +104,7 @@ CustomConstructor.add_constructor(
 )
 
 
-class FormattedEmitter(Emitter):
+class FormattedEmitter(Emitter):  # type: ignore[misc]
     """Emitter that applies custom formatting rules when dumping YAML.
 
     Differences from ruamel.yaml defaults:
@@ -142,7 +142,7 @@ class FormattedEmitter(Emitter):
 
 
 # pylint: disable=too-many-instance-attributes
-class FormattedYAML(YAML):
+class FormattedYAML(YAML):  # type: ignore[misc]
     """A YAML loader/dumper that handles ansible content better by default."""
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -235,8 +235,8 @@ class FormattedYAML(YAML):
         # max_spaces_inside: int = cast(int, config["max_spaces_inside"])
 
         self.default_flow_style = False
-        self.compact_seq_seq = True  # type: ignore[assignment] # dash after dash
-        self.compact_seq_map = True  # type: ignore[assignment] # key after dash
+        self.compact_seq_seq = True  # dash after dash
+        self.compact_seq_map = True  # key after dash
 
         # Do not use yaml.indent() as it obscures the purpose of these vars:
         self.map_indent = 2
@@ -322,7 +322,7 @@ class FormattedYAML(YAML):
             data,
             CommentedMap | CommentedSeq,
         ):
-            data.preamble_comment = preamble_comment  # type: ignore[union-attr]
+            data.preamble_comment = preamble_comment
         # Because data can validly also be None for empty documents, we cannot
         # really annotate the return type here, so we need to remember to
         # never save None or scalar data types when reformatting.

--- a/src/apme_engine/formatter.py
+++ b/src/apme_engine/formatter.py
@@ -72,9 +72,9 @@ class FormatResult:
     diff: str = field(default="", repr=False)
 
 
-def _normalize_jinja(match: re.Match) -> str:
+def _normalize_jinja(match: re.Match[str]) -> str:
     """Normalize {{ foo }} spacing to exactly one space inside braces."""
-    inner = match.group(2).strip()
+    inner: str = match.group(2).strip()
     if not inner:
         return "{{ }}"
     return "{{ " + inner + " }}"

--- a/src/apme_engine/opa_client.py
+++ b/src/apme_engine/opa_client.py
@@ -15,7 +15,7 @@ def _run_opa_podman(
     bundle_path: Path,
     entrypoint: str,
     timeout: int,
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """Run OPA via podman run with bundle mounted. Returns CompletedProcess.
     Uses --userns=keep-id and -u root so the container can read the bind mount
     when the OPA image runs as non-root (rootless Podman). :z allows SELinux
@@ -56,7 +56,7 @@ def _run_opa_local(
     bundle_path: Path,
     entrypoint: str,
     timeout: int,
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """Run local opa binary. Returns CompletedProcess."""
     return subprocess.run(
         ["opa", "eval", "-i", "-", "-d", str(bundle_path), entrypoint, "--format", "json"],
@@ -67,7 +67,7 @@ def _run_opa_local(
     )
 
 
-def _run_opa_test_podman(bundle_path: Path, timeout: int = 120) -> subprocess.CompletedProcess:
+def _run_opa_test_podman(bundle_path: Path, timeout: int = 120) -> subprocess.CompletedProcess[str]:
     """Run `opa test . -v` inside Podman with bundle mounted. Same volume/user flags as eval."""
     bundle_abs = bundle_path.resolve()
     cmd = [
@@ -92,7 +92,7 @@ def _run_opa_test_podman(bundle_path: Path, timeout: int = 120) -> subprocess.Co
     )
 
 
-def _run_opa_test_local(bundle_path: Path, timeout: int = 120) -> subprocess.CompletedProcess:
+def _run_opa_test_local(bundle_path: Path, timeout: int = 120) -> subprocess.CompletedProcess[str]:
     """Run `opa test . -v` using local opa binary with cwd = bundle_path."""
     return subprocess.run(
         ["opa", "test", ".", "-v"],
@@ -128,7 +128,9 @@ def run_opa_test(bundle_path: str | Path, timeout: int = 120) -> tuple[bool, str
     return (out.returncode == 0, out.stdout or "", out.stderr or "")
 
 
-def run_opa(input_data: dict, bundle_path: str, entrypoint: str = "data.apme.rules.violations") -> list[dict[str, Any]]:
+def run_opa(
+    input_data: dict[str, Any], bundle_path: str, entrypoint: str = "data.apme.rules.violations"
+) -> list[dict[str, Any]]:
     """
     Run OPA eval with input_data as input and bundle at bundle_path.
     Uses Podman container (openpolicyagent/opa) by default; set OPA_USE_PODMAN=0 to use a local opa binary.

--- a/src/apme_engine/remediation/engine.py
+++ b/src/apme_engine/remediation/engine.py
@@ -7,6 +7,7 @@ import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from apme_engine.remediation.partition import partition_violations
 from apme_engine.remediation.registry import TransformRegistry
@@ -26,13 +27,13 @@ class FixReport:
     passes: int
     fixed: int
     applied_patches: list[FilePatch]
-    remaining_ai: list[dict]
-    remaining_manual: list[dict]
-    ai_proposed: list[dict]
+    remaining_ai: list[dict[str, Any]]
+    remaining_manual: list[dict[str, Any]]
+    ai_proposed: list[dict[str, Any]]
     oscillation_detected: bool
 
 
-ScanFn = Callable[[list[str]], list[dict]]
+ScanFn = Callable[[list[str]], list[dict[str, Any]]]
 
 
 class RemediationEngine:

--- a/src/apme_engine/remediation/partition.py
+++ b/src/apme_engine/remediation/partition.py
@@ -2,30 +2,30 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from apme_engine.remediation.registry import TransformRegistry
 
 
-def is_finding_resolvable(violation: dict, registry: TransformRegistry) -> bool:
+def is_finding_resolvable(violation: dict[str, Any], registry: TransformRegistry) -> bool:
     """Return True if the violation has a registered deterministic transform (Tier 1)."""
     return violation.get("rule_id", "") in registry
 
 
 def partition_violations(
-    violations: list[dict],
+    violations: list[dict[str, Any]],
     registry: TransformRegistry,
-) -> tuple[list[dict], list[dict], list[dict]]:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     """Split violations into (tier1_fixable, tier2_ai, tier3_manual).
 
     Tier 1: deterministic transform exists in registry.
     Tier 2: no transform, but ai_proposable (default True if not set).
     Tier 3: no transform, ai_proposable explicitly False.
     """
-    tier1: list[dict] = []
-    tier2: list[dict] = []
-    tier3: list[dict] = []
+    tier1: list[dict[str, Any]] = []
+    tier2: list[dict[str, Any]] = []
+    tier3: list[dict[str, Any]] = []
 
     for v in violations:
         if is_finding_resolvable(v, registry):

--- a/src/apme_engine/remediation/registry.py
+++ b/src/apme_engine/remediation/registry.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import NamedTuple
+from collections.abc import Callable, Iterator
+from typing import Any, NamedTuple
 
 
 class TransformResult(NamedTuple):
@@ -11,7 +11,7 @@ class TransformResult(NamedTuple):
     applied: bool
 
 
-TransformFn = Callable[[str, dict], TransformResult]
+TransformFn = Callable[[str, dict[str, Any]], TransformResult]
 
 
 class TransformRegistry:
@@ -34,14 +34,14 @@ class TransformRegistry:
     def __len__(self) -> int:
         return len(self._transforms)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return iter(self._transforms)
 
     @property
     def rule_ids(self) -> list[str]:
         return sorted(self._transforms)
 
-    def apply(self, rule_id: str, content: str, violation: dict) -> TransformResult:
+    def apply(self, rule_id: str, content: str, violation: dict[str, Any]) -> TransformResult:
         fn = self._transforms.get(rule_id)
         if fn is None:
             return TransformResult(content=content, applied=False)

--- a/src/apme_engine/remediation/transforms/L007_shell_to_command.py
+++ b/src/apme_engine/remediation/transforms/L007_shell_to_command.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key, rename_key
@@ -19,7 +21,7 @@ def _uses_shell_features(cmd: str) -> bool:
     return any(ch in cmd for ch in _SHELL_CHARS)
 
 
-def fix_shell_to_command(content: str, violation: dict) -> TransformResult:
+def fix_shell_to_command(content: str, violation: dict[str, Any]) -> TransformResult:
     """Replace shell with command when the command string uses no shell features."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L008_local_action.py
+++ b/src/apme_engine/remediation/transforms/L008_local_action.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from ruamel.yaml.comments import CommentedMap
 
 from apme_engine.engine.yaml_utils import FormattedYAML
@@ -9,7 +11,7 @@ from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line
 
 
-def fix_local_action(content: str, violation: dict) -> TransformResult:
+def fix_local_action(content: str, violation: dict[str, Any]) -> TransformResult:
     """Convert local_action to the module key + delegate_to: localhost."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L009_empty_string.py
+++ b/src/apme_engine/remediation/transforms/L009_empty_string.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
@@ -16,7 +17,7 @@ _PATTERNS = [
 ]
 
 
-def fix_empty_string(content: str, violation: dict) -> TransformResult:
+def fix_empty_string(content: str, violation: dict[str, Any]) -> TransformResult:
     """Replace `var == ""` with `var | length == 0` and similar."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L011_literal_bool.py
+++ b/src/apme_engine/remediation/transforms/L011_literal_bool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
@@ -22,7 +23,7 @@ _REPLACEMENTS = [
 ]
 
 
-def fix_literal_bool(content: str, violation: dict) -> TransformResult:
+def fix_literal_bool(content: str, violation: dict[str, Any]) -> TransformResult:
     """Remove literal true/false comparisons from when clause."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L012_latest.py
+++ b/src/apme_engine/remediation/transforms/L012_latest.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key
 
 
-def fix_latest(content: str, violation: dict) -> TransformResult:
+def fix_latest(content: str, violation: dict[str, Any]) -> TransformResult:
     """Replace ``state: latest`` with ``state: present``."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L013_changed_when.py
+++ b/src/apme_engine/remediation/transforms/L013_changed_when.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key
@@ -21,7 +23,7 @@ _CMD_MODULES = frozenset(
 )
 
 
-def fix_changed_when(content: str, violation: dict) -> TransformResult:
+def fix_changed_when(content: str, violation: dict[str, Any]) -> TransformResult:
     """Add ``changed_when: false`` to command/shell/raw tasks.
 
     This is a conservative default — the task may actually change state,

--- a/src/apme_engine/remediation/transforms/L015_jinja_when.py
+++ b/src/apme_engine/remediation/transforms/L015_jinja_when.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
@@ -11,7 +12,7 @@ from apme_engine.remediation.transforms._helpers import find_task_at_line
 _JINJA_EXPR = re.compile(r"\{\{\s*(.+?)\s*\}\}")
 
 
-def fix_jinja_when(content: str, violation: dict) -> TransformResult:
+def fix_jinja_when(content: str, violation: dict[str, Any]) -> TransformResult:
     """Replace ``{{ var }}`` in when with bare ``var``."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L018_become.py
+++ b/src/apme_engine/remediation/transforms/L018_become.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line
 
 
-def fix_become(content: str, violation: dict) -> TransformResult:
+def fix_become(content: str, violation: dict[str, Any]) -> TransformResult:
     """Add ``become: true`` when ``become_user`` is set."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L020_octal_mode.py
+++ b/src/apme_engine/remediation/transforms/L020_octal_mode.py
@@ -7,6 +7,7 @@ octal ambiguity (``0644`` → int 420 vs ``644`` → int 644).
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from apme_engine.remediation.registry import TransformResult
 
@@ -21,7 +22,7 @@ _MODE_QUOTED_NO_ZERO = re.compile(
 )
 
 
-def fix_octal_mode(content: str, violation: dict) -> TransformResult:
+def fix_octal_mode(content: str, violation: dict[str, Any]) -> TransformResult:
     """Convert ``mode: 644`` or ``mode: 0644`` to ``mode: "0644"``."""
     target_line = violation.get("line", 0)
     if isinstance(target_line, (list, tuple)):

--- a/src/apme_engine/remediation/transforms/L021_missing_mode.py
+++ b/src/apme_engine/remediation/transforms/L021_missing_mode.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key
@@ -30,7 +32,7 @@ _FILE_MODULES = frozenset(
 )
 
 
-def fix_missing_mode(content: str, violation: dict) -> TransformResult:
+def fix_missing_mode(content: str, violation: dict[str, Any]) -> TransformResult:
     """Add mode: '0644' to file-related tasks that lack an explicit mode."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L022_pipefail.py
+++ b/src/apme_engine/remediation/transforms/L022_pipefail.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key
@@ -15,7 +17,7 @@ _SHELL_MODULES = frozenset(
 )
 
 
-def fix_pipefail(content: str, violation: dict) -> TransformResult:
+def fix_pipefail(content: str, violation: dict[str, Any]) -> TransformResult:
     """Prepend ``set -o pipefail &&`` to a piped shell command."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L025_name_casing.py
+++ b/src/apme_engine/remediation/transforms/L025_name_casing.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line
 
 
-def fix_name_casing(content: str, violation: dict) -> TransformResult:
+def fix_name_casing(content: str, violation: dict[str, Any]) -> TransformResult:
     """Capitalize the first letter of a task or play name."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L043_bare_vars.py
+++ b/src/apme_engine/remediation/transforms/L043_bare_vars.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
@@ -21,7 +22,7 @@ _LOOP_KEYS = (
 )
 
 
-def fix_bare_vars(content: str, violation: dict) -> TransformResult:
+def fix_bare_vars(content: str, violation: dict[str, Any]) -> TransformResult:
     """Wrap bare variable references in Jinja delimiters: ``foo`` -> ``{{ foo }}``."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/L046_no_free_form.py
+++ b/src/apme_engine/remediation/transforms/L046_no_free_form.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from ruamel.yaml.comments import CommentedMap
 
 from apme_engine.engine.yaml_utils import FormattedYAML
@@ -25,7 +27,7 @@ _FREE_FORM_MODULES = frozenset(
 )
 
 
-def fix_free_form(content: str, violation: dict) -> TransformResult:
+def fix_free_form(content: str, violation: dict[str, Any]) -> TransformResult:
     """Convert ``command: echo hi`` to ``command: { cmd: echo hi }``."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/M001_fqcn.py
+++ b/src/apme_engine/remediation/transforms/M001_fqcn.py
@@ -6,6 +6,8 @@ L002 violations are syntactic-only; we fall back to a static builtin map.
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key, rename_key
@@ -69,15 +71,15 @@ _BUILTIN_FQCN: dict[str, str] = {
 }
 
 
-def _resolve_fqcn(violation: dict, current_key: str) -> str | None:
+def _resolve_fqcn(violation: dict[str, Any], current_key: str) -> str | None:
     """Get the target FQCN from the violation or fall back to the static map."""
     fqcn = violation.get("resolved_fqcn")
-    if fqcn and fqcn != current_key:
-        return fqcn
+    if fqcn is not None and str(fqcn) != current_key:
+        return str(fqcn)
     return _BUILTIN_FQCN.get(current_key)
 
 
-def fix_fqcn(content: str, violation: dict) -> TransformResult:
+def fix_fqcn(content: str, violation: dict[str, Any]) -> TransformResult:
     """Rename a short module name to its FQCN."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/M006_become_unreachable.py
+++ b/src/apme_engine/remediation/transforms/M006_become_unreachable.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line
 
 
-def fix_become_unreachable(content: str, violation: dict) -> TransformResult:
+def fix_become_unreachable(content: str, violation: dict[str, Any]) -> TransformResult:
     """Add ``ignore_unreachable: true`` to tasks with become + ignore_errors."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/M008_bare_include.py
+++ b/src/apme_engine/remediation/transforms/M008_bare_include.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line, rename_key
 
 
-def fix_bare_include(content: str, violation: dict) -> TransformResult:
+def fix_bare_include(content: str, violation: dict[str, Any]) -> TransformResult:
     """Replace ``include:`` with ``ansible.builtin.include_tasks:``."""
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/transforms/M009_with_to_loop.py
+++ b/src/apme_engine/remediation/transforms/M009_with_to_loop.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from apme_engine.engine.yaml_utils import FormattedYAML
 from apme_engine.remediation.registry import TransformResult
 from apme_engine.remediation.transforms._helpers import find_task_at_line
@@ -15,7 +17,7 @@ _WITH_SIMPLE = frozenset(
 )
 
 
-def fix_with_to_loop(content: str, violation: dict) -> TransformResult:
+def fix_with_to_loop(content: str, violation: dict[str, Any]) -> TransformResult:
     """Convert simple ``with_items`` to ``loop:``.
 
     Only handles the straightforward cases (with_items, with_list,

--- a/src/apme_engine/remediation/transforms/_helpers.py
+++ b/src/apme_engine/remediation/transforms/_helpers.py
@@ -104,7 +104,7 @@ def get_module_key(task: CommentedMap) -> str | None:
     """
     for key in task:
         if key not in _TASK_META_KEYS:
-            return key
+            return str(key)
     return None
 
 

--- a/src/apme_engine/runner.py
+++ b/src/apme_engine/runner.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import time
 from pathlib import Path
+from typing import Any
 
 from apme_engine.engine.scanner import ARIScanner
 from apme_engine.validators.base import EngineDiagnostics, ScanContext
@@ -98,7 +99,7 @@ def run_scan(
     )
 
 
-def _extract_engine_diagnostics(scandata, engine_total_ms: float) -> EngineDiagnostics:
+def _extract_engine_diagnostics(scandata: Any, engine_total_ms: float) -> EngineDiagnostics:
     """Pull per-phase elapsed times from the scanner's time_records."""
     diag = EngineDiagnostics(total_ms=engine_total_ms)
     if not scandata:
@@ -109,7 +110,7 @@ def _extract_engine_diagnostics(scandata, engine_total_ms: float) -> EngineDiagn
         tr = getattr(scandata.findings, "metadata", {}).get("time_records", {})
 
     def _ms(key: str) -> float:
-        return tr.get(key, {}).get("elapsed", 0.0) * 1000
+        return float(tr.get(key, {}).get("elapsed", 0.0)) * 1000
 
     diag.parse_ms = _ms("target_load") + _ms("prm_load") + _ms("metadata_load")
     diag.annotate_ms = _ms("module_annotators") + _ms("variable_resolution")

--- a/src/apme_engine/validators/ansible/__init__.py
+++ b/src/apme_engine/validators/ansible/__init__.py
@@ -8,6 +8,7 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from apme_engine.validators.base import ScanContext
 
@@ -23,11 +24,11 @@ class AnsibleRuleTiming:
 
 @dataclass
 class AnsibleRunResult:
-    violations: list = field(default_factory=list)
-    rule_timings: list = field(default_factory=list)
+    violations: list[dict[str, Any]] = field(default_factory=list)
+    rule_timings: list[AnsibleRuleTiming] = field(default_factory=list)
 
 
-def _extract_task_nodes(hierarchy_payload: dict) -> list[dict]:
+def _extract_task_nodes(hierarchy_payload: dict[str, Any]) -> list[dict[str, Any]]:
     """Extract all taskcall nodes from the hierarchy payload."""
     nodes = []
     for tree in hierarchy_payload.get("hierarchy", []):
@@ -53,18 +54,18 @@ class AnsibleValidator:
     def __init__(
         self,
         venv_root: Path,
-        env_extra: dict | None = None,
+        env_extra: dict[str, str] | None = None,
     ):
         self._venv_root = venv_root
         self._env_extra = env_extra
 
-    def run(self, context: ScanContext) -> list[dict]:
+    def run(self, context: ScanContext) -> list[dict[str, Any]]:
         """Run all ansible checks and return violation dicts."""
         return self.run_with_timing(context).violations
 
     def run_with_timing(self, context: ScanContext) -> AnsibleRunResult:
         """Run all ansible checks and return violations + per-rule timing."""
-        violations: list[dict] = []
+        violations: list[dict[str, Any]] = []
         rule_timings: list[AnsibleRuleTiming] = []
         root_dir = Path(context.root_dir) if context.root_dir else None
 

--- a/src/apme_engine/validators/ansible/_venv.py
+++ b/src/apme_engine/validators/ansible/_venv.py
@@ -54,7 +54,7 @@ def resolve_ansible_playbook(version: str) -> Path | None:
     return None
 
 
-def setup_collections_env(collection_specs: list[str], cache_root: Path) -> dict | None:
+def setup_collections_env(collection_specs: list[str], cache_root: Path) -> dict[str, str] | None:
     """Build ANSIBLE_COLLECTIONS_PATH pointing at the cache so ansible finds collections."""
     if not collection_specs:
         return None

--- a/src/apme_engine/validators/ansible/rules/L057_syntax.py
+++ b/src/apme_engine/validators/ansible/rules/L057_syntax.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
+from typing import Any
 
 RULE_ID = "L057"
 
@@ -27,12 +28,12 @@ def _find_playbooks(root: Path) -> list[Path]:
 def run(
     venv_root: Path,
     root_dir: Path,
-    env_extra: dict | None = None,
-    **_kwargs,
-) -> list[dict]:
+    env_extra: dict[str, str] | None = None,
+    **_kwargs: Any,
+) -> list[dict[str, Any]]:
     """Run ansible-playbook --syntax-check on all playbooks under root_dir."""
     ansible_playbook = venv_root / "bin" / "ansible-playbook"
-    violations: list[dict] = []
+    violations: list[dict[str, Any]] = []
 
     if not ansible_playbook.exists():
         violations.append(

--- a/src/apme_engine/validators/ansible/rules/L058_argspec_doc.py
+++ b/src/apme_engine/validators/ansible/rules/L058_argspec_doc.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import Any
 
 RULE_ID = "L058"
 
@@ -116,23 +117,23 @@ json.dump(violations, sys.stdout)
 
 
 def run(
-    task_nodes: list[dict],
+    task_nodes: list[dict[str, Any]],
     venv_root: Path,
-    env_extra: dict | None = None,
-    **_kwargs,
-) -> list[dict]:
+    env_extra: dict[str, str] | None = None,
+    **_kwargs: Any,
+) -> list[dict[str, Any]]:
     """Run docstring-based argspec validation in the venv's Python."""
     return _run_argspec_script(_SCRIPT, task_nodes, venv_root, env_extra)
 
 
 def _run_argspec_script(
     script: str,
-    task_nodes: list[dict],
+    task_nodes: list[dict[str, Any]],
     venv_root: Path,
-    env_extra: dict | None = None,
-) -> list[dict]:
+    env_extra: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
     task_modules: dict[str, bool] = {}
-    tasks_for_check: list[dict] = []
+    tasks_for_check: list[dict[str, Any]] = []
     for node in task_nodes:
         module = node.get("module", "")
         module_options = node.get("module_options")

--- a/src/apme_engine/validators/ansible/rules/L059_argspec_mock.py
+++ b/src/apme_engine/validators/ansible/rules/L059_argspec_mock.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import Any
 
 RULE_ID = "L059"
 
@@ -176,14 +177,14 @@ json.dump(violations, sys.stdout)
 
 
 def run(
-    task_nodes: list[dict],
+    task_nodes: list[dict[str, Any]],
     venv_root: Path,
-    env_extra: dict | None = None,
-    **_kwargs,
-) -> list[dict]:
+    env_extra: dict[str, str] | None = None,
+    **_kwargs: Any,
+) -> list[dict[str, Any]]:
     """Run mock/patch-based argspec validation in the venv's Python."""
     task_modules: dict[str, bool] = {}
-    tasks_for_check: list[dict] = []
+    tasks_for_check: list[dict[str, Any]] = []
     for node in task_nodes:
         module = node.get("module", "")
         module_options = node.get("module_options")

--- a/src/apme_engine/validators/ansible/rules/M001_M004_introspect.py
+++ b/src/apme_engine/validators/ansible/rules/M001_M004_introspect.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import cast
 
 _SCRIPT = textwrap.dedent("""\
 import json, sys
@@ -53,7 +54,9 @@ json.dump(results, sys.stdout)
 """)
 
 
-def _run_introspection(module_names: list[str], venv_root: Path, env_extra: dict | None = None) -> dict:
+def _run_introspection(
+    module_names: list[str], venv_root: Path, env_extra: dict[str, str] | None = None
+) -> dict[str, object]:
     """Run plugin introspection in the venv's Python. Returns {name: info_dict}."""
     if not module_names:
         return {}
@@ -85,20 +88,20 @@ def _run_introspection(module_names: list[str], venv_root: Path, env_extra: dict
         return {}
 
     try:
-        return json.loads(result.stdout)
+        return cast(dict[str, object], json.loads(result.stdout))
     except json.JSONDecodeError:
         sys.stderr.write(f"Plugin introspection returned invalid JSON: {result.stdout[:200]}\n")
         return {}
 
 
 def run(
-    task_nodes: list[dict],
+    task_nodes: list[dict[str, object]],
     venv_root: Path,
-    env_extra: dict | None = None,
-    **_kwargs,
-) -> list[dict]:
+    env_extra: dict[str, str] | None = None,
+    **_kwargs: object,
+) -> list[dict[str, object]]:
     """Run plugin introspection and return M001-M004 violations."""
-    unique_modules = list({n.get("module", "") for n in task_nodes if n.get("module")})
+    unique_modules: list[str] = [str(m) for m in {n.get("module", "") for n in task_nodes if n.get("module")}]
     if not unique_modules:
         return []
 
@@ -108,15 +111,16 @@ def run(
 
     violations = []
     for node in task_nodes:
-        module_name = node.get("module", "")
+        module_name = str(node.get("module", ""))
         if not module_name:
             continue
 
-        info = intro.get(module_name)
-        if not info:
+        info_raw = intro.get(module_name)
+        if not isinstance(info_raw, dict):
             continue
+        info = info_raw
 
-        file_path = node.get("file", "")
+        file_path = str(node.get("file", ""))
         line = node.get("line")
         line_num = line[0] if isinstance(line, (list, tuple)) and line else 1
 
@@ -126,7 +130,7 @@ def run(
                 {
                     "rule_id": "M004",
                     "level": "error",
-                    "message": info.get("removal_msg") or f"Module {module_name} has been removed",
+                    "message": str(info.get("removal_msg", "")) or f"Module {module_name} has been removed",
                     "file": file_path,
                     "line": line_num,
                     "path": node.get("key", ""),
@@ -136,7 +140,8 @@ def run(
 
         # M001: FQCN resolution
         fqcn = info.get("fqcn", "")
-        if fqcn and fqcn != module_name and module_name.count(".") < 2:
+        fqcn = str(info.get("fqcn", ""))
+        if fqcn and fqcn != module_name and str(module_name).count(".") < 2:
             violations.append(
                 {
                     "rule_id": "M001",
@@ -153,7 +158,8 @@ def run(
         # M002: Deprecation
         if info.get("deprecated") or info.get("warnings"):
             warnings = info.get("warnings", [])
-            msg = warnings[0] if warnings else f"Module {module_name} is deprecated"
+            w_list = warnings if isinstance(warnings, list) else []
+            msg = str(w_list[0]) if w_list else f"Module {module_name} is deprecated"
             violations.append(
                 {
                     "rule_id": "M002",
@@ -178,8 +184,8 @@ def run(
                     "line": line_num,
                     "path": node.get("key", ""),
                     "original_module": module_name,
-                    "resolved_fqcn": redirects[-1],
-                    "redirect_chain": redirects,
+                    "resolved_fqcn": str(redirects[-1]) if redirects else "",
+                    "redirect_chain": [str(r) for r in redirects],
                 }
             )
 

--- a/src/apme_engine/validators/base.py
+++ b/src/apme_engine/validators/base.py
@@ -21,7 +21,7 @@ class EngineDiagnostics:
 class ScanContext:
     """What validators receive. Extensible so different backends get what they need."""
 
-    hierarchy_payload: dict
+    hierarchy_payload: dict[str, Any]
     scandata: Any = None
     root_dir: str = ""
     engine_diagnostics: EngineDiagnostics = field(default_factory=EngineDiagnostics)

--- a/src/apme_engine/validators/gitleaks/scanner.py
+++ b/src/apme_engine/validators/gitleaks/scanner.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any, cast
 
 GITLEAKS_BIN = "gitleaks"
 
@@ -35,7 +36,7 @@ def _build_rule_id(gitleaks_rule_id: str) -> str:
     return f"{RULE_PREFIX}:{gitleaks_rule_id}"
 
 
-def run_gitleaks(scan_dir: str | Path, *, timeout: int = 120) -> list[dict]:
+def run_gitleaks(scan_dir: str | Path, *, timeout: int = 120) -> list[dict[str, str | int | list[int] | None]]:
     """Run gitleaks detect on *scan_dir* (no git required) and return violation dicts."""
     scan_dir = Path(scan_dir)
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
@@ -74,7 +75,7 @@ def run_gitleaks(scan_dir: str | Path, *, timeout: int = 120) -> list[dict]:
         raw = Path(report_path).read_text()
         if not raw.strip():
             return []
-        findings = json.loads(raw)
+        findings = cast(list[dict[str, Any]], json.loads(raw))
     except (json.JSONDecodeError, OSError) as exc:
         sys.stderr.write(f"gitleaks report parse error: {exc}\n")
         sys.stderr.flush()
@@ -86,18 +87,18 @@ def run_gitleaks(scan_dir: str | Path, *, timeout: int = 120) -> list[dict]:
     return _convert_findings(findings, scan_dir)
 
 
-def _convert_findings(findings: list[dict], scan_dir: Path) -> list[dict]:
+def _convert_findings(findings: list[dict[str, Any]], scan_dir: Path) -> list[dict[str, str | int | list[int] | None]]:
     """Convert gitleaks JSON findings to APME violation dicts, filtering false positives."""
-    violations: list[dict] = []
+    violations: list[dict[str, str | int | list[int] | None]] = []
     for f in findings:
-        file_path = f.get("File", "")
+        file_path = str(f.get("File", ""))
+        match_text = str(f.get("Match", ""))
 
         try:
             rel = str(Path(file_path).relative_to(scan_dir))
         except ValueError:
             rel = file_path
 
-        match_text = f.get("Match", "")
         if _value_is_jinja(match_text):
             continue
 
@@ -108,15 +109,18 @@ def _convert_findings(findings: list[dict], scan_dir: Path) -> list[dict]:
         except OSError:
             pass
 
-        line = f.get("StartLine", 0)
-        end_line = f.get("EndLine", line)
-        gitleaks_rule = f.get("RuleID", "unknown")
+        line_val = f.get("StartLine", 0)
+        end_val = f.get("EndLine", line_val)
+        line = int(line_val) if line_val is not None else 0
+        end_line = int(end_val) if end_val is not None else line
+        gitleaks_rule = str(f.get("RuleID", "unknown"))
+        desc = str(f.get("Description", f"Secret detected: {gitleaks_rule}"))
 
         violations.append(
             {
                 "rule_id": _build_rule_id(gitleaks_rule),
                 "level": "error",
-                "message": f.get("Description", f"Secret detected: {gitleaks_rule}"),
+                "message": desc,
                 "file": rel,
                 "line": line if line == end_line else [line, end_line],
                 "path": "",

--- a/src/apme_engine/validators/native/__init__.py
+++ b/src/apme_engine/validators/native/__init__.py
@@ -20,18 +20,18 @@ class NativeRuleTiming:
 
 @dataclass
 class NativeRunResult:
-    violations: list = field(default_factory=list)
-    rule_timings: list = field(default_factory=list)
+    violations: list[dict[str, Any]] = field(default_factory=list)
+    rule_timings: list[NativeRuleTiming] = field(default_factory=list)
 
 
 def _default_rules_dir() -> str:
     return os.path.join(os.path.dirname(__file__), "rules")
 
 
-def _extract_results(data_report: dict) -> NativeRunResult:
+def _extract_results(data_report: dict[str, Any]) -> NativeRunResult:
     """Convert ARI detect() report to violations + per-rule timing."""
     violations: list[dict[str, Any]] = []
-    timing_accum: dict[str, dict] = defaultdict(lambda: {"elapsed_ms": 0.0, "violations": 0})
+    timing_accum: dict[str, dict[str, float | int]] = defaultdict(lambda: {"elapsed_ms": 0.0, "violations": 0})
 
     ari_result = data_report.get("ari_result")
     if not ari_result or not hasattr(ari_result, "targets"):
@@ -78,7 +78,11 @@ def _extract_results(data_report: dict) -> NativeRunResult:
                 )
 
     rule_timings = [
-        NativeRuleTiming(rule_id=rid, elapsed_ms=v["elapsed_ms"], violations=v["violations"])
+        NativeRuleTiming(
+            rule_id=rid,
+            elapsed_ms=v["elapsed_ms"],
+            violations=int(v["violations"]),
+        )
         for rid, v in sorted(timing_accum.items())
     ]
     return NativeRunResult(violations=violations, rule_timings=rule_timings)
@@ -87,13 +91,13 @@ def _extract_results(data_report: dict) -> NativeRunResult:
 class NativeValidator:
     """Validator that runs in-tree native (Python) rules on context.scandata (no second parse)."""
 
-    def __init__(self, rules_dir: str = "", exclude_rule_ids: tuple[str, ...] = None):
+    def __init__(self, rules_dir: str = "", exclude_rule_ids: tuple[str, ...] | None = None) -> None:
         self._rules_dir = rules_dir or _default_rules_dir()
         self._exclude_rule_ids = (
             list(exclude_rule_ids) if exclude_rule_ids is not None else list(RULES_REQUIRING_ANSIBLE)
         )
 
-    def run(self, context: ScanContext) -> list[dict]:
+    def run(self, context: ScanContext) -> list[dict[str, Any]]:
         """Run native rules on context.scandata; return list of violation dicts."""
         result = self.run_with_timing(context)
         return result.violations

--- a/src/apme_engine/validators/native/rules/L026_non_fqcn_use.py
+++ b/src/apme_engine/validators/native/rules/L026_non_fqcn_use.py
@@ -22,25 +22,33 @@ class NonFQCNUseRule(Rule):
     enabled: bool = True
     name: str = "NonFQCNUse"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
-        verdict = (
-            task.action_type == ActionType.MODULE_TYPE
-            and task.spec.action
-            and task.resolved_action
-            and task.spec.action != task.resolved_action
-            and not task.resolved_action.startswith("ansible.builtin.")
+        action_type = getattr(task, "action_type", "")
+        spec_action = getattr(task.spec, "action", None)
+        resolved_action = getattr(task, "resolved_action", "")
+        resolved_name = getattr(task, "resolved_name", "")
+        verdict = bool(
+            action_type == ActionType.MODULE_TYPE
+            and spec_action
+            and resolved_action
+            and spec_action != resolved_action
+            and not resolved_action.startswith("ansible.builtin.")
         )
         detail = {
-            "module": task.spec.action,
-            "fqcn": task.resolved_name,
+            "module": spec_action or "",
+            "fqcn": resolved_name,
         }
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L026_non_fqcn_use_test.py
+++ b/src/apme_engine/validators/native/rules/L026_non_fqcn_use_test.py
@@ -10,7 +10,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L026_non_fqcn_use import NonFQCNUseRule
 
 
-def test_L026_fires_when_short_module_not_builtin():
+def test_L026_fires_when_short_module_not_builtin() -> None:
     spec = make_task_spec(
         module="copy",
         executable="copy",
@@ -22,11 +22,12 @@ def test_L026_fires_when_short_module_not_builtin():
     rule = NonFQCNUseRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L026"
+    assert result.rule is not None and result.rule.rule_id == "L026"
 
 
-def test_L026_does_not_fire_when_fqcn_builtin():
+def test_L026_does_not_fire_when_fqcn_builtin() -> None:
     spec = make_task_spec(
         module="ansible.builtin.copy",
         executable="ansible.builtin.copy",
@@ -38,10 +39,11 @@ def test_L026_does_not_fire_when_fqcn_builtin():
     rule = NonFQCNUseRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_L026_does_not_fire_for_non_task():
+def test_L026_does_not_fire_for_non_task() -> None:
     from apme_engine.validators.native.rules._test_helpers import make_role_call, make_role_spec
 
     role_spec = make_role_spec(name="foo")

--- a/src/apme_engine/validators/native/rules/L027_role_without_metadata.py
+++ b/src/apme_engine/validators/native/rules/L027_role_without_metadata.py
@@ -19,15 +19,19 @@ class RoleWithoutMetadataRule(Rule):
     enabled: bool = True
     name: str = "RoleWithoutMetadata"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Role
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Role)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         role = ctx.current
+        if role is None:
+            return None
 
-        verdict = not role.spec.metadata
+        verdict = not getattr(role.spec, "metadata", None)
 
         return RuleResult(verdict=verdict, file=role.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L027_role_without_metadata_test.py
+++ b/src/apme_engine/validators/native/rules/L027_role_without_metadata_test.py
@@ -9,38 +9,41 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L027_role_without_metadata import RoleWithoutMetadataRule
 
 
-def test_L027_fires_when_role_has_no_metadata():
+def test_L027_fires_when_role_has_no_metadata() -> None:
     spec = make_role_spec(name="foo", metadata=None)
     role = make_role_call(spec)
     ctx = make_context(role)
     rule = RoleWithoutMetadataRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L027"
+    assert result.rule is not None and result.rule.rule_id == "L027"
 
 
-def test_L027_fires_when_role_metadata_empty_dict():
+def test_L027_fires_when_role_metadata_empty_dict() -> None:
     spec = make_role_spec(name="foo", metadata={})
     role = make_role_call(spec)
     ctx = make_context(role)
     rule = RoleWithoutMetadataRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
 
 
-def test_L027_does_not_fire_when_role_has_metadata():
+def test_L027_does_not_fire_when_role_has_metadata() -> None:
     spec = make_role_spec(name="foo", metadata={"galaxy_info": {"author": "me"}})
     role = make_role_call(spec)
     ctx = make_context(role)
     rule = RoleWithoutMetadataRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_L027_does_not_fire_for_task():
+def test_L027_does_not_fire_for_task() -> None:
     from apme_engine.validators.native.rules._test_helpers import make_task_call, make_task_spec
 
     spec = make_task_spec(module="copy")

--- a/src/apme_engine/validators/native/rules/L028_task_without_name.py
+++ b/src/apme_engine/validators/native/rules/L028_task_without_name.py
@@ -19,15 +19,19 @@ class TaskWithoutNameRule(Rule):
     enabled: bool = True
     name: str = "TaskWithoutName"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
-        verdict = not task.spec.name
+        verdict = not getattr(task.spec, "name", None)
 
         return RuleResult(verdict=verdict, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L028_task_without_name_test.py
+++ b/src/apme_engine/validators/native/rules/L028_task_without_name_test.py
@@ -9,7 +9,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L028_task_without_name import TaskWithoutNameRule
 
 
-def test_L028_fires_when_task_has_no_name():
+def test_L028_fires_when_task_has_no_name() -> None:
     spec = make_task_spec(module="copy")
     spec.name = ""
     task = make_task_call(spec)
@@ -17,21 +17,23 @@ def test_L028_fires_when_task_has_no_name():
     rule = TaskWithoutNameRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L028"
+    assert result.rule is not None and result.rule.rule_id == "L028"
 
 
-def test_L028_does_not_fire_when_task_has_name():
+def test_L028_does_not_fire_when_task_has_name() -> None:
     spec = make_task_spec(name="Install package", module="ansible.builtin.apt")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = TaskWithoutNameRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_L028_does_not_fire_for_role():
+def test_L028_does_not_fire_for_role() -> None:
     from apme_engine.validators.native.rules._test_helpers import make_role_call, make_role_spec
 
     spec = make_role_spec(name="foo")

--- a/src/apme_engine/validators/native/rules/L029_command_instead_of_shell.py
+++ b/src/apme_engine/validators/native/rules/L029_command_instead_of_shell.py
@@ -22,21 +22,28 @@ class UseShellRule(Rule):
     enabled: bool = True
     name: str = "UseShellRule"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.COMMAND
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.COMMAND,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         # define a condition for this rule here
-        verdict = (
-            task.action_type == ActionType.MODULE_TYPE
-            and task.spec.action
-            and task.resolved_action
-            and task.resolved_action == "ansible.builtin.shell"
+        action_type = getattr(task, "action_type", "")
+        spec_action = getattr(task.spec, "action", None)
+        resolved_action = getattr(task, "resolved_action", "")
+        verdict = bool(
+            action_type == ActionType.MODULE_TYPE
+            and spec_action
+            and resolved_action
+            and resolved_action == "ansible.builtin.shell"
         )
 
         return RuleResult(verdict=verdict, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L029_command_instead_of_shell_test.py
+++ b/src/apme_engine/validators/native/rules/L029_command_instead_of_shell_test.py
@@ -10,7 +10,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L029_command_instead_of_shell import UseShellRule
 
 
-def test_L029_fires_when_resolved_is_shell():
+def test_L029_fires_when_resolved_is_shell() -> None:
     spec = make_task_spec(
         module="shell",
         executable="shell",
@@ -22,11 +22,12 @@ def test_L029_fires_when_resolved_is_shell():
     rule = UseShellRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L029"
+    assert result.rule is not None and result.rule.rule_id == "L029"
 
 
-def test_L029_does_not_fire_when_resolved_is_command():
+def test_L029_does_not_fire_when_resolved_is_command() -> None:
     spec = make_task_spec(
         module="command",
         executable="command",
@@ -38,4 +39,5 @@ def test_L029_does_not_fire_when_resolved_is_command():
     rule = UseShellRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/L030_non_builtin_use.py
+++ b/src/apme_engine/validators/native/rules/L030_non_builtin_use.py
@@ -22,23 +22,30 @@ class NonBuiltinUseRule(Rule):
     enabled: bool = True
     name: str = "NonBuiltinUse"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
-        verdict = (
-            task.action_type == ActionType.MODULE_TYPE
-            and task.resolved_action
-            and not task.resolved_action.startswith("ansible.builtin.")
+        action_type = getattr(task, "action_type", "")
+        resolved_action = getattr(task, "resolved_action", "")
+        resolved_name = getattr(task, "resolved_name", "")
+        verdict = bool(
+            action_type == ActionType.MODULE_TYPE
+            and resolved_action
+            and not resolved_action.startswith("ansible.builtin.")
         )
 
         detail = {
-            "fqcn": task.resolved_name,
+            "fqcn": resolved_name,
         }
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L030_non_builtin_use_test.py
+++ b/src/apme_engine/validators/native/rules/L030_non_builtin_use_test.py
@@ -10,7 +10,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L030_non_builtin_use import NonBuiltinUseRule
 
 
-def test_L030_fires_when_module_not_builtin():
+def test_L030_fires_when_module_not_builtin() -> None:
     spec = make_task_spec(
         module="copy",
         executable_type=ExecutableType.MODULE_TYPE,
@@ -21,11 +21,12 @@ def test_L030_fires_when_module_not_builtin():
     rule = NonBuiltinUseRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L030"
+    assert result.rule is not None and result.rule.rule_id == "L030"
 
 
-def test_L030_does_not_fire_when_builtin():
+def test_L030_does_not_fire_when_builtin() -> None:
     spec = make_task_spec(
         module="ansible.builtin.copy",
         executable_type=ExecutableType.MODULE_TYPE,
@@ -36,4 +37,5 @@ def test_L030_does_not_fire_when_builtin():
     rule = NonBuiltinUseRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/L031_insecure_file_permission.py
+++ b/src/apme_engine/validators/native/rules/L031_insecure_file_permission.py
@@ -23,14 +23,18 @@ class FilePermissionRule(Rule):
     enabled: bool = False
     name: str = "FilePermissionRule"
     version: str = "v0.0.1"
-    severity: Severity = Severity.MEDIUM
-    tags: tuple = Tag.SYSTEM
+    severity: str = Severity.MEDIUM
+    tags: tuple[str, ...] = (Tag.SYSTEM,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         # define a condition for this rule here
         ac = AnnotationCondition().risk_type(RiskType.FILE_CHANGE).attr("is_insecure_permissions", True)

--- a/src/apme_engine/validators/native/rules/L031_insecure_file_permission_test.py
+++ b/src/apme_engine/validators/native/rules/L031_insecure_file_permission_test.py
@@ -4,11 +4,12 @@ from apme_engine.validators.native.rules._test_helpers import make_context, make
 from apme_engine.validators.native.rules.L031_insecure_file_permission import FilePermissionRule
 
 
-def test_R116_does_not_fire_when_no_annotation():
+def test_R116_does_not_fire_when_no_annotation() -> None:
     spec = make_task_spec(module="copy", resolved_name="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = FilePermissionRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/L032_changed_data_dependence.py
+++ b/src/apme_engine/validators/native/rules/L032_changed_data_dependence.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
@@ -19,20 +20,26 @@ class ChangedDataDependenceRule(Rule):
     enabled: bool = True
     name: str = "ChangedDataDependence"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         verdict = False
-        detail = {"variables": []}
-        if task.spec.defined_vars:
-            for v in task.spec.defined_vars:
-                all_definitions = task.variable_set.get(v, [])
+        detail: dict[str, Any] = {"variables": []}
+        defined_vars = getattr(task.spec, "defined_vars", None) or []
+        variable_set = getattr(task, "variable_set", {}) or {}
+        if defined_vars:
+            for v in defined_vars:
+                all_definitions = variable_set.get(v, [])
                 if len(all_definitions) > 1:
                     detail["variables"].append(
                         {

--- a/src/apme_engine/validators/native/rules/L032_changed_data_dependence_test.py
+++ b/src/apme_engine/validators/native/rules/L032_changed_data_dependence_test.py
@@ -9,18 +9,19 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L032_changed_data_dependence import ChangedDataDependenceRule
 
 
-def test_L032_does_not_fire_when_no_defined_vars():
+def test_L032_does_not_fire_when_no_defined_vars() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = ChangedDataDependenceRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
-    assert result.rule.rule_id == "L032"
+    assert result.rule is not None and result.rule.rule_id == "L032"
 
 
-def test_L032_fires_when_variable_redefined():
+def test_L032_fires_when_variable_redefined() -> None:
     spec = make_task_spec(module="ansible.builtin.set_fact")
     spec.set_facts = {"my_var": "x"}
     task = make_task_call(spec)
@@ -32,6 +33,8 @@ def test_L032_fires_when_variable_redefined():
     rule = ChangedDataDependenceRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
+    assert result.detail is not None
     assert len(result.detail["variables"]) == 1
     assert result.detail["variables"][0]["name"] == "my_var"

--- a/src/apme_engine/validators/native/rules/L033_unconditional_override.py
+++ b/src/apme_engine/validators/native/rules/L033_unconditional_override.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
@@ -19,20 +20,28 @@ class UnconditionalOverrideRule(Rule):
     enabled: bool = True
     name: str = "UnconditionalOverride"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         verdict = False
-        detail = {"variables": []}
-        if not task.spec.tags and not task.spec.when and task.spec.defined_vars:
-            for v in task.spec.defined_vars:
-                all_definitions = task.variable_set.get(v, [])
+        detail: dict[str, Any] = {"variables": []}
+        spec_tags = getattr(task.spec, "tags", None)
+        spec_when = getattr(task.spec, "when", None)
+        defined_vars = getattr(task.spec, "defined_vars", None) or []
+        variable_set = getattr(task, "variable_set", {}) or {}
+        if not spec_tags and not spec_when and defined_vars:
+            for v in defined_vars:
+                all_definitions = variable_set.get(v, [])
                 if len(all_definitions) > 1:
                     detail["variables"].append(
                         {

--- a/src/apme_engine/validators/native/rules/L033_unconditional_override_test.py
+++ b/src/apme_engine/validators/native/rules/L033_unconditional_override_test.py
@@ -8,18 +8,19 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L033_unconditional_override import UnconditionalOverrideRule
 
 
-def test_L033_does_not_fire_when_no_defined_vars():
+def test_L033_does_not_fire_when_no_defined_vars() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = UnconditionalOverrideRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
-    assert result.rule.rule_id == "L033"
+    assert result.rule is not None and result.rule.rule_id == "L033"
 
 
-def test_L033_does_not_fire_when_task_has_tags():
+def test_L033_does_not_fire_when_task_has_tags() -> None:
     spec = make_task_spec(module="ansible.builtin.set_fact", options={"tags": ["config"]})
     spec.set_facts = {"x": "y"}
     task = make_task_call(spec)
@@ -28,4 +29,5 @@ def test_L033_does_not_fire_when_task_has_tags():
     rule = UnconditionalOverrideRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/L034_unused_override.py
+++ b/src/apme_engine/validators/native/rules/L034_unused_override.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
@@ -19,20 +20,26 @@ class UnusedOverrideRule(Rule):
     enabled: bool = True
     name: str = "UnusedOverride"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         verdict = False
-        detail = {"variables": []}
-        if task.spec.defined_vars:
-            for v in task.spec.defined_vars:
-                all_definitions = task.variable_set.get(v, [])
+        detail: dict[str, Any] = {"variables": []}
+        defined_vars = getattr(task.spec, "defined_vars", None) or []
+        variable_set = getattr(task, "variable_set", {}) or {}
+        if defined_vars:
+            for v in defined_vars:
+                all_definitions = variable_set.get(v, [])
                 if len(all_definitions) > 1:
                     prev_prec = all_definitions[-2].type
                     new_prec = all_definitions[-1].type

--- a/src/apme_engine/validators/native/rules/L034_unused_override_test.py
+++ b/src/apme_engine/validators/native/rules/L034_unused_override_test.py
@@ -9,18 +9,19 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L034_unused_override import UnusedOverrideRule
 
 
-def test_L034_does_not_fire_when_no_defined_vars():
+def test_L034_does_not_fire_when_no_defined_vars() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = UnusedOverrideRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
-    assert result.rule.rule_id == "L034"
+    assert result.rule is not None and result.rule.rule_id == "L034"
 
 
-def test_L034_fires_when_new_definition_has_lower_precedence():
+def test_L034_fires_when_new_definition_has_lower_precedence() -> None:
     spec = make_task_spec(module="ansible.builtin.set_fact")
     spec.set_facts = {"my_var": "x"}
     task = make_task_call(spec)
@@ -32,12 +33,14 @@ def test_L034_fires_when_new_definition_has_lower_precedence():
     rule = UnusedOverrideRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
+    assert result.detail is not None
     assert len(result.detail["variables"]) == 1
     assert result.detail["variables"][0]["new_precedence"] == VariableType.RoleDefaults
 
 
-def test_L034_does_not_fire_when_single_definition():
+def test_L034_does_not_fire_when_single_definition() -> None:
     spec = make_task_spec(module="ansible.builtin.set_fact")
     spec.set_facts = {"my_var": "x"}
     task = make_task_call(spec)
@@ -46,4 +49,5 @@ def test_L034_does_not_fire_when_single_definition():
     rule = UnusedOverrideRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/L035_unnecessary_set_fact.py
+++ b/src/apme_engine/validators/native/rules/L035_unnecessary_set_fact.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
@@ -22,18 +23,23 @@ class UnnecessarySetFactRule(Rule):
     enabled: bool = True
     name: str = "UnnecessarySetFact"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
-        args = task.args.raw
+        args_obj = getattr(task, "args", None)
+        args = getattr(args_obj, "raw", None) if args_obj is not None else None
         is_impure = False
-        detail = {}
+        detail: dict[str, Any] = {}
         if isinstance(args, str):
             is_impure = "random" in args
             detail["impure_args"] = args
@@ -42,14 +48,18 @@ class UnnecessarySetFactRule(Rule):
                 if isinstance(v, str) and "random" in v:
                     is_impure = True
                     current = detail.get("impure_args", [])
-                    if not current:
+                    if not isinstance(current, list):
                         current = []
-                    detail["impure_args"] = current.append(v)
+                    current = list(current)
+                    current.append(v)
+                    detail["impure_args"] = current
 
-        verdict = (
-            task.action_type == ActionType.MODULE_TYPE
-            and task.resolved_action
-            and task.resolved_action == "ansible.builtin.set_fact"
+        action_type = getattr(task, "action_type", "")
+        resolved_action = getattr(task, "resolved_action", "")
+        verdict = bool(
+            action_type == ActionType.MODULE_TYPE
+            and resolved_action
+            and resolved_action == "ansible.builtin.set_fact"
             and is_impure
         )
 

--- a/src/apme_engine/validators/native/rules/L035_unnecessary_set_fact_test.py
+++ b/src/apme_engine/validators/native/rules/L035_unnecessary_set_fact_test.py
@@ -9,7 +9,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L035_unnecessary_set_fact import UnnecessarySetFactRule
 
 
-def test_L035_fires_when_set_fact_with_random_in_args():
+def test_L035_fires_when_set_fact_with_random_in_args() -> None:
     spec = make_task_spec(
         module="ansible.builtin.set_fact",
         executable_type=ExecutableType.MODULE_TYPE,
@@ -21,11 +21,12 @@ def test_L035_fires_when_set_fact_with_random_in_args():
     rule = UnnecessarySetFactRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L035"
+    assert result.rule is not None and result.rule.rule_id == "L035"
 
 
-def test_L035_does_not_fire_when_set_fact_without_random():
+def test_L035_does_not_fire_when_set_fact_without_random() -> None:
     spec = make_task_spec(
         module="ansible.builtin.set_fact",
         executable_type=ExecutableType.MODULE_TYPE,
@@ -37,14 +38,16 @@ def test_L035_does_not_fire_when_set_fact_without_random():
     rule = UnnecessarySetFactRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_L035_does_not_fire_for_non_set_fact():
+def test_L035_does_not_fire_for_non_set_fact() -> None:
     spec = make_task_spec(module="ansible.builtin.copy", resolved_name="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = UnnecessarySetFactRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/L036_unnecessary_include_vars.py
+++ b/src/apme_engine/validators/native/rules/L036_unnecessary_include_vars.py
@@ -22,21 +22,29 @@ class UnnecessaryIncludeVarsRule(Rule):
     enabled: bool = True
     name: str = "UnnecessaryIncludeVars"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
-        verdict = (
-            task.action_type == ActionType.MODULE_TYPE
-            and task.resolved_action
-            and task.resolved_action == "ansible.builtin.include_vars"
-            and not task.spec.tags
-            and not task.spec.when
+        action_type = getattr(task, "action_type", "")
+        resolved_action = getattr(task, "resolved_action", "")
+        spec_tags = getattr(task.spec, "tags", None)
+        spec_when = getattr(task.spec, "when", None)
+        verdict = bool(
+            action_type == ActionType.MODULE_TYPE
+            and resolved_action
+            and resolved_action == "ansible.builtin.include_vars"
+            and not spec_tags
+            and not spec_when
         )
 
         return RuleResult(verdict=verdict, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L036_unnecessary_include_vars_test.py
+++ b/src/apme_engine/validators/native/rules/L036_unnecessary_include_vars_test.py
@@ -9,7 +9,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L036_unnecessary_include_vars import UnnecessaryIncludeVarsRule
 
 
-def test_L036_fires_when_include_vars_no_tags_no_when():
+def test_L036_fires_when_include_vars_no_tags_no_when() -> None:
     spec = make_task_spec(
         module="ansible.builtin.include_vars",
         executable_type=ExecutableType.MODULE_TYPE,
@@ -21,11 +21,12 @@ def test_L036_fires_when_include_vars_no_tags_no_when():
     rule = UnnecessaryIncludeVarsRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L036"
+    assert result.rule is not None and result.rule.rule_id == "L036"
 
 
-def test_L036_does_not_fire_when_include_vars_has_tags():
+def test_L036_does_not_fire_when_include_vars_has_tags() -> None:
     spec = make_task_spec(
         module="ansible.builtin.include_vars",
         executable_type=ExecutableType.MODULE_TYPE,
@@ -37,10 +38,11 @@ def test_L036_does_not_fire_when_include_vars_has_tags():
     rule = UnnecessaryIncludeVarsRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_L036_does_not_fire_when_include_vars_has_when():
+def test_L036_does_not_fire_when_include_vars_has_when() -> None:
     spec = make_task_spec(
         module="ansible.builtin.include_vars",
         executable_type=ExecutableType.MODULE_TYPE,
@@ -52,10 +54,11 @@ def test_L036_does_not_fire_when_include_vars_has_when():
     rule = UnnecessaryIncludeVarsRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_L036_does_not_fire_for_non_include_vars():
+def test_L036_does_not_fire_for_non_include_vars() -> None:
     spec = make_task_spec(
         module="ansible.builtin.copy",
         resolved_name="ansible.builtin.copy",
@@ -65,4 +68,5 @@ def test_L036_does_not_fire_for_non_include_vars():
     rule = UnnecessaryIncludeVarsRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/L037_unresolved_module.py
+++ b/src/apme_engine/validators/native/rules/L037_unresolved_module.py
@@ -22,18 +22,25 @@ class UnresolvedModuleRule(Rule):
     enabled: bool = True
     name: str = "UnresolvedModule"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
-        verdict = task.action_type == ActionType.MODULE_TYPE and task.spec.action and not task.resolved_action
+        action_type = getattr(task, "action_type", "")
+        spec_action = getattr(task.spec, "action", None)
+        resolved_action = getattr(task, "resolved_action", "")
+        verdict = bool(action_type == ActionType.MODULE_TYPE and spec_action and not resolved_action)
         detail = {
-            "module": task.spec.action,
+            "module": spec_action or "",
         }
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L037_unresolved_module_test.py
+++ b/src/apme_engine/validators/native/rules/L037_unresolved_module_test.py
@@ -9,7 +9,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L037_unresolved_module import UnresolvedModuleRule
 
 
-def test_L037_fires_when_module_unresolved():
+def test_L037_fires_when_module_unresolved() -> None:
     spec = make_task_spec(
         module="unknown_module",
         executable_type=ExecutableType.MODULE_TYPE,
@@ -21,11 +21,12 @@ def test_L037_fires_when_module_unresolved():
     rule = UnresolvedModuleRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L037"
+    assert result.rule is not None and result.rule.rule_id == "L037"
 
 
-def test_L037_does_not_fire_when_module_resolved():
+def test_L037_does_not_fire_when_module_resolved() -> None:
     spec = make_task_spec(
         module="copy",
         executable_type=ExecutableType.MODULE_TYPE,
@@ -36,4 +37,5 @@ def test_L037_does_not_fire_when_module_resolved():
     rule = UnresolvedModuleRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/L038_unresolved_role.py
+++ b/src/apme_engine/validators/native/rules/L038_unresolved_role.py
@@ -27,19 +27,26 @@ class UnresolvedRoleRule(Rule):
     enabled: bool = True
     name: str = "UnresolvedRole"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
     result_type: type = UnresolvedRoleRuleResult
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
-        verdict = task.action_type == ActionType.ROLE_TYPE and task.spec.action and not task.resolved_action
+        action_type = getattr(task, "action_type", "")
+        spec_action = getattr(task.spec, "action", None)
+        resolved_action = getattr(task, "resolved_action", "")
+        verdict = bool(action_type == ActionType.ROLE_TYPE and spec_action and not resolved_action)
         detail = {
-            "role": task.spec.action,
+            "role": spec_action or "",
         }
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L038_unresolved_role_test.py
+++ b/src/apme_engine/validators/native/rules/L038_unresolved_role_test.py
@@ -9,7 +9,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L038_unresolved_role import UnresolvedRoleRule
 
 
-def test_L038_fires_when_role_unresolved():
+def test_L038_fires_when_role_unresolved() -> None:
     spec = make_task_spec(
         module="some_role",
         executable="some_role",
@@ -22,11 +22,12 @@ def test_L038_fires_when_role_unresolved():
     rule = UnresolvedRoleRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L038"
+    assert result.rule is not None and result.rule.rule_id == "L038"
 
 
-def test_L038_does_not_fire_when_role_resolved():
+def test_L038_does_not_fire_when_role_resolved() -> None:
     spec = make_task_spec(
         module="geerlingguy.docker",
         executable_type=ExecutableType.ROLE_TYPE,
@@ -37,14 +38,16 @@ def test_L038_does_not_fire_when_role_resolved():
     rule = UnresolvedRoleRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_L038_does_not_fire_for_module_task():
+def test_L038_does_not_fire_for_module_task() -> None:
     spec = make_task_spec(module="copy", executable_type=ExecutableType.MODULE_TYPE)
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = UnresolvedRoleRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/L039_undefined_variable.py
+++ b/src/apme_engine/validators/native/rules/L039_undefined_variable.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
@@ -20,22 +21,27 @@ class UndefinedVariableRule(Rule):
     enabled: bool = True
     name: str = "UndefinedVariable"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         verdict = False
-        detail = {}
-        for v_name in task.variable_use:
-            v = task.variable_use[v_name]
+        detail: dict[str, Any] = {}
+        variable_use = getattr(task, "variable_use", {}) or {}
+        for v_name in variable_use:
+            v = variable_use[v_name]
             if v and v[-1].type == VariableType.Unknown:
                 verdict = True
-                current = detail.get("undefined_variables", [])
+                current: list[str] = list(detail.get("undefined_variables", []))
                 current.append(v_name)
                 detail["undefined_variables"] = current
 

--- a/src/apme_engine/validators/native/rules/L039_undefined_variable_test.py
+++ b/src/apme_engine/validators/native/rules/L039_undefined_variable_test.py
@@ -9,18 +9,19 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L039_undefined_variable import UndefinedVariableRule
 
 
-def test_L039_does_not_fire_when_no_variable_use():
+def test_L039_does_not_fire_when_no_variable_use() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = UndefinedVariableRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
-    assert result.rule.rule_id == "L039"
+    assert result.rule is not None and result.rule.rule_id == "L039"
 
 
-def test_L039_fires_when_variable_use_has_unknown():
+def test_L039_fires_when_variable_use_has_unknown() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     v = Variable(name="unknown_var", value="", type=VariableType.Unknown)
@@ -29,6 +30,8 @@ def test_L039_fires_when_variable_use_has_unknown():
     rule = UndefinedVariableRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
+    assert result.detail is not None
     assert "undefined_variables" in result.detail
     assert "unknown_var" in result.detail["undefined_variables"]

--- a/src/apme_engine/validators/native/rules/L040_no_tabs.py
+++ b/src/apme_engine/validators/native/rules/L040_no_tabs.py
@@ -19,14 +19,18 @@ class NoTabsRule(Rule):
     enabled: bool = True
     name: str = "NoTabs"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         yaml_lines = getattr(task.spec, "yaml_lines", "") or ""
         lines_with_tabs = []
         for i, line in enumerate(yaml_lines.splitlines(), start=1):

--- a/src/apme_engine/validators/native/rules/L040_no_tabs_test.py
+++ b/src/apme_engine/validators/native/rules/L040_no_tabs_test.py
@@ -9,7 +9,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L040_no_tabs import NoTabsRule
 
 
-def test_L040_fires_when_yaml_has_tabs():
+def test_L040_fires_when_yaml_has_tabs() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     spec.yaml_lines = "- name: Copy\n\tcopy:\n  \tdest: /tmp"
     task = make_task_call(spec)
@@ -17,12 +17,14 @@ def test_L040_fires_when_yaml_has_tabs():
     rule = NoTabsRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L040"
+    assert result.rule is not None and result.rule.rule_id == "L040"
+    assert result.detail is not None
     assert "lines_with_tabs" in result.detail
 
 
-def test_L040_does_not_fire_when_no_tabs():
+def test_L040_does_not_fire_when_no_tabs() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     spec.yaml_lines = "- name: Copy\n  copy:\n    dest: /tmp"
     task = make_task_call(spec)
@@ -30,10 +32,11 @@ def test_L040_does_not_fire_when_no_tabs():
     rule = NoTabsRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_L040_does_not_fire_for_role():
+def test_L040_does_not_fire_for_role() -> None:
     from apme_engine.validators.native.rules._test_helpers import make_role_call, make_role_spec
 
     role = make_role_call(make_role_spec(name="foo"))

--- a/src/apme_engine/validators/native/rules/L041_key_order.py
+++ b/src/apme_engine/validators/native/rules/L041_key_order.py
@@ -1,5 +1,6 @@
 import re
 from dataclasses import dataclass
+from typing import Any
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
@@ -20,7 +21,7 @@ TASK_TOP_KEYS_ORDER = ["name", "block", "include", "import", "set_fact", "debug"
 PREFERRED_BEFORE_ACTION = {"name"}
 
 
-def _top_level_keys_from_yaml(yaml_lines: str):
+def _top_level_keys_from_yaml(yaml_lines: str) -> list[str]:
     """Return list of top-level task keys in source order (as they appear in yaml_lines)."""
     keys = []
     for line in yaml_lines.splitlines():
@@ -35,7 +36,7 @@ def _top_level_keys_from_yaml(yaml_lines: str):
     return keys
 
 
-def _first_action_key(keys, module_name: str):
+def _first_action_key(keys: list[str], module_name: str) -> str | None:
     """First key that looks like an action (module name or 'local_action', 'action')."""
     action_like = {"local_action", "action"}
     for k in keys:
@@ -51,14 +52,18 @@ class KeyOrderRule(Rule):
     enabled: bool = True
     name: str = "KeyOrder"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.QUALITY
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.QUALITY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         spec = task.spec
         yaml_lines = getattr(spec, "yaml_lines", "") or ""
         if not yaml_lines.strip():
@@ -77,7 +82,7 @@ class KeyOrderRule(Rule):
         action_index = keys.index(first_action) if first_action in keys else -1
         name_index = keys.index("name") if "name" in keys else -1
         verdict = name_index > action_index if (name_index >= 0 and action_index >= 0) else False
-        detail = {}
+        detail: dict[str, Any] = {}
         if verdict:
             detail["keys_order"] = keys
             detail["message"] = "name should appear before the action/module key"

--- a/src/apme_engine/validators/native/rules/L041_key_order_test.py
+++ b/src/apme_engine/validators/native/rules/L041_key_order_test.py
@@ -9,7 +9,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.L041_key_order import KeyOrderRule
 
 
-def test_L041_fires_when_name_after_action():
+def test_L041_fires_when_name_after_action() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     spec.yaml_lines = "copy:\n  src: a\n  dest: b\nname: Copy file"
     spec.module = "copy"
@@ -18,12 +18,14 @@ def test_L041_fires_when_name_after_action():
     rule = KeyOrderRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "L041"
+    assert result.rule is not None and result.rule.rule_id == "L041"
+    assert result.detail is not None
     assert "keys_order" in result.detail
 
 
-def test_L041_does_not_fire_when_name_before_action():
+def test_L041_does_not_fire_when_name_before_action() -> None:
     spec = make_task_spec(name="Copy", module="ansible.builtin.copy")
     spec.yaml_lines = "name: Copy\ncopy:\n  src: a\n  dest: b"
     spec.module = "copy"
@@ -32,10 +34,11 @@ def test_L041_does_not_fire_when_name_before_action():
     rule = KeyOrderRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_L041_does_not_fire_for_role():
+def test_L041_does_not_fire_for_role() -> None:
     from apme_engine.validators.native.rules._test_helpers import make_role_call, make_role_spec
 
     role = make_role_call(make_role_spec(name="foo"))

--- a/src/apme_engine/validators/native/rules/L042_complexity.py
+++ b/src/apme_engine/validators/native/rules/L042_complexity.py
@@ -22,14 +22,18 @@ class ComplexityRule(Rule):
     enabled: bool = True
     name: str = "Complexity"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         sequence = getattr(ctx.sequence, "items", []) or []
         task_count = sum(1 for t in sequence if getattr(t, "type", "") == RunTargetType.Task)
         threshold = getattr(self, "task_count_threshold", None) or DEFAULT_TASK_COUNT_THRESHOLD

--- a/src/apme_engine/validators/native/rules/L043_deprecated_bare_vars.py
+++ b/src/apme_engine/validators/native/rules/L043_deprecated_bare_vars.py
@@ -16,13 +16,13 @@ from apme_engine.engine.models import (
 BARE_VAR_PATTERN = re.compile(r"\{\{\s*[\w.]+\s*\}\}")
 
 
-def _find_bare_vars(text):
+def _find_bare_vars(text: str | None) -> list[str]:
     if not text or not isinstance(text, str):
         return []
     return BARE_VAR_PATTERN.findall(text)
 
 
-def _collect_strings_from_dict(d, out):
+def _collect_strings_from_dict(d: object, out: list[str]) -> None:
     if not isinstance(d, dict):
         if isinstance(d, str):
             out.append(d)
@@ -47,14 +47,18 @@ class DeprecatedBareVarsRule(Rule):
     enabled: bool = True
     name: str = "DeprecatedBareVars"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         spec = task.spec
         sources = []
         yaml_lines = getattr(spec, "yaml_lines", "") or ""
@@ -64,7 +68,7 @@ class DeprecatedBareVarsRule(Rule):
         module_options = getattr(spec, "module_options", None) or {}
         _collect_strings_from_dict(options, sources)
         _collect_strings_from_dict(module_options, sources)
-        raw = getattr(task.args, "raw", None)
+        raw = getattr(getattr(task, "args", None), "raw", None)
         if isinstance(raw, str):
             sources.append(raw)
         elif isinstance(raw, dict):

--- a/src/apme_engine/validators/native/rules/L044_avoid_implicit.py
+++ b/src/apme_engine/validators/native/rules/L044_avoid_implicit.py
@@ -47,14 +47,18 @@ class AvoidImplicitRule(Rule):
     enabled: bool = True
     name: str = "AvoidImplicit"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.CODING
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.CODING,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         resolved = getattr(task.spec, "resolved_name", "") or ""
         if resolved not in MODULES_NEEDING_STATE:
             return RuleResult(verdict=False, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L045_inline_env_var.py
+++ b/src/apme_engine/validators/native/rules/L045_inline_env_var.py
@@ -19,14 +19,18 @@ class InlineEnvVarRule(Rule):
     enabled: bool = True
     name: str = "InlineEnvVar"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.CODING
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.CODING,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         options = getattr(task.spec, "options", None) or {}
         has_env = "environment" in options and options.get("environment")
         verdict = bool(has_env)

--- a/src/apme_engine/validators/native/rules/L046_no_free_form.py
+++ b/src/apme_engine/validators/native/rules/L046_no_free_form.py
@@ -33,20 +33,25 @@ class NoFreeFormRule(Rule):
     enabled: bool = True
     name: str = "NoFreeForm"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.COMMAND
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.COMMAND,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
-        if task.action_type != ActionType.MODULE_TYPE:
+        if task is None:
+            return None
+        if getattr(task, "action_type", "") != ActionType.MODULE_TYPE:
             return RuleResult(verdict=False, file=task.file_info(), rule=self.get_metadata())
         resolved = getattr(task.spec, "resolved_name", "") or ""
         if resolved not in FREE_FORM_ACTIONS:
             return RuleResult(verdict=False, file=task.file_info(), rule=self.get_metadata())
-        raw = getattr(task.args, "raw", None)
+        args = getattr(task, "args", None)
+        raw = getattr(args, "raw", None) if args is not None else None
         # Free-form: args passed as a single string (no structured key)
         is_free_form = isinstance(raw, str) and raw.strip() != ""
         verdict = is_free_form

--- a/src/apme_engine/validators/native/rules/L047_no_log_password.py
+++ b/src/apme_engine/validators/native/rules/L047_no_log_password.py
@@ -14,7 +14,7 @@ from apme_engine.engine.models import (
 PASSWORD_LIKE_KEYS = frozenset({"password", "passwd", "pwd", "secret", "token", "api_key", "apikey", "private_key"})
 
 
-def _option_keys_look_like_password(module_options):
+def _option_keys_look_like_password(module_options: object) -> bool:
     if not isinstance(module_options, dict):
         return False
     return any(k and k.lower() in PASSWORD_LIKE_KEYS for k in module_options)
@@ -27,14 +27,18 @@ class NoLogPasswordRule(Rule):
     enabled: bool = False
     name: str = "NoLogPassword"
     version: str = "v0.0.1"
-    severity: Severity = Severity.MEDIUM
-    tags: tuple = Tag.SYSTEM
+    severity: str = Severity.MEDIUM
+    tags: tuple[str, ...] = (Tag.SYSTEM,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         options = getattr(task.spec, "options", None) or {}
         module_options = getattr(task.spec, "module_options", None) or {}
         has_no_log = options.get("no_log") is True

--- a/src/apme_engine/validators/native/rules/L048_no_same_owner.py
+++ b/src/apme_engine/validators/native/rules/L048_no_same_owner.py
@@ -26,14 +26,18 @@ class NoSameOwnerRule(Rule):
     enabled: bool = False
     name: str = "NoSameOwner"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.SYSTEM
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.SYSTEM,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         resolved = getattr(task.spec, "resolved_name", "") or ""
         if resolved not in COPY_MODULES:
             return RuleResult(verdict=False, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L049_loop_var_prefix.py
+++ b/src/apme_engine/validators/native/rules/L049_loop_var_prefix.py
@@ -22,14 +22,18 @@ class LoopVarPrefixRule(Rule):
     enabled: bool = True
     name: str = "LoopVarPrefix"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         options = getattr(task.spec, "options", None) or {}
         loop_control = options.get("loop_control") if isinstance(options.get("loop_control"), dict) else None
         loop_var = loop_control.get("loop_var") if loop_control else None

--- a/src/apme_engine/validators/native/rules/L050_var_naming.py
+++ b/src/apme_engine/validators/native/rules/L050_var_naming.py
@@ -1,5 +1,6 @@
 import re
 from dataclasses import dataclass
+from typing import Any
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
@@ -22,18 +23,22 @@ class VarNamingRule(Rule):
     enabled: bool = True
     name: str = "VarNaming"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         variable_use = getattr(task, "variable_use", None) or {}
         invalid = [k for k in variable_use if k and not VAR_NAMING_PATTERN.match(k)]
         verdict = len(invalid) > 0
-        detail = {}
+        detail: dict[str, Any] = {}
         if invalid:
             detail["variables"] = invalid
             detail["message"] = "variable names should be lowercase with underscores"

--- a/src/apme_engine/validators/native/rules/L051_jinja.py
+++ b/src/apme_engine/validators/native/rules/L051_jinja.py
@@ -1,5 +1,6 @@
 import re
 from dataclasses import dataclass
+from typing import Any
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
@@ -23,14 +24,18 @@ class JinjaRule(Rule):
     enabled: bool = True
     name: str = "Jinja"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.QUALITY
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.QUALITY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         spec = task.spec
         yaml_lines = getattr(spec, "yaml_lines", "") or ""
         options = getattr(spec, "options", None) or {}
@@ -43,7 +48,7 @@ class JinjaRule(Rule):
                         text += " " + val
         violations = JINJA_NO_SPACE.findall(text)
         verdict = len(violations) > 0
-        detail = {}
+        detail: dict[str, Any] = {}
         if violations:
             detail["bad_expressions"] = list(dict.fromkeys(violations))[:10]
             detail["message"] = "use spaces inside Jinja expressions: {{ var }}"

--- a/src/apme_engine/validators/native/rules/L052_galaxy_version_incorrect.py
+++ b/src/apme_engine/validators/native/rules/L052_galaxy_version_incorrect.py
@@ -24,14 +24,18 @@ class GalaxyVersionIncorrectRule(Rule):
     enabled: bool = True
     name: str = "GalaxyVersionIncorrect"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Role
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Role)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         role = ctx.current
+        if role is None:
+            return None
         metadata = getattr(role.spec, "metadata", None) or {}
         gi = metadata.get("galaxy_info")
         galaxy_info = gi if isinstance(gi, dict) else {}

--- a/src/apme_engine/validators/native/rules/L053_meta_incorrect.py
+++ b/src/apme_engine/validators/native/rules/L053_meta_incorrect.py
@@ -19,14 +19,18 @@ class MetaIncorrectRule(Rule):
     enabled: bool = True
     name: str = "MetaIncorrect"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Role
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Role)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         role = ctx.current
+        if role is None:
+            return None
         metadata = getattr(role.spec, "metadata", None) or {}
         if not isinstance(metadata, dict):
             return RuleResult(

--- a/src/apme_engine/validators/native/rules/L054_meta_no_tags.py
+++ b/src/apme_engine/validators/native/rules/L054_meta_no_tags.py
@@ -21,14 +21,18 @@ class MetaNoTagsRule(Rule):
     enabled: bool = True
     name: str = "MetaNoTags"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Role
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Role)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         role = ctx.current
+        if role is None:
+            return None
         metadata = getattr(role.spec, "metadata", None) or {}
         gi = metadata.get("galaxy_info")
         galaxy_info = gi if isinstance(gi, dict) else {}

--- a/src/apme_engine/validators/native/rules/L055_meta_video_links.py
+++ b/src/apme_engine/validators/native/rules/L055_meta_video_links.py
@@ -22,16 +22,21 @@ class MetaVideoLinksRule(Rule):
     enabled: bool = True
     name: str = "MetaVideoLinks"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Role
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Role)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         role = ctx.current
+        if role is None:
+            return None
         metadata = getattr(role.spec, "metadata", None) or {}
-        galaxy_info = metadata.get("galaxy_info") if isinstance(metadata.get("galaxy_info"), dict) else {}
+        gi = metadata.get("galaxy_info")
+        galaxy_info = gi if isinstance(gi, dict) else {}
         video_links = galaxy_info.get("video_links") if galaxy_info else None
         if not video_links:
             return RuleResult(verdict=False, file=role.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/L056_sanity.py
+++ b/src/apme_engine/validators/native/rules/L056_sanity.py
@@ -28,14 +28,16 @@ class SanityRule(Rule):
     enabled: bool = True
     name: str = "Sanity"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.QUALITY
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.QUALITY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type in (RunTargetType.Task, RunTargetType.Role)
+        return bool(ctx.current is not None and ctx.current.type in (RunTargetType.Task, RunTargetType.Role))
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         target = ctx.current
+        if target is None:
+            return None
         defined_in = getattr(target.spec, "defined_in", "") or ""
         verdict = any(p.search(defined_in) for p in SANITY_IGNORE_PATTERNS)
         detail = {}

--- a/src/apme_engine/validators/native/rules/M005_data_tagging.py
+++ b/src/apme_engine/validators/native/rules/M005_data_tagging.py
@@ -29,14 +29,18 @@ class DataTaggingRule(Rule):
     enabled: bool = True
     name: str = "DataTagging"
     version: str = "v0.0.1"
-    severity: Severity = Severity.HIGH
-    tags: tuple = Tag.CODING
+    severity: str = Severity.HIGH
+    tags: tuple[str, ...] = (Tag.CODING,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         options = getattr(task.spec, "options", None) or {}
         module_options = getattr(task.spec, "module_options", None) or {}
 
@@ -66,7 +70,7 @@ class DataTaggingRule(Rule):
                     flagged.append(var_name)
 
         verdict = len(flagged) > 0
-        detail = {}
+        detail: dict[str, object] = {}
         if flagged:
             detail["message"] = (
                 f"Registered variable(s) {', '.join(set(flagged))} used in Jinja template; may be untrusted in 2.19+"

--- a/src/apme_engine/validators/native/rules/M010_python2_interpreter.py
+++ b/src/apme_engine/validators/native/rules/M010_python2_interpreter.py
@@ -24,14 +24,18 @@ class Python2InterpreterRule(Rule):
     enabled: bool = True
     name: str = "Python2Interpreter"
     version: str = "v0.0.1"
-    severity: Severity = Severity.HIGH
-    tags: tuple = Tag.CODING
+    severity: str = Severity.HIGH
+    tags: tuple[str, ...] = (Tag.CODING,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
         options = getattr(task.spec, "options", None) or {}
         module_options = getattr(task.spec, "module_options", None) or {}
         task_vars = options.get("vars") or {}

--- a/src/apme_engine/validators/native/rules/P001_module_name_validation.py
+++ b/src/apme_engine/validators/native/rules/P001_module_name_validation.py
@@ -4,12 +4,13 @@ from apme_engine.engine.models import (
     AnsibleRunContext,
     ExecutableType,
     Rule,
+    RuleResult,
     RunTargetType,
     Severity,
+    Task,
+    TaskCall,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
 @dataclass
@@ -19,18 +20,25 @@ class ModuleNameValidationRule(Rule):
     enabled: bool = True
     name: str = "ModuleNameValidation"
     version: str = "v0.0.1"
-    severity: Severity = Severity.NONE
-    tags: tuple = Tag.QUALITY
+    severity: str = Severity.NONE
+    tags: tuple[str, ...] = (Tag.QUALITY,)
     precedence: int = 0
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None or not isinstance(task, TaskCall):
+            return None
+        spec = task.spec
+        if not isinstance(spec, Task):
+            return None
 
-        suggested_fqcns = []
-        suggested_dependency = []
+        suggested_fqcns: list[str] = []
+        suggested_dependency: list[object] = []
         resolved_fqcn = ""
         wrong_module_name = ""
         not_exist = False
@@ -38,38 +46,35 @@ class ModuleNameValidationRule(Rule):
         need_correction = False
 
         # normal task
-        if task.spec.executable_type == ExecutableType.MODULE_TYPE:
-            resolved_fqcn = task.spec.resolved_name
-            suggested_fqcns = [cand[0] for cand in task.spec.possible_candidates]
-            suggested_dependency = [cand[1] for cand in task.spec.possible_candidates]
+        if spec.executable_type == ExecutableType.MODULE_TYPE:
+            resolved_fqcn = spec.resolved_name
+            suggested_fqcns = [cand[0] for cand in spec.possible_candidates]
+            suggested_dependency = [cand[1] for cand in spec.possible_candidates]
 
-            if not task.spec.resolved_name:
+            if not spec.resolved_name:
                 for suggestion in suggested_fqcns:
-                    if suggestion != task.spec.module and not suggestion.endswith(f".{task.spec.module}"):
-                        wrong_module_name = task.spec.module
+                    if suggestion != spec.module and not suggestion.endswith(f".{spec.module}"):
+                        wrong_module_name = spec.module
                         break
-                if not task.spec.possible_candidates:
+                if not spec.possible_candidates:
                     not_exist = True
-                    wrong_module_name = task.spec.module
+                    wrong_module_name = spec.module
 
-            if task.spec.resolved_name:
-                correct_fqcn = task.spec.resolved_name
+            if spec.resolved_name:
+                correct_fqcn = spec.resolved_name
             elif suggested_fqcns:
                 correct_fqcn = suggested_fqcns[0]
 
-            if correct_fqcn != task.spec.module or not_exist:
+            if correct_fqcn != spec.module or not_exist:
                 need_correction = True
 
         # include_role, import_role
-        elif (
-            task.spec.executable_type == ExecutableType.ROLE_TYPE
-            or task.spec.executable_type == ExecutableType.TASKFILE_TYPE
-        ):
-            if "ansible.builtin." in task.spec.module:
-                resolved_fqcn = task.spec.module
+        elif spec.executable_type == ExecutableType.ROLE_TYPE or spec.executable_type == ExecutableType.TASKFILE_TYPE:
+            if "ansible.builtin." in spec.module:
+                resolved_fqcn = spec.module
                 correct_fqcn = resolved_fqcn
             else:
-                resolved_fqcn = "ansible.builtin." + task.spec.module
+                resolved_fqcn = "ansible.builtin." + spec.module
                 correct_fqcn = resolved_fqcn
                 need_correction = True
 

--- a/src/apme_engine/validators/native/rules/P002_module_argument_key_validation.py
+++ b/src/apme_engine/validators/native/rules/P002_module_argument_key_validation.py
@@ -5,19 +5,19 @@ from apme_engine.engine.models import (
     AnsibleRunContext,
     ExecutableType,
     Rule,
+    RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
-def is_set_fact(module_fqcn):
+def is_set_fact(module_fqcn: str) -> bool:
     return module_fqcn == "ansible.builtin.set_fact"
 
 
-def is_meta(module_fqcn):
+def is_meta(module_fqcn: str) -> bool:
     return module_fqcn == "ansible.builtin.meta"
 
 
@@ -28,18 +28,26 @@ class ModuleArgumentKeyValidationRule(Rule):
     enabled: bool = True
     name: str = "ModuleArgumentKeyValidation"
     version: str = "v0.0.1"
-    severity: Severity = Severity.NONE
-    tags: tuple = Tag.QUALITY
+    severity: str = Severity.NONE
+    tags: tuple[str, ...] = (Tag.QUALITY,)
     precedence: int = 0
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None or not isinstance(task, TaskCall):
+            return None
 
-        if task.spec.executable_type == ExecutableType.MODULE_TYPE and task.module and task.module.arguments:
-            mo = task.spec.module_options
+        if (
+            getattr(task.spec, "executable_type", "") == ExecutableType.MODULE_TYPE
+            and task.module
+            and task.module.arguments
+        ):
+            mo = getattr(task.spec, "module_options", {})
             module_fqcn = task.get_annotation(key="module.correct_fqcn")
             module_short = ""
             if module_fqcn:

--- a/src/apme_engine/validators/native/rules/P003_module_argument_value_validation.py
+++ b/src/apme_engine/validators/native/rules/P003_module_argument_value_validation.py
@@ -5,20 +5,21 @@ from apme_engine.engine.models import (
     ArgumentsType,
     ExecutableType,
     Rule,
+    RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
     VariableType,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
-def is_loop_var(value, task):
+def is_loop_var(value: str, task: TaskCall) -> bool:
     # `item` and alternative loop variable (if any) should not be replaced to avoid breaking loop
     skip_variables = ["item"]
-    if task.spec.loop and isinstance(task.spec.loop, dict):
-        skip_variables.extend(list(task.spec.loop.keys()))
+    loop = getattr(task.spec, "loop", None)
+    if loop and isinstance(loop, dict):
+        skip_variables.extend(list(loop.keys()))
 
     _v = value.replace(" ", "")
 
@@ -30,7 +31,7 @@ def is_loop_var(value, task):
     return False
 
 
-def is_debug(module_fqcn):
+def is_debug(module_fqcn: str) -> bool:
     return module_fqcn == "ansible.builtin.debug"
 
 
@@ -41,17 +42,25 @@ class ModuleArgumentValueValidationRule(Rule):
     enabled: bool = True
     name: str = "ModuleArgumentValueValidation"
     version: str = "v0.0.1"
-    severity: Severity = Severity.NONE
-    tags: tuple = Tag.QUALITY
+    severity: str = Severity.NONE
+    tags: tuple[str, ...] = (Tag.QUALITY,)
     precedence: int = 0
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None or not isinstance(task, TaskCall):
+            return None
 
-        if task.spec.executable_type == ExecutableType.MODULE_TYPE and task.module and task.module.arguments:
+        if (
+            getattr(task.spec, "executable_type", "") == ExecutableType.MODULE_TYPE
+            and task.module
+            and task.module.arguments
+        ):
             wrong_values = []
             undefined_values = []
             unknown_type_values = []

--- a/src/apme_engine/validators/native/rules/P004_variable_validation.py
+++ b/src/apme_engine/validators/native/rules/P004_variable_validation.py
@@ -4,20 +4,21 @@ from apme_engine.engine.models import (
     AnsibleRunContext,
     ArgumentsType,
     Rule,
+    RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
     VariableType,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
-def is_loop_var(value, task):
+def is_loop_var(value: str, task: TaskCall) -> bool:
     # `item` or alternative loop variable (if any) should not be replaced to avoid breaking loop
-    skip_variables = []
-    if task.spec.loop and isinstance(task.spec.loop, dict):
-        skip_variables.extend(list(task.spec.loop.keys()))
+    skip_variables: list[str] = []
+    loop = getattr(task.spec, "loop", None)
+    if loop and isinstance(loop, dict):
+        skip_variables.extend(list(loop.keys()))
 
     _v = value.replace(" ", "")
 
@@ -36,19 +37,23 @@ class VariableValidationRule(Rule):
     enabled: bool = True
     name: str = "VariableValidation"
     version: str = "v0.0.1"
-    severity: Severity = Severity.NONE
-    tags: tuple = Tag.QUALITY
+    severity: str = Severity.NONE
+    tags: tuple[str, ...] = (Tag.QUALITY,)
     precedence: int = 0
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None or not isinstance(task, TaskCall):
+            return None
 
-        undefined_variables = []
-        unknown_name_vars = []
-        unnecessary_loop = []
+        undefined_variables: list[str] = []
+        unknown_name_vars: list[str] = []
+        unnecessary_loop: list[dict[str, str]] = []
         task_arg_keys = []
         if task.args.type == ArgumentsType.DICT:
             task_arg_keys = list(task.args.raw.keys())
@@ -69,9 +74,10 @@ class VariableValidationRule(Rule):
             if v and v[-1].type == VariableType.Unknown:
                 if v_name not in undefined_variables:
                     undefined_variables.append(v_name)
+                existing_names = [x["name"] for x in unnecessary_loop if isinstance(x, dict) and "name" in x]
                 if v_name not in unknown_name_vars and v_name not in task_arg_keys:
                     unknown_name_vars.append(v_name)
-                if v_name not in unnecessary_loop:
+                if v_name not in existing_names:
                     v_str = "{{ " + v_name + " }}"
                     if not is_loop_var(v_str, task):
                         unnecessary_loop.append({"name": v_name, "suggested": v_name.replace("item.", "")})

--- a/src/apme_engine/validators/native/rules/R101_command_exec.py
+++ b/src/apme_engine/validators/native/rules/R101_command_exec.py
@@ -21,14 +21,18 @@ class CommandExecRule(Rule):
     enabled: bool = True
     name: str = "CommandExec"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.COMMAND
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.COMMAND,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         ac = AnnotationCondition().risk_type(RiskType.CMD_EXEC).attr("is_mutable_cmd", True)
         verdict = task.has_annotation_by_condition(ac)
@@ -37,6 +41,8 @@ class CommandExecRule(Rule):
         if verdict:
             anno = task.get_annotation_by_condition(ac)
             if anno:
-                detail["cmd"] = anno.command.raw
+                cmd = getattr(anno, "command", None)
+                if cmd is not None:
+                    detail["cmd"] = cmd.raw
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/R101_command_exec_test.py
+++ b/src/apme_engine/validators/native/rules/R101_command_exec_test.py
@@ -4,17 +4,18 @@ from apme_engine.validators.native.rules._test_helpers import make_context, make
 from apme_engine.validators.native.rules.R101_command_exec import CommandExecRule
 
 
-def test_R101_does_not_fire_when_no_annotation():
+def test_R101_does_not_fire_when_no_annotation() -> None:
     spec = make_task_spec(module="ansible.builtin.command", resolved_name="ansible.builtin.command")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = CommandExecRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_R101_match_only_tasks():
+def test_R101_match_only_tasks() -> None:
     from apme_engine.validators.native.rules._test_helpers import make_role_call, make_role_spec
 
     role = make_role_call(make_role_spec(name="foo"))

--- a/src/apme_engine/validators/native/rules/R103_download_exec.py
+++ b/src/apme_engine/validators/native/rules/R103_download_exec.py
@@ -23,15 +23,19 @@ class DownloadExecRule(Rule):
     enabled: bool = True
     name: str = "Download & Exec"
     version: str = "v0.0.1"
-    severity: Severity = Severity.HIGH
-    tags: tuple = (Tag.NETWORK, Tag.COMMAND)
+    severity: str = Severity.HIGH
+    tags: tuple[str, ...] = (Tag.NETWORK, Tag.COMMAND)
     precedence: int = 11
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         verdict = False
         detail = {}
@@ -40,7 +44,9 @@ class DownloadExecRule(Rule):
         if task.has_annotation_by_condition(ac):
             cmd_an = task.get_annotation_by_condition(ac)
             if cmd_an:
-                detail["command"] = cmd_an.command.raw
+                cmd = getattr(cmd_an, "command", None)
+                if cmd is not None:
+                    detail["command"] = cmd.raw
 
             ac2 = AnnotationCondition().risk_type(RiskType.INBOUND).attr("is_mutable_src", True)
             inbound_tasks = ctx.before(task).search(ac2)
@@ -48,12 +54,16 @@ class DownloadExecRule(Rule):
                 inbound_an = inbound_task.get_annotation_by_condition(ac2)
                 if not inbound_an:
                     continue
-                detail["src"] = inbound_an.src.value
+                src = getattr(inbound_an, "src", None)
+                if src is not None:
+                    detail["src"] = src.value
 
                 # check if any of the exec_files are inside the download location
                 # if so, the downloaded file is executed, so we report it
-                download_location = inbound_an.dest
-                executed_files = cmd_an.exec_files
+                download_location = getattr(inbound_an, "dest", None)
+                executed_files = getattr(cmd_an, "exec_files", []) if cmd_an else []
+                if download_location is None:
+                    continue
                 matched_files = [f for f in executed_files if f.is_inside(download_location)]
                 if matched_files:
                     detail["executed_file"] = [f.value for f in matched_files]

--- a/src/apme_engine/validators/native/rules/R103_download_exec_test.py
+++ b/src/apme_engine/validators/native/rules/R103_download_exec_test.py
@@ -4,11 +4,12 @@ from apme_engine.validators.native.rules._test_helpers import make_context, make
 from apme_engine.validators.native.rules.R103_download_exec import DownloadExecRule
 
 
-def test_R103_does_not_fire_when_no_annotation():
+def test_R103_does_not_fire_when_no_annotation() -> None:
     spec = make_task_spec(module="get_url", resolved_name="ansible.builtin.get_url")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = DownloadExecRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/R104_unauthorized_download_src.py
+++ b/src/apme_engine/validators/native/rules/R104_unauthorized_download_src.py
@@ -28,14 +28,18 @@ class InvalidDownloadSourceRule(Rule):
     enabled: bool = True
     name: str = "InvalidDownloadSource"
     version: str = "v0.0.1"
-    severity: Severity = Severity.HIGH
-    tags: tuple = Tag.NETWORK
+    severity: str = Severity.HIGH
+    tags: tuple[str, ...] = (Tag.NETWORK,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         ac = AnnotationCondition().risk_type(RiskType.INBOUND)
 
@@ -43,14 +47,15 @@ class InvalidDownloadSourceRule(Rule):
         detail = {}
 
         anno = task.get_annotation_by_condition(ac)
-        if anno and not self.is_allowed_url(anno.src.value, allow_url_list, deny_url_list):
+        src = getattr(anno, "src", None) if anno else None
+        if anno and src is not None and not self.is_allowed_url(src.value, allow_url_list, deny_url_list):
             verdict = True
-            detail["invalid_src"] = anno.src.value
+            detail["invalid_src"] = src.value
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())
 
-    def is_allowed_url(self, src, allow_list, deny_list):
-        matched = True
+    def is_allowed_url(self, src: str, allow_list: list[str], deny_list: list[str]) -> bool:
+        matched: bool = True
         if len(allow_list) > 0:
             matched = False
             for a in allow_list:

--- a/src/apme_engine/validators/native/rules/R105_outbound_transfer.py
+++ b/src/apme_engine/validators/native/rules/R105_outbound_transfer.py
@@ -23,14 +23,18 @@ class InboundTransferRule(Rule):
     enabled: bool = True
     name: str = "OutboundTransfer"
     version: str = "v0.0.1"
-    severity: Severity = Severity.MEDIUM
-    tags: tuple = Tag.NETWORK
+    severity: str = Severity.MEDIUM
+    tags: tuple[str, ...] = (Tag.NETWORK,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         ac = AnnotationCondition().risk_type(RiskType.OUTBOUND).attr("is_mutable_dest", True)
         verdict = task.has_annotation_by_condition(ac)
@@ -39,7 +43,11 @@ class InboundTransferRule(Rule):
         if verdict:
             anno = task.get_annotation_by_condition(ac)
             if anno:
-                detail["from"] = anno.src.value
-                detail["to"] = anno.dest.value
+                src = getattr(anno, "src", None)
+                dest = getattr(anno, "dest", None)
+                if src is not None:
+                    detail["from"] = src.value
+                if dest is not None:
+                    detail["to"] = dest.value
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/R106_inbound_transfer.py
+++ b/src/apme_engine/validators/native/rules/R106_inbound_transfer.py
@@ -28,15 +28,19 @@ class InboundTransferRule(Rule):
     enabled: bool = True
     name: str = "InboundTransfer"
     version: str = "v0.0.1"
-    severity: Severity = Severity.MEDIUM
-    tags: tuple = Tag.NETWORK
+    severity: str = Severity.MEDIUM
+    tags: tuple[str, ...] = (Tag.NETWORK,)
     result_type: type = InboundRuleResult
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         ac = AnnotationCondition().risk_type(RiskType.INBOUND).attr("is_mutable_src", True)
         verdict = task.has_annotation_by_condition(ac)
@@ -45,7 +49,11 @@ class InboundTransferRule(Rule):
         if verdict:
             anno = task.get_annotation_by_condition(ac)
             if anno:
-                detail["from"] = anno.src.value
-                detail["to"] = anno.dest.value
+                src = getattr(anno, "src", None)
+                dest = getattr(anno, "dest", None)
+                if src is not None:
+                    detail["from"] = src.value
+                if dest is not None:
+                    detail["to"] = dest.value
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/R106_inbound_transfer_test.py
+++ b/src/apme_engine/validators/native/rules/R106_inbound_transfer_test.py
@@ -4,11 +4,12 @@ from apme_engine.validators.native.rules._test_helpers import make_context, make
 from apme_engine.validators.native.rules.R106_inbound_transfer import InboundTransferRule
 
 
-def test_R106_does_not_fire_when_no_annotation():
+def test_R106_does_not_fire_when_no_annotation() -> None:
     spec = make_task_spec(module="get_url", resolved_name="ansible.builtin.get_url")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = InboundTransferRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/R107_pkg_install_with_insecure_option.py
+++ b/src/apme_engine/validators/native/rules/R107_pkg_install_with_insecure_option.py
@@ -23,14 +23,18 @@ class InsecurePkgInstallRule(Rule):
     enabled: bool = True
     name: str = "InsecurePkgInstall"
     version: str = "v0.0.1"
-    severity: Severity = Severity.HIGH
-    tags: tuple = Tag.PACKAGE
+    severity: str = Severity.HIGH
+    tags: tuple[str, ...] = (Tag.PACKAGE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         ac = AnnotationCondition().risk_type(RiskType.PACKAGE_INSTALL).attr("disable_validate_certs", True)
         ac2 = AnnotationCondition().risk_type(RiskType.PACKAGE_INSTALL).attr("allow_downgrade", True)
@@ -40,9 +44,9 @@ class InsecurePkgInstallRule(Rule):
         if verdict:
             anno = task.get_annotation_by_condition(ac)
             if anno:
-                detail["pkg"] = anno.pkg
+                detail["pkg"] = getattr(anno, "pkg", None)
             anno2 = task.get_annotation_by_condition(ac2)
             if anno2:
-                detail["pkg"] = anno2.pkg
+                detail["pkg"] = getattr(anno2, "pkg", None)
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/R108_privilege_escalation.py
+++ b/src/apme_engine/validators/native/rules/R108_privilege_escalation.py
@@ -6,10 +6,9 @@ from apme_engine.engine.models import (
     RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
 @dataclass
@@ -19,16 +18,20 @@ class PrivilegeEscalationRule(Rule):
     enabled: bool = True
     name: str = "PrivilegeEscalation"
     version: str = "v0.0.1"
-    severity: Severity = Severity.HIGH
-    tags: tuple = Tag.SYSTEM
+    severity: str = Severity.HIGH
+    tags: tuple[str, ...] = (Tag.SYSTEM,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None or not isinstance(task, TaskCall):
+            return None
 
-        verdict = task.become and task.become.enabled
+        verdict = bool(task.become and task.become.enabled)
         detail = {}
         if verdict:
             detail = task.become.__dict__

--- a/src/apme_engine/validators/native/rules/R108_privilege_escalation_test.py
+++ b/src/apme_engine/validators/native/rules/R108_privilege_escalation_test.py
@@ -4,11 +4,12 @@ from apme_engine.validators.native.rules._test_helpers import make_context, make
 from apme_engine.validators.native.rules.R108_privilege_escalation import PrivilegeEscalationRule
 
 
-def test_R108_does_not_fire_when_no_annotation():
+def test_R108_does_not_fire_when_no_annotation() -> None:
     spec = make_task_spec(module="become", resolved_name="ansible.builtin.become")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = PrivilegeEscalationRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/R109_key_config_change.py
+++ b/src/apme_engine/validators/native/rules/R109_key_config_change.py
@@ -23,14 +23,18 @@ class KeyConfigChangeRule(Rule):
     enabled: bool = True
     name: str = "ConfigChange"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.SYSTEM
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.SYSTEM,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         ac = AnnotationCondition().risk_type(RiskType.CONFIG_CHANGE).attr("is_mutable_key", True)
         verdict = task.has_annotation_by_condition(ac)

--- a/src/apme_engine/validators/native/rules/R109_key_config_change_test.py
+++ b/src/apme_engine/validators/native/rules/R109_key_config_change_test.py
@@ -4,11 +4,12 @@ from apme_engine.validators.native.rules._test_helpers import make_context, make
 from apme_engine.validators.native.rules.R109_key_config_change import KeyConfigChangeRule
 
 
-def test_R109_does_not_fire_when_no_annotation():
+def test_R109_does_not_fire_when_no_annotation() -> None:
     spec = make_task_spec(module="lineinfile", resolved_name="ansible.builtin.lineinfile")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = KeyConfigChangeRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/R111_parameterized_import_role.py
+++ b/src/apme_engine/validators/native/rules/R111_parameterized_import_role.py
@@ -6,13 +6,12 @@ from apme_engine.engine.models import (
     RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
 )
 from apme_engine.engine.models import (
     ExecutableType as ActionType,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
 @dataclass
@@ -22,17 +21,23 @@ class ParameterizedImportRoleRule(Rule):
     enabled: bool = True
     name: str = "ParameterizedImportRole"
     version: str = "v0.0.1"
-    severity: Severity = Severity.HIGH
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.HIGH
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None or not isinstance(task, TaskCall):
+            return None
 
         role_ref_arg = task.args.get("name")
-        verdict = task.action_type == ActionType.ROLE_TYPE and role_ref_arg and role_ref_arg.is_mutable
+        verdict = bool(
+            task.action_type == ActionType.ROLE_TYPE and role_ref_arg is not None and role_ref_arg.is_mutable
+        )
         role_ref = role_ref_arg.raw if role_ref_arg else None
         detail = {
             "role": role_ref,

--- a/src/apme_engine/validators/native/rules/R112_parameterized_import_taskfile.py
+++ b/src/apme_engine/validators/native/rules/R112_parameterized_import_taskfile.py
@@ -6,13 +6,12 @@ from apme_engine.engine.models import (
     RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
 )
 from apme_engine.engine.models import (
     ExecutableType as ActionType,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
 @dataclass
@@ -22,14 +21,18 @@ class ParameterizedImportTaskfileRule(Rule):
     enabled: bool = True
     name: str = "ParameterizedImportTaskfile"
     version: str = "v0.0.1"
-    severity: Severity = Severity.MEDIUM
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.MEDIUM
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None or not isinstance(task, TaskCall):
+            return None
 
         # import_tasks: xxx.yml
         #   or
@@ -40,7 +43,11 @@ class ParameterizedImportTaskfileRule(Rule):
         if not taskfile_ref_arg:
             taskfile_ref_arg = task.args
 
-        verdict = task.action_type == ActionType.TASKFILE_TYPE and taskfile_ref_arg and taskfile_ref_arg.is_mutable
+        verdict = bool(
+            task.action_type == ActionType.TASKFILE_TYPE
+            and taskfile_ref_arg is not None
+            and taskfile_ref_arg.is_mutable
+        )
         taskfile_ref = taskfile_ref_arg.raw if taskfile_ref_arg else None
         detail = {
             "taskfile": taskfile_ref,

--- a/src/apme_engine/validators/native/rules/R113_parameterized_pkg_install.py
+++ b/src/apme_engine/validators/native/rules/R113_parameterized_pkg_install.py
@@ -28,15 +28,19 @@ class PkgInstallRule(Rule):
     enabled: bool = True
     name: str = "PkgInstall"
     version: str = "v0.0.1"
-    severity: Severity = Severity.MEDIUM
-    tags: tuple = Tag.PACKAGE
+    severity: str = Severity.MEDIUM
+    tags: tuple[str, ...] = (Tag.PACKAGE,)
     result_type: type = PkgInstallRuleResult
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         ac = AnnotationCondition().risk_type(RiskType.PACKAGE_INSTALL).attr("is_mutable_pkg", True)
         verdict = task.has_annotation_by_condition(ac)
@@ -45,6 +49,6 @@ class PkgInstallRule(Rule):
         if verdict:
             anno = task.get_annotation_by_condition(ac)
             if anno:
-                detail["pkg"] = anno.pkg
+                detail["pkg"] = getattr(anno, "pkg", None)
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/R113_parameterized_pkg_install_test.py
+++ b/src/apme_engine/validators/native/rules/R113_parameterized_pkg_install_test.py
@@ -4,11 +4,12 @@ from apme_engine.validators.native.rules._test_helpers import make_context, make
 from apme_engine.validators.native.rules.R113_parameterized_pkg_install import PkgInstallRule
 
 
-def test_R113_does_not_fire_when_no_annotation():
+def test_R113_does_not_fire_when_no_annotation() -> None:
     spec = make_task_spec(module="yum", resolved_name="ansible.builtin.yum")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = PkgInstallRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/R114_file_change.py
+++ b/src/apme_engine/validators/native/rules/R114_file_change.py
@@ -23,14 +23,18 @@ class FileChangeRule(Rule):
     enabled: bool = True
     name: str = "ConfigChange"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.SYSTEM
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.SYSTEM,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         ac = AnnotationCondition().risk_type(RiskType.FILE_CHANGE).attr("is_mutable_path", True)
         ac2 = AnnotationCondition().risk_type(RiskType.FILE_CHANGE).attr("is_mutable_src", True)
@@ -40,12 +44,16 @@ class FileChangeRule(Rule):
             verdict = True
             anno = task.get_annotation_by_condition(ac)
             if anno:
-                detail["path"] = anno.path.value
+                path = getattr(anno, "path", None)
+                if path is not None:
+                    detail["path"] = path.value
 
         if task.has_annotation_by_condition(ac2):
             verdict = True
             anno = task.get_annotation_by_condition(ac2)
             if anno:
-                detail["src"] = anno.src.value
+                src = getattr(anno, "src", None)
+                if src is not None:
+                    detail["src"] = src.value
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/R114_file_change_test.py
+++ b/src/apme_engine/validators/native/rules/R114_file_change_test.py
@@ -4,11 +4,12 @@ from apme_engine.validators.native.rules._test_helpers import make_context, make
 from apme_engine.validators.native.rules.R114_file_change import FileChangeRule
 
 
-def test_R114_does_not_fire_when_no_annotation():
+def test_R114_does_not_fire_when_no_annotation() -> None:
     spec = make_task_spec(module="copy", resolved_name="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = FileChangeRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/R115_file_deletion.py
+++ b/src/apme_engine/validators/native/rules/R115_file_deletion.py
@@ -7,13 +7,10 @@ from apme_engine.engine.models import (
     RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
 )
-from apme_engine.engine.models import (
-    DefaultRiskType as RiskType,
-)
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import DefaultRiskType as RiskType
+from apme_engine.engine.models import RuleTag as Tag
 
 
 @dataclass
@@ -23,23 +20,27 @@ class FileDeletionRule(Rule):
     enabled: bool = False
     name: str = "FileDeletionRule"
     version: str = "v0.0.1"
-    severity: Severity = Severity.LOW
-    tags: tuple = Tag.SYSTEM
+    severity: str = Severity.LOW
+    tags: tuple[str, ...] = (Tag.SYSTEM,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None or not isinstance(task, TaskCall):
+            return None
 
         # define a condition for this rule here
         ac = AnnotationCondition().risk_type(RiskType.FILE_CHANGE).attr("is_delete", True).attr("is_mutable_path", True)
         verdict = task.has_annotation_by_condition(ac)
 
-        detail = {}
+        detail: dict[str, object] = {}
         if verdict:
             anno = task.get_annotation_by_condition(ac)
-            if anno:
+            if anno is not None and hasattr(anno, "path") and anno.path is not None:
                 detail["path"] = anno.path.value
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/R115_file_deletion_test.py
+++ b/src/apme_engine/validators/native/rules/R115_file_deletion_test.py
@@ -4,11 +4,12 @@ from apme_engine.validators.native.rules._test_helpers import make_context, make
 from apme_engine.validators.native.rules.R115_file_deletion import FileDeletionRule
 
 
-def test_R115_does_not_fire_when_no_annotation():
+def test_R115_does_not_fire_when_no_annotation() -> None:
     spec = make_task_spec(module="file", resolved_name="ansible.builtin.file")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = FileDeletionRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/R117_external_role.py
+++ b/src/apme_engine/validators/native/rules/R117_external_role.py
@@ -2,14 +2,13 @@ from dataclasses import dataclass
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
+    RoleCall,
     Rule,
     RuleResult,
     RunTargetType,
     Severity,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
 @dataclass
@@ -24,21 +23,27 @@ class ExternalRoleRule(Rule):
     enabled: bool = True
     name: str = "ExternalRole"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.DEPENDENCY
-    result_type: type = ExternalRoleRuleResult
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
+    result_type: type[RuleResult] = ExternalRoleRuleResult
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Role
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Role)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         role = ctx.current
+        if role is None:
+            return None
 
-        verdict = (
+        spec_metadata = getattr(role.spec, "metadata", None)
+        verdict = bool(
             not ctx.is_begin(role)
-            and role.spec.metadata
-            and isinstance(role.spec.metadata, dict)
-            and role.spec.metadata.get("galaxy_info", None)
+            and isinstance(role, RoleCall)
+            and spec_metadata
+            and isinstance(spec_metadata, dict)
+            and spec_metadata.get("galaxy_info", None)
         )
 
         return RuleResult(verdict=verdict, file=role.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/R117_external_role_test.py
+++ b/src/apme_engine/validators/native/rules/R117_external_role_test.py
@@ -9,7 +9,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.R117_external_role import ExternalRoleRule
 
 
-def test_R117_fires_when_role_not_begin_and_has_galaxy_info():
+def test_R117_fires_when_role_not_begin_and_has_galaxy_info() -> None:
     r1_spec = make_role_spec(name="internal", key="role role:internal")
     r2_spec = make_role_spec(
         name="external",
@@ -22,11 +22,12 @@ def test_R117_fires_when_role_not_begin_and_has_galaxy_info():
     rule = ExternalRoleRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "R117"
+    assert result.rule is not None and result.rule.rule_id == "R117"
 
 
-def test_R117_does_not_fire_when_role_is_begin():
+def test_R117_does_not_fire_when_role_is_begin() -> None:
     spec = make_role_spec(
         name="external",
         metadata={"galaxy_info": {"galaxy_api_url": "https://galaxy.ansible.com"}},
@@ -36,10 +37,11 @@ def test_R117_does_not_fire_when_role_is_begin():
     rule = ExternalRoleRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
 
 
-def test_R117_does_not_fire_when_role_has_no_galaxy_info():
+def test_R117_does_not_fire_when_role_has_no_galaxy_info() -> None:
     r1_spec = make_role_spec(name="a", key="role role:a")
     r2_spec = make_role_spec(name="b", key="role role:b", metadata={})
     r1 = make_role_call(r1_spec)
@@ -48,4 +50,5 @@ def test_R117_does_not_fire_when_role_has_no_galaxy_info():
     rule = ExternalRoleRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/R401_list_all_inbound_src.py
+++ b/src/apme_engine/validators/native/rules/R401_list_all_inbound_src.py
@@ -3,17 +3,14 @@ from dataclasses import dataclass
 from apme_engine.engine.models import (
     AnnotationCondition,
     AnsibleRunContext,
+    DefaultRiskType,
     Rule,
     RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
 )
-from apme_engine.engine.models import (
-    DefaultRiskType as RiskType,
-)
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
 @dataclass
@@ -23,25 +20,30 @@ class ListAllInboundSrcRule(Rule):
     enabled: bool = True
     name: str = "ListAllInboundSrcRule"
     version: str = "v0.0.1"
-    severity: Severity = Severity.VERY_LOW
-    tags: tuple = Tag.DEBUG
+    severity: str = Severity.VERY_LOW
+    tags: tuple[str, ...] = (Tag.DEBUG,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
-        ac = AnnotationCondition().risk_type(RiskType.INBOUND)
+        ac = AnnotationCondition().risk_type(DefaultRiskType.INBOUND)
         verdict = False
-        detail = {}
-        src_list = []
+        detail: dict[str, object] = {}
+        src_list: list[str] = []
         if ctx.is_end(task):
             tasks = ctx.search(ac)
             for t in tasks:
-                anno = t.get_annotation_by_condition(ac)
-                if anno:
-                    src_list.append(anno.src.value)
+                if isinstance(t, TaskCall):
+                    anno = t.get_annotation_by_condition(ac)
+                    if anno is not None and hasattr(anno, "src") and anno.src is not None:
+                        src_list.append(anno.src.value)
             if len(src_list) > 0:
                 verdict = True
                 detail["inbound_src"] = src_list

--- a/src/apme_engine/validators/native/rules/R401_list_all_inbound_src_test.py
+++ b/src/apme_engine/validators/native/rules/R401_list_all_inbound_src_test.py
@@ -8,22 +8,24 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.R401_list_all_inbound_src import ListAllInboundSrcRule
 
 
-def test_R401_does_not_fire_when_not_end():
+def test_R401_does_not_fire_when_not_end() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = ListAllInboundSrcRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False
-    assert result.rule.rule_id == "R401"
+    assert result.rule is not None and result.rule.rule_id == "R401"
 
 
-def test_R401_does_not_fire_at_end_when_no_inbound_sources():
+def test_R401_does_not_fire_at_end_when_no_inbound_sources() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task, sequence=[task])
     rule = ListAllInboundSrcRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/R402_list_all_used_variables.py
+++ b/src/apme_engine/validators/native/rules/R402_list_all_used_variables.py
@@ -6,10 +6,9 @@ from apme_engine.engine.models import (
     RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
 @dataclass
@@ -19,18 +18,22 @@ class ListAllUsedVariablesRule(Rule):
     enabled: bool = True
     name: str = "ListAllUsedVariables"
     version: str = "v0.0.1"
-    severity: Severity = Severity.NONE
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.NONE
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         verdict = False
-        detail = {}
-        if ctx.is_end(task):
+        detail: dict[str, object] = {}
+        if ctx.is_end(task) and isinstance(task, TaskCall):
             verdict = True
             detail["metadata"] = ctx.info
             detail["variables"] = list(task.variable_use.keys())

--- a/src/apme_engine/validators/native/rules/R402_list_all_used_variables_test.py
+++ b/src/apme_engine/validators/native/rules/R402_list_all_used_variables_test.py
@@ -8,7 +8,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.R402_list_all_used_variables import ListAllUsedVariablesRule
 
 
-def test_R402_fires_at_end_and_includes_variable_use_keys():
+def test_R402_fires_at_end_and_includes_variable_use_keys() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     task.variable_use["my_var"] = []
@@ -16,17 +16,20 @@ def test_R402_fires_at_end_and_includes_variable_use_keys():
     rule = ListAllUsedVariablesRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "R402"
+    assert result.rule is not None and result.rule.rule_id == "R402"
+    assert result.detail is not None
     assert "variables" in result.detail
     assert "my_var" in result.detail["variables"]
 
 
-def test_R402_does_not_fire_when_not_end():
+def test_R402_does_not_fire_when_not_end() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)  # sequence empty
     rule = ListAllUsedVariablesRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/R404_show_variables.py
+++ b/src/apme_engine/validators/native/rules/R404_show_variables.py
@@ -6,11 +6,10 @@ from apme_engine.engine.models import (
     RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
     VariableDict,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
 @dataclass
@@ -20,23 +19,30 @@ class ShowVariablesRule(Rule):
     enabled: bool = False
     name: str = "ShowVariables"
     version: str = "v0.0.1"
-    severity: Severity = Severity.NONE
-    tags: tuple = Tag.VARIABLE
+    severity: str = Severity.NONE
+    tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         verdict = True
-        detail = {"variables": task.variable_set}
+        variables: dict[str, object] = {}
+        if isinstance(task, TaskCall):
+            variables = task.variable_set
+        detail: dict[str, object] = {"variables": variables}
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())
 
-    def print(self, result: RuleResult):
-        variables = result.detail["variables"]
-        var_table = "None"
+    def print(self, result: RuleResult) -> str:
+        variables = result.detail.get("variables") if result.detail is not None else None
+        var_table: str = "None"
         if variables:
             var_table = "\n" + VariableDict.print_table(variables)
         output = f"ruleID={self.rule_id}, \

--- a/src/apme_engine/validators/native/rules/R404_show_variables_test.py
+++ b/src/apme_engine/validators/native/rules/R404_show_variables_test.py
@@ -8,7 +8,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.R404_show_variables import ShowVariablesRule
 
 
-def test_R404_always_fires_and_exposes_variable_set():
+def test_R404_always_fires_and_exposes_variable_set() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     task.variable_set["foo"] = []
@@ -16,16 +16,20 @@ def test_R404_always_fires_and_exposes_variable_set():
     rule = ShowVariablesRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "R404"
+    assert result.rule is not None and result.rule.rule_id == "R404"
+    assert result.detail is not None
     assert result.detail["variables"] == {"foo": []}
 
 
-def test_R404_empty_variable_set():
+def test_R404_empty_variable_set() -> None:
     spec = make_task_spec(module="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = ShowVariablesRule()
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
+    assert result.detail is not None
     assert "variables" in result.detail

--- a/src/apme_engine/validators/native/rules/R501_dependency_suggestion.py
+++ b/src/apme_engine/validators/native/rules/R501_dependency_suggestion.py
@@ -6,10 +6,9 @@ from apme_engine.engine.models import (
     RuleResult,
     RunTargetType,
     Severity,
+    Task,
 )
-from apme_engine.engine.models import (
-    RuleTag as Tag,
-)
+from apme_engine.engine.models import RuleTag as Tag
 
 
 @dataclass
@@ -19,25 +18,32 @@ class DependencySuggestionRule(Rule):
     enabled: bool = True
     name: str = "DependencySuggestion"
     version: str = "v0.0.1"
-    severity: Severity = Severity.NONE
-    tags: tuple = Tag.DEPENDENCY
+    severity: str = Severity.NONE
+    tags: tuple[str, ...] = (Tag.DEPENDENCY,)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
         task = ctx.current
+        if task is None:
+            return None
 
         verdict = False
-        detail = {}
-        if task.spec.possible_candidates:
+        detail: dict[str, object] = {}
+        spec = task.spec
+        if isinstance(spec, Task) and spec.possible_candidates:
             verdict = True
-            detail["type"] = task.spec.executable_type.lower()
-            detail["fqcn"] = task.spec.possible_candidates[0][0]
-            req_info = task.spec.possible_candidates[0][1]
-            detail["suggestion"] = {}
-            detail["suggestion"]["type"] = req_info.get("type", "")
-            detail["suggestion"]["name"] = req_info.get("name", "")
-            detail["suggestion"]["version"] = req_info.get("version", "")
+            detail["type"] = spec.executable_type.lower()
+            detail["fqcn"] = spec.possible_candidates[0][0]
+            req_info = spec.possible_candidates[0][1]
+            req_dict = req_info if isinstance(req_info, dict) else {}
+            detail["suggestion"] = {
+                "type": req_dict.get("type", ""),
+                "name": req_dict.get("name", ""),
+                "version": req_dict.get("version", ""),
+            }
 
         return RuleResult(verdict=verdict, detail=detail, file=task.file_info(), rule=self.get_metadata())

--- a/src/apme_engine/validators/native/rules/R501_dependency_suggestion_test.py
+++ b/src/apme_engine/validators/native/rules/R501_dependency_suggestion_test.py
@@ -8,7 +8,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.R501_dependency_suggestion import DependencySuggestionRule
 
 
-def test_R501_fires_when_possible_candidates():
+def test_R501_fires_when_possible_candidates() -> None:
     spec = make_task_spec(
         module="ansible.builtin.some_unknown",
         possible_candidates=[
@@ -20,17 +20,20 @@ def test_R501_fires_when_possible_candidates():
     rule = DependencySuggestionRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "R501"
+    assert result.rule is not None and result.rule.rule_id == "R501"
+    assert result.detail is not None
     assert result.detail.get("fqcn") == "ansible.builtin.copy"
     assert "suggestion" in result.detail
 
 
-def test_R501_does_not_fire_when_no_possible_candidates():
+def test_R501_does_not_fire_when_no_possible_candidates() -> None:
     spec = make_task_spec(module="ansible.builtin.copy", resolved_name="ansible.builtin.copy")
     task = make_task_call(spec)
     ctx = make_context(task)
     rule = DependencySuggestionRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is False

--- a/src/apme_engine/validators/native/rules/_test_helpers.py
+++ b/src/apme_engine/validators/native/rules/_test_helpers.py
@@ -1,28 +1,31 @@
 # Test helpers for colocated native rule tests. Build minimal Python context/task objects.
 
+from typing import Any, cast
+
 from apme_engine.engine.models import (
     AnsibleRunContext,
     ExecutableType,
     Role,
     RoleCall,
+    RunTarget,
     Task,
     TaskCall,
 )
 
 
 def make_task_spec(
-    name=None,
-    module="",
-    executable="",
-    executable_type=ExecutableType.MODULE_TYPE,
-    resolved_name="",
-    options=None,
-    module_options=None,
-    defined_in="tasks/main.yml",
-    line_num_in_file=None,
-    key=None,
-    possible_candidates=None,
-):
+    name: str | None = None,
+    module: str = "",
+    executable: str = "",
+    executable_type: str = ExecutableType.MODULE_TYPE,
+    resolved_name: str = "",
+    options: dict[str, Any] | None = None,
+    module_options: dict[str, Any] | None = None,
+    defined_in: str = "tasks/main.yml",
+    line_num_in_file: list[int] | None = None,
+    key: str | None = None,
+    possible_candidates: list[Any] | None = None,
+) -> Task:
     """Build a minimal Task spec for rule tests."""
     # Key must be "type rest" (space-separated) for set_call_object_key.
     if key is None:
@@ -44,12 +47,17 @@ def make_task_spec(
     return spec
 
 
-def make_task_call(spec):
+def make_task_call(spec: Task) -> TaskCall:
     """Build a TaskCall from a Task spec."""
-    return TaskCall.from_spec(spec, None, 0)
+    return cast(TaskCall, TaskCall.from_spec(spec, None, 0))
 
 
-def make_role_spec(name="", defined_in="roles/foo/meta/main.yml", key=None, metadata=None):
+def make_role_spec(
+    name: str = "",
+    defined_in: str = "roles/foo/meta/main.yml",
+    key: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Role:
     """Build a minimal Role spec for rule tests."""
     # Key must be "type rest" (space-separated) for set_call_object_key.
     if key is None:
@@ -62,12 +70,15 @@ def make_role_spec(name="", defined_in="roles/foo/meta/main.yml", key=None, meta
     )
 
 
-def make_role_call(spec):
+def make_role_call(spec: Role) -> RoleCall:
     """Build a RoleCall from a Role spec."""
-    return RoleCall.from_spec(spec, None, 0)
+    return cast(RoleCall, RoleCall.from_spec(spec, None, 0))
 
 
-def make_context(current, sequence=None):
+def make_context(
+    current: RunTarget | None,
+    sequence: list[RunTarget] | None = None,
+) -> AnsibleRunContext:
     """Build an AnsibleRunContext with current set (task or role). Optionally set sequence for is_begin/is_end."""
     ctx = AnsibleRunContext(root_key="playbook.yml")
     ctx.current = current

--- a/src/apme_engine/validators/native/rules/sample_rule.py
+++ b/src/apme_engine/validators/native/rules/sample_rule.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from apme_engine.engine.models import (
     AnsibleRunContext,
@@ -6,6 +7,7 @@ from apme_engine.engine.models import (
     RuleResult,
     RunTargetType,
     Severity,
+    TaskCall,
 )
 
 
@@ -16,18 +18,24 @@ class SampleRule(Rule):
     enabled: bool = False
     name: str = "EchoTaskContent"
     version: str = "v0.0.1"
-    severity: Severity = Severity.NONE
-    tags: tuple = "sample"
+    severity: str = Severity.NONE
+    tags: tuple[str, ...] = ("sample",)
 
     def match(self, ctx: AnsibleRunContext) -> bool:
         # specify targets to be checked
-        return ctx.current.type == RunTargetType.Task
+        if ctx.current is None:
+            return False
+        return bool(ctx.current.type == RunTargetType.Task)
 
-    def process(self, ctx: AnsibleRunContext):
+    def process(self, ctx: AnsibleRunContext) -> RuleResult | None:
+        if ctx.current is None:
+            return None
         task = ctx.current
+        if not isinstance(task, TaskCall) or task.content is None:
+            return None
 
         verdict = True
-        detail = {}
+        detail: dict[str, Any] = {}
         task_block = task.content.yaml()
         detail["task_block"] = task_block
 

--- a/src/apme_engine/validators/native/rules/sample_rule_test.py
+++ b/src/apme_engine/validators/native/rules/sample_rule_test.py
@@ -9,7 +9,7 @@ from apme_engine.validators.native.rules._test_helpers import (
 from apme_engine.validators.native.rules.sample_rule import SampleRule
 
 
-def test_sample_rule_matches_task_and_process_returns_task_block():
+def test_sample_rule_matches_task_and_process_returns_task_block() -> None:
     spec = make_task_spec(module="ansible.builtin.copy", name="Copy file")
     task = make_task_call(spec)
     task.content = MutableContent(_yaml="- name: Copy file\n  copy:\n    src: a\n    dest: b", _task_spec=spec)
@@ -17,7 +17,9 @@ def test_sample_rule_matches_task_and_process_returns_task_block():
     rule = SampleRule()
     assert rule.match(ctx)
     result = rule.process(ctx)
+    assert result is not None
     assert result.verdict is True
-    assert result.rule.rule_id == "Sample101"
+    assert result.rule is not None and result.rule.rule_id == "Sample101"
+    assert result.detail is not None
     assert "task_block" in result.detail
     assert "copy:" in result.detail["task_block"]

--- a/src/apme_engine/validators/opa/__init__.py
+++ b/src/apme_engine/validators/opa/__init__.py
@@ -1,6 +1,9 @@
 """OPA validator: runs Rego policy on hierarchy payload. Built-in bundle in this package."""
 
+from __future__ import annotations
+
 import os
+from typing import Any
 
 from apme_engine.opa_client import run_opa
 from apme_engine.validators.base import ScanContext
@@ -21,7 +24,7 @@ class OpaValidator:
         self.bundle_path = bundle_path or _default_bundle_path()
         self.entrypoint = entrypoint
 
-    def run(self, context: ScanContext) -> list[dict]:
+    def run(self, context: ScanContext) -> list[dict[str, Any]]:
         """Run OPA on hierarchy_payload; return list of violation dicts."""
         return run_opa(
             context.hierarchy_payload,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,20 +5,20 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture
-def repo_root():
+@pytest.fixture  # type: ignore[untyped-decorator]
+def repo_root() -> Path:
     """Project root (ansible-forward)."""
     return Path(__file__).resolve().parent.parent
 
 
-@pytest.fixture
-def opa_bundle_path(repo_root):
+@pytest.fixture  # type: ignore[untyped-decorator]
+def opa_bundle_path(repo_root: Path) -> Path:
     """Path to OPA bundle directory (built-in validator bundle)."""
     return repo_root / "src" / "apme_engine" / "validators" / "opa" / "bundle"
 
 
-@pytest.fixture
-def sample_hierarchy_payload():
+@pytest.fixture  # type: ignore[untyped-decorator]
+def sample_hierarchy_payload() -> dict[str, object]:
     """Minimal valid OPA input (hierarchy payload)."""
     return {
         "scan_id": "test-scan-1",
@@ -56,8 +56,8 @@ def sample_hierarchy_payload():
     }
 
 
-@pytest.fixture
-def opa_eval_result_with_violations():
+@pytest.fixture  # type: ignore[untyped-decorator]
+def opa_eval_result_with_violations() -> dict[str, object]:
     """OPA eval JSON output format with a list of violations."""
     return {
         "result": [
@@ -81,7 +81,7 @@ def opa_eval_result_with_violations():
     }
 
 
-@pytest.fixture
-def opa_eval_result_empty():
+@pytest.fixture  # type: ignore[untyped-decorator]
+def opa_eval_result_empty() -> dict[str, object]:
     """OPA eval JSON with empty violations."""
     return {"result": [{"expressions": [{"value": []}]}]}

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import time
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -24,22 +25,22 @@ POD_STARTUP_TIMEOUT = 90
 SERVICE_SETTLE_SECONDS = 5
 
 
-def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+def _run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
     return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
 
 
-def _podman(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+def _podman(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
     return _run(["podman", *args], check=check)
 
 
 def _pod_status() -> str:
     r = _podman("pod", "list", "--filter", f"name={POD_NAME}", "--format", "{{.Status}}", check=False)
-    return r.stdout.strip()
+    return (r.stdout or "").strip()
 
 
 def _container_logs(name: str) -> str:
     r = _podman("logs", f"{POD_NAME}-{name}", check=False)
-    return r.stdout + r.stderr
+    return (r.stdout or "") + (r.stderr or "")
 
 
 # ---------------------------------------------------------------------------
@@ -47,8 +48,8 @@ def _container_logs(name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="module")
-def pod():
+@pytest.fixture(scope="module")  # type: ignore[untyped-decorator]
+def pod() -> Any:
     """Build images (unless skipped), start the pod, yield, then tear down."""
     skip_build = os.environ.get("APME_E2E_SKIP_BUILD", "0") == "1"
     skip_teardown = os.environ.get("APME_E2E_SKIP_TEARDOWN", "0") == "1"
@@ -80,8 +81,8 @@ def pod():
         _podman("pod", "rm", "-f", POD_NAME, check=False)
 
 
-@pytest.fixture(scope="module")
-def scan_result(pod) -> dict:
+@pytest.fixture(scope="module")  # type: ignore[untyped-decorator]
+def scan_result(pod: Any) -> dict[str, Any]:
     """Run a scan of the test playbook via the CLI container and return parsed JSON."""
     test_dir = str(REPO_ROOT / "tests" / "integration")
     r = _run(
@@ -107,12 +108,13 @@ def scan_result(pod) -> dict:
     )
     assert r.returncode == 0, f"Scan failed (rc={r.returncode}):\n{r.stdout}\n{r.stderr}"
     try:
-        return json.loads(r.stdout)
+        return cast(dict[str, Any], json.loads(r.stdout))
     except json.JSONDecodeError:
         pytest.fail(f"Scan output is not valid JSON:\n{r.stdout}")
+        return {}  # unreachable; pytest.fail raises
 
 
-def _violation_rule_ids(scan_result: dict) -> set[str]:
+def _violation_rule_ids(scan_result: dict[str, Any]) -> set[str]:
     return {v.get("rule_id", "") for v in scan_result.get("violations", [])}
 
 
@@ -123,7 +125,7 @@ def _violation_rule_ids(scan_result: dict) -> set[str]:
 
 @pytest.mark.integration
 class TestHealthCheck:
-    def test_overall_ok(self, pod):
+    def test_overall_ok(self, pod: Any) -> None:
         r = _run(
             [
                 "podman",
@@ -152,7 +154,7 @@ class TestHealthCheck:
 
 @pytest.mark.integration
 class TestScanViolations:
-    def test_violations_returned(self, scan_result):
+    def test_violations_returned(self, scan_result: dict[str, Any]) -> None:
         count = scan_result.get("count", 0)
         assert count > 0, f"Expected >0 violations, got {count}"
 
@@ -166,8 +168,8 @@ class TestScanViolations:
             ("L025", "name not starting uppercase"),
             ("R118", "inbound transfer (annotation-based)"),
         ],
-    )
-    def test_opa_rule(self, scan_result, rule_id, desc):
+    )  # type: ignore[untyped-decorator]
+    def test_opa_rule(self, scan_result: dict[str, Any], rule_id: str, desc: str) -> None:
         assert rule_id in _violation_rule_ids(scan_result), f"{rule_id} ({desc}) not found"
 
     # Native rules
@@ -178,12 +180,12 @@ class TestScanViolations:
             ("native:L029", "command instead of shell"),
             ("native:L046", "free-form args"),
         ],
-    )
-    def test_native_rule(self, scan_result, rule_id, desc):
+    )  # type: ignore[untyped-decorator]
+    def test_native_rule(self, scan_result: dict[str, Any], rule_id: str, desc: str) -> None:
         assert rule_id in _violation_rule_ids(scan_result), f"{rule_id} ({desc}) not found"
 
     # Modernize rules
-    def test_m001_fqcn_resolution(self, scan_result):
+    def test_m001_fqcn_resolution(self, scan_result: dict[str, Any]) -> None:
         assert "M001" in _violation_rule_ids(scan_result), "M001 (FQCN resolution) not found"
 
     # Ansible validator rules
@@ -193,8 +195,8 @@ class TestScanViolations:
             ("L058", "argspec validation - docstring"),
             ("L059", "argspec validation - mock/patch"),
         ],
-    )
-    def test_ansible_rule(self, scan_result, rule_id, desc):
+    )  # type: ignore[untyped-decorator]
+    def test_ansible_rule(self, scan_result: dict[str, Any], rule_id: str, desc: str) -> None:
         assert rule_id in _violation_rule_ids(scan_result), f"{rule_id} ({desc}) not found"
 
 
@@ -205,9 +207,9 @@ class TestScanViolations:
 
 @pytest.mark.integration
 class TestNoDuplicates:
-    def test_no_duplicate_violations(self, scan_result):
-        seen: set[tuple] = set()
-        dups: list[tuple] = []
+    def test_no_duplicate_violations(self, scan_result: dict[str, Any]) -> None:
+        seen: set[tuple[str, str, int | tuple[int, ...]]] = set()
+        dups: list[tuple[str, str, int | tuple[int, ...]]] = []
         for v in scan_result.get("violations", []):
             line = v.get("line")
             if isinstance(line, list):
@@ -226,27 +228,27 @@ class TestNoDuplicates:
 
 @pytest.mark.integration
 class TestContainerLogs:
-    def test_primary_logged_opa_count(self, scan_result):
+    def test_primary_logged_opa_count(self, scan_result: dict[str, Any]) -> None:
         logs = _container_logs("primary")
         assert "Opa=" in logs, f"Primary did not log OPA count:\n{logs[-500:]}"
 
-    def test_primary_logged_native_count(self, scan_result):
+    def test_primary_logged_native_count(self, scan_result: dict[str, Any]) -> None:
         logs = _container_logs("primary")
         assert "Native=" in logs, f"Primary did not log Native count:\n{logs[-500:]}"
 
-    def test_opa_wrapper_logged(self, scan_result):
+    def test_opa_wrapper_logged(self, scan_result: dict[str, Any]) -> None:
         logs = _container_logs("opa")
         assert "OPA returned" in logs, f"OPA wrapper did not log:\n{logs[-500:]}"
 
-    def test_native_validator_logged(self, scan_result):
+    def test_native_validator_logged(self, scan_result: dict[str, Any]) -> None:
         logs = _container_logs("native")
         assert "Native validator returned" in logs, f"Native did not log:\n{logs[-500:]}"
 
-    def test_ansible_introspection(self, scan_result):
+    def test_ansible_introspection(self, scan_result: dict[str, Any]) -> None:
         logs = _container_logs("ansible")
         assert "introspecting" in logs, f"Ansible did not run introspection:\n{logs[-500:]}"
 
-    def test_ansible_argspec(self, scan_result):
+    def test_ansible_argspec(self, scan_result: dict[str, Any]) -> None:
         logs = _container_logs("ansible")
         assert "argspec" in logs, f"Ansible did not run argspec:\n{logs[-500:]}"
 
@@ -260,7 +262,7 @@ SECRETS_FIXTURE = REPO_ROOT / "tests" / "integration" / "test_secrets_playbook.y
 
 @pytest.mark.integration
 class TestGitleaks:
-    def test_gitleaks_container_healthy(self, pod):
+    def test_gitleaks_container_healthy(self, pod: Any) -> None:
         r = _run(
             [
                 "podman",
@@ -283,11 +285,11 @@ class TestGitleaks:
             f"Gitleaks not reported in health check:\n{combined}"
         )
 
-    def test_gitleaks_logged(self, scan_result):
+    def test_gitleaks_logged(self, scan_result: dict[str, Any]) -> None:
         logs = _container_logs("gitleaks")
         assert "Gitleaks validator" in logs, f"Gitleaks did not log:\n{logs[-500:]}"
 
-    def test_primary_logged_gitleaks_count(self, scan_result):
+    def test_primary_logged_gitleaks_count(self, scan_result: dict[str, Any]) -> None:
         logs = _container_logs("primary")
         assert "Gitleaks=" in logs, f"Primary did not log Gitleaks count:\n{logs[-500:]}"
 
@@ -301,7 +303,7 @@ FORMAT_FIXTURE = REPO_ROOT / "tests" / "integration" / "test_format_playbook.yml
 
 @pytest.mark.integration
 class TestFormat:
-    def test_format_check_detects_issues(self, pod):
+    def test_format_check_detects_issues(self, pod: Any) -> None:
         """format --check on messy fixture exits 1."""
         test_dir = str(FORMAT_FIXTURE.parent)
         r = _run(
@@ -325,7 +327,7 @@ class TestFormat:
         )
         assert r.returncode == 1, f"Expected exit 1 for messy file:\n{r.stdout}\n{r.stderr}"
 
-    def test_format_diff_shows_transforms(self, pod):
+    def test_format_diff_shows_transforms(self, pod: Any) -> None:
         """format (no --apply) shows unified diff with expected transforms."""
         test_dir = str(FORMAT_FIXTURE.parent)
         r = _run(
@@ -349,7 +351,7 @@ class TestFormat:
         assert r.returncode == 0
         assert "@@" in r.stdout or "---" in r.stdout, f"Expected unified diff output:\n{r.stdout[:500]}"
 
-    def test_format_apply_then_check_passes(self, pod, tmp_path):
+    def test_format_apply_then_check_passes(self, pod: Any, tmp_path: Path) -> None:
         """format --apply writes file; subsequent --check exits 0."""
         import shutil
 

--- a/tests/rule_doc_integration_test.py
+++ b/tests/rule_doc_integration_test.py
@@ -1,6 +1,7 @@
 """Integration tests: run engine + validators on YAML from rule .md examples and assert expected violation/pass."""
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -10,19 +11,19 @@ from apme_engine.validators.opa import OpaValidator
 from tests.rule_doc_parser import discover_rule_docs
 
 
-def _repo_root():
+def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
-def _native_rules_dir():
+def _native_rules_dir() -> Path:
     return _repo_root() / "src" / "apme_engine" / "validators" / "native" / "rules"
 
 
-def _opa_bundle_dir():
+def _opa_bundle_dir() -> Path:
     return _repo_root() / "src" / "apme_engine" / "validators" / "opa" / "bundle"
 
 
-def _violation_ids_for_rule(violations: list[dict], rule_id: str, validator: str) -> list[str]:
+def _violation_ids_for_rule(violations: list[dict[str, Any]], rule_id: str, validator: str) -> list[str]:
     """Return violation rule_id values that match this doc rule (for assertion)."""
     expected = f"native:{rule_id}" if validator == "native" else rule_id
     return [v["rule_id"] for v in violations if v.get("rule_id") == expected]
@@ -45,7 +46,7 @@ def _ensure_playbook(yaml_content: str) -> str:
         return (
             "- name: Example play\n  hosts: localhost\n  connection: local\n  tasks:\n"
             + "    - "
-            + yaml.dump(data, default_flow_style=False).strip().replace("\n", "\n    ")
+            + str(yaml.dump(data, default_flow_style=False)).strip().replace("\n", "\n    ")
         )
     # List: could be list of plays or list of tasks
     if isinstance(data, list) and data:
@@ -53,15 +54,15 @@ def _ensure_playbook(yaml_content: str) -> str:
         if isinstance(first, dict) and ("hosts" in first or "tasks" in first):
             return yaml_content
         # List of tasks
-        tasks_yaml = yaml.dump(data, default_flow_style=False)
+        tasks_yaml = str(yaml.dump(data, default_flow_style=False))
         return "- name: Example play\n  hosts: localhost\n  connection: local\n  tasks:\n" + "\n".join(
             "    " + line for line in tasks_yaml.splitlines()
         )
     return yaml_content
 
 
-@pytest.fixture(scope="module")
-def validators():
+@pytest.fixture(scope="module")  # type: ignore[untyped-decorator]
+def validators() -> dict[str, Any]:
     """OPA and Native validators. Native with no exclusions so all rules can run."""
     opa_bundle = str(_opa_bundle_dir())
     return {
@@ -70,7 +71,7 @@ def validators():
     }
 
 
-def _collect_violations(yaml_content: str, validators: dict) -> list[dict]:
+def _collect_violations(yaml_content: str, validators: dict[str, Any]) -> list[dict[str, Any]]:
     """Run scan on YAML and return combined violations from both validators."""
     content = _ensure_playbook(yaml_content)
     try:
@@ -85,7 +86,7 @@ def _collect_violations(yaml_content: str, validators: dict) -> list[dict]:
     return violations
 
 
-def _rule_doc_params():
+def _rule_doc_params() -> tuple[list[tuple[str, dict[str, Any]]], list[str]]:
     """List of (md_path, doc) and corresponding ids for parametrize."""
     pairs = discover_rule_docs(_native_rules_dir(), _opa_bundle_dir())
     if not pairs:
@@ -100,8 +101,8 @@ _param_tuples, _param_ids = _rule_doc_params()
     "md_path,doc",
     _param_tuples if _param_tuples else [("", {})],
     ids=_param_ids if _param_ids else ["no_docs"],
-)
-def test_rule_doc_examples(md_path, doc, validators):
+)  # type: ignore[untyped-decorator]
+def test_rule_doc_examples(md_path: str, doc: dict[str, Any], validators: dict[str, Any]) -> None:
     """For each rule .md with frontmatter and examples, run YAML and assert violation/pass."""
     if not doc.get("examples"):
         pytest.skip(f"No examples in {md_path}")
@@ -124,7 +125,7 @@ def test_rule_doc_examples(md_path, doc, validators):
             assert not matching, f"{md_path} example {i + 1} (pass): expected no {rule_id}, got: {matching}"
 
 
-def test_rule_doc_parser_smoke():
+def test_rule_doc_parser_smoke() -> None:
     """Ensure at least one rule doc is discoverable and parseable."""
     docs = discover_rule_docs(_native_rules_dir(), _opa_bundle_dir())
     # R102 should have frontmatter and examples

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 import json
 from io import StringIO
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,19 +12,19 @@ import apme_engine.cli as cli_module
 from apme_engine.validators.base import ScanContext
 
 
-def _make_context(hierarchy_payload: dict, scandata=None):
+def _make_context(hierarchy_payload: dict[str, Any], scandata: Any = None) -> ScanContext:
     return ScanContext(hierarchy_payload=hierarchy_payload, scandata=scandata, root_dir="")
 
 
 class TestMain:
     """Tests for main() CLI entrypoint."""
 
-    @pytest.fixture(autouse=True)
-    def _repo_root(self, repo_root):
+    @pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
+    def _repo_root(self, repo_root: Path) -> None:
         """Ensure repo_root is available; main uses Path(__file__).parent.parent."""
         pass
 
-    def test_main_scan_failure_exits_1(self):
+    def test_main_scan_failure_exits_1(self) -> None:
         """When run_scan raises, main writes to stderr and exits 1."""
         stderr_io = StringIO()
         with (
@@ -36,7 +37,7 @@ class TestMain:
         assert exc_info.value.code == 1
         assert "path not found" in stderr_io.getvalue() or "Scan failed" in stderr_io.getvalue()
 
-    def test_main_empty_payload_exits_0_with_json(self):
+    def test_main_empty_payload_exits_0_with_json(self) -> None:
         """When hierarchy_payload is empty and --json, print JSON and exit 0."""
         stdout_io = StringIO()
         with (
@@ -53,7 +54,7 @@ class TestMain:
         assert data["violations"] == []
         assert "hierarchy_payload" in data
 
-    def test_main_empty_payload_exits_0_without_json(self):
+    def test_main_empty_payload_exits_0_without_json(self) -> None:
         """When hierarchy_payload is empty and no --json, exit 0 after stderr message."""
         stderr_io = StringIO()
         with (
@@ -66,7 +67,7 @@ class TestMain:
         assert exc_info.value.code == 0
         assert "No hierarchy payload" in stderr_io.getvalue()
 
-    def test_main_no_validators_json_outputs_hierarchy_only(self, sample_hierarchy_payload):
+    def test_main_no_validators_json_outputs_hierarchy_only(self, sample_hierarchy_payload: dict[str, object]) -> None:
         """With --no-opa --no-native and --json, output is hierarchy_payload only."""
         stdout_io = StringIO()
         with (
@@ -81,7 +82,7 @@ class TestMain:
         assert data["hierarchy_payload"]["scan_id"] == sample_hierarchy_payload["scan_id"]
         assert "violations" not in data
 
-    def test_main_no_validators_no_json_prints_message(self, sample_hierarchy_payload):
+    def test_main_no_validators_no_json_prints_message(self, sample_hierarchy_payload: dict[str, object]) -> None:
         """With --no-opa --no-native and no --json, print message about validators skipped."""
         stdout_io = StringIO()
         with (
@@ -93,11 +94,11 @@ class TestMain:
         assert "validators skipped" in stdout_io.getvalue().lower() or "hierarchy" in stdout_io.getvalue().lower()
 
     def test_main_with_opa_json_outputs_violations_and_count(
-        self, sample_hierarchy_payload, opa_eval_result_with_violations
-    ):
+        self, sample_hierarchy_payload: dict[str, object], opa_eval_result_with_violations: dict[str, object]
+    ) -> None:
         """With OPA and --json, output includes violations and count."""
         stdout_io = StringIO()
-        violations = opa_eval_result_with_violations["result"][0]["expressions"][0]["value"]
+        violations = opa_eval_result_with_violations["result"][0]["expressions"][0]["value"]  # type: ignore[index]
         with (
             patch.object(cli_module, "run_scan", return_value=_make_context(sample_hierarchy_payload)),
             patch("apme_engine.validators.opa.run_opa", return_value=violations),
@@ -111,7 +112,7 @@ class TestMain:
         assert data["count"] == 1
         assert data["violations"][0]["rule_id"] == "task-name"
 
-    def test_main_with_opa_no_json_prints_summary_and_list(self, sample_hierarchy_payload):
+    def test_main_with_opa_no_json_prints_summary_and_list(self, sample_hierarchy_payload: dict[str, object]) -> None:
         """With OPA and no --json, print Scan line and violation lines."""
         stdout_io = StringIO()
         violations = [{"rule_id": "r1", "level": "warning", "message": "msg", "file": "f.yml", "line": 1, "path": "p"}]
@@ -128,7 +129,9 @@ class TestMain:
         assert "f.yml" in out
         assert "msg" in out
 
-    def test_main_with_opa_no_violations_prints_no_violations(self, sample_hierarchy_payload):
+    def test_main_with_opa_no_violations_prints_no_violations(
+        self, sample_hierarchy_payload: dict[str, object]
+    ) -> None:
         """With OPA and no violations, print 'No violations.'"""
         stdout_io = StringIO()
         with (
@@ -140,7 +143,9 @@ class TestMain:
             cli_module.main()
         assert "No violations" in stdout_io.getvalue()
 
-    def test_main_uses_custom_opa_bundle_when_provided(self, sample_hierarchy_payload, tmp_path):
+    def test_main_uses_custom_opa_bundle_when_provided(
+        self, sample_hierarchy_payload: dict[str, object], tmp_path: Path
+    ) -> None:
         """When --opa-bundle is passed, OpaValidator receives that path."""
         bundle = tmp_path / "custom_bundle"
         bundle.mkdir()
@@ -157,7 +162,7 @@ class TestMain:
 class TestRunScan:
     """Tests for run_scan (runner module) via CLI integration."""
 
-    def test_run_scan_nonexistent_path_raises(self, repo_root):
+    def test_run_scan_nonexistent_path_raises(self, repo_root: Path) -> None:
         """run_scan raises FileNotFoundError when target does not exist."""
         with (
             patch.object(
@@ -168,7 +173,9 @@ class TestRunScan:
         ):
             cli_module.main()
 
-    def test_run_scan_playbook_file_called_with_correct_args(self, repo_root, tmp_path, sample_hierarchy_payload):
+    def test_run_scan_playbook_file_called_with_correct_args(
+        self, repo_root: Path, tmp_path: Path, sample_hierarchy_payload: dict[str, object]
+    ) -> None:
         """When target is a file, run_scan is called with playbook path and repo_root (from CLI's __file__)."""
         playbook = tmp_path / "play.yml"
         playbook.write_text("---\n- hosts: localhost\n  tasks: []\n")
@@ -186,7 +193,9 @@ class TestRunScan:
         assert call_args[0][1] == expected_root
         assert call_args[1]["include_scandata"] is True
 
-    def test_run_scan_returns_context_with_payload(self, repo_root, tmp_path, sample_hierarchy_payload):
+    def test_run_scan_returns_context_with_payload(
+        self, repo_root: Path, tmp_path: Path, sample_hierarchy_payload: dict[str, object]
+    ) -> None:
         """run_scan returns ScanContext with hierarchy_payload."""
         from apme_engine.runner import run_scan
 

--- a/tests/test_collection_cache_venv_builder.py
+++ b/tests/test_collection_cache_venv_builder.py
@@ -16,46 +16,46 @@ from apme_engine.collection_cache.venv_builder import (
 
 
 class TestVenvKey:
-    def test_stable_for_same_inputs(self):
+    def test_stable_for_same_inputs(self) -> None:
         assert _venv_key("2.15.0", ["ansible.builtin.debug"]) == _venv_key("2.15.0", ["ansible.builtin.debug"])
 
-    def test_different_version_different_key(self):
+    def test_different_version_different_key(self) -> None:
         k1 = _venv_key("2.14.0", [])
         k2 = _venv_key("2.15.0", [])
         assert k1 != k2
 
-    def test_different_collections_different_key(self):
+    def test_different_collections_different_key(self) -> None:
         k1 = _venv_key("2.15.0", ["a.b"])
         k2 = _venv_key("2.15.0", ["a.b", "c.d"])
         assert k1 != k2
 
-    def test_order_of_collections_irrelevant(self):
+    def test_order_of_collections_irrelevant(self) -> None:
         k1 = _venv_key("2.15.0", ["c.d", "a.b"])
         k2 = _venv_key("2.15.0", ["a.b", "c.d"])
         assert k1 == k2
 
 
 class TestVenvSitePackages:
-    def test_returns_site_packages_under_lib_python(self, tmp_path):
+    def test_returns_site_packages_under_lib_python(self, tmp_path: Path) -> None:
         (tmp_path / "lib" / "python3.12" / "site-packages").mkdir(parents=True)
         assert _venv_site_packages(tmp_path) == tmp_path / "lib" / "python3.12" / "site-packages"
 
-    def test_creates_site_packages_if_missing(self, tmp_path):
+    def test_creates_site_packages_if_missing(self, tmp_path: Path) -> None:
         (tmp_path / "lib" / "python3.11").mkdir(parents=True)
         out = _venv_site_packages(tmp_path)
         assert out.is_dir()
         assert out == tmp_path / "lib" / "python3.11" / "site-packages"
 
-    def test_no_lib_raises(self, tmp_path):
+    def test_no_lib_raises(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError, match="no lib dir"):
             _venv_site_packages(tmp_path)
 
 
 class TestResolveCollectionPath:
-    def test_returns_none_when_not_in_cache(self, tmp_path):
+    def test_returns_none_when_not_in_cache(self, tmp_path: Path) -> None:
         assert _resolve_collection_path("namespace.collection", tmp_path) is None
 
-    def test_returns_path_when_in_galaxy_cache(self, tmp_path):
+    def test_returns_path_when_in_galaxy_cache(self, tmp_path: Path) -> None:
         ac = tmp_path / "galaxy" / "ansible_collections" / "ns" / "coll"
         ac.mkdir(parents=True)
         path = _resolve_collection_path("ns.coll", tmp_path)
@@ -63,14 +63,14 @@ class TestResolveCollectionPath:
 
 
 class TestGetVenvPython:
-    def test_returns_bin_python_on_unix(self, tmp_path):
+    def test_returns_bin_python_on_unix(self, tmp_path: Path) -> None:
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir()
         (bin_dir / "python").touch()
         assert get_venv_python(tmp_path) == tmp_path / "bin" / "python"
 
-    @pytest.mark.skipif(os.name != "nt", reason="Windows only")
-    def test_returns_scripts_python_on_windows(self, tmp_path):
+    @pytest.mark.skipif(os.name != "nt", reason="Windows only")  # type: ignore[untyped-decorator]
+    def test_returns_scripts_python_on_windows(self, tmp_path: Path) -> None:
         scripts = tmp_path / "Scripts"
         scripts.mkdir()
         (scripts / "python.exe").touch()
@@ -78,13 +78,13 @@ class TestGetVenvPython:
 
 
 class TestBuildVenv:
-    def test_missing_collection_raises(self, tmp_path):
+    def test_missing_collection_raises(self, tmp_path: Path) -> None:
         """When a collection spec is not in cache, build_venv raises FileNotFoundError."""
         base = tmp_path / "v"
         base.mkdir()
 
-        def run_side_effect(*args, **kwargs):
-            cmd = list(args[0]) if args else list(kwargs.get("args", []))
+        def run_side_effect(*args: object, **kwargs: object) -> object:
+            cmd = list(args[0]) if args else list(kwargs.get("args", []))  # type: ignore[call-overload]
             if not cmd:
                 return MagicMock(returncode=0)
             # First run: venv create (uv venv <path> or python -m venv <path>)
@@ -106,8 +106,8 @@ class TestBuildVenv:
                 venvs_root=base,
             )
 
-    @pytest.mark.integration
-    def test_build_venv_empty_collections(self, tmp_path):
+    @pytest.mark.integration  # type: ignore[untyped-decorator]
+    def test_build_venv_empty_collections(self, tmp_path: Path) -> None:
         """With no collections, build_venv creates venv with ansible-core only (needs network)."""
         venv_root = build_venv(
             "2.15.0",

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -28,12 +28,12 @@ def _fmt(text: str, filename: str = "test.yml") -> FormatResult:
 
 
 class TestTabRemoval:
-    def test_tabs_replaced_with_spaces(self):
+    def test_tabs_replaced_with_spaces(self) -> None:
         result = _fmt("- name: Test\n\tansible.builtin.debug:\n\t\tmsg: hello\n")
         assert "\t" not in result.formatted
         assert result.changed
 
-    def test_no_tabs_unchanged(self):
+    def test_no_tabs_unchanged(self) -> None:
         text = "- name: Test\n  ansible.builtin.debug:\n    msg: hello\n"
         result = format_content(text)
         assert "\t" not in result.formatted
@@ -45,7 +45,7 @@ class TestTabRemoval:
 
 
 class TestKeyReorder:
-    def test_name_moved_before_module(self):
+    def test_name_moved_before_module(self) -> None:
         text = textwrap.dedent("""\
         - ansible.builtin.debug:
             msg: hello
@@ -58,7 +58,7 @@ class TestKeyReorder:
         assert name_line < debug_line, "name should come before module"
         assert result.changed
 
-    def test_already_ordered_unchanged(self):
+    def test_already_ordered_unchanged(self) -> None:
         text = textwrap.dedent("""\
         - name: Say hello
           ansible.builtin.debug:
@@ -71,7 +71,7 @@ class TestKeyReorder:
         debug_line = next(i for i, line in enumerate(lines) if "debug" in line)
         assert name_line < debug_line
 
-    def test_play_level_key_order(self):
+    def test_play_level_key_order(self) -> None:
         text = textwrap.dedent("""\
         - tasks:
             - ansible.builtin.debug:
@@ -93,23 +93,23 @@ class TestKeyReorder:
 
 
 class TestJinjaSpacing:
-    def test_no_space_gets_space(self):
+    def test_no_space_gets_space(self) -> None:
         text = '- name: Test\n  ansible.builtin.debug:\n    msg: "{{foo}}"\n'
         result = format_content(text)
         assert "{{ foo }}" in result.formatted
         assert result.changed
 
-    def test_extra_spaces_normalized(self):
+    def test_extra_spaces_normalized(self) -> None:
         text = '- name: Test\n  ansible.builtin.debug:\n    msg: "{{  foo  }}"\n'
         result = format_content(text)
         assert "{{ foo }}" in result.formatted
 
-    def test_already_correct_unchanged(self):
+    def test_already_correct_unchanged(self) -> None:
         text = '- name: Test\n  ansible.builtin.debug:\n    msg: "{{ foo }}"\n'
         result = format_content(text)
         assert "{{ foo }}" in result.formatted
 
-    def test_complex_expression(self):
+    def test_complex_expression(self) -> None:
         text = "- name: Test\n  ansible.builtin.debug:\n    msg: \"{{item.name | default('none')}}\"\n"
         result = format_content(text)
         assert "{{ item.name | default('none') }}" in result.formatted
@@ -121,7 +121,7 @@ class TestJinjaSpacing:
 
 
 class TestIndentation:
-    def test_mixed_indent_normalized(self):
+    def test_mixed_indent_normalized(self) -> None:
         text = "- name: Test\n    ansible.builtin.debug:\n        msg: hello\n"
         result = format_content(text)
         lines = result.formatted.splitlines()
@@ -138,17 +138,17 @@ class TestIndentation:
 
 
 class TestComments:
-    def test_inline_comment_preserved(self):
+    def test_inline_comment_preserved(self) -> None:
         text = "- name: Test  # important\n  ansible.builtin.debug:\n    msg: hello\n"
         result = format_content(text)
         assert "# important" in result.formatted
 
-    def test_full_line_comment_preserved(self):
+    def test_full_line_comment_preserved(self) -> None:
         text = "# This is a play\n- name: Test\n  ansible.builtin.debug:\n    msg: hello\n"
         result = format_content(text)
         assert "# This is a play" in result.formatted
 
-    def test_preamble_comment_preserved(self):
+    def test_preamble_comment_preserved(self) -> None:
         text = "# Header comment\n---\n- name: Test\n  ansible.builtin.debug:\n    msg: hello\n"
         result = format_content(text)
         assert "# Header comment" in result.formatted
@@ -160,7 +160,7 @@ class TestComments:
 
 
 class TestOctal:
-    def test_octal_mode_preserved(self):
+    def test_octal_mode_preserved(self) -> None:
         text = textwrap.dedent("""\
         - name: Set perms
           ansible.builtin.file:
@@ -177,24 +177,24 @@ class TestOctal:
 
 
 class TestEdgeCases:
-    def test_empty_file(self):
+    def test_empty_file(self) -> None:
         result = format_content("")
         assert not result.changed
 
-    def test_non_yaml_content(self):
+    def test_non_yaml_content(self) -> None:
         result = format_content("this is not yaml: [[[invalid")
         assert not result.changed
 
-    def test_scalar_document_returned_unchanged(self):
+    def test_scalar_document_returned_unchanged(self) -> None:
         result = format_content("hello\n")
         assert not result.changed
         assert result.formatted == "hello\n"
 
-    def test_empty_document_marker(self):
+    def test_empty_document_marker(self) -> None:
         result = format_content("---\n")
         assert not result.changed or result.formatted.strip() == "---"
 
-    def test_already_formatted_no_change(self):
+    def test_already_formatted_no_change(self) -> None:
         text = textwrap.dedent("""\
         - name: Already clean
           ansible.builtin.debug:
@@ -221,12 +221,12 @@ class TestIdempotency:
             ("- name: Test\n    ansible.builtin.debug:\n        msg: deep\n", "mixed indent"),
             ("# comment\n- name: Test\n  ansible.builtin.debug:\n    msg: hi\n", "with comment"),
         ],
-    )
-    def test_format_twice_no_diff(self, text, desc):
+    )  # type: ignore[untyped-decorator]
+    def test_format_twice_no_diff(self, text: str, desc: str) -> None:
         first = format_content(text, filename=f"test_{desc}.yml")
         assert check_idempotent(first), f"Formatter is not idempotent for: {desc}"
 
-    def test_idempotent_complex_playbook(self):
+    def test_idempotent_complex_playbook(self) -> None:
         text = textwrap.dedent("""\
         # Playbook header
         ---
@@ -263,7 +263,7 @@ class TestIdempotency:
 
 
 class TestFormatFile:
-    def test_format_file_reads_and_formats(self, tmp_path):
+    def test_format_file_reads_and_formats(self, tmp_path: Path) -> None:
         p = tmp_path / "test.yml"
         p.write_text("- ansible.builtin.debug:\n    msg: hi\n  name: Test\n")
         result = format_file(p)
@@ -281,7 +281,7 @@ class TestFormatFile:
 
 
 class TestFormatDirectory:
-    def test_discovers_yaml_files(self, tmp_path):
+    def test_discovers_yaml_files(self, tmp_path: Path) -> None:
         (tmp_path / "a.yml").write_text("- name: A\n  ansible.builtin.debug:\n    msg: a\n")
         (tmp_path / "b.yaml").write_text("- name: B\n  ansible.builtin.debug:\n    msg: b\n")
         (tmp_path / "c.txt").write_text("not yaml")
@@ -291,7 +291,7 @@ class TestFormatDirectory:
         assert "b.yaml" in paths
         assert "c.txt" not in paths
 
-    def test_skips_git_dir(self, tmp_path):
+    def test_skips_git_dir(self, tmp_path: Path) -> None:
         git_dir = tmp_path / ".git"
         git_dir.mkdir()
         (git_dir / "config.yml").write_text("- name: Git\n  debug: msg=hi\n")
@@ -301,7 +301,7 @@ class TestFormatDirectory:
         assert "config.yml" not in paths
         assert "play.yml" in paths
 
-    def test_multidepth_workspace(self, tmp_path):
+    def test_multidepth_workspace(self, tmp_path: Path) -> None:
         """Formatter recurses into nested role/playbook directory structures."""
         (tmp_path / "site.yml").write_text("- ansible.builtin.debug:\n    msg: hi\n  name: Top\n")
         roles = tmp_path / "roles" / "web" / "tasks"
@@ -325,7 +325,7 @@ class TestFormatDirectory:
         for r in changed:
             assert check_idempotent(r), f"Not idempotent: {r.path}"
 
-    def test_exclude_pattern(self, tmp_path):
+    def test_exclude_pattern(self, tmp_path: Path) -> None:
         vendor = tmp_path / "vendor"
         vendor.mkdir()
         (vendor / "lib.yml").write_text("- name: Vendor\n  debug: msg=hi\n")
@@ -342,14 +342,14 @@ class TestFormatDirectory:
 
 
 class TestDiffOutput:
-    def test_diff_contains_file_paths(self):
+    def test_diff_contains_file_paths(self) -> None:
         text = "- ansible.builtin.debug:\n    msg: hi\n  name: Test\n"
         result = format_content(text, filename="playbook.yml")
         assert result.changed
         assert "a/playbook.yml" in result.diff
         assert "b/playbook.yml" in result.diff
 
-    def test_no_diff_when_unchanged(self):
+    def test_no_diff_when_unchanged(self) -> None:
         text = "- name: Test\n  ansible.builtin.debug:\n    msg: hi\n"
         result = format_content(text)
         if not result.changed:

--- a/tests/test_formatter_cli.py
+++ b/tests/test_formatter_cli.py
@@ -15,7 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURE = REPO_ROOT / "tests" / "integration" / "test_format_playbook.yml"
 
 
-def _cli(*args: str, cwd: str | None = None) -> subprocess.CompletedProcess:
+def _cli(*args: str, cwd: str | None = None) -> subprocess.CompletedProcess[str]:
     """Run apme-scan CLI via ``python -m apme_engine.cli``."""
     return subprocess.run(
         [sys.executable, "-m", "apme_engine.cli", *args],
@@ -30,7 +30,7 @@ def _cli(*args: str, cwd: str | None = None) -> subprocess.CompletedProcess:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def messy_dir(tmp_path: Path) -> Path:
     """Copy the messy fixture into a temp directory so tests can mutate it."""
     dest = tmp_path / "project"
@@ -39,7 +39,7 @@ def messy_dir(tmp_path: Path) -> Path:
     return dest
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def messy_file(messy_dir: Path) -> Path:
     return messy_dir / "playbook.yml"
 
@@ -52,20 +52,20 @@ def messy_file(messy_dir: Path) -> Path:
 class TestFormatDiff:
     """format (no flags) — show diff on stdout, exit 0."""
 
-    def test_produces_diff_output(self, messy_file: Path):
+    def test_produces_diff_output(self, messy_file: Path) -> None:
         r = _cli("format", str(messy_file))
         assert r.returncode == 0
         assert "---" in r.stdout or "@@" in r.stdout, "Expected unified diff in stdout"
 
-    def test_diff_contains_filename(self, messy_file: Path):
+    def test_diff_contains_filename(self, messy_file: Path) -> None:
         r = _cli("format", str(messy_file))
         assert "playbook.yml" in r.stdout
 
-    def test_diff_shows_jinja_fix(self, messy_file: Path):
+    def test_diff_shows_jinja_fix(self, messy_file: Path) -> None:
         r = _cli("format", str(messy_file))
         assert "{{ inventory_hostname }}" in r.stdout or "{{inventory_hostname}}" in r.stdout
 
-    def test_file_not_modified(self, messy_file: Path):
+    def test_file_not_modified(self, messy_file: Path) -> None:
         original = messy_file.read_text()
         _cli("format", str(messy_file))
         assert messy_file.read_text() == original, "format without --apply should not modify file"
@@ -74,15 +74,15 @@ class TestFormatDiff:
 class TestFormatCheck:
     """format --check — exit 1 if files need formatting."""
 
-    def test_exits_1_on_messy_file(self, messy_file: Path):
+    def test_exits_1_on_messy_file(self, messy_file: Path) -> None:
         r = _cli("format", "--check", str(messy_file))
         assert r.returncode == 1
 
-    def test_message_mentions_reformatted(self, messy_file: Path):
+    def test_message_mentions_reformatted(self, messy_file: Path) -> None:
         r = _cli("format", "--check", str(messy_file))
         assert "reformatted" in r.stderr.lower() or "would be" in r.stderr.lower()
 
-    def test_exits_0_after_apply(self, messy_file: Path):
+    def test_exits_0_after_apply(self, messy_file: Path) -> None:
         _cli("format", "--apply", str(messy_file))
         r = _cli("format", "--check", str(messy_file))
         assert r.returncode == 0
@@ -91,24 +91,24 @@ class TestFormatCheck:
 class TestFormatApply:
     """format --apply — write files in place."""
 
-    def test_modifies_file(self, messy_file: Path):
+    def test_modifies_file(self, messy_file: Path) -> None:
         original = messy_file.read_text()
         r = _cli("format", "--apply", str(messy_file))
         assert r.returncode == 0
         assert messy_file.read_text() != original
 
-    def test_tabs_removed(self, messy_file: Path):
+    def test_tabs_removed(self, messy_file: Path) -> None:
         _cli("format", "--apply", str(messy_file))
         assert "\t" not in messy_file.read_text()
 
-    def test_jinja_normalized(self, messy_file: Path):
+    def test_jinja_normalized(self, messy_file: Path) -> None:
         _cli("format", "--apply", str(messy_file))
         content = messy_file.read_text()
         assert "{{ inventory_hostname }}" in content
         assert "{{ some_var }}" in content
         assert "{{ item.name | default('none') }}" in content
 
-    def test_name_before_module(self, messy_file: Path):
+    def test_name_before_module(self, messy_file: Path) -> None:
         _cli("format", "--apply", str(messy_file))
         content = messy_file.read_text()
         lines = content.splitlines()
@@ -121,18 +121,18 @@ class TestFormatApply:
                     pytest.fail("Expected ansible.builtin.debug after 'name: Say hello'")
                 break
 
-    def test_comments_preserved(self, messy_file: Path):
+    def test_comments_preserved(self, messy_file: Path) -> None:
         _cli("format", "--apply", str(messy_file))
         content = messy_file.read_text()
         assert "# Play-level comment" in content
         assert "# keep this" in content
         assert "# Misordered keys" in content
 
-    def test_octal_preserved(self, messy_file: Path):
+    def test_octal_preserved(self, messy_file: Path) -> None:
         _cli("format", "--apply", str(messy_file))
         assert "0644" in messy_file.read_text()
 
-    def test_idempotent_after_apply(self, messy_file: Path):
+    def test_idempotent_after_apply(self, messy_file: Path) -> None:
         _cli("format", "--apply", str(messy_file))
         first_pass = messy_file.read_text()
         _cli("format", "--apply", str(messy_file))
@@ -142,13 +142,13 @@ class TestFormatApply:
 class TestFormatDirectory:
     """format on a directory discovers all YAML files."""
 
-    def test_formats_all_yaml_in_dir(self, messy_dir: Path):
+    def test_formats_all_yaml_in_dir(self, messy_dir: Path) -> None:
         (messy_dir / "extra.yml").write_text("- ansible.builtin.debug:\n    msg: hi\n  name: Reorder me\n")
         r = _cli("format", "--check", str(messy_dir))
         assert r.returncode == 1
         assert "2 file(s)" in r.stderr or "file(s) would be" in r.stderr
 
-    def test_skips_non_yaml(self, messy_dir: Path):
+    def test_skips_non_yaml(self, messy_dir: Path) -> None:
         (messy_dir / "readme.txt").write_text("not yaml at all")
         r = _cli("format", "--apply", str(messy_dir))
         assert r.returncode == 0
@@ -158,7 +158,7 @@ class TestFormatDirectory:
 class TestFormatExclude:
     """format --exclude skips matching files."""
 
-    def test_exclude_pattern(self, messy_dir: Path):
+    def test_exclude_pattern(self, messy_dir: Path) -> None:
         vendor = messy_dir / "vendor"
         vendor.mkdir()
         shutil.copy2(FIXTURE, vendor / "lib.yml")
@@ -176,17 +176,17 @@ class TestFormatExclude:
 class TestFixApply:
     """fix --apply — format → idempotency check → (modernize stub)."""
 
-    def test_formats_and_passes_idempotency(self, messy_file: Path):
+    def test_formats_and_passes_idempotency(self, messy_file: Path) -> None:
         r = _cli("fix", "--apply", str(messy_file))
         assert r.returncode == 0
         assert "Passed" in r.stderr or "zero diffs" in r.stderr.lower()
 
-    def test_file_is_formatted_after_fix(self, messy_file: Path):
+    def test_file_is_formatted_after_fix(self, messy_file: Path) -> None:
         _cli("fix", "--apply", str(messy_file))
         r = _cli("format", "--check", str(messy_file))
         assert r.returncode == 0, "File should pass format --check after fix --apply"
 
-    def test_remediation_runs_full_pipeline(self, messy_file: Path):
+    def test_remediation_runs_full_pipeline(self, messy_file: Path) -> None:
         r = _cli("fix", "--apply", str(messy_file))
         assert r.returncode == 0
         assert "phase 4: remediating" in r.stderr.lower()
@@ -197,11 +197,11 @@ class TestFixApply:
 class TestFixCheck:
     """fix --check — exit 1 if formatting changes are needed."""
 
-    def test_exits_1_on_messy_file(self, messy_file: Path):
+    def test_exits_1_on_messy_file(self, messy_file: Path) -> None:
         r = _cli("fix", "--check", str(messy_file))
         assert r.returncode == 1
 
-    def test_exits_0_after_apply(self, messy_file: Path):
+    def test_exits_0_after_apply(self, messy_file: Path) -> None:
         _cli("fix", "--apply", str(messy_file))
         r = _cli("fix", "--check", str(messy_file))
         assert r.returncode == 0

--- a/tests/test_gitleaks_scanner.py
+++ b/tests/test_gitleaks_scanner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from apme_engine.validators.gitleaks.scanner import (
@@ -16,41 +17,41 @@ from apme_engine.validators.gitleaks.scanner import (
 
 
 class TestVaultDetection:
-    def test_vault_header_detected(self):
+    def test_vault_header_detected(self) -> None:
         assert _is_vault_encrypted("  $ANSIBLE_VAULT;1.1;AES256\ndeadbeef")
 
-    def test_plain_content_not_vault(self):
+    def test_plain_content_not_vault(self) -> None:
         assert not _is_vault_encrypted("password: s3cret")
 
-    def test_empty_string(self):
+    def test_empty_string(self) -> None:
         assert not _is_vault_encrypted("")
 
 
 class TestJinjaFiltering:
-    def test_jinja_expression(self):
+    def test_jinja_expression(self) -> None:
         assert _value_is_jinja("{{ vault_password }}")
 
-    def test_quoted_jinja(self):
+    def test_quoted_jinja(self) -> None:
         assert _value_is_jinja('\'{{ lookup("env", "SECRET") }}\'')
 
-    def test_literal_value(self):
+    def test_literal_value(self) -> None:
         assert not _value_is_jinja("hardcoded_secret_123")
 
-    def test_mixed_not_full_jinja(self):
+    def test_mixed_not_full_jinja(self) -> None:
         assert not _value_is_jinja("prefix-{{ var }}-suffix")
 
 
 class TestRuleIdMapping:
-    def test_unmapped_rule(self):
+    def test_unmapped_rule(self) -> None:
         assert _build_rule_id("aws-access-key-id") == f"{RULE_PREFIX}:aws-access-key-id"
 
-    def test_mapped_rule(self):
+    def test_mapped_rule(self) -> None:
         with patch.dict("apme_engine.validators.gitleaks.scanner.RULE_ID_MAP", {"generic-api-key": "SEC001"}):
             assert _build_rule_id("generic-api-key") == "SEC001"
 
 
 class TestConvertFindings:
-    def test_basic_finding(self, tmp_path):
+    def test_basic_finding(self, tmp_path: Path) -> None:
         secret_file = tmp_path / "vars.yml"
         secret_file.write_text("password: s3cret123\n")
 
@@ -71,7 +72,7 @@ class TestConvertFindings:
         assert violations[0]["file"] == "vars.yml"
         assert violations[0]["line"] == 1
 
-    def test_jinja_value_filtered(self, tmp_path):
+    def test_jinja_value_filtered(self, tmp_path: Path) -> None:
         jinja_file = tmp_path / "vars.yml"
         jinja_file.write_text("password: '{{ vault_pw }}'\n")
 
@@ -88,7 +89,7 @@ class TestConvertFindings:
         violations = _convert_findings(findings, tmp_path)
         assert len(violations) == 0
 
-    def test_vault_encrypted_filtered(self, tmp_path):
+    def test_vault_encrypted_filtered(self, tmp_path: Path) -> None:
         vault_file = tmp_path / "secrets.yml"
         vault_file.write_text("$ANSIBLE_VAULT;1.1;AES256\ndeadbeef\n")
 
@@ -105,7 +106,7 @@ class TestConvertFindings:
         violations = _convert_findings(findings, tmp_path)
         assert len(violations) == 0
 
-    def test_multiline_range(self, tmp_path):
+    def test_multiline_range(self, tmp_path: Path) -> None:
         f = tmp_path / "key.pem"
         f.write_text("-----BEGIN RSA PRIVATE KEY-----\ndata\n-----END RSA PRIVATE KEY-----\n")
 
@@ -125,12 +126,12 @@ class TestConvertFindings:
 
 
 class TestRunGitleaks:
-    def test_binary_not_found(self, tmp_path):
+    def test_binary_not_found(self, tmp_path: Path) -> None:
         with patch("apme_engine.validators.gitleaks.scanner.GITLEAKS_BIN", "/nonexistent/gitleaks"):
             result = run_gitleaks(tmp_path)
         assert result == []
 
-    def test_successful_scan_no_findings(self, tmp_path):
+    def test_successful_scan_no_findings(self, tmp_path: Path) -> None:
         clean = tmp_path / "clean.yml"
         clean.write_text("---\n- name: Clean play\n  hosts: all\n  tasks: []\n")
 
@@ -152,7 +153,7 @@ class TestRunGitleaks:
 
         assert result == []
 
-    def test_successful_scan_with_findings(self, tmp_path):
+    def test_successful_scan_with_findings(self, tmp_path: Path) -> None:
         secret_file = tmp_path / "vars.yml"
         secret_file.write_text("api_key: AKIAIOSFODNN7EXAMPLE\n")
 
@@ -189,7 +190,7 @@ class TestRunGitleaks:
         assert result[0]["rule_id"] == f"{RULE_PREFIX}:aws-access-key-id"
         assert result[0]["file"] == "vars.yml"
 
-    def test_timeout_handled(self, tmp_path):
+    def test_timeout_handled(self, tmp_path: Path) -> None:
         import subprocess as sp
 
         with patch(
@@ -202,17 +203,17 @@ class TestRunGitleaks:
 class TestGitleaksServicer:
     """Test the async gRPC servicer layer."""
 
-    async def test_validate_no_files(self):
+    async def test_validate_no_files(self) -> None:
         from apme.v1 import validate_pb2
         from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
 
         servicer = GitleaksValidatorServicer()
         request = validate_pb2.ValidateRequest(files=[], request_id="gl-1")
         resp = await servicer.Validate(request, None)
-        assert len(resp.violations) == 0
-        assert resp.request_id == "gl-1"
+        assert len(resp.violations) == 0  # type: ignore[attr-defined]
+        assert resp.request_id == "gl-1"  # type: ignore[attr-defined]
 
-    async def test_validate_with_files(self):
+    async def test_validate_with_files(self) -> None:
         from apme.v1 import common_pb2, validate_pb2
         from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
 
@@ -236,11 +237,11 @@ class TestGitleaksServicer:
         with patch("apme_engine.daemon.gitleaks_validator_server.run_gitleaks", return_value=fake_violations):
             resp = await servicer.Validate(request, None)
 
-        assert len(resp.violations) == 1
-        assert resp.violations[0].rule_id == "SEC:aws-access-key-id"
-        assert resp.request_id == "gl-2"
+        assert len(resp.violations) == 1  # type: ignore[attr-defined]
+        assert resp.violations[0].rule_id == "SEC:aws-access-key-id"  # type: ignore[attr-defined]
+        assert resp.request_id == "gl-2"  # type: ignore[attr-defined]
 
-    async def test_health_binary_present(self):
+    async def test_health_binary_present(self) -> None:
         from apme.v1 import common_pb2
         from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
 
@@ -255,7 +256,7 @@ class TestGitleaksServicer:
         assert "ok" in resp.status
         assert "8.18.0" in resp.status
 
-    async def test_health_binary_missing(self):
+    async def test_health_binary_missing(self) -> None:
         from apme.v1 import common_pb2
         from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
 

--- a/tests/test_opa_client.py
+++ b/tests/test_opa_client.py
@@ -1,6 +1,7 @@
 """Tests for apme_engine.opa_client."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,20 +12,20 @@ from apme_engine.opa_client import run_opa, run_opa_test
 class TestRunOpa:
     """Tests for run_opa()."""
 
-    def test_bundle_not_directory_raises(self, tmp_path):
+    def test_bundle_not_directory_raises(self, tmp_path: Path) -> None:
         """Non-directory bundle path raises FileNotFoundError."""
         not_dir = tmp_path / "file.txt"
         not_dir.write_text("x")
         with pytest.raises(FileNotFoundError, match="is not a directory"):
             run_opa({"hierarchy": []}, str(not_dir))
 
-    def test_bundle_nonexistent_raises(self, tmp_path):
+    def test_bundle_nonexistent_raises(self, tmp_path: Path) -> None:
         """Nonexistent bundle path raises FileNotFoundError."""
         missing = tmp_path / "missing"
         with pytest.raises(FileNotFoundError, match="is not a directory"):
             run_opa({"hierarchy": []}, str(missing))
 
-    def test_opa_not_found_returns_empty_list(self, opa_bundle_path):
+    def test_opa_not_found_returns_empty_list(self, opa_bundle_path: Path) -> None:
         """When opa command is not found, returns [] and writes to stderr."""
         with (
             patch("apme_engine.opa_client.subprocess.run", side_effect=FileNotFoundError("opa not found")),
@@ -35,7 +36,9 @@ class TestRunOpa:
         mock_stderr.assert_called_once()
         assert "opa" in mock_stderr.call_args[0][0].lower()
 
-    def test_opa_nonzero_exit_returns_empty_list(self, opa_bundle_path, sample_hierarchy_payload):
+    def test_opa_nonzero_exit_returns_empty_list(
+        self, opa_bundle_path: Path, sample_hierarchy_payload: dict[str, object]
+    ) -> None:
         """When OPA returns non-zero exit code, returns [] and writes stderr."""
         with patch("apme_engine.opa_client.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="policy error")
@@ -45,7 +48,9 @@ class TestRunOpa:
         mock_stderr.assert_called_once()
         assert "policy error" in mock_stderr.call_args[0][0]
 
-    def test_opa_invalid_json_returns_empty_list(self, opa_bundle_path, sample_hierarchy_payload):
+    def test_opa_invalid_json_returns_empty_list(
+        self, opa_bundle_path: Path, sample_hierarchy_payload: dict[str, object]
+    ) -> None:
         """When OPA stdout is not valid JSON, returns [] and writes stderr."""
         with patch("apme_engine.opa_client.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="not json", stderr="")
@@ -56,15 +61,20 @@ class TestRunOpa:
         assert "invalid JSON" in mock_stderr.call_args[0][0]
 
     def test_opa_empty_result_returns_empty_list(
-        self, opa_bundle_path, sample_hierarchy_payload, opa_eval_result_empty
-    ):
+        self,
+        opa_bundle_path: Path,
+        sample_hierarchy_payload: dict[str, object],
+        opa_eval_result_empty: dict[str, object],
+    ) -> None:
         """When OPA result has no expressions, returns []."""
         with patch("apme_engine.opa_client.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"result": []}), stderr="")
             result = run_opa(sample_hierarchy_payload, str(opa_bundle_path))
         assert result == []
 
-    def test_opa_value_none_returns_empty_list(self, opa_bundle_path, sample_hierarchy_payload):
+    def test_opa_value_none_returns_empty_list(
+        self, opa_bundle_path: Path, sample_hierarchy_payload: dict[str, object]
+    ) -> None:
         """When expressions[0].expressions[0].value is None, returns []."""
         with patch("apme_engine.opa_client.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
@@ -75,7 +85,9 @@ class TestRunOpa:
             result = run_opa(sample_hierarchy_payload, str(opa_bundle_path))
         assert result == []
 
-    def test_opa_value_not_list_returns_empty_list(self, opa_bundle_path, sample_hierarchy_payload):
+    def test_opa_value_not_list_returns_empty_list(
+        self, opa_bundle_path: Path, sample_hierarchy_payload: dict[str, object]
+    ) -> None:
         """When value is not a list (e.g. object), returns []."""
         with patch("apme_engine.opa_client.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
@@ -87,8 +99,11 @@ class TestRunOpa:
         assert result == []
 
     def test_opa_success_returns_violations_list(
-        self, opa_bundle_path, sample_hierarchy_payload, opa_eval_result_with_violations
-    ):
+        self,
+        opa_bundle_path: Path,
+        sample_hierarchy_payload: dict[str, object],
+        opa_eval_result_with_violations: dict[str, object],
+    ) -> None:
         """When OPA returns valid result with violations, returns that list."""
         with patch("apme_engine.opa_client.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
@@ -103,7 +118,12 @@ class TestRunOpa:
         assert result[0]["file"] == "/examples/pb.yml"
         assert result[0]["line"] == 5
 
-    def test_opa_success_empty_violations(self, opa_bundle_path, sample_hierarchy_payload, opa_eval_result_empty):
+    def test_opa_success_empty_violations(
+        self,
+        opa_bundle_path: Path,
+        sample_hierarchy_payload: dict[str, object],
+        opa_eval_result_empty: dict[str, object],
+    ) -> None:
         """When OPA returns valid result with empty value list, returns []."""
         with patch("apme_engine.opa_client.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
@@ -114,7 +134,12 @@ class TestRunOpa:
             result = run_opa(sample_hierarchy_payload, str(opa_bundle_path))
         assert result == []
 
-    def test_opa_custom_entrypoint(self, opa_bundle_path, sample_hierarchy_payload, opa_eval_result_empty):
+    def test_opa_custom_entrypoint(
+        self,
+        opa_bundle_path: Path,
+        sample_hierarchy_payload: dict[str, object],
+        opa_eval_result_empty: dict[str, object],
+    ) -> None:
         """run_opa passes custom entrypoint to opa eval."""
         with patch("apme_engine.opa_client.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(opa_eval_result_empty), stderr="")
@@ -122,7 +147,12 @@ class TestRunOpa:
         call_args = mock_run.call_args[0][0]
         assert "data.custom.violations" in call_args
 
-    def test_opa_input_passed_via_stdin(self, opa_bundle_path, sample_hierarchy_payload, opa_eval_result_empty):
+    def test_opa_input_passed_via_stdin(
+        self,
+        opa_bundle_path: Path,
+        sample_hierarchy_payload: dict[str, object],
+        opa_eval_result_empty: dict[str, object],
+    ) -> None:
         """Input JSON is passed to opa via stdin."""
         with patch("apme_engine.opa_client.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(opa_eval_result_empty), stderr="")
@@ -134,21 +164,21 @@ class TestRunOpa:
 class TestRunOpaTest:
     """Tests for run_opa_test() — runs OPA Rego unit tests in the bundle."""
 
-    def test_opa_bundle_rego_tests_pass(self, opa_bundle_path):
+    def test_opa_bundle_rego_tests_pass(self, opa_bundle_path: Path) -> None:
         """Run `opa test . -v` in the bundle (Podman or local opa). All Rego tests must pass."""
         success, stdout, stderr = run_opa_test(opa_bundle_path)
         if not success and "not found" in stderr.lower():
             pytest.skip("podman and opa not available; install one to run OPA bundle tests")
         assert success, f"OPA Rego tests failed.\nstdout:\n{stdout}\nstderr:\n{stderr}"
 
-    def test_run_opa_test_bundle_not_directory_raises(self, tmp_path):
+    def test_run_opa_test_bundle_not_directory_raises(self, tmp_path: Path) -> None:
         """Non-directory bundle path raises FileNotFoundError."""
         not_dir = tmp_path / "file.txt"
         not_dir.write_text("x")
         with pytest.raises(FileNotFoundError, match="is not a directory"):
             run_opa_test(not_dir)
 
-    def test_run_opa_test_bundle_nonexistent_raises(self, tmp_path):
+    def test_run_opa_test_bundle_nonexistent_raises(self, tmp_path: Path) -> None:
         """Nonexistent bundle path raises FileNotFoundError."""
         missing = tmp_path / "missing"
         with pytest.raises(FileNotFoundError, match="is not a directory"):

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -1,6 +1,8 @@
 """Tests for the remediation engine: registry, partition, transforms, convergence."""
 
 import textwrap
+from pathlib import Path
+from typing import Any
 
 from apme_engine.remediation.engine import RemediationEngine
 from apme_engine.remediation.partition import is_finding_resolvable, partition_violations
@@ -31,33 +33,33 @@ from apme_engine.remediation.transforms.M009_with_to_loop import fix_with_to_loo
 
 
 class TestTransformRegistry:
-    def test_register_and_contains(self):
+    def test_register_and_contains(self) -> None:
         reg = TransformRegistry()
         reg.register("L021", lambda c, v: TransformResult(c, False))
         assert "L021" in reg
         assert "L999" not in reg
 
-    def test_apply_known_rule(self):
+    def test_apply_known_rule(self) -> None:
         reg = TransformRegistry()
         reg.register("TEST", lambda c, v: TransformResult("fixed", True))
         result = reg.apply("TEST", "original", {})
         assert result.content == "fixed"
         assert result.applied is True
 
-    def test_apply_unknown_rule(self):
+    def test_apply_unknown_rule(self) -> None:
         reg = TransformRegistry()
         result = reg.apply("UNKNOWN", "original", {})
         assert result.content == "original"
         assert result.applied is False
 
-    def test_len_and_iter(self):
+    def test_len_and_iter(self) -> None:
         reg = TransformRegistry()
         reg.register("A", lambda c, v: TransformResult(c, False))
         reg.register("B", lambda c, v: TransformResult(c, False))
         assert len(reg) == 2
         assert set(reg) == {"A", "B"}
 
-    def test_rule_ids_sorted(self):
+    def test_rule_ids_sorted(self) -> None:
         reg = TransformRegistry()
         reg.register("Z", lambda c, v: TransformResult(c, False))
         reg.register("A", lambda c, v: TransformResult(c, False))
@@ -70,17 +72,17 @@ class TestTransformRegistry:
 
 
 class TestPartition:
-    def test_is_finding_resolvable(self):
+    def test_is_finding_resolvable(self) -> None:
         reg = TransformRegistry()
         reg.register("L021", lambda c, v: TransformResult(c, False))
         assert is_finding_resolvable({"rule_id": "L021"}, reg) is True
         assert is_finding_resolvable({"rule_id": "L999"}, reg) is False
 
-    def test_partition_three_tiers(self):
+    def test_partition_three_tiers(self) -> None:
         reg = TransformRegistry()
         reg.register("L021", lambda c, v: TransformResult(c, False))
 
-        violations = [
+        violations: list[dict[str, Any]] = [
             {"rule_id": "L021"},
             {"rule_id": "R118"},
             {"rule_id": "POLICY", "ai_proposable": False},
@@ -100,7 +102,7 @@ class TestPartition:
 
 
 class TestDefaultRegistry:
-    def test_build_default_registry(self):
+    def test_build_default_registry(self) -> None:
         reg = build_default_registry()
         for rule_id in (
             "L002",
@@ -134,7 +136,7 @@ class TestDefaultRegistry:
 
 
 class TestL021MissingMode:
-    def test_adds_mode_to_file_module(self):
+    def test_adds_mode_to_file_module(self) -> None:
         content = textwrap.dedent("""\
         - name: Copy a file
           ansible.builtin.copy:
@@ -146,7 +148,7 @@ class TestL021MissingMode:
         assert "mode:" in result.content
         assert "0644" in result.content
 
-    def test_no_change_when_mode_present(self):
+    def test_no_change_when_mode_present(self) -> None:
         content = textwrap.dedent("""\
         - name: Copy a file
           ansible.builtin.copy:
@@ -157,7 +159,7 @@ class TestL021MissingMode:
         result = fix_missing_mode(content, {"rule_id": "L021", "line": 1})
         assert result.applied is False
 
-    def test_no_change_for_non_file_module(self):
+    def test_no_change_for_non_file_module(self) -> None:
         content = textwrap.dedent("""\
         - name: Run command
           ansible.builtin.command: echo hello
@@ -165,7 +167,7 @@ class TestL021MissingMode:
         result = fix_missing_mode(content, {"rule_id": "L021", "line": 1})
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - name: Template it
           ansible.builtin.template:
@@ -177,7 +179,7 @@ class TestL021MissingMode:
         r2 = fix_missing_mode(r1.content, {"rule_id": "L021", "line": 1})
         assert r2.applied is False
 
-    def test_handles_invalid_yaml(self):
+    def test_handles_invalid_yaml(self) -> None:
         result = fix_missing_mode("{{{{invalid", {"rule_id": "L021", "line": 1})
         assert result.applied is False
 
@@ -188,7 +190,7 @@ class TestL021MissingMode:
 
 
 class TestL007ShellToCommand:
-    def test_replaces_shell_with_command(self):
+    def test_replaces_shell_with_command(self) -> None:
         content = textwrap.dedent("""\
         - name: List files
           ansible.builtin.shell: ls -la /tmp
@@ -198,7 +200,7 @@ class TestL007ShellToCommand:
         assert "ansible.builtin.command" in result.content
         assert "ansible.builtin.shell" not in result.content
 
-    def test_no_change_when_pipe_present(self):
+    def test_no_change_when_pipe_present(self) -> None:
         content = textwrap.dedent("""\
         - name: Grep output
           ansible.builtin.shell: cat /tmp/log | grep error
@@ -206,7 +208,7 @@ class TestL007ShellToCommand:
         result = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
-    def test_no_change_when_and_present(self):
+    def test_no_change_when_and_present(self) -> None:
         content = textwrap.dedent("""\
         - name: Chain commands
           ansible.builtin.shell:
@@ -215,7 +217,7 @@ class TestL007ShellToCommand:
         result = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
-    def test_no_change_when_redirect_present(self):
+    def test_no_change_when_redirect_present(self) -> None:
         content = textwrap.dedent("""\
         - name: Write output
           ansible.builtin.shell: echo hello > /tmp/out
@@ -223,7 +225,7 @@ class TestL007ShellToCommand:
         result = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
-    def test_no_change_for_command_module(self):
+    def test_no_change_for_command_module(self) -> None:
         content = textwrap.dedent("""\
         - name: Already command
           ansible.builtin.command: echo hello
@@ -231,7 +233,7 @@ class TestL007ShellToCommand:
         result = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - name: Simple command
           ansible.builtin.shell: whoami
@@ -241,7 +243,7 @@ class TestL007ShellToCommand:
         r2 = fix_shell_to_command(r1.content, {"rule_id": "L007", "line": 1})
         assert r2.applied is False
 
-    def test_dict_form_cmd(self):
+    def test_dict_form_cmd(self) -> None:
         content = textwrap.dedent("""\
         - name: Simple command
           ansible.builtin.shell:
@@ -258,7 +260,7 @@ class TestL007ShellToCommand:
 
 
 class TestFQCNTransform:
-    def test_rewrites_short_name_with_resolved_fqcn(self):
+    def test_rewrites_short_name_with_resolved_fqcn(self) -> None:
         content = textwrap.dedent("""\
         - name: Debug message
           debug:
@@ -275,7 +277,7 @@ class TestFQCNTransform:
         assert "ansible.builtin.debug" in result.content
         assert "\n  debug:" not in result.content
 
-    def test_falls_back_to_static_map_for_l002(self):
+    def test_falls_back_to_static_map_for_l002(self) -> None:
         content = textwrap.dedent("""\
         - name: Copy file
           copy:
@@ -287,7 +289,7 @@ class TestFQCNTransform:
         assert result.applied is True
         assert "ansible.builtin.copy" in result.content
 
-    def test_no_change_when_already_fqcn(self):
+    def test_no_change_when_already_fqcn(self) -> None:
         content = textwrap.dedent("""\
         - name: Debug message
           ansible.builtin.debug:
@@ -297,7 +299,7 @@ class TestFQCNTransform:
         result = fix_fqcn(content, violation)
         assert result.applied is False
 
-    def test_no_change_for_unknown_short_name(self):
+    def test_no_change_for_unknown_short_name(self) -> None:
         content = textwrap.dedent("""\
         - name: Custom module
           my_custom_module:
@@ -307,7 +309,7 @@ class TestFQCNTransform:
         result = fix_fqcn(content, violation)
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - name: Install package
           yum:
@@ -319,7 +321,7 @@ class TestFQCNTransform:
         r2 = fix_fqcn(r1.content, {"rule_id": "L002", "line": 1})
         assert r2.applied is False
 
-    def test_m003_redirect_uses_resolved_fqcn(self):
+    def test_m003_redirect_uses_resolved_fqcn(self) -> None:
         content = textwrap.dedent("""\
         - name: Install package
           yum:
@@ -343,7 +345,7 @@ class TestFQCNTransform:
 
 
 class TestRemediationEngine:
-    def test_converges_in_one_pass(self, tmp_path):
+    def test_converges_in_one_pass(self, tmp_path: Path) -> None:
         playbook = tmp_path / "play.yml"
         playbook.write_text(
             textwrap.dedent("""\
@@ -354,7 +356,7 @@ class TestRemediationEngine:
         """)
         )
 
-        def scan_fn(paths):
+        def scan_fn(paths: list[str]) -> list[dict[str, Any]]:
             content = playbook.read_text()
             if "mode:" not in content:
                 return [{"rule_id": "L021", "file": str(playbook), "line": 1}]
@@ -369,7 +371,7 @@ class TestRemediationEngine:
         assert report.oscillation_detected is False
         assert "mode:" in playbook.read_text()
 
-    def test_no_apply_restores_originals(self, tmp_path):
+    def test_no_apply_restores_originals(self, tmp_path: Path) -> None:
         playbook = tmp_path / "play.yml"
         original = textwrap.dedent("""\
         - name: Copy file
@@ -379,7 +381,7 @@ class TestRemediationEngine:
         """)
         playbook.write_text(original)
 
-        def scan_fn(paths):
+        def scan_fn(paths: list[str]) -> list[dict[str, Any]]:
             content = playbook.read_text()
             if "mode:" not in content:
                 return [{"rule_id": "L021", "file": str(playbook), "line": 1}]
@@ -395,17 +397,17 @@ class TestRemediationEngine:
         assert report.applied_patches[0].diff != ""
         assert playbook.read_text() == original
 
-    def test_oscillation_detection(self, tmp_path):
+    def test_oscillation_detection(self, tmp_path: Path) -> None:
         playbook = tmp_path / "play.yml"
         playbook.write_text("- name: test\n  debug: msg=hi\n")
 
         call_count = [0]
 
-        def scan_fn(paths):
+        def scan_fn(paths: list[str]) -> list[dict[str, Any]]:
             call_count[0] += 1
             return [{"rule_id": "FLIP", "file": str(playbook), "line": 1}]
 
-        def flip_transform(content, violation):
+        def flip_transform(content: str, violation: dict[str, Any]) -> TransformResult:
             return TransformResult(content + "\n# flipped", True)
 
         reg = TransformRegistry()
@@ -416,11 +418,11 @@ class TestRemediationEngine:
         assert report.oscillation_detected is True
         assert report.passes <= 3
 
-    def test_empty_scan_no_changes(self, tmp_path):
+    def test_empty_scan_no_changes(self, tmp_path: Path) -> None:
         playbook = tmp_path / "play.yml"
         playbook.write_text("- name: Clean\n  ansible.builtin.debug:\n    msg: hi\n")
 
-        def scan_fn(paths):
+        def scan_fn(paths: list[str]) -> list[dict[str, Any]]:
             return []
 
         reg = build_default_registry()
@@ -431,11 +433,11 @@ class TestRemediationEngine:
         assert report.passes == 1
         assert report.oscillation_detected is False
 
-    def test_report_tiers(self, tmp_path):
+    def test_report_tiers(self, tmp_path: Path) -> None:
         playbook = tmp_path / "play.yml"
         playbook.write_text("- name: test\n  debug: msg=hi\n")
 
-        def scan_fn(paths):
+        def scan_fn(paths: list[str]) -> list[dict[str, Any]]:
             return [
                 {"rule_id": "UNKNOWN_AI", "file": str(playbook), "line": 1},
                 {"rule_id": "MANUAL", "file": str(playbook), "line": 1, "ai_proposable": False},
@@ -457,7 +459,7 @@ class TestRemediationEngine:
 
 
 class TestL008LocalAction:
-    def test_string_form(self):
+    def test_string_form(self) -> None:
         content = textwrap.dedent("""\
         - name: Run locally
           local_action: command echo hello
@@ -468,7 +470,7 @@ class TestL008LocalAction:
         assert "delegate_to: localhost" in result.content
         assert "command:" in result.content or "ansible.builtin.command:" in result.content
 
-    def test_dict_form(self):
+    def test_dict_form(self) -> None:
         content = textwrap.dedent("""\
         - name: Run locally
           local_action:
@@ -481,7 +483,7 @@ class TestL008LocalAction:
         assert "delegate_to: localhost" in result.content
         assert "ansible.builtin.debug" in result.content
 
-    def test_no_change_without_local_action(self):
+    def test_no_change_without_local_action(self) -> None:
         content = textwrap.dedent("""\
         - name: Normal task
           ansible.builtin.debug:
@@ -490,7 +492,7 @@ class TestL008LocalAction:
         result = fix_local_action(content, {"rule_id": "L008", "line": 1})
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - name: Run locally
           local_action: command whoami
@@ -507,7 +509,7 @@ class TestL008LocalAction:
 
 
 class TestL009EmptyString:
-    def test_double_quote_equality(self):
+    def test_double_quote_equality(self) -> None:
         content = textwrap.dedent("""\
         - name: Check var
           ansible.builtin.debug:
@@ -518,7 +520,7 @@ class TestL009EmptyString:
         assert result.applied is True
         assert "myvar | length == 0" in result.content
 
-    def test_single_quote_inequality(self):
+    def test_single_quote_inequality(self) -> None:
         content = textwrap.dedent("""\
         - name: Check var
           ansible.builtin.debug:
@@ -529,7 +531,7 @@ class TestL009EmptyString:
         assert result.applied is True
         assert "myvar | length > 0" in result.content
 
-    def test_no_change_without_pattern(self):
+    def test_no_change_without_pattern(self) -> None:
         content = textwrap.dedent("""\
         - name: Check var
           ansible.builtin.debug:
@@ -539,7 +541,7 @@ class TestL009EmptyString:
         result = fix_empty_string(content, {"rule_id": "L009", "line": 1})
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - name: Check
           ansible.builtin.debug:
@@ -557,7 +559,7 @@ class TestL009EmptyString:
 
 
 class TestL011LiteralBool:
-    def test_eq_true(self):
+    def test_eq_true(self) -> None:
         content = textwrap.dedent("""\
         - name: Check
           ansible.builtin.debug:
@@ -569,7 +571,7 @@ class TestL011LiteralBool:
         assert "enabled" in result.content
         assert "== true" not in result.content
 
-    def test_eq_false(self):
+    def test_eq_false(self) -> None:
         content = textwrap.dedent("""\
         - name: Check
           ansible.builtin.debug:
@@ -580,7 +582,7 @@ class TestL011LiteralBool:
         assert result.applied is True
         assert "not enabled" in result.content
 
-    def test_is_true(self):
+    def test_is_true(self) -> None:
         content = textwrap.dedent("""\
         - name: Check
           ansible.builtin.debug:
@@ -591,7 +593,7 @@ class TestL011LiteralBool:
         assert result.applied is True
         assert "is true" not in result.content
 
-    def test_python_True(self):
+    def test_python_True(self) -> None:
         content = textwrap.dedent("""\
         - name: Check
           ansible.builtin.debug:
@@ -601,7 +603,7 @@ class TestL011LiteralBool:
         result = fix_literal_bool(content, {"rule_id": "L011", "line": 1})
         assert result.applied is True
 
-    def test_no_change_without_pattern(self):
+    def test_no_change_without_pattern(self) -> None:
         content = textwrap.dedent("""\
         - name: Check
           ansible.builtin.debug:
@@ -618,7 +620,7 @@ class TestL011LiteralBool:
 
 
 class TestL015JinjaWhen:
-    def test_strips_jinja_delimiters(self):
+    def test_strips_jinja_delimiters(self) -> None:
         content = textwrap.dedent("""\
         - name: Check
           ansible.builtin.debug:
@@ -631,7 +633,7 @@ class TestL015JinjaWhen:
         assert "}}" not in result.content
         assert "my_var" in result.content
 
-    def test_no_change_without_jinja(self):
+    def test_no_change_without_jinja(self) -> None:
         content = textwrap.dedent("""\
         - name: Check
           ansible.builtin.debug:
@@ -641,7 +643,7 @@ class TestL015JinjaWhen:
         result = fix_jinja_when(content, {"rule_id": "L015", "line": 1})
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - name: Check
           ansible.builtin.debug:
@@ -659,7 +661,7 @@ class TestL015JinjaWhen:
 
 
 class TestL020OctalMode:
-    def test_octal_literal_to_string(self):
+    def test_octal_literal_to_string(self) -> None:
         """YAML 1.1 parses 0644 as octal int 420; should become '0644'."""
         content = textwrap.dedent("""\
         - name: Set perms
@@ -671,7 +673,7 @@ class TestL020OctalMode:
         assert result.applied is True
         assert "0644" in result.content
 
-    def test_decimal_int_to_octal_string(self):
+    def test_decimal_int_to_octal_string(self) -> None:
         """Bare 644 is decimal in YAML; digits are all valid octal, treated as intended octal."""
         content = textwrap.dedent("""\
         - name: Set perms
@@ -683,7 +685,7 @@ class TestL020OctalMode:
         assert result.applied is True
         assert "0644" in result.content
 
-    def test_no_change_when_already_string(self):
+    def test_no_change_when_already_string(self) -> None:
         content = textwrap.dedent("""\
         - name: Set perms
           ansible.builtin.file:
@@ -693,7 +695,7 @@ class TestL020OctalMode:
         result = fix_octal_mode(content, {"rule_id": "L020", "line": 1})
         assert result.applied is False
 
-    def test_string_without_leading_zero(self):
+    def test_string_without_leading_zero(self) -> None:
         content = textwrap.dedent("""\
         - name: Set perms
           ansible.builtin.file:
@@ -711,7 +713,7 @@ class TestL020OctalMode:
 
 
 class TestL025NameCasing:
-    def test_capitalizes_task_name(self):
+    def test_capitalizes_task_name(self) -> None:
         content = textwrap.dedent("""\
         - name: install packages
           ansible.builtin.debug:
@@ -721,7 +723,7 @@ class TestL025NameCasing:
         assert result.applied is True
         assert "Install packages" in result.content
 
-    def test_no_change_when_already_uppercase(self):
+    def test_no_change_when_already_uppercase(self) -> None:
         content = textwrap.dedent("""\
         - name: Install packages
           ansible.builtin.debug:
@@ -730,7 +732,7 @@ class TestL025NameCasing:
         result = fix_name_casing(content, {"rule_id": "L025", "line": 1})
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - name: setup network
           ansible.builtin.debug:
@@ -747,7 +749,7 @@ class TestL025NameCasing:
 
 
 class TestL046FreeForm:
-    def test_converts_string_to_dict(self):
+    def test_converts_string_to_dict(self) -> None:
         content = textwrap.dedent("""\
         - name: Run it
           ansible.builtin.command: echo hello
@@ -757,7 +759,7 @@ class TestL046FreeForm:
         assert "cmd:" in result.content
         assert "echo hello" in result.content
 
-    def test_no_change_when_already_dict(self):
+    def test_no_change_when_already_dict(self) -> None:
         content = textwrap.dedent("""\
         - name: Run it
           ansible.builtin.command:
@@ -766,7 +768,7 @@ class TestL046FreeForm:
         result = fix_free_form(content, {"rule_id": "L046", "line": 1})
         assert result.applied is False
 
-    def test_no_change_for_non_command_module(self):
+    def test_no_change_for_non_command_module(self) -> None:
         content = textwrap.dedent("""\
         - name: Debug
           ansible.builtin.debug:
@@ -775,7 +777,7 @@ class TestL046FreeForm:
         result = fix_free_form(content, {"rule_id": "L046", "line": 1})
         assert result.applied is False
 
-    def test_shell_module(self):
+    def test_shell_module(self) -> None:
         content = textwrap.dedent("""\
         - name: Run shell
           ansible.builtin.shell: cat /etc/hosts | grep localhost
@@ -791,7 +793,7 @@ class TestL046FreeForm:
 
 
 class TestL043BareVars:
-    def test_wraps_bare_var_in_with_items(self):
+    def test_wraps_bare_var_in_with_items(self) -> None:
         content = textwrap.dedent("""\
         - name: Loop
           ansible.builtin.debug:
@@ -802,7 +804,7 @@ class TestL043BareVars:
         assert result.applied is True
         assert "{{ packages }}" in result.content
 
-    def test_no_change_when_already_jinja(self):
+    def test_no_change_when_already_jinja(self) -> None:
         content = textwrap.dedent("""\
         - name: Loop
           ansible.builtin.debug:
@@ -812,7 +814,7 @@ class TestL043BareVars:
         result = fix_bare_vars(content, {"rule_id": "L043", "line": 1})
         assert result.applied is False
 
-    def test_no_change_without_loop(self):
+    def test_no_change_without_loop(self) -> None:
         content = textwrap.dedent("""\
         - name: Simple
           ansible.builtin.debug:
@@ -828,7 +830,7 @@ class TestL043BareVars:
 
 
 class TestL013ChangedWhen:
-    def test_adds_changed_when(self):
+    def test_adds_changed_when(self) -> None:
         content = textwrap.dedent("""\
         - name: Check version
           ansible.builtin.command: python --version
@@ -837,7 +839,7 @@ class TestL013ChangedWhen:
         assert result.applied is True
         assert "changed_when:" in result.content
 
-    def test_no_change_when_creates_present(self):
+    def test_no_change_when_creates_present(self) -> None:
         content = textwrap.dedent("""\
         - name: Create file
           ansible.builtin.command:
@@ -847,7 +849,7 @@ class TestL013ChangedWhen:
         result = fix_changed_when(content, {"rule_id": "L013", "line": 1})
         assert result.applied is False
 
-    def test_no_change_when_already_set(self):
+    def test_no_change_when_already_set(self) -> None:
         content = textwrap.dedent("""\
         - name: Check
           ansible.builtin.command: echo test
@@ -856,7 +858,7 @@ class TestL013ChangedWhen:
         result = fix_changed_when(content, {"rule_id": "L013", "line": 1})
         assert result.applied is False
 
-    def test_no_change_for_non_command_module(self):
+    def test_no_change_for_non_command_module(self) -> None:
         content = textwrap.dedent("""\
         - name: Debug
           ansible.builtin.debug:
@@ -872,7 +874,7 @@ class TestL013ChangedWhen:
 
 
 class TestL018Become:
-    def test_adds_become(self):
+    def test_adds_become(self) -> None:
         content = textwrap.dedent("""\
         - name: Switch user
           ansible.builtin.command: whoami
@@ -882,7 +884,7 @@ class TestL018Become:
         assert result.applied is True
         assert "become: true" in result.content or "become: True" in result.content
 
-    def test_no_change_when_become_present(self):
+    def test_no_change_when_become_present(self) -> None:
         content = textwrap.dedent("""\
         - name: Switch user
           ansible.builtin.command: whoami
@@ -892,7 +894,7 @@ class TestL018Become:
         result = fix_become(content, {"rule_id": "L018", "line": 1})
         assert result.applied is False
 
-    def test_no_change_without_become_user(self):
+    def test_no_change_without_become_user(self) -> None:
         content = textwrap.dedent("""\
         - name: Normal
           ansible.builtin.debug:
@@ -901,7 +903,7 @@ class TestL018Become:
         result = fix_become(content, {"rule_id": "L018", "line": 1})
         assert result.applied is False
 
-    def test_become_inserted_after_become_user(self):
+    def test_become_inserted_after_become_user(self) -> None:
         content = textwrap.dedent("""\
         - name: Switch user
           ansible.builtin.command: whoami
@@ -921,7 +923,7 @@ class TestL018Become:
 
 
 class TestL022Pipefail:
-    def test_prepends_pipefail_string_form(self):
+    def test_prepends_pipefail_string_form(self) -> None:
         content = textwrap.dedent("""\
         - name: Grep logs
           ansible.builtin.shell: cat /var/log/syslog | grep error
@@ -930,7 +932,7 @@ class TestL022Pipefail:
         assert result.applied is True
         assert "set -o pipefail &&" in result.content
 
-    def test_prepends_pipefail_dict_form(self):
+    def test_prepends_pipefail_dict_form(self) -> None:
         content = textwrap.dedent("""\
         - name: Grep logs
           ansible.builtin.shell:
@@ -940,7 +942,7 @@ class TestL022Pipefail:
         assert result.applied is True
         assert "set -o pipefail &&" in result.content
 
-    def test_no_change_without_pipe(self):
+    def test_no_change_without_pipe(self) -> None:
         content = textwrap.dedent("""\
         - name: Simple
           ansible.builtin.shell: echo hello
@@ -948,7 +950,7 @@ class TestL022Pipefail:
         result = fix_pipefail(content, {"rule_id": "L022", "line": 1})
         assert result.applied is False
 
-    def test_no_change_when_already_set(self):
+    def test_no_change_when_already_set(self) -> None:
         content = textwrap.dedent("""\
         - name: Grep logs
           ansible.builtin.shell: set -o pipefail && cat /var/log/syslog | grep error
@@ -956,7 +958,7 @@ class TestL022Pipefail:
         result = fix_pipefail(content, {"rule_id": "L022", "line": 1})
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - name: Grep
           ansible.builtin.shell: cat log | grep err
@@ -972,7 +974,7 @@ class TestL022Pipefail:
 
 
 class TestL012Latest:
-    def test_replaces_latest_with_present(self):
+    def test_replaces_latest_with_present(self) -> None:
         content = textwrap.dedent("""\
         - name: Install httpd
           ansible.builtin.yum:
@@ -984,7 +986,7 @@ class TestL012Latest:
         assert "state: present" in result.content
         assert "state: latest" not in result.content
 
-    def test_no_change_when_present(self):
+    def test_no_change_when_present(self) -> None:
         content = textwrap.dedent("""\
         - name: Install httpd
           ansible.builtin.yum:
@@ -994,7 +996,7 @@ class TestL012Latest:
         result = fix_latest(content, {"rule_id": "L012", "line": 1})
         assert result.applied is False
 
-    def test_no_change_for_absent(self):
+    def test_no_change_for_absent(self) -> None:
         content = textwrap.dedent("""\
         - name: Remove httpd
           ansible.builtin.yum:
@@ -1004,7 +1006,7 @@ class TestL012Latest:
         result = fix_latest(content, {"rule_id": "L012", "line": 1})
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - name: Install
           ansible.builtin.apt:
@@ -1022,7 +1024,7 @@ class TestL012Latest:
 
 
 class TestM006BecomeUnreachable:
-    def test_adds_ignore_unreachable(self):
+    def test_adds_ignore_unreachable(self) -> None:
         content = textwrap.dedent("""\
         - name: Risky task
           ansible.builtin.command: whoami
@@ -1033,7 +1035,7 @@ class TestM006BecomeUnreachable:
         assert result.applied is True
         assert "ignore_unreachable: true" in result.content or "ignore_unreachable: True" in result.content
 
-    def test_no_change_when_already_set(self):
+    def test_no_change_when_already_set(self) -> None:
         content = textwrap.dedent("""\
         - name: Safe task
           ansible.builtin.command: whoami
@@ -1044,7 +1046,7 @@ class TestM006BecomeUnreachable:
         result = fix_become_unreachable(content, {"rule_id": "M006", "line": 1})
         assert result.applied is False
 
-    def test_no_change_without_become(self):
+    def test_no_change_without_become(self) -> None:
         content = textwrap.dedent("""\
         - name: Normal task
           ansible.builtin.command: whoami
@@ -1053,7 +1055,7 @@ class TestM006BecomeUnreachable:
         result = fix_become_unreachable(content, {"rule_id": "M006", "line": 1})
         assert result.applied is False
 
-    def test_inserted_after_ignore_errors(self):
+    def test_inserted_after_ignore_errors(self) -> None:
         content = textwrap.dedent("""\
         - name: Risky task
           ansible.builtin.command: whoami
@@ -1073,7 +1075,7 @@ class TestM006BecomeUnreachable:
 
 
 class TestM008BareInclude:
-    def test_replaces_include(self):
+    def test_replaces_include(self) -> None:
         content = textwrap.dedent("""\
         - include: tasks/setup.yml
         """)
@@ -1082,14 +1084,14 @@ class TestM008BareInclude:
         assert "ansible.builtin.include_tasks" in result.content
         assert "\n- include:" not in result.content
 
-    def test_no_change_for_include_tasks(self):
+    def test_no_change_for_include_tasks(self) -> None:
         content = textwrap.dedent("""\
         - ansible.builtin.include_tasks: tasks/setup.yml
         """)
         result = fix_bare_include(content, {"rule_id": "M008", "line": 1})
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - include: tasks/setup.yml
         """)
@@ -1104,7 +1106,7 @@ class TestM008BareInclude:
 
 
 class TestM009WithToLoop:
-    def test_with_items_to_loop(self):
+    def test_with_items_to_loop(self) -> None:
         content = textwrap.dedent("""\
         - name: Install packages
           ansible.builtin.yum:
@@ -1119,7 +1121,7 @@ class TestM009WithToLoop:
         assert "loop:" in result.content
         assert "with_items" not in result.content
 
-    def test_no_change_for_loop(self):
+    def test_no_change_for_loop(self) -> None:
         content = textwrap.dedent("""\
         - name: Install packages
           ansible.builtin.yum:
@@ -1132,7 +1134,7 @@ class TestM009WithToLoop:
         result = fix_with_to_loop(content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
         assert result.applied is False
 
-    def test_with_dict_not_handled(self):
+    def test_with_dict_not_handled(self) -> None:
         content = textwrap.dedent("""\
         - name: Create users
           ansible.builtin.user:
@@ -1142,7 +1144,7 @@ class TestM009WithToLoop:
         result = fix_with_to_loop(content, {"rule_id": "M009", "line": 1, "with_key": "with_dict"})
         assert result.applied is False
 
-    def test_idempotent(self):
+    def test_idempotent(self) -> None:
         content = textwrap.dedent("""\
         - name: Install
           ansible.builtin.yum:

--- a/tests/test_rule_doc_coverage.py
+++ b/tests/test_rule_doc_coverage.py
@@ -15,7 +15,7 @@ _SKIP_NATIVE_FILES = {"__init__", "base_rule", "sample_rule"}
 
 def _discover_native_rule_ids() -> list[tuple[str, str, Path]]:
     """Return (rule_id, source_file, expected_md_dir) for each native Python rule."""
-    results = []
+    results: list[tuple[str, str, Path]] = []
     pat = re.compile(r'rule_id:\s*str\s*=\s*"([^"]+)"')
     for py in NATIVE_RULES_DIR.glob("*.py"):
         if py.name.endswith("_test.py") or py.stem in _SKIP_NATIVE_FILES:
@@ -29,7 +29,7 @@ def _discover_native_rule_ids() -> list[tuple[str, str, Path]]:
 
 def _discover_opa_rule_ids() -> list[tuple[str, str, Path]]:
     """Return (rule_id, source_file, expected_md_dir) for each OPA rego rule."""
-    results = []
+    results: list[tuple[str, str, Path]] = []
     pat = re.compile(r'"rule_id":\s*"([^"]+)"')
     for rego in OPA_BUNDLE_DIR.glob("*.rego"):
         if rego.name.endswith("_test.rego") or rego.name.startswith("_"):
@@ -43,7 +43,7 @@ def _discover_opa_rule_ids() -> list[tuple[str, str, Path]]:
 
 def _discover_ansible_rule_ids() -> list[tuple[str, str, Path]]:
     """Return (rule_id, source_file, expected_md_dir) for each ansible validator rule."""
-    results = []
+    results: list[tuple[str, str, Path]] = []
     if not ANSIBLE_RULES_DIR.is_dir():
         return results
 
@@ -75,11 +75,11 @@ def _find_md_for_rule(rule_id: str, md_dir: Path) -> Path | None:
     return None
 
 
-def _collect_all_rules():
-    rules = []
-    rules.extend(("native", *r) for r in _discover_native_rule_ids())
-    rules.extend(("opa", *r) for r in _discover_opa_rule_ids())
-    rules.extend(("ansible", *r) for r in _discover_ansible_rule_ids())
+def _collect_all_rules() -> list[tuple[str, str, str, Path]]:
+    rules: list[tuple[str, str, str, Path]] = []
+    rules.extend(("native", r[0], r[1], r[2]) for r in _discover_native_rule_ids())
+    rules.extend(("opa", r[0], r[1], r[2]) for r in _discover_opa_rule_ids())
+    rules.extend(("ansible", r[0], r[1], r[2]) for r in _discover_ansible_rule_ids())
     return rules
 
 
@@ -91,8 +91,8 @@ _PARAM_IDS = [f"{validator}:{rule_id}" for validator, rule_id, _, _ in _ALL_RULE
     "validator,rule_id,source_file,md_dir",
     _ALL_RULES if _ALL_RULES else [("skip", "skip", "skip", Path("."))],
     ids=_PARAM_IDS if _PARAM_IDS else ["no_rules"],
-)
-def test_rule_has_doc(validator, rule_id, source_file, md_dir):
+)  # type: ignore[untyped-decorator]
+def test_rule_has_doc(validator: str, rule_id: str, source_file: str, md_dir: Path) -> None:
     """Every rule must have a .md doc file."""
     if rule_id == "skip":
         pytest.skip("No rules discovered")
@@ -102,7 +102,7 @@ def test_rule_has_doc(validator, rule_id, source_file, md_dir):
     )
 
 
-def test_minimum_rule_count():
+def test_minimum_rule_count() -> None:
     """Sanity check: we should discover a reasonable number of rules."""
     native = _discover_native_rule_ids()
     opa = _discover_opa_rule_ids()

--- a/tests/test_scanner_hierarchy.py
+++ b/tests/test_scanner_hierarchy.py
@@ -1,11 +1,12 @@
 """Tests for integrated engine scanner hierarchy payload (build_hierarchy_payload, _node_to_dict, apply_rules)."""
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 
-def _import_single_scan():
+def _import_single_scan() -> type[Any] | None:
     """Import SingleScan from apme_engine.engine; return None if import fails."""
     try:
         from apme_engine.engine.scanner import SingleScan
@@ -15,13 +16,13 @@ def _import_single_scan():
         return None
 
 
-@pytest.fixture
-def single_scan_with_mock_contexts():
+@pytest.fixture  # type: ignore[untyped-decorator]
+def single_scan_with_mock_contexts() -> Any:
     """SingleScan with minimal mock contexts so build_hierarchy_payload runs."""
     SingleScan = _import_single_scan()
     if SingleScan is None:
         pytest.skip("apme_engine.engine not importable (missing deps)")
-    scan = SingleScan(type="playbook", name="test.yml", root_dir="/tmp", rules_dir="")
+    scan = SingleScan(type="playbook", name="test.yml", root_dir="/tmp", rules_dir="")  # type: ignore[misc]
     # Mock context: root_key, sequence of nodes
     mock_spec = MagicMock()
     mock_spec.defined_in = "/path/to/play.yml"
@@ -50,7 +51,7 @@ def single_scan_with_mock_contexts():
 class TestScannerHierarchy:
     """Tests for integrated engine scanner build_hierarchy_payload and apply_rules."""
 
-    def test_build_hierarchy_payload_structure(self, single_scan_with_mock_contexts):
+    def test_build_hierarchy_payload_structure(self, single_scan_with_mock_contexts: Any) -> None:
         """build_hierarchy_payload returns dict with scan_id, hierarchy, metadata."""
         scan = single_scan_with_mock_contexts
         payload = scan.build_hierarchy_payload(scan_id="fixed-id")
@@ -65,7 +66,7 @@ class TestScannerHierarchy:
         assert payload["metadata"]["type"] == "playbook"
         assert payload["metadata"]["name"] == "test.yml"
 
-    def test_build_hierarchy_payload_node_serialization(self, single_scan_with_mock_contexts):
+    def test_build_hierarchy_payload_node_serialization(self, single_scan_with_mock_contexts: Any) -> None:
         """_node_to_dict serializes playcall and taskcall with file, line, module."""
         scan = single_scan_with_mock_contexts
         payload = scan.build_hierarchy_payload(scan_id="x")
@@ -86,23 +87,25 @@ class TestScannerHierarchy:
         assert task_node["options"] == {}
         assert task_node["module_options"] == {}
 
-    def test_build_hierarchy_payload_empty_scan_id_generates_timestamp(self, single_scan_with_mock_contexts):
+    def test_build_hierarchy_payload_empty_scan_id_generates_timestamp(
+        self, single_scan_with_mock_contexts: Any
+    ) -> None:
         """When scan_id is empty, build_hierarchy_payload uses timestamp."""
         scan = single_scan_with_mock_contexts
         payload = scan.build_hierarchy_payload()
         assert payload["scan_id"] != ""
         assert len(payload["scan_id"]) >= 14  # YYYYMMDDHHMMSS
 
-    def test_build_hierarchy_payload_empty_contexts_returns_empty_trees(self):
+    def test_build_hierarchy_payload_empty_contexts_returns_empty_trees(self) -> None:
         SingleScan = _import_single_scan()
         if SingleScan is None:
             pytest.skip("apme_engine.engine not importable")
-        scan = SingleScan(type="playbook", name="test.yml", root_dir="/tmp", rules_dir="")
+        scan = SingleScan(type="playbook", name="test.yml", root_dir="/tmp", rules_dir="")  # type: ignore[misc]
         scan.contexts = []
         payload = scan.build_hierarchy_payload(scan_id="id")
         assert payload["hierarchy"] == []
 
-    def test_apply_rules_sets_findings_and_hierarchy_payload(self, single_scan_with_mock_contexts):
+    def test_apply_rules_sets_findings_and_hierarchy_payload(self, single_scan_with_mock_contexts: Any) -> None:
         """apply_rules builds hierarchy_payload and sets findings with it in report."""
         scan = single_scan_with_mock_contexts
         scan.apply_rules()
@@ -112,7 +115,7 @@ class TestScannerHierarchy:
         assert scan.findings.report["hierarchy_payload"] == scan.hierarchy_payload
         assert scan.result is None
 
-    def test_node_to_dict_no_spec(self, single_scan_with_mock_contexts):
+    def test_node_to_dict_no_spec(self, single_scan_with_mock_contexts: Any) -> None:
         """_node_to_dict handles node without spec (file/line empty)."""
         scan = single_scan_with_mock_contexts
         node = MagicMock()

--- a/tests/test_validator_servicers.py
+++ b/tests/test_validator_servicers.py
@@ -16,18 +16,18 @@ from apme.v1 import common_pb2, validate_pb2
 class FakeGrpcContext:
     """Minimal stub for grpc.ServicerContext."""
 
-    def set_code(self, code):
+    def set_code(self, code: object) -> None:
         pass
 
-    def set_details(self, details):
+    def set_details(self, details: object) -> None:
         pass
 
 
 class TestOpaValidatorServicer:
-    async def test_validate_posts_to_opa_rest(self):
+    async def test_validate_posts_to_opa_rest(self) -> None:
         from apme_engine.daemon.opa_validator_server import OpaValidatorServicer
 
-        hierarchy = {"hierarchy": [{"tree_type": "playbook", "nodes": []}]}
+        hierarchy: dict[str, object] = {"hierarchy": [{"tree_type": "playbook", "nodes": []}]}
         violations = [{"rule_id": "L024", "level": "warning", "message": "m", "file": "f.yml", "line": 1, "path": "p"}]
 
         request = validate_pb2.ValidateRequest(
@@ -48,14 +48,14 @@ class TestOpaValidatorServicer:
         mock_post.assert_called_once()
         call_args = mock_post.call_args
         assert call_args[1]["json"]["input"] == hierarchy
-        assert len(resp.violations) == 1
-        assert resp.violations[0].rule_id == "L024"
-        assert resp.request_id == "test-req-1"
+        assert len(resp.violations) == 1  # type: ignore[attr-defined]
+        assert resp.violations[0].rule_id == "L024"  # type: ignore[attr-defined]
+        assert resp.request_id == "test-req-1"  # type: ignore[attr-defined]
 
-    async def test_validate_returns_diagnostics(self):
+    async def test_validate_returns_diagnostics(self) -> None:
         from apme_engine.daemon.opa_validator_server import OpaValidatorServicer
 
-        hierarchy = {"hierarchy": []}
+        hierarchy: dict[str, object] = {"hierarchy": []}
         violations = [
             {"rule_id": "L024", "level": "warning", "message": "m1", "file": "a.yml", "line": 1, "path": ""},
             {"rule_id": "L024", "level": "warning", "message": "m2", "file": "a.yml", "line": 5, "path": ""},
@@ -76,8 +76,8 @@ class TestOpaValidatorServicer:
         with patch.object(servicer._client, "post", new_callable=AsyncMock, return_value=mock_response):
             resp = await servicer.Validate(request, FakeGrpcContext())
 
-        assert resp.HasField("diagnostics")
-        diag = resp.diagnostics
+        assert resp.HasField("diagnostics")  # type: ignore[attr-defined]
+        diag = resp.diagnostics  # type: ignore[attr-defined]
         assert diag.validator_name == "opa"
         assert diag.request_id == "diag-opa-1"
         assert diag.violations_found == 3
@@ -92,7 +92,7 @@ class TestOpaValidatorServicer:
         l024_timing = next(rt for rt in diag.rule_timings if rt.rule_id == "L024")
         assert l024_timing.violations == 2
 
-    async def test_validate_empty_payload_returns_empty(self):
+    async def test_validate_empty_payload_returns_empty(self) -> None:
         from apme_engine.daemon.opa_validator_server import OpaValidatorServicer
 
         request = validate_pb2.ValidateRequest(request_id="test-req-2")
@@ -105,12 +105,12 @@ class TestOpaValidatorServicer:
 
         with patch.object(servicer._client, "post", new_callable=AsyncMock, return_value=mock_response):
             resp = await servicer.Validate(request, FakeGrpcContext())
-        assert len(resp.violations) == 0
-        assert resp.request_id == "test-req-2"
-        assert resp.HasField("diagnostics")
-        assert resp.diagnostics.violations_found == 0
+        assert len(resp.violations) == 0  # type: ignore[attr-defined]
+        assert resp.request_id == "test-req-2"  # type: ignore[attr-defined]
+        assert resp.HasField("diagnostics")  # type: ignore[attr-defined]
+        assert resp.diagnostics.violations_found == 0  # type: ignore[attr-defined]
 
-    async def test_validate_opa_http_error_returns_empty(self):
+    async def test_validate_opa_http_error_returns_empty(self) -> None:
         from apme_engine.daemon.opa_validator_server import OpaValidatorServicer
 
         request = validate_pb2.ValidateRequest(
@@ -123,9 +123,9 @@ class TestOpaValidatorServicer:
         servicer = OpaValidatorServicer()
         with patch.object(servicer._client, "post", new_callable=AsyncMock, return_value=mock_response):
             resp = await servicer.Validate(request, FakeGrpcContext())
-        assert len(resp.violations) == 0
+        assert len(resp.violations) == 0  # type: ignore[attr-defined]
 
-    async def test_health_opa_up(self):
+    async def test_health_opa_up(self) -> None:
         from apme_engine.daemon.opa_validator_server import OpaValidatorServicer
 
         mock_response = MagicMock()
@@ -136,7 +136,7 @@ class TestOpaValidatorServicer:
             resp = await servicer.Health(common_pb2.HealthRequest(), FakeGrpcContext())
         assert resp.status == "ok"
 
-    async def test_health_opa_down(self):
+    async def test_health_opa_down(self) -> None:
         from apme_engine.daemon.opa_validator_server import OpaValidatorServicer
 
         servicer = OpaValidatorServicer()
@@ -146,12 +146,12 @@ class TestOpaValidatorServicer:
 
 
 class TestNativeValidatorServicer:
-    async def test_validate_deserializes_scandata_and_runs(self):
+    async def test_validate_deserializes_scandata_and_runs(self) -> None:
         from apme_engine.daemon.native_validator_server import NativeValidatorServicer
         from apme_engine.validators.native import NativeRuleTiming, NativeRunResult
 
         mock_scandata = type("Scandata", (), {"contexts": []})()
-        hierarchy = {"hierarchy": []}
+        hierarchy: dict[str, object] = {"hierarchy": []}
         request = validate_pb2.ValidateRequest(
             request_id="native-1",
             hierarchy_payload=json.dumps(hierarchy).encode(),
@@ -178,11 +178,11 @@ class TestNativeValidatorServicer:
         with patch("apme_engine.daemon.native_validator_server._run_native", return_value=mock_result):
             resp = await servicer.Validate(request, FakeGrpcContext())
 
-        assert len(resp.violations) == 1
-        assert resp.violations[0].rule_id == "native:L028"
-        assert resp.request_id == "native-1"
+        assert len(resp.violations) == 1  # type: ignore[attr-defined]
+        assert resp.violations[0].rule_id == "native:L028"  # type: ignore[attr-defined]
+        assert resp.request_id == "native-1"  # type: ignore[attr-defined]
 
-    async def test_validate_returns_diagnostics(self):
+    async def test_validate_returns_diagnostics(self) -> None:
         from apme_engine.daemon.native_validator_server import NativeValidatorServicer
         from apme_engine.validators.native import NativeRuleTiming, NativeRunResult
 
@@ -208,8 +208,8 @@ class TestNativeValidatorServicer:
         with patch("apme_engine.daemon.native_validator_server._run_native", return_value=mock_result):
             resp = await servicer.Validate(request, FakeGrpcContext())
 
-        assert resp.HasField("diagnostics")
-        diag = resp.diagnostics
+        assert resp.HasField("diagnostics")  # type: ignore[attr-defined]
+        diag = resp.diagnostics  # type: ignore[attr-defined]
         assert diag.validator_name == "native"
         assert diag.request_id == "diag-native-1"
         assert diag.violations_found == 2
@@ -221,7 +221,7 @@ class TestNativeValidatorServicer:
         assert l028.elapsed_ms == pytest.approx(2.1)
         assert l028.violations == 1
 
-    async def test_validate_no_scandata_returns_empty(self):
+    async def test_validate_no_scandata_returns_empty(self) -> None:
         from apme_engine.daemon.native_validator_server import NativeValidatorServicer
         from apme_engine.validators.native import NativeRunResult
 
@@ -234,9 +234,9 @@ class TestNativeValidatorServicer:
         mock_result = NativeRunResult(violations=[], rule_timings=[])
         with patch("apme_engine.daemon.native_validator_server._run_native", return_value=mock_result):
             resp = await servicer.Validate(request, FakeGrpcContext())
-        assert len(resp.violations) == 0
+        assert len(resp.violations) == 0  # type: ignore[attr-defined]
 
-    async def test_validate_bad_scandata_returns_empty(self):
+    async def test_validate_bad_scandata_returns_empty(self) -> None:
         from apme_engine.daemon.native_validator_server import NativeValidatorServicer
 
         request = validate_pb2.ValidateRequest(
@@ -246,9 +246,9 @@ class TestNativeValidatorServicer:
         )
         servicer = NativeValidatorServicer()
         resp = await servicer.Validate(request, FakeGrpcContext())
-        assert len(resp.violations) == 0
+        assert len(resp.violations) == 0  # type: ignore[attr-defined]
 
-    async def test_health_returns_ok(self):
+    async def test_health_returns_ok(self) -> None:
         from apme_engine.daemon.native_validator_server import NativeValidatorServicer
 
         servicer = NativeValidatorServicer()
@@ -257,7 +257,7 @@ class TestNativeValidatorServicer:
 
 
 class TestGitleaksValidatorServicerDiagnostics:
-    async def test_validate_returns_diagnostics(self):
+    async def test_validate_returns_diagnostics(self) -> None:
         from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
 
         request = validate_pb2.ValidateRequest(
@@ -273,8 +273,8 @@ class TestGitleaksValidatorServicerDiagnostics:
         with patch("apme_engine.daemon.gitleaks_validator_server._run_scan", return_value=(mock_violations, 1)):
             resp = await servicer.Validate(request, FakeGrpcContext())
 
-        assert resp.HasField("diagnostics")
-        diag = resp.diagnostics
+        assert resp.HasField("diagnostics")  # type: ignore[attr-defined]
+        diag = resp.diagnostics  # type: ignore[attr-defined]
         assert diag.validator_name == "gitleaks"
         assert diag.request_id == "diag-gl-1"
         assert diag.violations_found == 1
@@ -284,31 +284,31 @@ class TestGitleaksValidatorServicerDiagnostics:
         assert "files_written" in diag.metadata
         assert diag.metadata["files_written"] == "1"
 
-    async def test_validate_empty_files_no_diagnostics(self):
+    async def test_validate_empty_files_no_diagnostics(self) -> None:
         from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
 
         request = validate_pb2.ValidateRequest(request_id="diag-gl-2")
         servicer = GitleaksValidatorServicer()
         resp = await servicer.Validate(request, FakeGrpcContext())
-        assert len(resp.violations) == 0
+        assert len(resp.violations) == 0  # type: ignore[attr-defined]
 
 
 class TestAnsibleValidatorServicerMigration:
     """Verify Ansible validator now uses the unified Validator service."""
 
-    def test_servicer_extends_validator_servicer(self):
+    def test_servicer_extends_validator_servicer(self) -> None:
         from apme_engine.daemon.ansible_validator_server import AnsibleValidatorServicer
 
         assert hasattr(AnsibleValidatorServicer, "Validate")
 
-    def test_serve_is_async(self):
+    def test_serve_is_async(self) -> None:
         import inspect
 
         from apme_engine.daemon.ansible_validator_server import serve
 
         assert inspect.iscoroutinefunction(serve)
 
-    async def test_validate_returns_diagnostics(self):
+    async def test_validate_returns_diagnostics(self) -> None:
         from apme_engine.daemon.ansible_validator_server import AnsibleValidatorServicer, _AnsibleResult
         from apme_engine.validators.ansible import AnsibleRuleTiming, AnsibleRunResult
 
@@ -342,8 +342,8 @@ class TestAnsibleValidatorServicerMigration:
         with patch("apme_engine.daemon.ansible_validator_server._run_ansible_validate", return_value=mock_result):
             resp = await servicer.Validate(request, FakeGrpcContext())
 
-        assert resp.HasField("diagnostics")
-        diag = resp.diagnostics
+        assert resp.HasField("diagnostics")  # type: ignore[attr-defined]
+        diag = resp.diagnostics  # type: ignore[attr-defined]
         assert diag.validator_name == "ansible"
         assert diag.request_id == "diag-ans-1"
         assert diag.violations_found == 1
@@ -358,7 +358,7 @@ class TestAnsibleValidatorServicerMigration:
 class TestPrimaryFanOut:
     """Verify Primary uses async fan-out for all backends."""
 
-    async def test_call_validator_uses_async_channel(self):
+    async def test_call_validator_uses_async_channel(self) -> None:
         from apme_engine.daemon.primary_server import _call_validator
 
         mock_resp = MagicMock()
@@ -379,7 +379,7 @@ class TestPrimaryFanOut:
         mock_stub.Validate.assert_called_once()
         assert result.violations == []
 
-    async def test_call_validator_captures_diagnostics(self):
+    async def test_call_validator_captures_diagnostics(self) -> None:
         from apme_engine.daemon.primary_server import _call_validator
 
         diag = common_pb2.ValidatorDiagnostics(
@@ -407,7 +407,7 @@ class TestPrimaryFanOut:
         assert result.diagnostics.validator_name == "native"
         assert result.diagnostics.total_ms == 42.0
 
-    def test_primary_no_longer_imports_native_validator(self):
+    def test_primary_no_longer_imports_native_validator(self) -> None:
         """Primary should not import NativeValidator directly (it's in its own container)."""
         import apme_engine.daemon.primary_server as ps
 
@@ -415,7 +415,7 @@ class TestPrimaryFanOut:
         assert "from apme_engine.validators.native" not in source
         assert "NativeValidator()" not in source
 
-    def test_primary_no_longer_imports_opa_client(self):
+    def test_primary_no_longer_imports_opa_client(self) -> None:
         """Primary should not import opa_client (OPA is behind gRPC now)."""
         import apme_engine.daemon.primary_server as ps
 
@@ -423,21 +423,21 @@ class TestPrimaryFanOut:
         assert "from apme_engine.opa_client" not in source
         assert "_call_opa" not in source
 
-    def test_primary_propagates_request_id(self):
+    def test_primary_propagates_request_id(self) -> None:
         """Primary should set request_id on ValidateRequest."""
         import apme_engine.daemon.primary_server as ps
 
         source = Path(ps.__file__).read_text()
         assert "request_id=scan_id" in source
 
-    def test_primary_serve_is_async(self):
+    def test_primary_serve_is_async(self) -> None:
         import inspect
 
         from apme_engine.daemon.primary_server import serve
 
         assert inspect.iscoroutinefunction(serve)
 
-    def test_primary_aggregates_diagnostics(self):
+    def test_primary_aggregates_diagnostics(self) -> None:
         """Primary should collect validator diagnostics into ScanDiagnostics."""
         import apme_engine.daemon.primary_server as ps
 
@@ -459,12 +459,12 @@ class TestGrpcAioConsistency:
             "apme_engine.daemon.ansible_validator_server",
             "apme_engine.daemon.gitleaks_validator_server",
         ],
-    )
-    def test_serve_is_async_coroutine(self, module_path):
+    )  # type: ignore[untyped-decorator]
+    def test_serve_is_async_coroutine(self, module_path: str) -> None:
         import importlib
         import inspect
 
-        mod = importlib.import_module(module_path)
+        mod = importlib.import_module(str(module_path))
         assert inspect.iscoroutinefunction(mod.serve), f"{module_path}.serve should be async"
 
     @pytest.mark.parametrize(
@@ -476,12 +476,12 @@ class TestGrpcAioConsistency:
             "apme_engine.daemon.ansible_validator_server",
             "apme_engine.daemon.gitleaks_validator_server",
         ],
-    )
-    def test_server_uses_grpc_aio(self, module_path):
+    )  # type: ignore[untyped-decorator]
+    def test_server_uses_grpc_aio(self, module_path: str) -> None:
         import importlib
 
         mod = importlib.import_module(module_path)
-        source = Path(mod.__file__).read_text()
+        source = Path(str(mod.__file__)).read_text()
         assert "grpc.aio" in source, f"{module_path} should use grpc.aio"
 
     @pytest.mark.parametrize(
@@ -492,12 +492,12 @@ class TestGrpcAioConsistency:
             "apme_engine.daemon.ansible_validator_server",
             "apme_engine.daemon.gitleaks_validator_server",
         ],
-    )
-    def test_validator_echoes_request_id(self, module_path):
+    )  # type: ignore[untyped-decorator]
+    def test_validator_echoes_request_id(self, module_path: str) -> None:
         import importlib
 
         mod = importlib.import_module(module_path)
-        source = Path(mod.__file__).read_text()
+        source = Path(str(mod.__file__)).read_text()
         assert "request_id" in source, f"{module_path} should handle request_id"
 
     @pytest.mark.parametrize(
@@ -508,13 +508,13 @@ class TestGrpcAioConsistency:
             "apme_engine.daemon.ansible_validator_server",
             "apme_engine.daemon.gitleaks_validator_server",
         ],
-    )
-    def test_validator_returns_diagnostics(self, module_path):
+    )  # type: ignore[untyped-decorator]
+    def test_validator_returns_diagnostics(self, module_path: str) -> None:
         """All validator servicers should populate diagnostics in ValidateResponse."""
         import importlib
 
-        mod = importlib.import_module(module_path)
-        source = Path(mod.__file__).read_text()
+        mod = importlib.import_module(str(module_path))
+        source = Path(str(mod.__file__ or "")).read_text()
         assert "ValidatorDiagnostics" in source, f"{module_path} should build ValidatorDiagnostics"
         assert "diagnostics=" in source, f"{module_path} should set diagnostics= in response"
 
@@ -522,15 +522,15 @@ class TestGrpcAioConsistency:
 class TestRequestIdPropagation:
     """Verify request_id flows through the proto contract."""
 
-    def test_validate_request_has_request_id_field(self):
+    def test_validate_request_has_request_id_field(self) -> None:
         req = validate_pb2.ValidateRequest(request_id="abc-123")
         assert req.request_id == "abc-123"
 
-    def test_validate_response_has_request_id_field(self):
+    def test_validate_response_has_request_id_field(self) -> None:
         resp = validate_pb2.ValidateResponse(request_id="abc-123")
-        assert resp.request_id == "abc-123"
+        assert resp.request_id == "abc-123"  # type: ignore[attr-defined]
 
-    def test_validate_response_has_diagnostics_field(self):
+    def test_validate_response_has_diagnostics_field(self) -> None:
         diag = common_pb2.ValidatorDiagnostics(
             validator_name="test",
             total_ms=10.0,
@@ -540,21 +540,21 @@ class TestRequestIdPropagation:
             request_id="abc-123",
             diagnostics=diag,
         )
-        assert resp.HasField("diagnostics")
-        assert resp.diagnostics.validator_name == "test"
-        assert resp.diagnostics.total_ms == 10.0
+        assert resp.HasField("diagnostics")  # type: ignore[attr-defined]
+        assert resp.diagnostics.validator_name == "test"  # type: ignore[attr-defined]
+        assert resp.diagnostics.total_ms == 10.0  # type: ignore[attr-defined]
 
 
 class TestDiagnosticsProtoMessages:
     """Verify the diagnostics proto messages work correctly."""
 
-    def test_rule_timing(self):
+    def test_rule_timing(self) -> None:
         rt = common_pb2.RuleTiming(rule_id="L024", elapsed_ms=5.2, violations=3)
         assert rt.rule_id == "L024"
         assert rt.elapsed_ms == pytest.approx(5.2)
         assert rt.violations == 3
 
-    def test_validator_diagnostics(self):
+    def test_validator_diagnostics(self) -> None:
         rt = common_pb2.RuleTiming(rule_id="L024", elapsed_ms=5.2, violations=3)
         diag = common_pb2.ValidatorDiagnostics(
             validator_name="opa",
@@ -570,7 +570,7 @@ class TestDiagnosticsProtoMessages:
         assert len(diag.rule_timings) == 1
         assert diag.metadata["key"] == "value"
 
-    def test_scan_diagnostics(self):
+    def test_scan_diagnostics(self) -> None:
         from apme.v1 import primary_pb2
 
         vd = common_pb2.ValidatorDiagnostics(validator_name="native", total_ms=10.0)
@@ -595,22 +595,22 @@ class TestDiagnosticsProtoMessages:
 class TestCliDiagnosticsDisplay:
     """Verify the CLI diagnostics formatting functions."""
 
-    def test_fmt_ms_sub_1(self):
+    def test_fmt_ms_sub_1(self) -> None:
         from apme_engine.cli import _fmt_ms
 
         assert _fmt_ms(0.5) == "<1ms"
 
-    def test_fmt_ms_normal(self):
+    def test_fmt_ms_normal(self) -> None:
         from apme_engine.cli import _fmt_ms
 
         assert _fmt_ms(42.3) == "42ms"
 
-    def test_fmt_ms_seconds(self):
+    def test_fmt_ms_seconds(self) -> None:
         from apme_engine.cli import _fmt_ms
 
         assert _fmt_ms(1500.0) == "1.5s"
 
-    def test_diag_to_dict(self):
+    def test_diag_to_dict(self) -> None:
         from apme.v1 import primary_pb2
         from apme_engine.cli import _diag_to_dict
 
@@ -644,7 +644,7 @@ class TestCliDiagnosticsDisplay:
         assert v["rule_timings"][0]["rule_id"] == "L028"
         assert v["metadata"] == {"foo": "bar"}
 
-    def test_print_diagnostics_v_no_crash(self, capsys):
+    def test_print_diagnostics_v_no_crash(self, capsys: pytest.CaptureFixture[str]) -> None:
         from apme.v1 import primary_pb2
         from apme_engine.cli import _print_diagnostics_v
 
@@ -667,7 +667,7 @@ class TestCliDiagnosticsDisplay:
         assert "Native" in captured.err
         assert "L028" in captured.err
 
-    def test_print_diagnostics_vv_no_crash(self, capsys):
+    def test_print_diagnostics_vv_no_crash(self, capsys: pytest.CaptureFixture[str]) -> None:
         from apme.v1 import primary_pb2
         from apme_engine.cli import _print_diagnostics_vv
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,18 +1,20 @@
 """Tests for validator abstraction (ScanContext, OpaValidator, NativeValidator)."""
 
+from pathlib import Path
+
 from apme_engine.validators.base import ScanContext
 from apme_engine.validators.native import NativeValidator
 from apme_engine.validators.opa import OpaValidator
 
 
 class TestScanContext:
-    def test_scan_context_defaults(self):
+    def test_scan_context_defaults(self) -> None:
         ctx = ScanContext(hierarchy_payload={"scan_id": "x"})
         assert ctx.hierarchy_payload["scan_id"] == "x"
         assert ctx.scandata is None
         assert ctx.root_dir == ""
 
-    def test_scan_context_with_scandata(self):
+    def test_scan_context_with_scandata(self) -> None:
         mock = object()
         ctx = ScanContext(hierarchy_payload={}, scandata=mock, root_dir="/tmp")
         assert ctx.scandata is mock
@@ -20,7 +22,9 @@ class TestScanContext:
 
 
 class TestOpaValidator:
-    def test_opa_validator_run_calls_run_opa(self, opa_bundle_path, sample_hierarchy_payload):
+    def test_opa_validator_run_calls_run_opa(
+        self, opa_bundle_path: Path, sample_hierarchy_payload: dict[str, object]
+    ) -> None:
         from unittest.mock import patch
 
         ctx = ScanContext(hierarchy_payload=sample_hierarchy_payload)
@@ -32,7 +36,9 @@ class TestOpaValidator:
         assert mock_opa.call_args[0][1] == str(opa_bundle_path)
         assert result == []
 
-    def test_opa_validator_run_returns_violations(self, sample_hierarchy_payload, tmp_path):
+    def test_opa_validator_run_returns_violations(
+        self, sample_hierarchy_payload: dict[str, object], tmp_path: Path
+    ) -> None:
         from unittest.mock import patch
 
         (tmp_path / "bundle").mkdir()
@@ -45,17 +51,17 @@ class TestOpaValidator:
 
 
 class TestNativeValidator:
-    def test_native_empty_context_returns_empty(self):
+    def test_native_empty_context_returns_empty(self) -> None:
         ctx = ScanContext(hierarchy_payload={}, scandata=None)
         v = NativeValidator()
         assert v.run(ctx) == []
 
-    def test_native_no_scandata_returns_empty(self):
+    def test_native_no_scandata_returns_empty(self) -> None:
         ctx = ScanContext(hierarchy_payload={"scan_id": "x"}, scandata=None)
         v = NativeValidator()
         assert v.run(ctx) == []
 
-    def test_native_scandata_without_contexts_returns_empty(self):
+    def test_native_scandata_without_contexts_returns_empty(self) -> None:
         mock_scandata = type("Scandata", (), {"contexts": []})()
         ctx = ScanContext(hierarchy_payload={}, scandata=mock_scandata)
         v = NativeValidator()


### PR DESCRIPTION
## Summary
- Enable mypy strict mode for all 234 Python source files, fixing ~3,800 type errors
- Add mypy as a prek pre-commit hook for ongoing enforcement alongside ruff
- Add ADR-018 documenting the decision

## Changes
- **pyproject.toml**: Add `[tool.mypy]` strict config with Python 3.10, protobuf exclusions, and per-module `ignore_missing_imports` overrides for third-party libs without stubs
- **pyproject.toml**: Add `mypy`, `types-protobuf`, `types-PyYAML`, `types-requests`, `types-tabulate`, `grpc-stubs` to dev dependencies
- **.pre-commit-config.yaml**: Add `mirrors-mypy` hook with `pass_filenames: false` to respect pyproject.toml config
- **src/**: Add return types, parameter types, generic params (`dict[str, Any]`, `list[str]`), None guards, isinstance checks, and targeted `# type: ignore` for genuinely dynamic code across all engine, validator, daemon, remediation, formatter, collection_cache, and runner modules
- **tests/**: Add type annotations to test helpers, fixtures, and test functions
- **scripts/**: Add type annotations to rule catalog/doc generators
- **src/apme/v1/*.pyi**: Add protobuf type stubs for message classes used in daemon imports
- **.sdlc/adrs/ADR-018-mypy-strict-type-checking.md**: Document the architectural decision
- **.sdlc/adrs/README.md**: Update index with ADR-018

## Test plan
- [x] `prek run --all-files` passes (ruff, ruff-format, mypy)
- [x] `mypy --strict src/ tests/ scripts/` — 0 errors in 234 source files
- [ ] CI prek workflow passes
- [x] ADR-018 added

Made with [Cursor](https://cursor.com)