### PR TITLE
docs: ansible-core 2.21-2.24 deprecation mining research

### DIFF
--- a/.sdlc/research/ansible-core-deprecation-mining.md
+++ b/.sdlc/research/ansible-core-deprecation-mining.md
@@ -340,6 +340,6 @@ Per ADR-009, validators are read-only — remediation is a separate engine. Each
 ## References
 
 - [ANSIBLE_CORE_MIGRATION.md](/docs/ANSIBLE_CORE_MIGRATION.md) — existing 2.19/2.20 migration rules
-- [ansible-core changelog](https://github.com/ansible/ansible/blob/devel/changelogs/CHANGELOG-v2.20.rst)
+- [ansible-core changelogs](https://github.com/ansible/ansible/tree/devel/changelogs) — porting guides and version-specific changes
 - ansible-core source: `lib/ansible/` on `devel` branch
 - ADR-008: Rule ID conventions (M = modernization)


### PR DESCRIPTION
## Summary

- Mine the ansible-core `devel` branch for all version-gated deprecation warnings (2.21–2.24 horizon)
- Catalog 73 deprecation instances across 3 mechanisms (`display.deprecated`, comment-staged, `_tags.Deprecated`)
- Identify 35 content-facing patterns statically detectable by APME
- Propose M014–M030 as new rules, prioritized by impact and feasibility
- Include remediation analysis: 10 of 17 rules (59%) have fully mechanical auto-fixes
- Pin analysis to ansible-core commit `80ee6b5d920d` (2026-03-16)

## Details

Key findings:
- **2.23** is a massive deprecation wave (59 instances)
- **2.24** top-level fact injection (`ansible_*` → `ansible_facts["*"]`) affects virtually every playbook
- Existing APME rules (L015, M001–M004) already cover 5 patterns; 17 new rules proposed
- Remediation tiers: 10 auto-fix, 4 AI-assisted, 3 manual/informational

## Test plan

- [x] Document renders correctly in GitHub markdown
- [x] No code changes — research document only


Made with [Cursor](https://cursor.com)