### PR TITLE
feat: add ansible-lint --fix as Phase 5 of the fix pipeline

### DIFF
--- a/.sdlc/context/ansiblelint-coverage.md
+++ b/.sdlc/context/ansiblelint-coverage.md
@@ -145,8 +145,9 @@ These are **APME-specific rules** with no direct ansible-lint equivalent. They u
 | **OPA** | Structural JSON checks (fast, declarative, data-driven) |
 | **Native** | Model-walking checks that need Python (variable tracking, heuristics, complex logic) |
 | **Ansible** | Checks that require ansible-core runtime (syntax check, argspec, plugin resolution) |
+| **ansible-lint** | Fix pipeline Phase 5: runs `ansible-lint --fix` with production profile as a final polish step |
 
-**No ansible-lint adapter** — we implement our own rules walking the ARI model. See `DESIGN_VALIDATORS.md` for rationale.
+**No ansible-lint adapter for scanning** — APME implements its own rules walking the ARI model for the scan/validation phase. See `DESIGN_VALIDATORS.md` for rationale. ansible-lint is used only in the fix pipeline as a complementary auto-fix step.
 
 ---
 

--- a/.sdlc/context/dependencies.md
+++ b/.sdlc/context/dependencies.md
@@ -236,6 +236,62 @@ with open(path, "w") as f:
 
 ---
 
+### ansible-lint
+
+**Package**: `ansible-lint`
+**Purpose**: Complementary linting and auto-fixing in the `apme fix` pipeline (Phase 5).
+
+#### Installation
+
+```bash
+pip install ansible-lint
+```
+
+Included as a core dependency in `pyproject.toml` — installed automatically with `pip install .` or `pip install -e .`.
+
+#### Usage Pattern
+
+ansible-lint is invoked as a subprocess in the fix pipeline, not imported as a Python library:
+
+```python
+from apme_engine.lint_runner import run_ansible_lint
+
+# Report-only mode (dry-run)
+result = run_ansible_lint(target_path, fix=False, profile="production")
+
+# Fix mode (auto-correct violations)
+result = run_ansible_lint(target_path, fix=True, profile="production")
+
+# Custom config file
+result = run_ansible_lint(target_path, fix=True, profile="production",
+                          config_file="/path/to/.ansible-lint.yml")
+```
+
+#### CLI Integration
+
+```bash
+# Default: production profile, ansible-lint runs as Phase 5
+apme-scan fix --apply /path/to/project
+
+# Custom profile
+apme-scan fix --apply --lint-profile shared /path/to/project
+
+# Custom config file
+apme-scan fix --apply --lint-config /path/to/.ansible-lint.yml /path/to/project
+
+# Skip ansible-lint
+apme-scan fix --apply --no-lint /path/to/project
+```
+
+#### Key Features Used
+
+- `--fix` flag for auto-correcting violations
+- `--profile` flag for selecting strictness level (min, basic, moderate, safety, shared, production)
+- `-c` flag for custom config files
+- Automatic detection of `.ansible-lint` config in the target repo
+
+---
+
 ## Development Dependencies
 
 ### pytest
@@ -359,6 +415,7 @@ def safe_transform(playbook_path: Path) -> tuple[bool, str]:
 |------------|-------------|-------------|-------|
 | Python | 3.11 | 3.12 | Type syntax requirements |
 | ansible-risk-insight | 0.1.0 | latest | Core scanner |
+| ansible-lint | latest | latest | Fix pipeline Phase 5 (auto-fix + production profile) |
 | langgraph | 0.1.0 | latest | Agent workflows |
 | typer | 0.9.0 | latest | CLI framework |
 | streamlit | 1.28.0 | latest | Dashboard |

--- a/.sdlc/context/design-remediation.md
+++ b/.sdlc/context/design-remediation.md
@@ -73,13 +73,19 @@ Phase 4: Remediate (Tier 1 — deterministic)
   └─► apply Tier 1 transforms from the Transform Registry
   └─► re-scan → repeat until converged or oscillation (max --max-passes)
 
-Phase 5: AI Escalation (Tier 2 — AI-proposable)
+Phase 5: ansible-lint
+  └─► run ansible-lint with production profile (default)
+  └─► if --apply: run with --fix to auto-correct violations
+  └─► if not --apply: report-only mode (show findings)
+  └─► configurable via --lint-profile, --lint-config, --no-lint
+
+Phase 6: AI Escalation (Tier 2 — AI-proposable)
   └─► route Tier 2 violations to OpenLLM (if available)
   └─► generate patches with confidence scores
   └─► apply accepted patches (--auto) or present for review
 
