### PR TITLE
feat: Add zero-dependency ANSI styling for CLI output

### DIFF
--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -32,6 +32,9 @@ If `prek` is not installed, fall back to:
 ruff check src/ tests/ && ruff format --check src/ tests/
 ```
 
+**All `prek` checks must pass cleanly on all files** — not just the files you changed.
+If the branch has pre-existing violations (e.g., from an old base), rebase onto `upstream/main` first.
+
 If violations are found:
 1. Run `ruff check --fix src/ tests/` and `ruff format src/ tests/` to auto-fix
 2. Manually fix any remaining violations

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -62,6 +62,7 @@ ruff format --check src/ tests/ # format check (CI mode)
 ```
 src/apme_engine/
 ├── cli.py                  CLI entry point (scan, format, fix, health-check)
+├── ansi.py                 Zero-dependency ANSI styling (NO_COLOR/FORCE_COLOR)
 ├── runner.py               run_scan() → ScanContext
 ├── formatter.py            YAML formatter (format_file, format_directory)
 ├── opa_client.py           OPA eval (Podman or local binary)
@@ -372,6 +373,21 @@ apme-scan scan --primary-addr localhost:50051 -vv .
 
 # JSON output includes diagnostics when -v or -vv is set
 apme-scan scan --primary-addr localhost:50051 -v --json .
