### PR TITLE
feat: add proactive PR feedback workflow (ADR-021)

### DIFF
--- a/.github/workflows/pr-feedback.yml
+++ b/.github/workflows/pr-feedback.yml
@@ -1,0 +1,208 @@
+---
+name: pr-feedback
+
+on:
+  workflow_run:
+    workflows: [prek, test]
+    types: [completed]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 */6 * * *"
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-failures:
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const LABEL = "checks-failing";
+            const run = context.payload.workflow_run;
+
+            // Only care about PRs
+            if (!run.pull_requests || run.pull_requests.length === 0) {
+              console.log("No associated PRs, skipping.");
+              return;
+            }
+
+            for (const pr of run.pull_requests) {
+              const { data: pull } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+
+              // Skip bot-authored PRs
+              if (pull.user.type === "Bot") {
+                console.log(`PR #${pr.number} is bot-authored, skipping.`);
+                continue;
+              }
+
+              const labels = pull.labels.map((l) => l.name);
+              const hasLabel = labels.includes(LABEL);
+
+              if (run.conclusion === "failure") {
+                if (!hasLabel) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    labels: [LABEL],
+                  });
+                }
+
+                // Check if we already posted a failure comment recently
+                const { data: comments } = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  per_page: 5,
+                });
+                const alreadyPosted = comments.some(
+                  (c) =>
+                    c.user.type === "Bot" &&
+                    c.body.includes(LABEL) &&
+                    c.body.includes(run.name),
+                );
+                if (!alreadyPosted) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body: [
+                      `<!-- ${LABEL} -->`,
+                      `@${pull.user.login} — the **${run.name}** check is failing on this PR.`,
+                      "",
+                      `Please review the [workflow run](${run.html_url}) and push a fix.`,
+                    ].join("\n"),
+                  });
+                }
+              } else if (run.conclusion === "success" && hasLabel) {
+                // Check if ALL workflow runs are now passing before removing
+                const { data: checkRuns } =
+                  await github.rest.checks.listForRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: pull.head.sha,
+                  });
+                const anyFailing = checkRuns.check_runs.some(
+                  (cr) =>
+                    cr.status === "completed" && cr.conclusion === "failure",
+                );
+                if (!anyFailing) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    name: LABEL,
+                  });
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body: [
+                      `<!-- ${LABEL}-clear -->`,
+                      `@${pull.user.login} — all checks are passing now. :white_check_mark:`,
+                    ].join("\n"),
+                  });
+                }
+              }
+            }
+
+  check-conflicts:
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const LABEL = "needs-rebase";
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              base: "main",
+              per_page: 100,
+            });
+
+            for (const pr of pulls) {
+              // Skip bot-authored and draft PRs
+              if (pr.user.type === "Bot" || pr.draft) {
+                continue;
+              }
+
+              // Fetch full PR to get mergeable state (list endpoint doesn't include it)
+              const { data: pull } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+
+              // GitHub computes mergeable asynchronously; null means not ready yet
+              if (pull.mergeable === null) {
+                // Wait briefly and retry once
+                await new Promise((r) => setTimeout(r, 3000));
+                const { data: retry } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                pull.mergeable = retry.mergeable;
+                pull.mergeable_state = retry.mergeable_state;
+              }
+
+              const labels = pull.labels.map((l) => l.name);
+              const hasLabel = labels.includes(LABEL);
+              const hasConflict =
+                pull.mergeable === false || pull.mergeable_state === "dirty";
+
+              if (hasConflict && !hasLabel) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: [LABEL],
+                });
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: [
+                    `<!-- ${LABEL} -->`,
+                    `@${pull.user.login} — this PR has merge conflicts with \`main\`.`,
+                    "",
+                    "Please rebase onto the latest `main`:",
+                    "```bash",
+                    "git fetch upstream",
+                    "git rebase upstream/main",
+                    "git push --force-with-lease",
+                    "```",
+                  ].join("\n"),
+                });
+              } else if (!hasConflict && hasLabel) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: LABEL,
+                });
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: [
+                    `<!-- ${LABEL}-clear -->`,
+                    `@${pull.user.login} — conflicts resolved, branch is up to date with \`main\`. :white_check_mark:`,
+                  ].join("\n"),
+                });
+              }
+            }