-Phase 6: Report
-  └─► summary: Tier 1 fixed, Tier 2 proposals, Tier 3 manual review
+Phase 7: Report
+  └─► summary: Tier 1 fixed, ansible-lint results, Tier 2 proposals, Tier 3 manual review
 ```
 
 ---
@@ -92,6 +98,7 @@ Phase 6: Report
 | Scan | Primary service (gRPC) or CLI (in-process) | Already implemented |
 | Remediation Engine | Primary service (`Fix` RPC) | Needs access to scan results and file content; can call OpenLLM |
 | Transform Registry | `src/apme_engine/remediation/transforms/` | Pure functions, no container needed |
+| ansible-lint | CLI (in-process, subprocess) | Runs `ansible-lint --fix` as a final polish step; pip dependency |
 | AI Escalation | OpenLLM daemon (gRPC) | Separate container, optional |
 
 ---
@@ -529,6 +536,9 @@ Options:
   --min-confidence N   AI confidence threshold (default: 0.0)
   --max-passes N       Max convergence passes (default: 5)
   --exclude PATTERN    Glob patterns to skip
+  --lint-profile NAME  ansible-lint profile (default: production)
+  --lint-config PATH   Path to ansible-lint config file (passed as -c)
+  --no-lint            Skip the ansible-lint phase
 ```
 
 ### Output
@@ -541,9 +551,13 @@ Phase 4: Remediating...
   Pass 1: 28 fixable (Tier 1) → applied 26, 2 failed
   Pass 2: 4 fixable (Tier 1) → applied 4
   Pass 3: 0 fixable → converged
-Phase 5: AI escalation (Tier 2)... 10 candidates → 8 proposals (skipped: --no-ai)
-Phase 6: Summary
+Phase 5: ansible-lint...
+  Running: ansible-lint --fix --profile production .
+  ansible-lint: applied fixes (exit code 2)
+Phase 6: AI escalation (Tier 2)... 10 candidates → 8 proposals (skipped: --no-ai)
+Phase 7: Summary
   Tier 1 (deterministic):  30 fixed
+  ansible-lint (fix):      exit 2
   Tier 2 (AI-proposable):  10 remaining → 8 proposals generated
   Tier 3 (manual review):   2 (policy/judgment required)
   Passes:    3
@@ -558,8 +572,9 @@ Phase 6: Summary
 3. **Convergence loop** — scan → transform → re-scan loop with oscillation detection
 4. **Fix RPC** — gRPC contract on Primary
 5. **CLI fix integration** — wire the existing `_run_fix` stub to the real engine
-6. **AI escalation** — OpenLLM gRPC client + prompt builder (Phase 3)
-7. **Web UI remediation queue** — accept/reject AI proposals (Phase 4)
+6. **ansible-lint integration** — subprocess runner with `--fix`/`--profile` support (done)
+7. **AI escalation** — OpenLLM gRPC client + prompt builder (Phase 3)
+8. **Web UI remediation queue** — accept/reject AI proposals (Phase 4)
 
 ---
 

--- a/.sdlc/context/project-overview.md
+++ b/.sdlc/context/project-overview.md
@@ -64,4 +64,4 @@ APME provides:
 
 - **ARI (Ansible Risk Insights)**: The underlying scanning engine
 - **x2a-convertor**: Reference implementation for conversion patterns
-- **ansible-lint**: Complementary linting tool
+- **ansible-lint**: Integrated as Phase 5 of the fix pipeline (`ansible-lint --fix --profile production`)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Seven containers, one pod. All inter-service communication is gRPC. The CLI is r
 - **Structured diagnostics** — every validator reports per-rule timing data via the gRPC contract; use `-v` for summaries or `-vv` for full per-rule breakdowns.
 - **Collection cache** — pull from Galaxy or clone GitHub orgs; mount read-only into the Ansible validator. Managed by a dedicated Cache Maintainer service.
 - **YAML formatter** — normalize indentation, key ordering, Jinja spacing, and tab removal with comment preservation. Idempotent by design; runs as a pre-pass before semantic fixes.