+```
+
+### Color output
+
+Scan results use ANSI styling (summary box, severity badges, tree view). Color is auto-detected via TTY and respects the [no-color.org](https://no-color.org) standard:
+
+```bash
+# Disable color via environment variable (any value, including empty string)
+NO_COLOR=1 apme-scan scan .
+
+# Force color in non-TTY contexts (CI pipelines)
+FORCE_COLOR=1 apme-scan scan .
+
+# Disable color via CLI flag
+apme-scan scan --no-ansi .
 ```
 
 ### Adding diagnostics to a new validator

--- a/src/apme_engine/ansi.py
+++ b/src/apme_engine/ansi.py
@@ -1,14 +1,14 @@
-"""Zero-dependency ANSI color/style abstraction for CLI output.
+r"""Zero-dependency ANSI color/style abstraction for CLI output.
 
 Provides terminal styling with NO_COLOR/FORCE_COLOR support, severity badges,
-box drawing, simple tables, and tree connectors. See ADR-014.
+box drawing, simple tables, and tree connectors.
 
 Usage:
     from apme_engine.ansi import bold, red, green, severity_badge, box, table
 
     print(bold(red("Error:")), "something went wrong")
     print(severity_badge("high"))  # -> " ERROR " on red background
-    print(box("Summary\\n2 errors", title="Scan Results"))
+    print(box("Summary\n2 errors", title="Scan Results"))
 """
 
 from __future__ import annotations
@@ -25,13 +25,17 @@ _color_enabled: bool | None = None
 
 
 def _use_color() -> bool:
-    """Check if color output should be used. Follows https://no-color.org."""
+    """Check if color output should be used. Follows https://no-color.org.
+
+    Returns:
+        Whether color output should be used.
+    """
     global _color_enabled
     if _color_enabled is not None:
         return _color_enabled
 
     # NO_COLOR takes precedence (any value disables color)
-    if os.environ.get("NO_COLOR"):
+    if "NO_COLOR" in os.environ:
         _color_enabled = False
         return False
 
@@ -51,21 +55,61 @@ def reset_color_detection() -> None:
     _color_enabled = None
 
 
+def force_no_color() -> None:
+    """Programmatically disable color output (for --no-ansi flag)."""
+    global _color_enabled
+    _color_enabled = False
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # ANSI SGR codes
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 class Style:
-    """ANSI SGR (Select Graphic Rendition) escape codes."""
+    """ANSI SGR (Select Graphic Rendition) escape codes.
+
+    Color constants aligned with ansible-creator's Color class.
+
+    Attributes:
+        RESET: Reset all styles.
+        BOLD: Bold text.
+        DIM: Dim text.
+        UNDERLINE: Underlined text.
+        REVERSE: Reverse video.
+        BLACK: Black foreground.
+        RED: Red foreground.
+        GREEN: Green foreground.
+        YELLOW: Yellow foreground.
+        BLUE: Blue foreground.
+        MAGENTA: Magenta foreground.
+        CYAN: Cyan foreground.
+        WHITE: White foreground.
+        GREY: Grey foreground.
+        GRAY: Grey foreground (alias).
+        BRIGHT_RED: Bright red foreground.
+        BRIGHT_GREEN: Bright green foreground.
+        BRIGHT_YELLOW: Bright yellow foreground.
+        BRIGHT_BLUE: Bright blue foreground.
+        BRIGHT_MAGENTA: Bright magenta foreground.
+        BRIGHT_CYAN: Bright cyan foreground.
+        BRIGHT_WHITE: Bright white foreground.
+        BG_RED: Red background.
+        BG_GREEN: Green background.
+        BG_YELLOW: Yellow background.
+        BG_BLUE: Blue background.
+        BG_MAGENTA: Magenta background.
+        BG_CYAN: Cyan background.
+    """
 
     RESET = "\033[0m"
     BOLD = "\033[1m"
     DIM = "\033[2m"
     UNDERLINE = "\033[4m"
-    REVERSE = "\033[7m"  # Swap foreground/background (used for badges)
+    REVERSE = "\033[7m"
 
     # Foreground colors
+    BLACK = "\033[30m"
     RED = "\033[31m"
     GREEN = "\033[32m"
     YELLOW = "\033[33m"
@@ -73,13 +117,23 @@ class Style:
     MAGENTA = "\033[35m"
     CYAN = "\033[36m"
     WHITE = "\033[37m"
+    GREY = "\033[90m"
     GRAY = "\033[90m"
+    BRIGHT_RED = "\033[91m"
+    BRIGHT_GREEN = "\033[92m"
+    BRIGHT_YELLOW = "\033[93m"
+    BRIGHT_BLUE = "\033[94m"
+    BRIGHT_MAGENTA = "\033[95m"
+    BRIGHT_CYAN = "\033[96m"
+    BRIGHT_WHITE = "\033[97m"
 
     # Background colors (for badges)
     BG_RED = "\033[41m"
     BG_GREEN = "\033[42m"
     BG_YELLOW = "\033[43m"
     BG_BLUE = "\033[44m"
+    BG_MAGENTA = "\033[45m"
+    BG_CYAN = "\033[46m"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -88,60 +142,138 @@ class Style:
 
 
 def style(text: str, *styles: str) -> str:
-    """Wrap text with ANSI style codes. Respects NO_COLOR."""
+    """Wrap text with ANSI style codes. Respects NO_COLOR.
+
+    Args:
+        text: Text to style.
+        *styles: ANSI SGR code strings to apply.
+
+    Returns:
+        Styled text string.
+    """
     if not _use_color() or not styles:
         return text
     return "".join(styles) + text + Style.RESET
 
 
 def bold(text: str) -> str:
-    """Apply bold style."""
+    """Apply bold style.
+
+    Args:
+        text: Text to style.
+
+    Returns:
+        Styled text string.
+    """
     return style(text, Style.BOLD)
 
 
 def dim(text: str) -> str:
-    """Apply dim style."""
+    """Apply dim style.
+
+    Args:
+        text: Text to style.
+
+    Returns:
+        Styled text string.
+    """
     return style(text, Style.DIM)
 
 
 def underline(text: str) -> str:
-    """Apply underline style."""
+    """Apply underline style.
+
+    Args:
+        text: Text to style.
+
+    Returns:
+        Styled text string.
+    """
     return style(text, Style.UNDERLINE)
 
 
 def red(text: str) -> str:
-    """Apply red foreground color."""
+    """Apply red foreground color.
+
+    Args:
+        text: Text to style.
+
+    Returns:
+        Styled text string.
+    """
     return style(text, Style.RED)
 
 
 def green(text: str) -> str:
-    """Apply green foreground color."""
+    """Apply green foreground color.
+
+    Args:
+        text: Text to style.
+
+    Returns:
+        Styled text string.
+    """
     return style(text, Style.GREEN)
 
 
 def yellow(text: str) -> str:
-    """Apply yellow foreground color."""
+    """Apply yellow foreground color.
+
+    Args:
+        text: Text to style.
+
+    Returns:
+        Styled text string.
+    """
     return style(text, Style.YELLOW)
 
 
 def blue(text: str) -> str:
-    """Apply blue foreground color."""
+    """Apply blue foreground color.
+
+    Args:
+        text: Text to style.
+
+    Returns:
+        Styled text string.
+    """
     return style(text, Style.BLUE)
 
 
 def magenta(text: str) -> str:
-    """Apply magenta foreground color."""
+    """Apply magenta foreground color.
+
+    Args:
+        text: Text to style.
+
+    Returns:
+        Styled text string.
+    """
     return style(text, Style.MAGENTA)
 
 
 def cyan(text: str) -> str:
-    """Apply cyan foreground color."""
+    """Apply cyan foreground color.
+
+    Args:
+        text: Text to style.
+
+    Returns:
+        Styled text string.
+    """
     return style(text, Style.CYAN)
 
 
 def gray(text: str) -> str:
-    """Apply gray foreground color."""
-    return style(text, Style.GRAY)
+    """Apply gray foreground color.
+
+    Args:
+        text: Text to style.
+
+    Returns:
+        Styled text string.
+    """
+    return style(text, Style.GREY)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -153,17 +285,40 @@ _ANSI_ESCAPE = re.compile(r"\033\[[0-9;]*m")
 
 
 def strip_ansi(text: str) -> str:
-    """Remove ANSI escape sequences from text."""
+    """Remove ANSI escape sequences from text.
+
+    Args:
+        text: Text possibly containing ANSI codes.
+
+    Returns:
+        Text with ANSI codes removed.
+    """
     return _ANSI_ESCAPE.sub("", text)
 
 
 def visible_width(text: str) -> int:
-    """Get visible width of text (excluding ANSI codes)."""
+    """Get visible width of text (excluding ANSI codes).
+
+    Args:
+        text: Text possibly containing ANSI codes.
+
+    Returns:
+        Visible character count.
+    """
     return len(strip_ansi(text))
 
 
 def ljust_ansi(text: str, width: int, fillchar: str = " ") -> str:
-    """Left-justify text to width, accounting for ANSI codes."""
+    """Left-justify text to width, accounting for ANSI codes.
+
+    Args:
+        text: Text to justify.
+        width: Target width.
+        fillchar: Fill character.
+
+    Returns:
+        Left-justified text string.
+    """
     visible = visible_width(text)
     if visible >= width:
         return text
@@ -171,7 +326,16 @@ def ljust_ansi(text: str, width: int, fillchar: str = " ") -> str:
 
 
 def rjust_ansi(text: str, width: int, fillchar: str = " ") -> str:
-    """Right-justify text to width, accounting for ANSI codes."""
+    """Right-justify text to width, accounting for ANSI codes.
+
+    Args:
+        text: Text to justify.
+        width: Target width.
+        fillchar: Fill character.
+
+    Returns:
+        Right-justified text string.
+    """
     visible = visible_width(text)
     if visible >= width:
         return text
@@ -188,13 +352,13 @@ SEVERITY_DISPLAY: dict[str, tuple[str, str]] = {
     "high": ("ERROR", Style.BG_RED + Style.WHITE + Style.BOLD),
     "medium": ("WARN", Style.BG_YELLOW + Style.BOLD),
     "low": ("WARN", Style.BG_YELLOW + Style.BOLD),
-    "very_low": ("HINT", Style.BG_BLUE + Style.WHITE),
-    "none": ("HINT", Style.BG_BLUE + Style.WHITE),
+    "very_low": ("HINT", Style.BG_CYAN + Style.WHITE),
+    "none": ("HINT", Style.BG_CYAN + Style.WHITE),
     # Also support direct level names
     "error": ("ERROR", Style.BG_RED + Style.WHITE + Style.BOLD),
     "warning": ("WARN", Style.BG_YELLOW + Style.BOLD),
-    "hint": ("HINT", Style.BG_BLUE + Style.WHITE),
-    "info": ("INFO", Style.BG_GREEN + Style.WHITE),
+    "hint": ("HINT", Style.BG_CYAN + Style.WHITE),
+    "info": ("INFO", Style.BG_MAGENTA + Style.WHITE),
 }
 
 
@@ -221,14 +385,14 @@ def severity_indicator(level: str) -> str:
         level: Severity level
 
     Returns:
-        Colored indicator: x (red), △ (yellow), i (blue)
+        Colored indicator: x (red), △ (yellow), i (cyan)
     """
     level_lower = level.lower() if level else "none"
     if level_lower in ("very_high", "high", "error"):
         return red("x")
     if level_lower in ("medium", "low", "warning"):
         return yellow("△")
-    return blue("i")
+    return cyan("i")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -349,9 +513,7 @@ def table(
 
     # Header row
     if headers:
-        header_cells = [
-            ljust_ansi(bold(h), col_widths[i]) for i, h in enumerate(headers)
-        ]
+        header_cells = [ljust_ansi(bold(h), col_widths[i]) for i, h in enumerate(headers)]
         lines.append(sep.join(header_cells))
         # Underline
         underline_cells = [BOX_H * w for w in col_widths]

--- a/src/apme_engine/cli.py
+++ b/src/apme_engine/cli.py
@@ -9,16 +9,20 @@ from typing import cast
 
 import grpc
 
-from apme.v1 import primary_pb2, primary_pb2_grpc
+from apme.v1 import primary_pb2_grpc
 from apme.v1.primary_pb2 import ScanDiagnostics
 from apme_engine.ansi import (
     TREE_LAST,
     TREE_MID,
+    TREE_PIPE,
+    TREE_SPACE,
     bold,
     box,
+    cyan,
     dim,
     gray,
     green,
+    magenta,
     red,
     severity_badge,
     severity_indicator,
@@ -245,25 +249,41 @@ def _diag_to_dict(diag: ScanDiagnostics) -> YAMLDict:
     )
 
 
-def _count_by_severity(violations: list[dict]) -> dict[str, int]:
-    """Count violations by severity level."""
-    counts = {"error": 0, "warning": 0, "hint": 0}
+def _count_by_severity(violations: list[ViolationDict]) -> dict[str, int]:
+    """Count violations by severity level.
+
+    Args:
+        violations: List of violation dictionaries.
+
+    Returns:
+        Counts keyed by severity bucket.
+    """
+    counts = {"error": 0, "warning": 0, "info": 0, "hint": 0}
     for v in violations:
-        level = (v.get("level") or "").lower()
+        level = str(v.get("level") or "").lower()
         if level in ("very_high", "high", "error"):
             counts["error"] += 1
         elif level in ("medium", "low", "warning"):
             counts["warning"] += 1
+        elif level == "info":
+            counts["info"] += 1
         else:
             counts["hint"] += 1
     return counts
 
 
-def _group_by_file(violations: list[dict]) -> dict[str, list[dict]]:
-    """Group violations by file."""
-    grouped: dict[str, list[dict]] = {}
+def _group_by_file(violations: list[ViolationDict]) -> dict[str, list[ViolationDict]]:
+    """Group violations by file.
+
+    Args:
+        violations: List of violation dictionaries.
+
+    Returns:
+        Violations grouped by file path.
+    """
+    grouped: dict[str, list[ViolationDict]] = {}
     for v in violations:
-        f = v.get("file") or "(unknown)"
+        f = str(v.get("file") or "(unknown)")
         if f not in grouped:
             grouped[f] = []
         grouped[f].append(v)
@@ -271,7 +291,7 @@ def _group_by_file(violations: list[dict]) -> dict[str, list[dict]]:
 
 
 def _render_scan_results(
-    violations: list[dict],
+    violations: list[ViolationDict],
     scan_id: str = "",
     scan_time_ms: float | None = None,
 ) -> None:
@@ -281,6 +301,11 @@ def _render_scan_results(
     1. Summary box with pass/fail status and counts
     2. Issues table with rule, severity badge, message, location
     3. Issues-by-file tree view
+
+    Args:
+        violations: List of violation dictionaries.
+        scan_id: Scan identifier for display.
+        scan_time_ms: Scan duration in milliseconds.
     """
     counts = _count_by_severity(violations)
     has_errors = counts["error"] > 0
@@ -297,8 +322,10 @@ def _render_scan_results(
         counts_line.append(red(f"{counts['error']} error(s)"))
     if counts["warning"]:
         counts_line.append(yellow(f"{counts['warning']} warning(s)"))
+    if counts["info"]:
+        counts_line.append(magenta(f"{counts['info']} info(s)"))
     if counts["hint"]:
-        counts_line.append(f"{counts['hint']} hint(s)")
+        counts_line.append(cyan(f"{counts['hint']} hint(s)"))
     if counts_line:
         summary_lines.append("Issues: " + ", ".join(counts_line))
     else:
@@ -316,15 +343,15 @@ def _render_scan_results(
     headers = ["Rule", "Severity", "Message", "Location"]
     rows = []
     for v in violations:
-        rule_id = v.get("rule_id") or "?"
-        level = v.get("level") or "none"
-        message = v.get("message") or ""
+        rule_id = str(v.get("rule_id") or "?")
+        level = str(v.get("level") or "none")
+        message = str(v.get("message") or "")
         if len(message) > 50:
             message = message[:47] + "..."
 
-        file_path = v.get("file") or ""
+        file_path = str(v.get("file") or "")
         line = v.get("line")
-        if isinstance(line, list | tuple) and len(line) >= 2:
+        if isinstance(line, (list, tuple)) and len(line) >= 2:
             location = f"{file_path}:{line[0]}-{line[1]}"
         elif line is not None:
             location = f"{file_path}:{line}"
@@ -349,12 +376,19 @@ def _render_scan_results(
 
         for j, v in enumerate(file_violations):
             is_last_v = j == len(file_violations) - 1
-            indent = "    " if is_last_file else "│   "
+            indent = TREE_SPACE if is_last_file else TREE_PIPE
             v_prefix = TREE_LAST if is_last_v else TREE_MID
-            indicator = severity_indicator(v.get("level") or "none")
+            indicator = severity_indicator(str(v.get("level") or "none"))
             line = v.get("line")
-            line_str = f"{line[0]}" if isinstance(line, list | tuple) else (str(line) if line is not None else "?")
-            rule_id = v.get("rule_id") or "?"
+            if isinstance(line, (list, tuple)) and len(line) >= 2:
+                line_str = f"{line[0]}-{line[1]}"
+            elif isinstance(line, (list, tuple)):
+                line_str = str(line[0])
+            elif line is not None:
+                line_str = str(line)
+            else:
+                line_str = "?"
+            rule_id = str(v.get("rule_id") or "?")
             print(f"{indent}{v_prefix}{indicator} {gray(f'L{line_str}')} [{rule_id}] {v.get('message', '')}")
 
     print()
@@ -413,7 +447,7 @@ def _run_scan(args: argparse.Namespace) -> None:
     payload: YAMLDict = context.hierarchy_payload or {}
     _render_scan_results(
         violations,
-        scan_id=payload.get("scan_id", ""),
+        scan_id=str(payload.get("scan_id", "")),
     )
 
 
@@ -758,9 +792,18 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Run APME scan: engine + OPA and native validators; or manage collection cache.",
     )
+    global_opts = argparse.ArgumentParser(add_help=False)
+    global_opts.add_argument(
+        "--na",
+        "--no-ansi",
+        action="store_true",
+        default=False,
+        dest="no_ansi",
+        help="Disable ANSI color output",
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    scan_parser = subparsers.add_parser("scan", help="Run scan on a playbook, role, or project")
+    scan_parser = subparsers.add_parser("scan", parents=[global_opts], help="Run scan on a playbook, role, or project")
     scan_parser.add_argument("target", nargs="?", default=".", help="Path to playbook, role, or project")
     scan_parser.add_argument(
         "--primary-addr",
@@ -797,7 +840,9 @@ def main() -> None:
         help="Diagnostics verbosity: -v for summary + top 10, -vv for full per-rule breakdown",
     )
 
-    cache_parser = subparsers.add_parser("cache", help="Manage collection cache (Galaxy + GitHub)")
+    cache_parser = subparsers.add_parser(
+        "cache", parents=[global_opts], help="Manage collection cache (Galaxy + GitHub)"
+    )
     cache_parser.add_argument(
         "--cache-root",
         default=None,
@@ -826,6 +871,7 @@ def main() -> None:
     # ── format ──
     format_parser = subparsers.add_parser(
         "format",
+        parents=[global_opts],
         help="Normalize YAML formatting (indentation, key order, jinja spacing, tabs)",
     )
     format_parser.add_argument("target", nargs="?", default=".", help="Path to file or directory")
@@ -836,6 +882,7 @@ def main() -> None:
     # ── fix ──
     fix_parser = subparsers.add_parser(
         "fix",
+        parents=[global_opts],
         help="Format then modernize: format → idempotency check → re-scan → modernize",
     )
     fix_parser.add_argument("target", nargs="?", default=".", help="Path to file or directory")
@@ -848,7 +895,9 @@ def main() -> None:
 
     # ── health-check ──
     health_parser = subparsers.add_parser(
-        "health-check", help="Check health of all services (Primary, Native, OPA, Ansible, Cache maintainer) via gRPC"
+        "health-check",
+        parents=[global_opts],
+        help="Check health of all services (Primary, Native, OPA, Ansible, Cache maintainer) via gRPC",
     )
     health_parser.add_argument(
         "--primary-addr",
@@ -871,6 +920,11 @@ def main() -> None:
     health_parser.add_argument("--json", action="store_true", help="Output results as JSON")
 
     args = parser.parse_args()
+
+    if args.no_ansi:
+        from apme_engine.ansi import force_no_color  # noqa: PLC0415
+
+        force_no_color()
 
     if args.command == "scan":
         _run_scan(args)

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from unittest import mock
 
 import pytest
@@ -11,6 +12,7 @@ from apme_engine.ansi import (
     bold,
     box,
     dim,
+    force_no_color,
     green,
     ljust_ansi,
     red,
@@ -32,25 +34,37 @@ from apme_engine.ansi import (
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-@pytest.fixture(autouse=True)
-def reset_color_cache():
-    """Reset color detection before each test."""
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
+def reset_color_cache() -> Iterator[None]:
+    """Reset color detection before each test.
+
+    Yields:
+        None: No value is yielded.
+    """
     reset_color_detection()
     yield
     reset_color_detection()
 
 
-@pytest.fixture
-def force_color(monkeypatch):
-    """Force color output on."""
+@pytest.fixture  # type: ignore[untyped-decorator]
+def force_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force color output on.
+
+    Args:
+        monkeypatch: Pytest fixture for modifying environment.
+    """
     monkeypatch.setenv("FORCE_COLOR", "1")
     monkeypatch.delenv("NO_COLOR", raising=False)
     reset_color_detection()
 
 
-@pytest.fixture
-def no_color(monkeypatch):
-    """Force color output off."""
+@pytest.fixture  # type: ignore[untyped-decorator]
+def no_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force color output off.
+
+    Args:
+        monkeypatch: Pytest fixture for modifying environment.
+    """
     monkeypatch.setenv("NO_COLOR", "1")
     monkeypatch.delenv("FORCE_COLOR", raising=False)
     reset_color_detection()
@@ -64,44 +78,80 @@ def no_color(monkeypatch):
 class TestStyle:
     """Test style() function and convenience wrappers."""
 
-    def test_style_with_color(self, force_color):
-        """Style wraps text with ANSI codes when color enabled."""
+    def test_style_with_color(self, force_color: None) -> None:
+        """Style wraps text with ANSI codes when color enabled.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         result = style("hello", Style.RED)
         assert result == "\033[31mhello\033[0m"
 
-    def test_style_multiple_codes(self, force_color):
-        """Multiple style codes are concatenated."""
+    def test_style_multiple_codes(self, force_color: None) -> None:
+        """Multiple style codes are concatenated.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         result = style("hello", Style.BOLD, Style.RED)
         assert result == "\033[1m\033[31mhello\033[0m"
 
-    def test_style_no_color_env(self, no_color):
-        """NO_COLOR env var suppresses ANSI codes."""
+    def test_style_no_color_env(self, no_color: None) -> None:
+        """NO_COLOR env var suppresses ANSI codes.
+
+        Args:
+            no_color: Fixture that disables color output.
+        """
         result = style("hello", Style.RED)
         assert result == "hello"
         assert "\033[" not in result
 
-    def test_bold(self, force_color):
-        """bold() applies bold style."""
+    def test_bold(self, force_color: None) -> None:
+        """bold() applies bold style.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         assert bold("test") == "\033[1mtest\033[0m"
 
-    def test_red(self, force_color):
-        """red() applies red foreground."""
+    def test_red(self, force_color: None) -> None:
+        """red() applies red foreground.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         assert red("error") == "\033[31merror\033[0m"
 
-    def test_green(self, force_color):
-        """green() applies green foreground."""
+    def test_green(self, force_color: None) -> None:
+        """green() applies green foreground.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         assert green("ok") == "\033[32mok\033[0m"
 
-    def test_yellow(self, force_color):
-        """yellow() applies yellow foreground."""
+    def test_yellow(self, force_color: None) -> None:
+        """yellow() applies yellow foreground.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         assert yellow("warn") == "\033[33mwarn\033[0m"
 
-    def test_dim(self, force_color):
-        """dim() applies dim style."""
+    def test_dim(self, force_color: None) -> None:
+        """dim() applies dim style.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         assert dim("faded") == "\033[2mfaded\033[0m"
 
-    def test_composability(self, force_color):
-        """Styles can be composed (nested calls)."""
+    def test_composability(self, force_color: None) -> None:
+        """Styles can be composed (nested calls).
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         result = bold(red("important"))
         # The inner red is applied first, then bold wraps it
         assert "\033[1m" in result
@@ -112,18 +162,32 @@ class TestStyle:
 class TestNoColorCompliance:
     """Test NO_COLOR standard compliance (https://no-color.org)."""
 
-    def test_no_color_any_value(self, monkeypatch):
-        """NO_COLOR with any value disables color."""
-        monkeypatch.setenv("NO_COLOR", "")  # Empty string counts
-        reset_color_detection()
-        # Empty string is falsy, so this won't disable
-        # Per spec, "exists" means disable - let's test with "1"
-        monkeypatch.setenv("NO_COLOR", "0")  # Even "0" should disable
+    def test_no_color_any_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NO_COLOR with any value (including empty string) disables color.
+
+        Args:
+            monkeypatch: Pytest fixture for modifying environment.
+        """
+        monkeypatch.setenv("NO_COLOR", "")
         reset_color_detection()
         assert style("x", Style.RED) == "x"
 
-    def test_force_color_overrides_tty(self, monkeypatch):
-        """FORCE_COLOR enables color even without TTY."""
+    def test_no_color_zero_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NO_COLOR set to '0' also disables color.
+
+        Args:
+            monkeypatch: Pytest fixture for modifying environment.
+        """
+        monkeypatch.setenv("NO_COLOR", "0")
+        reset_color_detection()
+        assert style("x", Style.RED) == "x"
+
+    def test_force_color_overrides_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FORCE_COLOR enables color even without TTY.
+
+        Args:
+            monkeypatch: Pytest fixture for modifying environment.
+        """
         monkeypatch.setenv("FORCE_COLOR", "1")
         monkeypatch.delenv("NO_COLOR", raising=False)
         reset_color_detection()
@@ -132,12 +196,33 @@ class TestNoColorCompliance:
             result = style("x", Style.RED)
             assert "\033[31m" in result
 
-    def test_no_color_beats_force_color(self, monkeypatch):
-        """NO_COLOR takes precedence over FORCE_COLOR."""
+    def test_no_color_beats_force_color(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NO_COLOR takes precedence over FORCE_COLOR.
+
+        Args:
+            monkeypatch: Pytest fixture for modifying environment.
+        """
         monkeypatch.setenv("NO_COLOR", "1")
         monkeypatch.setenv("FORCE_COLOR", "1")
         reset_color_detection()
         assert style("x", Style.RED) == "x"
+
+
+class TestForceNoColor:
+    """Test programmatic color disable (for --no-ansi)."""
+
+    def test_force_no_color_disables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """force_no_color() disables color output.
+
+        Args:
+            monkeypatch: Pytest fixture for modifying environment.
+        """
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.delenv("FORCE_COLOR", raising=False)
+        reset_color_detection()
+        force_no_color()
+        assert style("x", Style.RED) == "x"
+        reset_color_detection()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -148,42 +233,50 @@ class TestNoColorCompliance:
 class TestAnsiWidth:
     """Test ANSI-aware string width functions."""
 
-    def test_strip_ansi_removes_codes(self):
+    def test_strip_ansi_removes_codes(self) -> None:
         """strip_ansi removes all ANSI escape sequences."""
         styled = "\033[1m\033[31mhello\033[0m"
         assert strip_ansi(styled) == "hello"
 
-    def test_strip_ansi_plain_text(self):
+    def test_strip_ansi_plain_text(self) -> None:
         """strip_ansi leaves plain text unchanged."""
         assert strip_ansi("hello world") == "hello world"
 
-    def test_visible_width_plain(self):
+    def test_visible_width_plain(self) -> None:
         """visible_width returns length of plain text."""
         assert visible_width("hello") == 5
 
-    def test_visible_width_styled(self):
+    def test_visible_width_styled(self) -> None:
         """visible_width excludes ANSI codes."""
         styled = "\033[1m\033[31mhello\033[0m"
         assert visible_width(styled) == 5
 
-    def test_ljust_ansi_plain(self):
+    def test_ljust_ansi_plain(self) -> None:
         """ljust_ansi pads plain text correctly."""
         assert ljust_ansi("hi", 5) == "hi   "
 
-    def test_ljust_ansi_styled(self, force_color):
-        """ljust_ansi accounts for invisible ANSI codes."""
+    def test_ljust_ansi_styled(self, force_color: None) -> None:
+        """ljust_ansi accounts for invisible ANSI codes.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         styled = red("hi")
         result = ljust_ansi(styled, 5)
         # Should have 3 spaces of padding
         assert result.endswith("   ")
         assert visible_width(result) == 5
 
-    def test_rjust_ansi_plain(self):
+    def test_rjust_ansi_plain(self) -> None:
         """rjust_ansi pads plain text correctly."""
         assert rjust_ansi("hi", 5) == "   hi"
 
-    def test_rjust_ansi_styled(self, force_color):
-        """rjust_ansi accounts for invisible ANSI codes."""
+    def test_rjust_ansi_styled(self, force_color: None) -> None:
+        """rjust_ansi accounts for invisible ANSI codes.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         styled = red("hi")
         result = rjust_ansi(styled, 5)
         assert result.startswith("   ")
@@ -198,62 +291,102 @@ class TestAnsiWidth:
 class TestSeverityBadge:
     """Test severity badge rendering."""
 
-    def test_badge_high(self, force_color):
-        """High severity shows ERROR badge."""
+    def test_badge_high(self, force_color: None) -> None:
+        """High severity shows ERROR badge.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         badge = severity_badge("high")
         assert "ERROR" in strip_ansi(badge)
         assert Style.BG_RED in badge
 
-    def test_badge_medium(self, force_color):
-        """Medium severity shows WARN badge."""
+    def test_badge_medium(self, force_color: None) -> None:
+        """Medium severity shows WARN badge.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         badge = severity_badge("medium")
         assert "WARN" in strip_ansi(badge)
         assert Style.BG_YELLOW in badge
 
-    def test_badge_low(self, force_color):
-        """Low severity shows WARN badge."""
+    def test_badge_low(self, force_color: None) -> None:
+        """Low severity shows WARN badge.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         badge = severity_badge("low")
         assert "WARN" in strip_ansi(badge)
 
-    def test_badge_very_low(self, force_color):
-        """Very low severity shows HINT badge."""
+    def test_badge_very_low(self, force_color: None) -> None:
+        """Very low severity shows HINT badge.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         badge = severity_badge("very_low")
         assert "HINT" in strip_ansi(badge)
-        assert Style.BG_BLUE in badge
+        assert Style.BG_CYAN in badge
 
-    def test_badge_case_insensitive(self, force_color):
-        """Badge lookup is case-insensitive."""
+    def test_badge_case_insensitive(self, force_color: None) -> None:
+        """Badge lookup is case-insensitive.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         assert strip_ansi(severity_badge("HIGH")) == strip_ansi(severity_badge("high"))
         assert strip_ansi(severity_badge("Medium")) == strip_ansi(severity_badge("medium"))
 
-    def test_badge_unknown_level(self, force_color):
-        """Unknown level shows ? badge."""
+    def test_badge_unknown_level(self, force_color: None) -> None:
+        """Unknown level shows ? badge.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         badge = severity_badge("unknown")
         assert "?" in strip_ansi(badge)
 
-    def test_badge_no_color(self, no_color):
-        """Badge shows label without styling when NO_COLOR."""
+    def test_badge_no_color(self, no_color: None) -> None:
+        """Badge shows label without styling when NO_COLOR.
+
+        Args:
+            no_color: Fixture that disables color output.
+        """
         badge = severity_badge("high")
         assert badge == " ERROR "
         assert "\033[" not in badge
 
-    def test_severity_indicator_error(self, force_color):
-        """Error indicator is red x."""
+    def test_severity_indicator_error(self, force_color: None) -> None:
+        """Error indicator is red x.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         indicator = severity_indicator("high")
         assert "x" in strip_ansi(indicator)
         assert Style.RED in indicator
 
-    def test_severity_indicator_warn(self, force_color):
-        """Warning indicator is yellow triangle."""
+    def test_severity_indicator_warn(self, force_color: None) -> None:
+        """Warning indicator is yellow triangle.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         indicator = severity_indicator("medium")
         assert "△" in strip_ansi(indicator)
         assert Style.YELLOW in indicator
 
-    def test_severity_indicator_hint(self, force_color):
-        """Hint indicator is blue i."""
+    def test_severity_indicator_hint(self, force_color: None) -> None:
+        """Hint indicator is cyan i.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         indicator = severity_indicator("very_low")
         assert "i" in strip_ansi(indicator)
-        assert Style.BLUE in indicator
+        assert Style.CYAN in indicator
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -264,7 +397,7 @@ class TestSeverityBadge:
 class TestBox:
     """Test Unicode box drawing."""
 
-    def test_box_simple(self):
+    def test_box_simple(self) -> None:
         """Simple box around content."""
         result = box("hello")
         lines = result.split("\n")
@@ -276,7 +409,7 @@ class TestBox:
         assert "└" in lines[2]
         assert "┘" in lines[2]
 
-    def test_box_multiline(self):
+    def test_box_multiline(self) -> None:
         """Box around multiline content."""
         result = box("line1\nline2\nline3")
         lines = result.split("\n")
@@ -285,20 +418,24 @@ class TestBox:
         assert "line2" in lines[2]
         assert "line3" in lines[3]
 
-    def test_box_with_title(self, force_color):
-        """Box with title in top border."""
+    def test_box_with_title(self, force_color: None) -> None:
+        """Box with title in top border.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         result = box("content", title="Title")
         lines = result.split("\n")
         assert "Title" in strip_ansi(lines[0])
 
-    def test_box_width(self):
+    def test_box_width(self) -> None:
         """Box respects specified width."""
         result = box("hi", width=20)
         lines = result.split("\n")
         # Content line should be 22 chars (20 inner + 2 borders)
         assert visible_width(lines[1]) == 22
 
-    def test_box_minimum_width(self):
+    def test_box_minimum_width(self) -> None:
         """Box has minimum width."""
         result = box("x")
         lines = result.split("\n")
@@ -308,8 +445,12 @@ class TestBox:
 class TestSectionHeader:
     """Test section header rendering."""
 
-    def test_section_header_centered(self, force_color):
-        """Section header has centered title."""
+    def test_section_header_centered(self, force_color: None) -> None:
+        """Section header has centered title.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         result = section_header("Test", width=20)
         assert "Test" in strip_ansi(result)
         assert "─" in result
@@ -324,8 +465,12 @@ class TestSectionHeader:
 class TestTable:
     """Test table formatting."""
 
-    def test_table_simple(self, force_color):
-        """Simple table with headers and rows."""
+    def test_table_simple(self, force_color: None) -> None:
+        """Simple table with headers and rows.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         result = table(
             headers=["Name", "Value"],
             rows=[["foo", "1"], ["bar", "2"]],
@@ -338,7 +483,7 @@ class TestTable:
         assert "foo" in lines[2]
         assert "bar" in lines[3]
 
-    def test_table_auto_width(self):
+    def test_table_auto_width(self) -> None:
         """Table auto-calculates column widths."""
         result = table(
             headers=["A", "LongerHeader"],
@@ -348,7 +493,7 @@ class TestTable:
         # LongerHeader should determine second column width
         assert "LongerHeader" in strip_ansi(lines[0])
 
-    def test_table_explicit_widths(self):
+    def test_table_explicit_widths(self) -> None:
         """Table respects explicit column widths."""
         result = table(
             headers=["A", "B"],
@@ -360,12 +505,16 @@ class TestTable:
         # Header line should be "A" padded to 10 + sep + "B" padded to 10
         assert visible_width(lines[0]) == 10 + 2 + 10  # 2 = default sep
 
-    def test_table_empty(self):
+    def test_table_empty(self) -> None:
         """Empty table returns empty string."""
         assert table(headers=[], rows=[]) == ""
 
-    def test_table_with_styled_content(self, force_color):
-        """Table handles styled cell content."""
+    def test_table_with_styled_content(self, force_color: None) -> None:
+        """Table handles styled cell content.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
         result = table(
             headers=["Status"],
             rows=[[red("ERROR")]],
@@ -382,22 +531,63 @@ class TestTable:
 class TestTreePrefix:
     """Test tree connector generation."""
 
-    def test_tree_last_item(self):
+    def test_tree_last_item(self) -> None:
         """Last item uses └──."""
         assert tree_prefix(is_last=True) == "└── "
 
-    def test_tree_middle_item(self):
+    def test_tree_middle_item(self) -> None:
         """Middle item uses ├──."""
         assert tree_prefix(is_last=False) == "├── "
 
-    def test_tree_nested_last(self):
+    def test_tree_nested_last(self) -> None:
         """Nested last item has correct prefix."""
         result = tree_prefix(is_last=True, depth=1, parent_prefixes=[False])
         assert "│" in result
         assert "└" in result
 
-    def test_tree_nested_after_last_parent(self):
+    def test_tree_nested_after_last_parent(self) -> None:
         """Item after last parent has space prefix."""
         result = tree_prefix(is_last=True, depth=1, parent_prefixes=[True])
         assert "│" not in result
         assert "└" in result
+
+
+class TestNoAnsiFlag:
+    """Test --no-ansi CLI flag with real CLI parser."""
+
+    def test_no_ansi_flag_before_subcommand(self) -> None:
+        """--no-ansi is accepted after the subcommand via shared parent parser."""
+        import argparse  # noqa: PLC0415
+
+        parser = argparse.ArgumentParser()
+        global_opts = argparse.ArgumentParser(add_help=False)
+        global_opts.add_argument("--na", "--no-ansi", action="store_true", default=False, dest="no_ansi")
+        subs = parser.add_subparsers(dest="command", required=True)
+        scan = subs.add_parser("scan", parents=[global_opts])
+        scan.add_argument("target", nargs="?", default=".")
+        args = parser.parse_args(["scan", "--no-ansi", "."])
+        assert args.no_ansi is True
+
+    def test_no_ansi_disables_color_via_main(self) -> None:
+        """--no-ansi flag disables color when processed by main()."""
+        from io import StringIO  # noqa: PLC0415
+        from unittest.mock import patch  # noqa: PLC0415
+
+        import apme_engine.cli as cli_module  # noqa: PLC0415
+        from apme_engine.validators.base import ScanContext  # noqa: PLC0415
+
+        ctx = ScanContext(
+            hierarchy_payload={"scan_id": "test"},
+            scandata=None,
+            root_dir="",
+        )
+        stdout_io = StringIO()
+        with (
+            patch.object(cli_module, "run_scan", return_value=ctx),
+            patch("apme_engine.validators.opa.run_opa", return_value=[]),
+            patch("sys.argv", ["apme-scan", "scan", "--no-ansi", "--no-native", "."]),
+            patch("sys.stdout", stdout_io),
+        ):
+            cli_module.main()
+        out = stdout_io.getvalue()
+        assert "\033[" not in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import apme_engine.cli as cli_module
+from apme_engine.ansi import strip_ansi
 from apme_engine.cli import (
     _deduplicate_violations,
     _fmt_ms,
@@ -155,13 +156,14 @@ class TestMain:
         ):
             cli_module.main()
         out = stdout_io.getvalue()
-        assert "Violations: 1" in out or "Violations:" in out
-        assert "r1" in out
-        assert "f.yml" in out
-        assert "msg" in out
+        clean = strip_ansi(out)
+        assert "1 warning(s)" in clean or "WARN" in clean
+        assert "r1" in clean
+        assert "f.yml" in clean
+        assert "msg" in clean
 
     def test_main_with_opa_no_violations_prints_no_violations(self, sample_hierarchy_payload: YAMLDict) -> None:
-        """With OPA and no violations, print 'No violations.'.
+        """With OPA and no violations, print 'No issues found'.
 
         Args:
             sample_hierarchy_payload: Fixture providing sample hierarchy data.
@@ -175,7 +177,7 @@ class TestMain:
             patch("sys.stdout", stdout_io),
         ):
             cli_module.main()
-        assert "No violations" in stdout_io.getvalue()
+        assert "No issues found" in strip_ansi(stdout_io.getvalue())
 
     def test_main_uses_custom_opa_bundle_when_provided(
         self, sample_hierarchy_payload: YAMLDict, tmp_path: Path


### PR DESCRIPTION
## Summary
- Add `src/apme_engine/ansi.py` — zero-dependency ANSI styling module
- Implement styled scan output with summary box, issues table, tree view
- NO_COLOR / FORCE_COLOR support (no-color.org compliant)
- Add `--no-ansi` / `-na` CLI flag for programmatic disable (works before or after subcommand)
- Color scheme aligned with ansible-creator conventions

## Changes

### ANSI Module (`src/apme_engine/ansi.py`)
- `Style` class with full 16-color palette (foreground + background)
- Core styling functions: `bold`, `dim`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `gray`
- ANSI-aware string width: `strip_ansi`, `visible_width`, `ljust_ansi`, `rjust_ansi`
- Severity badges and indicators (ansible-creator aligned: HINT→cyan, INFO→magenta)
- Box drawing, section headers, table formatting, tree connectors
- `force_no_color()` for `--no-ansi` CLI flag support

### CLI Integration (`src/apme_engine/cli.py`)
- `_render_scan_results()` — styled output with summary box, issues table, tree view
- `_count_by_severity()` — accurate bucketing (error, warning, info, hint)
- `--no-ansi` / `-na` via shared parent parser (`parents=[global_opts]`) — works in any position
- Tree view uses `TREE_PIPE`/`TREE_SPACE` constants and renders line ranges consistently

### Tests (`tests/test_ansi.py`, `tests/test_cli.py`)
- Full test coverage for styling, NO_COLOR compliance, badges, box, table, tree
- Tests for `force_no_color()` and `--no-ansi` flag (parser structure + integration via `main()`)
- Updated CLI tests use `strip_ansi()` for output assertions

### Docs (`docs/DEVELOPMENT.md`)
- Added `ansi.py` to code organization tree
- Added "Color output" section (NO_COLOR, FORCE_COLOR, --no-ansi)

## Review Feedback Addressed

### Round 1 (5 Copilot comments):
1. NO_COLOR spec compliance (`"NO_COLOR" in os.environ`)
2. Removed incorrect ADR-014 reference
3. `isinstance(x, list | tuple)` — confirmed valid Python 3.10+ (PEP 604), kept per ruff UP038
4. Added explicit "info" severity bucket
5. Split NO_COLOR test for empty string and "0" values

### Round 2 (6 Copilot comments, fixed in 05b32e9):
1. `--no-ansi` moved to shared parent parser — works before or after subcommand
2. Tree view now renders line ranges (`Lstart-end`) consistently with table
3. Replaced hard-coded tree indentation with `TREE_PIPE`/`TREE_SPACE` constants
4. Docs example corrected (parser now supports documented ordering)
5. `--no-ansi` test replaced with parser structure test + `main()` integration test
6. Grammar: "pass clean" → "pass cleanly"

## Test plan
- [x] `prek run --all-files` passes (ruff, ruff format, mypy, pydoclint)
- [x] `pytest` passes (799 passed, 82 skipped, 1 unrelated OPA/Podman skip)
- [x] Coverage threshold met (38.11% >= 36%)
- [x] Docs updated (DEVELOPMENT.md — color output section)

## prek
All checks pass: `ruff`, `ruff format`, `mypy`, `pydoclint` ✓