--- a/.sdlc/adrs/ADR-021-proactive-pr-feedback.md
+++ b/.sdlc/adrs/ADR-021-proactive-pr-feedback.md
@@ -1,0 +1,114 @@
+# ADR-021: Proactive PR Feedback via GitHub Actions
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-17
+
+## Context
+
+APME requires all CI checks to pass, all review conversations to be resolved, and the branch to be up-to-date with `main` before a PR can merge. Contributors often don't realize their PR has drifted into a failing state — checks break after a push to main introduces a conflict, or a review comment goes unaddressed. Maintainers end up manually pinging contributors to fix their PRs, which doesn't scale.
+
+We need an automated system that gives contributors clear, actionable feedback when their PR needs attention, so they can self-service fixes without maintainer intervention.
+
+## Decision
+
+**We will implement a GitHub Actions workflow that labels open PRs and posts `@mention` comments when a PR has failing checks or merge conflicts with `main`.**
+
+The workflow will:
+1. Add descriptive labels (`checks-failing`, `needs-rebase`) when conditions are detected
+2. Post a comment `@mentioning` the PR author with specific guidance on what to fix
+3. Automatically remove labels and post an "all clear" comment when the condition resolves
+
+Labels and comments are informational — merge protection continues to be enforced by branch protection rules (required checks, up-to-date branch, resolved conversations).
+
+## Alternatives Considered
+
+### Alternative 1: Convert PRs to Draft
+
+**Description**: Use the `convertPullRequestToDraft` GraphQL mutation to move failing PRs back to draft state automatically.
+
+**Pros**:
+- Clear visual signal in the PR list (grey "Draft" badge)
+- Prevents accidental review of broken PRs
+- Common pattern in some large projects
+
+**Cons**:
+- Author must manually click "Ready for review" to recover — friction for external contributors
+- Can be confusing for contributors who don't expect it
+- Reviews already posted become less visible
+- `GITHUB_TOKEN` cannot convert fork PRs to draft — requires a PAT or GitHub App
+
+**Why not chosen**: Too disruptive for a project with external contributors. The manual "Ready for review" step adds unnecessary friction and may discourage participation.
+
+### Alternative 2: Do Nothing (manual maintainer pings)
+
+**Description**: Maintainers manually monitor PR state and ask contributors to fix issues.
+
+**Pros**:
+- No automation to maintain
+- Human judgment on when to ping
+
+**Cons**:
+- Doesn't scale — maintainers become bottlenecks
+- Inconsistent feedback timing
+- Contributors may not know their PR needs attention until a maintainer notices
+
+**Why not chosen**: Current pain point that motivated this ADR.
+
+### Alternative 3: Labels Only (no comments)
+
+**Description**: Add/remove labels automatically but don't post comments.
+
+**Pros**:
+- Less noisy — no email notifications from comments
+- Labels visible in PR list for maintainer triage
+
+**Cons**:
+- Contributors may not notice a label change — no email notification for label events
+- No actionable guidance on how to fix the issue
+
+**Why not chosen**: Labels alone don't reliably notify contributors. The `@mention` comment ensures an email notification with specific instructions.
+
+## Consequences
+
+### Positive
+
+- Contributors get immediate, actionable feedback when their PR needs attention
+- Maintainers spend less time manually triaging PR state
+- PR list is filterable by label (`needs-rebase`, `checks-failing`) for quick triage
+- Labels auto-clear when issues are resolved — no stale signals
+- Works for both same-repo and fork PRs (labels and comments don't require special permissions)
+
+### Negative
+
+- Additional GitHub Actions minutes consumed (mitigated: API-only workflow, no builds)
+- Comment notifications may feel noisy if checks are flaky (mitigated: required checks should be stable per ADR-015)
+- Scheduled runs add a small delay for conflict detection after pushes to main
+
+### Neutral
+
+- Branch protection rules remain the actual enforcement mechanism — this workflow is advisory only
+
+## Implementation Notes
+
+- **Triggers**: `workflow_run.completed` for check failures, `push` to `main` for conflicts, `schedule` (every 6h) as a safety net for stale `mergeable` state
+- **Labels**: Create `checks-failing` (red) and `needs-rebase` (yellow) repository labels
+- **Comment format**: Include the label name, a one-line explanation, and a link to relevant docs (e.g., "run `git fetch upstream && git rebase upstream/main`")
+- **Idempotency**: Don't post duplicate comments — check if the most recent bot comment already describes the current issue before posting
+- **Skip bots**: Exclude PRs authored by bots (Dependabot, Copilot, etc.)
+- **Unresolved conversations**: Defer to a future iteration — no reliable event-driven trigger exists; would require scheduled polling of the GraphQL `reviewThreads` API
+
+## Related Decisions
+
+- ADR-015: GitHub Actions CI with prek (the checks being monitored)
+- ADR-016: Single-branch `main` strategy (defines the base branch)
+
+## References
+
+- GitHub Docs: [Managing labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels)
+- GitHub Docs: [Pull request mergeability](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request)
+- GitHub Docs: [workflow_run event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -26,6 +26,7 @@ This directory contains the Architecture Decision Records (ADRs) for APME.
 | [ADR-018](ADR-018-mypy-strict-type-checking.md) | mypy Strict Mode Type Checking | Accepted | 2026-03 |
 | [ADR-019](ADR-019-dependency-governance.md) | Dependency Governance Policy | Accepted | 2026-03 |
 | [ADR-020](ADR-020-reporting-service.md) | Reporting Service and Event Delivery Model | Proposed | 2026-03 |
+| [ADR-021](ADR-021-proactive-pr-feedback.md) | Proactive PR Feedback via GitHub Actions | Accepted | 2026-03 |
 
 ## Categories
 
@@ -59,6 +60,7 @@ This directory contains the Architecture Decision Records (ADRs) for APME.
 - ADR-016: Single-branch `main` strategy
 - ADR-017: Trust-and-verify agent SDLC invocation
 - ADR-019: Dependency governance policy
+- ADR-021: Proactive PR feedback via GitHub Actions
 
 ## Archived
 
@@ -73,7 +75,7 @@ Original planning ADRs that were superseded by implementation decisions:
 ## Creating New ADRs
 
 1. Copy the template from `../.sdlc/templates/adr.md`
-2. Use the next available number (currently ADR-021)
+2. Use the next available number (currently ADR-022)
 3. Include:
    - Status (Proposed → Accepted)
    - Date
@@ -109,3 +111,4 @@ Original planning ADRs that were superseded by implementation decisions:
 | 018 | 2026-03 | mypy strict mode type checking |
 | 019 | 2026-03 | Dependency governance policy |
 | 020 | 2026-03 | Reporting service and event delivery model (proposed) |
+| 021 | 2026-03 | Proactive PR feedback via GitHub Actions |


### PR DESCRIPTION
## Summary

- Add ADR-021 documenting the decision to use labels + `@mention` comments (over draft conversion) for automated PR feedback
- Add `pr-feedback.yml` GitHub Actions workflow with two jobs:
  - **check-failures**: triggered on `workflow_run` completion — labels PRs `checks-failing` when CI fails, removes label when all checks pass
  - **check-conflicts**: triggered on `push` to main and every 6h schedule — labels PRs `needs-rebase` when merge conflicts exist, removes label when resolved
- Both jobs post `@mention` comments with actionable guidance and auto-clear when the issue is resolved
- Create `checks-failing` (red) and `needs-rebase` (yellow) repository labels

## Design decisions

- **Labels + comments over draft conversion**: Draft is too disruptive for external contributors — requires manual "Ready for review" to recover, and `GITHUB_TOKEN` can't convert fork PRs to draft
- **Idempotent comments**: The workflow checks recent comments before posting to avoid duplicates
- **Bot/draft skip**: Bot-authored and draft PRs are excluded from conflict checks
- **Async mergeable handling**: Retries once after 3s if GitHub hasn't computed the mergeable state yet

## Test plan

- [ ] Merge to main → verify `check-conflicts` job runs and scans open PRs
- [ ] Open a PR with a deliberate conflict → verify `needs-rebase` label and comment appear
- [ ] Rebase the PR → verify label is removed and "all clear" comment posted
- [ ] Push a failing commit to a PR → verify `checks-failing` label and comment after CI completes
- [ ] Push a fix → verify label removed and "all clear" comment posted
- [ ] Verify bot PRs and draft PRs are skipped


Made with [Cursor](https://cursor.com)