+- **ansible-lint integration** — runs `ansible-lint --fix` with the `production` profile as a final polish step in the `fix` pipeline. Configurable via `--lint-profile`, `--lint-config`, or `--no-lint`.
 - **Colocated tests** — every rule has a `*_test.py` (native), `*_test.rego` (OPA), or `.md` doc with violation/pass examples usable as integration tests.
 
 ## Quick start
@@ -72,8 +73,17 @@ apme-scan format --apply /path/to/project
 # CI check mode (exit 1 if changes needed)
 apme-scan format --check /path/to/project
 
-# Full fix pipeline: format → idempotency check → re-scan → modernize
+# Full fix pipeline: format → idempotency check → scan → remediate → ansible-lint
 apme-scan fix --apply /path/to/project
+
+# Fix with custom ansible-lint profile
+apme-scan fix --apply --lint-profile shared /path/to/project
+
+# Fix with custom ansible-lint config file
+apme-scan fix --apply --lint-config /path/to/.ansible-lint.yml /path/to/project
+
+# Fix without ansible-lint phase
+apme-scan fix --apply --no-lint /path/to/project
 ```
 
 ### Container deployment (Podman)
@@ -135,6 +145,7 @@ src/apme_engine/
   ├── daemon/           gRPC server implementations
   ├── collection_cache/ Galaxy/GitHub cache management
   ├── formatter.py      YAML formatter (phase 1 remediation)
+  ├── lint_runner.py    ansible-lint subprocess runner (phase 5)
   ├── cli.py            CLI entry point (scan, format, fix, health-check)
   └── runner.py         scan orchestration
 containers/             Dockerfiles + Podman pod config
@@ -169,7 +180,7 @@ tests/                  unit, integration, rule doc coverage
 
 ### Phase 2 — Modernization Engine
 
-- `fix` subcommand: format → idempotency gate → re-scan → semantic transforms.
+- `fix` subcommand: format → idempotency gate → scan → remediate → ansible-lint → report.
 - **`is_finding_resolvable()` partition**: each rule declares a `fixable` attribute; the fix pipeline splits findings into auto-fixable vs manual/AI.
 - **Multi-pass convergence loop**: scan → fix → rescan → repeat until stable or oscillation detected (max N passes).
 - **`module_metadata.json`**: machine-readable module lifecycle data (introduced, deprecated, removed, parameter renames) generated from `ansible-doc` across core versions. M-series rules become data-driven lookups instead of per-rule hardcoded logic.

--- a/docs/ANSIBLELINT_COVERAGE.md
+++ b/docs/ANSIBLELINT_COVERAGE.md
@@ -138,7 +138,8 @@ These are APME-specific rules with no direct ansible-lint equivalent. They use t
 - **OPA** for structural JSON checks (fast, declarative, data-driven)
 - **Native** for model-walking checks that need Python (variable tracking, heuristics, complex logic)
 - **Ansible** for checks that require ansible-core runtime (syntax check, argspec, plugin resolution)
-- **No ansible-lint adapter** — we implement our own rules walking the ARI model. See [DESIGN_VALIDATORS.md](DESIGN_VALIDATORS.md) for rationale.
+- **ansible-lint integration** — the `apme fix` pipeline runs `ansible-lint --fix` with the `production` profile as Phase 5 (after APME's own remediation). This provides complementary auto-fixes for rules that ansible-lint handles natively (YAML formatting, FQCN, `changed_when`, deprecated `include`, etc.). Configurable via `--lint-profile`, `--lint-config`, and `--no-lint`.
+- **No ansible-lint adapter for scanning** — APME implements its own rules walking the ARI model for the scan/validation phase. See [DESIGN_VALIDATORS.md](DESIGN_VALIDATORS.md) for rationale. ansible-lint is used only in the fix pipeline as a final polish step.
 
 ---
 

--- a/docs/DESIGN_REMEDIATION.md
+++ b/docs/DESIGN_REMEDIATION.md
@@ -65,13 +65,19 @@ Phase 4: Remediate (Tier 1 — deterministic)
   └─► apply Tier 1 transforms from the Transform Registry
   └─► re-scan → repeat until converged or oscillation (max --max-passes)
 
-Phase 5: AI Escalation (Tier 2 — AI-proposable)
+Phase 5: ansible-lint
+  └─► run ansible-lint with production profile (default)
+  └─► if --apply: run with --fix to auto-correct violations
+  └─► if not --apply: report-only mode (show findings)
+  └─► configurable via --lint-profile, --lint-config, --no-lint
+
+Phase 6: AI Escalation (Tier 2 — AI-proposable)
   └─► route Tier 2 violations to OpenLLM (if available)
   └─► generate patches with confidence scores
   └─► apply accepted patches (--auto) or present for review
 
-Phase 6: Report
-  └─► summary: Tier 1 fixed, Tier 2 proposals, Tier 3 manual review
+Phase 7: Report
+  └─► summary: Tier 1 fixed, ansible-lint results, Tier 2 proposals, Tier 3 manual review
 ```
 
 ### Where Each Component Lives
