### PR TITLE
refactor: remove tabulate dependency, use internal ansi.table()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
         additional_dependencies:
           - types-protobuf
           - types-PyYAML
-          - types-tabulate
           - grpc-stubs
   - repo: https://github.com/jsh9/pydoclint
     rev: 0.8.3

--- a/.sdlc/adrs/ADR-019-dependency-governance.md
+++ b/.sdlc/adrs/ADR-019-dependency-governance.md
@@ -91,7 +91,7 @@ If the answer to question 1 is "convenience wrapper," the default answer is **no
 
 - Remove `gitdb`, `smmap` from `[project.dependencies]` (unused; leftover from removed GitPython)
 - Move `setuptools` to `[build-system] requires` only; move `grpcio-tools` to `[project.optional-dependencies] dev`
-- Replace `tabulate` with internal ANSI `table()` when the ANSI abstraction lands
+- ~~Replace `tabulate` with internal ANSI `table()` when the ANSI abstraction lands~~ **Done**
 - Consolidate `requests` into `httpx` (1 file to migrate)
 - Evaluate replacing `filelock` with an `fcntl.flock()` wrapper
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "jsonpickle",
     "PyYAML",
     "ruamel.yaml",
-    "tabulate",
     "filelock",
     "rapidfuzz",
     "joblib",
@@ -33,7 +32,6 @@ dev = [
     "pydoclint>=0.8.0",
     "types-protobuf",
     "types-PyYAML",
-    "types-tabulate",
     "grpc-stubs",
     "grpcio-tools>=1.60",
 ]
