### PR TITLE
fix: handle IndexError in finder and TimeoutExpired in OPA client

### DIFF
--- a/src/apme_engine/engine/finder.py
+++ b/src/apme_engine/engine/finder.py
@@ -344,9 +344,8 @@ def identify_lines_with_jsonpath(
                 p_num = int(p)
                 blocks = find_child_yaml_block(current_lines, line_num_offset=current_line_num)
                 if not blocks or p_num < 0 or p_num >= len(blocks):
-                    logger.debug(
-                        f"no block at index {p_num} for jsonpath '{jsonpath}' (blocks count: {len(blocks) if blocks else 0})"
-                    )
+                    n_blocks = len(blocks) if blocks else 0
+                    logger.debug(f"no block at index {p_num} for jsonpath '{jsonpath}' (blocks count: {n_blocks})")
                     return None, None
                 current_lines, line_num_tuple = blocks[p_num]
                 current_line_num = line_num_tuple[0]

--- a/src/apme_engine/opa_client.py
+++ b/src/apme_engine/opa_client.py
@@ -26,7 +26,11 @@ _opa_disabled = False
 
 
 def _max_consecutive_timeouts() -> int:
-    """Return max consecutive timeouts before disabling OPA (from env or default 3)."""
+    """Return max consecutive timeouts before disabling OPA (from env or default 3).
+
+    Returns:
+        Positive int from APME_OPA_MAX_CONSECUTIVE_TIMEOUTS, or 3 if unset/invalid.
+    """
     raw = os.environ.get("APME_OPA_MAX_CONSECUTIVE_TIMEOUTS", "3")
     try:
         n = int(raw)

--- a/tests/test_engine_finder.py
+++ b/tests/test_engine_finder.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from apme_engine.engine.finder import identify_lines_with_jsonpath
 
 
@@ -76,13 +74,7 @@ class TestIdentifyLinesWithJsonpathSuccess:
 
     def test_valid_key_path_returns_fragment_and_range(self) -> None:
         """When path exists, returns (yaml_fragment, (start_line, end_line))."""
-        yaml_str = (
-            "- hosts: localhost\n"
-            "  tasks:\n"
-            "    - name: hello\n"
-            "      ansible.builtin.debug:\n"
-            "        msg: world\n"
-        )
+        yaml_str = "- hosts: localhost\n  tasks:\n    - name: hello\n      ansible.builtin.debug:\n        msg: world\n"
         result_lines, result_range = identify_lines_with_jsonpath(
             yaml_str=yaml_str,
             jsonpath=".0.tasks.0",

--- a/tests/test_opa_client.py
+++ b/tests/test_opa_client.py
@@ -12,7 +12,7 @@ from apme_engine.engine.models import YAMLDict
 from apme_engine.opa_client import reset_opa_circuit_breaker, run_opa, run_opa_test
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
 def _reset_circuit_breaker() -> None:
     """Reset the OPA timeout circuit-breaker before each test."""
     reset_opa_circuit_breaker()


### PR DESCRIPTION
## Summary

Prevents crashes and long hangs in the engine finder and OPA client: guard against empty or out-of-range blocks in `identify_lines_with_jsonpath`, and add a configurable timeout circuit-breaker in `run_opa` so repeated OPA timeouts do not block large-repo runs.

## Changes

- **finder.py**
  - Key-based path: when `find_child_yaml_block` returns no blocks for `pre_tasks`/`tasks`/`post_tasks`/`handlers`/`block`/`rescue`/`always`, return `(None, None)` and log at debug instead of raising `IndexError` on `blocks[0]`.
  - Numeric-index path: when `blocks` is empty or index is out of range (`p_num < 0` or `p_num >= len(blocks)`), return `(None, None)` and log at debug instead of raising `IndexError` on `blocks[p_num]`.
  - Narrow exception handling for the numeric branch to `ValueError` (from `int(p)`) and return `(None, None)` instead of continuing with invalid state.
- **opa_client.py**
  - Catch `subprocess.TimeoutExpired` on both Podman and local OPA paths; return `[]` and log to stderr with context (Podman vs local, input size, count).
  - Circuit-breaker: after a configurable number of consecutive timeouts (env `APME_OPA_MAX_CONSECUTIVE_TIMEOUTS`, default 3), disable OPA for the process; `run_opa` then short-circuits and returns `[]` without invoking OPA. A successful call resets the counter.
  - Expose `reset_opa_circuit_breaker()` for test isolation and session reuse.
  - Reset `_consecutive_timeouts` on non-timeout early returns (e.g. `FileNotFoundError`) so only true consecutive timeouts trip the breaker.
  - Module and `run_opa` docstrings updated to describe circuit-breaker behavior and that an empty list may mean OPA is disabled.
- **tests**
  - **test_opa_client.py**: autouse fixture to reset circuit-breaker between tests; tests for disable-after-N, counter reset on success, re-enable via `reset_opa_circuit_breaker`, and configurable `APME_OPA_MAX_CONSECUTIVE_TIMEOUTS`.
  - **test_engine_finder.py**: tests for key-based empty blocks, numeric index OOB, negative index, non-numeric path segment, and a successful path.

## Related Specs

- None (bug fix / robustness).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Test Plan

- [ ] `prek run --all-files` passes (or `ruff check src/ tests/ && ruff format --check src/ tests/`)
- [ ] `pytest` passes (excluding integration if needed: `pytest -k "not test_opa_bundle_rego_tests_pass"`)
- [ ] Unit tests added/updated for finder and OPA circuit-breaker
- [ ] Documentation updated (module/docstring only; no doc files changed)

## Security Checklist

- [x] No secrets in code
- [x] Input validation / bounds checks (finder guards, env parsing for `APME_OPA_MAX_CONSECUTIVE_TIMEOUTS`)
- [ ] Pre-commit hooks pass

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated
- [x] Docstrings updated (opa_client)