@@ -82,6 +88,7 @@ Phase 6: Report
 | Scan | Primary service (gRPC) or CLI (in-process) | Already implemented |
 | Remediation Engine | Primary service (`Fix` RPC) | Needs access to scan results and file content; can call OpenLLM |
 | Transform Registry | `src/apme_engine/remediation/transforms/` | Pure functions, no container needed |
+| ansible-lint | CLI (in-process, subprocess) | Runs `ansible-lint --fix` as a final polish step; pip dependency |
 | AI Escalation | OpenLLM daemon (gRPC) | Separate container, optional |
 
 ## Three-Tier Finding Classification
@@ -497,6 +504,9 @@ Options:
   --min-confidence N   AI confidence threshold (default: 0.0)
   --max-passes N       Max convergence passes (default: 5)
   --exclude PATTERN    Glob patterns to skip
+  --lint-profile NAME  ansible-lint profile (default: production)
+  --lint-config PATH   Path to ansible-lint config file (passed as -c)
+  --no-lint            Skip the ansible-lint phase
 ```
 
 ### Output
@@ -509,9 +519,13 @@ Phase 4: Remediating...
   Pass 1: 28 fixable (Tier 1) → applied 26, 2 failed
   Pass 2: 4 fixable (Tier 1) → applied 4
   Pass 3: 0 fixable → converged
-Phase 5: AI escalation (Tier 2)... 10 candidates → 8 proposals (skipped: --no-ai)
-Phase 6: Summary
+Phase 5: ansible-lint...
+  Running: ansible-lint --fix --profile production .
+  ansible-lint: applied fixes (exit code 2)
+Phase 6: AI escalation (Tier 2)... 10 candidates → 8 proposals (skipped: --no-ai)
+Phase 7: Summary
   Tier 1 (deterministic):  30 fixed
+  ansible-lint (fix):      exit 2
   Tier 2 (AI-proposable):  10 remaining → 8 proposals generated
   Tier 3 (manual review):   2 (policy/judgment required)
   Passes:    3
@@ -524,5 +538,6 @@ Phase 6: Summary
 3. **Convergence loop** — scan → transform → re-scan loop with oscillation detection
 4. **`Fix` RPC** — gRPC contract on Primary
 5. **CLI `fix` integration** — wire the existing `_run_fix` stub to the real engine
-6. **AI escalation** — OpenLLM gRPC client + prompt builder (Phase 3)
-7. **Web UI remediation queue** — accept/reject AI proposals (Phase 4)
+6. **ansible-lint integration** — subprocess runner with `--fix`/`--profile` support (done)
+7. **AI escalation** — OpenLLM gRPC client + prompt builder (Phase 3)
+8. **Web UI remediation queue** — accept/reject AI proposals (Phase 4)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -64,6 +64,7 @@ src/apme_engine/
 ├── cli.py                  CLI entry point (scan, format, fix, health-check)
 ├── runner.py               run_scan() → ScanContext
 ├── formatter.py            YAML formatter (format_file, format_directory)
+├── lint_runner.py           ansible-lint subprocess runner (Phase 5 of fix pipeline)
 ├── opa_client.py           OPA eval (Podman or local binary)
 │
 ├── engine/                 ARI-based scanner
@@ -332,13 +333,23 @@ apme-scan format --apply --exclude "vendor/*" "tests/fixtures/*" .
 
 ### Fix pipeline
 
-The `fix` subcommand chains format → idempotency check → re-scan → modernize:
+The `fix` subcommand chains format → idempotency check → scan → remediate → ansible-lint → report:
 
 ```bash