@@ -102,7 +100,6 @@ module = [
     "rapidfuzz.*",
     "joblib",
     "httpx",
-    "tabulate",
     "yaml",
     "grpc",
     "grpc.*",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ setuptools
 jsonpickle
 PyYAML
 ruamel.yaml
-tabulate
 filelock
 rapidfuzz
 requests

--- a/research.md
+++ b/research.md
@@ -10,7 +10,7 @@
 **Rationale**:
 - ARI is already declared as a dependency in x2a-convertor's `pyproject.toml`
 - It has a clean programmatic Python API via `ARIScanner` class - no need to shell out to CLI
-- All ARI dependencies (jsonpickle, PyYAML, ruamel.yaml, requests, tabulate, rapidfuzz, joblib, filelock, gitdb, smmap) are compatible with x2a-convertor's existing deps
+- All ARI dependencies (jsonpickle, PyYAML, ruamel.yaml, requests, rapidfuzz, joblib, filelock, gitdb, smmap) are compatible with x2a-convertor's existing deps
 - The local `ansible-risk-insight/` directory serves as reference code for custom rule development
 
 **Alternatives Considered**:

--- a/src/apme_engine/engine/models.py
+++ b/src/apme_engine/engine/models.py
@@ -14,7 +14,8 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 import jsonpickle
 from rapidfuzz.distance import Levenshtein
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
-from tabulate import tabulate
+
+from apme_engine.ansi import table as ansi_table
 
 # Recursive type for YAML/JSON values (defined before local imports to avoid circular import)
 YAMLScalar = str | int | float | bool | None
@@ -1092,19 +1093,18 @@ class VariableDict:
 
     @staticmethod
     def print_table(data: dict[str, list[Variable]]) -> str:
-        """Format variable data as a tabulate table string.
+        """Format variable data as a table string.
 
         Args:
             data: Map from variable name to list of Variable by precedence.
 
         Returns:
-            Tabulated string.
+            Formatted table string.
 
         """
         d = VariableDict(_dict=data)
-        table = []
-        type_labels = []
-        found_type_label_names = []
+        type_labels: list[VariablePrecedence] = []
+        found_type_label_names: list[str] = []
         for v_list in d._dict.values():
             for v in v_list:
                 if not v.type or v.type.name in found_type_label_names:
@@ -1113,9 +1113,11 @@ class VariableDict:
                 found_type_label_names.append(v.type.name)
         type_labels = sorted(type_labels, key=lambda x: x.order, reverse=True)
 
+        headers = ["NAME", *(t.name.upper() for t in type_labels)]
+        rows: list[list[str]] = []
         for v_name in d._dict:
             v_list = d._dict[v_name]
-            row: dict[str, YAMLValue] = {"NAME": v_name}
+            row: list[str] = [v_name]
             for t in type_labels:
                 cell_value: YAMLValue = "-"
                 for v in v_list:
@@ -1124,10 +1126,9 @@ class VariableDict:
                     cell_value = v.value
                     if isinstance(cell_value, str) and cell_value == "":
                         cell_value = '""'
-                type_label = t.name.upper()
-                row[type_label] = cell_value
-            table.append(row)
-        return str(tabulate(table, headers="keys"))
+                row.append(str(cell_value))
+            rows.append(row)
+        return ansi_table(headers, rows)
 
 
 class ArgumentsType:

--- a/src/apme_engine/engine/requirements.txt
+++ b/src/apme_engine/engine/requirements.txt
@@ -4,4 +4,3 @@ joblib==1.2.0
 jsonpickle==2.2.0
 PyYAML==6.0
 smmap==5.0.0
-tabulate==0.8.10

--- a/src/apme_engine/engine/utils.py
+++ b/src/apme_engine/engine/utils.py
@@ -16,7 +16,8 @@ from typing import TYPE_CHECKING, cast
 import httpx
 import yaml
 from filelock import FileLock
-from tabulate import tabulate
+
+from apme_engine.ansi import table as ansi_table
 
 from . import logger
 from .models import YAMLDict
@@ -569,7 +570,7 @@ def summarize_findings_data(
 
     if len(dependencies) > 0:
         output_lines.append("External Dependencies")
-        dep_table = [("NAME", "VERSION", "HASH")]
+        dep_rows: list[list[str]] = []
         for dep_info in dependencies:
             dep_meta = cast(dict[str, object], dep_info.get("metadata", {}))
             dep_name = str(dep_meta.get("name", ""))
@@ -577,8 +578,8 @@ def summarize_findings_data(
                 continue
             dep_version = str(dep_meta.get("version", ""))
             dep_hash = str(dep_meta.get("hash", ""))
-            dep_table.append((dep_name, dep_version, dep_hash))
-        output_lines.append(tabulate(dep_table))
+            dep_rows.append([dep_name, dep_version, dep_hash])
+        output_lines.append(ansi_table(["NAME", "VERSION", "HASH"], dep_rows))
 
     #     print("-" * 90)
     #     print("ARI scan completed!")
@@ -647,38 +648,38 @@ def summarize_findings_data(
 
         if len(unresolved_modules) > 0:
             output_lines.append("Unresolved modules:")
-            table = [("NAME", "USED_IN")]
+            mod_rows: list[list[str]] = []
             thresh = 4
             for ext_req in unresolved_modules[:thresh]:
                 obj_name = str(ext_req.get("name", ""))
                 used_in = str(ext_req.get("used_in", ""))
                 req_name = cast(dict[str, object], ext_req.get("defined_in", {})).get("name", None)
                 short_name = obj_name.replace(f"{req_name}.", "") if req_name else obj_name
-                table.append((short_name, used_in))
+                mod_rows.append([short_name, used_in])
             if len(unresolved_modules) > thresh:
                 rest_num = len(unresolved_modules) - thresh
-                table.append(("", f"... and {rest_num} other modules"))
-            output_lines.append(tabulate(table))
+                mod_rows.append(["", f"... and {rest_num} other modules"])
+            output_lines.append(ansi_table(["NAME", "USED_IN"], mod_rows))
 
         if len(unresolved_roles) > 0:
             output_lines.append("Unresolved roles:")
-            table = [("NAME", "USED_IN")]
+            role_rows: list[list[str]] = []
             thresh = 4
             for ext_req in unresolved_roles[:thresh]:
                 obj_name = str(ext_req.get("name", ""))
                 used_in = str(ext_req.get("used_in", ""))
                 req_name = cast(dict[str, object], ext_req.get("defined_in", {})).get("name", None)
                 short_name = obj_name.replace(f"{req_name}.", "") if req_name else obj_name
-                table.append((short_name, used_in))
+                role_rows.append([short_name, used_in])
             if len(unresolved_roles) > thresh:
                 rest_num = len(unresolved_roles) - thresh
-                table.append(("", f"... and {rest_num} other roles"))
-            output_lines.append(tabulate(table))
+                role_rows.append(["", f"... and {rest_num} other roles"])
+            output_lines.append(ansi_table(["NAME", "USED_IN"], role_rows))
 
         req_name_keys = sorted(list(suggestion.keys()))
         output_lines.append("")
         output_lines.append("-- Suggested Dependencies --")
-        table_data = [("NAME", "VERSION", "SUGGESTED_FOR")]
+        suggest_rows: list[list[str]] = []
         for req_str in req_name_keys:
             req_dict = suggestion[req_str]
             req_module_list = req_dict["module"]
@@ -712,8 +713,8 @@ def summarize_findings_data(
                 prefix = "role" if req_role_num == 1 else "roles"
                 role_names += f" (total {req_role_num} {prefix})"
                 summary_str += role_names
-            table_data.append((req_name, req_version, summary_str))
-        output_lines.append(tabulate(table_data))
+            suggest_rows.append([req_name, req_version, summary_str])
+        output_lines.append(ansi_table(["NAME", "VERSION", "SUGGESTED_FOR"], suggest_rows))
     output = "\n".join(output_lines)
     return output
 
@@ -725,10 +726,10 @@ def show_all_ram_metadata(ram_meta_list: list[dict[str, str]]) -> None:
         ram_meta_list: List of dicts with name, version, hash keys.
 
     """
-    table: list[tuple[str, str, str]] = [("NAME", "VERSION", "HASH")]
-    for meta in ram_meta_list:
-        table.append((str(meta.get("name", "")), str(meta.get("version", "")), str(meta.get("hash", ""))))
-    print(tabulate(table))
+    rows = [
+        [str(meta.get("name", "")), str(meta.get("version", "")), str(meta.get("hash", ""))] for meta in ram_meta_list
+    ]
+    print(ansi_table(["NAME", "VERSION", "HASH"], rows))
 
 
 def diff_files_data(files1: dict[str, object], files2: dict[str, object]) -> list[dict[str, str]]:
@@ -812,10 +813,8 @@ def show_diffs(diffs: list[dict[str, str]]) -> None:
         diffs: List of dicts with filepath and type keys.
 
     """
-    table = [("NAME", "DIFF_TYPE")]
-    for d in diffs:
-        table.append((d["filepath"], d["type"]))
-    print(tabulate(table))
+    rows = [[d["filepath"], d["type"]] for d in diffs]
+    print(ansi_table(["NAME", "DIFF_TYPE"], rows))
 
 
 def get_module_specs_by_ansible_doc(


### PR DESCRIPTION
## Summary

- Replace all 7 `tabulate` call sites with the internal `ansi.table()` function (landed in the ANSI PR)
- Remove `tabulate` and `types-tabulate` from all dependency manifests
- Mark the tabulate cleanup action as done in ADR-019

Per [ADR-019](/.sdlc/adrs/ADR-019-dependency-governance.md) (Dependency Governance), `tabulate` is a Tier 2 utility dependency — thin wrapper around simple functionality that should be owned internally. The internal `ansi.table()` provides equivalent columnar formatting with ANSI styling support.

## Changes

| File | Change |
|------|--------|
| `engine/utils.py` | Replace 6 `tabulate()` calls with `ansi_table()` |
| `engine/models.py` | Replace 1 dict-based `tabulate()` call with `ansi_table()` |
| `pyproject.toml` | Remove `tabulate`, `types-tabulate`, mypy override |
| `requirements.txt` | Remove `tabulate` |
| `engine/requirements.txt` | Remove `tabulate==0.8.10` |
| `.pre-commit-config.yaml` | Remove `types-tabulate` from mypy additional deps |
| `ADR-019` | Mark tabulate cleanup action as done |
| `research.md` | Remove `tabulate` from dep list |

## Test plan

- [x] `prek run --all-files` passes (ruff, ruff-format, mypy, pydoclint)
- [ ] CI checks pass
- [ ] Verify table output renders correctly in CLI (manual)


Made with [Cursor](https://cursor.com)