+# Apply all fixes including ansible-lint --fix
 apme-scan fix --apply /path/to/project
+
+# Custom ansible-lint profile (default: production)
+apme-scan fix --apply --lint-profile shared /path/to/project
+
+# Custom ansible-lint config file
+apme-scan fix --apply --lint-config /path/to/.ansible-lint.yml /path/to/project
+
+# Skip ansible-lint phase
+apme-scan fix --apply --no-lint /path/to/project
 ```
 
-This runs the formatter, verifies idempotency (a second format pass produces zero diffs), then re-scans. The modernization step will be added in Phase 2.
+This runs the formatter, verifies idempotency (a second format pass produces zero diffs), scans for violations, applies deterministic remediation transforms, runs ansible-lint (with `--fix` when `--apply` is set), and reports results.
 
 ### gRPC Format RPC
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "joblib",
     "grpcio>=1.60",
     "httpx",
+    "ansible-lint",
 ]
 
 [project.optional-dependencies]

--- a/src/apme_engine/cli.py
+++ b/src/apme_engine/cli.py
@@ -482,10 +482,11 @@ def _scan_files_local(file_paths: list[str], repo_root: str, opa_bundle: str | N
 
 
 def _run_fix(args: argparse.Namespace) -> None:
-    """Format → idempotency check → scan → remediate (convergence loop).
+    """Format → idempotency check → scan → remediate → ansible-lint (convergence loop).
 
     Args:
-        args: Parsed CLI namespace with target, exclude, apply, check, max_passes, opa_bundle.
+        args: Parsed CLI namespace with target, exclude, apply, check, max_passes, opa_bundle,
+            lint_profile, lint_config, no_lint.
 
     """
     target = Path(args.target).resolve()
@@ -572,14 +573,49 @@ def _run_fix(args: argparse.Namespace) -> None:
     sys.stderr.write("Phase 4: Remediating...\n")
     report = engine.remediate(yaml_files, apply=apply_changes)
 
-    # Phase 5: Report
-    sys.stderr.write("Phase 5: Summary\n")
+    # Phase 5: ansible-lint
+    lint_result = None
+    if not getattr(args, "no_lint", False):
+        from apme_engine.lint_runner import run_ansible_lint
+
+        sys.stderr.write("Phase 5: ansible-lint...\n")
+        lint_profile = getattr(args, "lint_profile", "production")
+        lint_config = getattr(args, "lint_config", None)
+        try:
+            lint_result = run_ansible_lint(
+                target,
+                fix=apply_changes,
+                profile=lint_profile,
+                config_file=lint_config,
+            )
+            if lint_result.stdout:
+                sys.stdout.write(lint_result.stdout)
+            if lint_result.stderr:
+                sys.stderr.write(lint_result.stderr)
+
+            if lint_result.returncode == 0:
+                sys.stderr.write("  ansible-lint: clean\n")
+            elif apply_changes:
+                sys.stderr.write(f"  ansible-lint: applied fixes (exit code {lint_result.returncode})\n")
+            else:
+                sys.stderr.write(f"  ansible-lint: {lint_result.returncode} (violations found)\n")
+        except FileNotFoundError as e:
+            sys.stderr.write(f"  WARNING: {e}\n")
+    else:
+        sys.stderr.write("Phase 5: ansible-lint (skipped)\n")
+
+    # Phase 6: Report
+    sys.stderr.write("Phase 6: Summary\n")
     sys.stderr.write(f"  Tier 1 (deterministic):  {report.fixed} fixed\n")
     sys.stderr.write(f"  Tier 2 (AI-proposable):  {len(report.remaining_ai)} remaining\n")
     sys.stderr.write(f"  Tier 3 (manual review):  {len(report.remaining_manual)} remaining\n")
     sys.stderr.write(f"  Passes:                  {report.passes}\n")
     if report.oscillation_detected:
         sys.stderr.write("  WARNING: oscillation detected, stopped early\n")
+    if lint_result is not None:
+        status = "clean" if lint_result.returncode == 0 else f"exit {lint_result.returncode}"
+        mode = "fix" if lint_result.fixed else "report"
+        sys.stderr.write(f"  ansible-lint ({mode}):    {status}\n")
 
     if not apply_changes and report.applied_patches:
         sys.stderr.write(f"\n{len(report.applied_patches)} file(s) would be patched (use --apply to write):\n")
@@ -722,6 +758,9 @@ def main() -> None:
     fix_parser.add_argument("--max-passes", type=int, default=5, help="Max convergence passes (default: 5)")
     fix_parser.add_argument("--no-ai", action="store_true", help="Skip AI escalation (deterministic fixes only)")
     fix_parser.add_argument("--opa-bundle", default=None, help="Path to OPA bundle directory")
+    fix_parser.add_argument("--lint-profile", default="production", help="ansible-lint profile (default: production)")
+    fix_parser.add_argument("--lint-config", default=None, help="Path to ansible-lint config file (passed as -c)")
+    fix_parser.add_argument("--no-lint", action="store_true", help="Skip the ansible-lint phase")
 
     # ── health-check ──
     health_parser = subparsers.add_parser(

--- a/src/apme_engine/lint_runner.py
+++ b/src/apme_engine/lint_runner.py
@@ -1,0 +1,72 @@
+"""Run ansible-lint as a subprocess with profile and config support."""
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class LintResult:
+    """Result of an ansible-lint invocation.
+
+    Attributes:
+        returncode: Process exit code (0 = clean, 2 = violations found).
+        stdout: Captured standard output.
+        stderr: Captured standard error.
+        fixed: Whether --fix mode was used.
+    """
+
+    returncode: int
+    stdout: str
+    stderr: str
+    fixed: bool
+
+
+def run_ansible_lint(
+    target: Path,
+    *,
+    fix: bool = False,
+    profile: str = "production",
+    config_file: str | None = None,
+) -> LintResult:
+    """Run ansible-lint on a target path.
+
+    Args:
+        target: File or directory to lint.
+        fix: If True, pass --fix to auto-correct violations.
+        profile: ansible-lint profile name (default: production).
+        config_file: Optional path to an ansible-lint config file (-c).
+
+    Returns:
+        LintResult with exit code and captured output.
+
+    Raises:
+        FileNotFoundError: If ansible-lint is not installed.
+    """
+    cmd: list[str] = ["ansible-lint"]
+
+    if fix:
+        cmd.append("--fix")
+
+    cmd.extend(["--profile", profile])
+
+    if config_file:
+        cmd.extend(["-c", config_file])
+
+    cmd.append(str(target))
+
+    sys.stderr.write(f"  Running: {' '.join(cmd)}\n")
+    sys.stderr.flush()
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, cwd=str(target) if target.is_dir() else None)
+    except FileNotFoundError:
+        raise FileNotFoundError("ansible-lint is not installed. Install it with: pip install ansible-lint") from None
+
+    return LintResult(
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        fixed=fix,
+    )

--- a/tests/test_lint_runner.py
+++ b/tests/test_lint_runner.py
@@ -1,0 +1,205 @@
+"""Unit tests for the ansible-lint runner module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from apme_engine.lint_runner import LintResult, run_ansible_lint
+
+
+class TestRunAnsibleLint:
+    """Tests for run_ansible_lint subprocess wrapper."""
+
+    def test_report_mode_default_profile(self, tmp_path: Path) -> None:
+        """Report mode uses --profile production and no --fix.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = ""
+        mock_proc.stderr = ""
+
+        with patch("apme_engine.lint_runner.subprocess.run", return_value=mock_proc) as mock_run:
+            result = run_ansible_lint(tmp_path, fix=False)
+
+        args = mock_run.call_args[0][0]
+        assert args[0] == "ansible-lint"
+        assert "--fix" not in args
+        assert "--profile" in args
+        assert args[args.index("--profile") + 1] == "production"
+        assert str(tmp_path) in args
+        assert result.returncode == 0
+        assert result.fixed is False
+
+    def test_fix_mode(self, tmp_path: Path) -> None:
+        """Fix mode passes --fix flag.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = ""
+        mock_proc.stderr = ""
+
+        with patch("apme_engine.lint_runner.subprocess.run", return_value=mock_proc) as mock_run:
+            result = run_ansible_lint(tmp_path, fix=True)
+
+        args = mock_run.call_args[0][0]
+        assert "--fix" in args
+        assert result.fixed is True
+
+    def test_custom_profile(self, tmp_path: Path) -> None:
+        """Custom profile overrides the default.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = ""
+        mock_proc.stderr = ""
+
+        with patch("apme_engine.lint_runner.subprocess.run", return_value=mock_proc) as mock_run:
+            run_ansible_lint(tmp_path, profile="shared")
+
+        args = mock_run.call_args[0][0]
+        assert args[args.index("--profile") + 1] == "shared"
+
+    def test_config_file_flag(self, tmp_path: Path) -> None:
+        """Config file is passed as -c.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = ""
+        mock_proc.stderr = ""
+
+        with patch("apme_engine.lint_runner.subprocess.run", return_value=mock_proc) as mock_run:
+            run_ansible_lint(tmp_path, config_file="/path/to/.ansible-lint.yml")
+
+        args = mock_run.call_args[0][0]
+        assert "-c" in args
+        assert args[args.index("-c") + 1] == "/path/to/.ansible-lint.yml"
+
+    def test_no_config_file_omits_flag(self, tmp_path: Path) -> None:
+        """Without config_file, -c flag is not passed.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = ""
+        mock_proc.stderr = ""
+
+        with patch("apme_engine.lint_runner.subprocess.run", return_value=mock_proc) as mock_run:
+            run_ansible_lint(tmp_path)
+
+        args = mock_run.call_args[0][0]
+        assert "-c" not in args
+
+    def test_violations_found_nonzero_exit(self, tmp_path: Path) -> None:
+        """Non-zero exit code is captured in result.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        mock_proc = MagicMock()
+        mock_proc.returncode = 2
+        mock_proc.stdout = "playbook.yml:3: [yaml] trailing spaces"
+        mock_proc.stderr = ""
+
+        with patch("apme_engine.lint_runner.subprocess.run", return_value=mock_proc):
+            result = run_ansible_lint(tmp_path)
+
+        assert result.returncode == 2
+        assert "trailing spaces" in result.stdout
+
+    def test_binary_not_found_raises(self, tmp_path: Path) -> None:
+        """FileNotFoundError is raised when ansible-lint is missing.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        with patch(
+            "apme_engine.lint_runner.subprocess.run",
+            side_effect=FileNotFoundError("No such file"),
+        ):
+            try:
+                run_ansible_lint(tmp_path)
+                raised = False
+            except FileNotFoundError as e:
+                raised = True
+                assert "ansible-lint" in str(e)
+
+        assert raised, "Expected FileNotFoundError"
+
+    def test_cwd_set_for_directory(self, tmp_path: Path) -> None:
+        """When target is a directory, cwd is set to that directory.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = ""
+        mock_proc.stderr = ""
+
+        with patch("apme_engine.lint_runner.subprocess.run", return_value=mock_proc) as mock_run:
+            run_ansible_lint(tmp_path)
+
+        assert mock_run.call_args[1]["cwd"] == str(tmp_path)
+
+    def test_cwd_none_for_file(self, tmp_path: Path) -> None:
+        """When target is a file, cwd is None.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        target_file = tmp_path / "playbook.yml"
+        target_file.write_text("---\n- name: Test\n  hosts: all\n  tasks: []\n")
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = ""
+        mock_proc.stderr = ""
+
+        with patch("apme_engine.lint_runner.subprocess.run", return_value=mock_proc) as mock_run:
+            run_ansible_lint(target_file)
+
+        assert mock_run.call_args[1]["cwd"] is None
+
+    def test_stdout_and_stderr_captured(self, tmp_path: Path) -> None:
+        """Both stdout and stderr are captured in result.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.stdout = "some output"
+        mock_proc.stderr = "some warning"
+
+        with patch("apme_engine.lint_runner.subprocess.run", return_value=mock_proc):
+            result = run_ansible_lint(tmp_path)
+
+        assert result.stdout == "some output"
+        assert result.stderr == "some warning"
+
+
+class TestLintResult:
+    """Tests for the LintResult dataclass."""
+
+    def test_fields(self) -> None:
+        """LintResult stores all expected fields."""
+        r = LintResult(returncode=0, stdout="ok", stderr="", fixed=True)
+        assert r.returncode == 0
+        assert r.stdout == "ok"
+        assert r.stderr == ""
+        assert r.fixed is True


### PR DESCRIPTION
Add ansible-lint as a pip dependency and integrate it as the final remediation step in `apme-scan fix`. Defaults to production profile; configurable via --lint-profile, --lint-config, and --no-lint.

Made-with: Cursor with Claude-4.6-opus-high