### PR TITLE
fix: remediation engine never applied transforms due to path and prefix mismatches

### DIFF
--- a/src/apme_engine/remediation/engine.py
+++ b/src/apme_engine/remediation/engine.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.remediation.partition import partition_violations
+from apme_engine.remediation.partition import normalize_rule_id, partition_violations
 from apme_engine.remediation.registry import TransformRegistry
 
 
@@ -133,16 +133,25 @@ class RemediationEngine:
 
         # Violations may report relative filenames (e.g. "site.yml") while
         # file_contents keys are absolute paths.  Build a reverse lookup so we
-        # can resolve either form to the canonical key.
-        _basename_to_key: dict[str, str] = {}
+        # can resolve either form to the canonical key.  When multiple files
+        # share a basename the entry is set to None so we skip rather than
+        # resolving to the wrong file.
+        _basename_to_key: dict[str, str | None] = {}
         for fp in file_paths:
-            _basename_to_key[Path(fp).name] = fp
+            bn = Path(fp).name
+            if bn in _basename_to_key and _basename_to_key[bn] != fp:
+                _basename_to_key[bn] = None
+            else:
+                _basename_to_key[bn] = fp
             _basename_to_key[fp] = fp
 
         def _resolve_file(vf: str) -> str | None:
             if vf in file_contents:
                 return vf
-            return _basename_to_key.get(vf) or _basename_to_key.get(Path(vf).name)
+            candidate = _basename_to_key.get(vf) or _basename_to_key.get(Path(vf).name)
+            if candidate is None and vf:
+                self._log(f"  Skipping violation: ambiguous or unknown file '{vf}'")
+            return candidate
 
         originals = dict(file_contents)
         all_applied_rules: dict[str, list[str]] = {fp: [] for fp in file_paths}
@@ -165,9 +174,7 @@ class RemediationEngine:
 
             applied_this_pass = 0
             for v in tier1:
-                rule_id = str(v.get("rule_id", ""))
-                if rule_id.startswith("native:"):
-                    rule_id = rule_id[len("native:") :]
+                rule_id = normalize_rule_id(str(v.get("rule_id", "")))
                 vf_raw = str(v.get("file", ""))
                 vf = _resolve_file(vf_raw)
 

--- a/src/apme_engine/remediation/partition.py
+++ b/src/apme_engine/remediation/partition.py
@@ -9,6 +9,20 @@ if TYPE_CHECKING:
 from apme_engine.remediation.registry import TransformRegistry
 
 
+def normalize_rule_id(rule_id: str) -> str:
+    """Strip validator-specific prefixes from a rule ID for registry lookup.
+
+    Args:
+        rule_id: Raw rule ID, possibly prefixed (e.g. ``native:L021``).
+
+    Returns:
+        Bare rule ID suitable for registry lookup (e.g. ``L021``).
+    """
+    if rule_id.startswith("native:"):
+        rule_id = rule_id[len("native:") :]
+    return rule_id
+
+
 def is_finding_resolvable(violation: ViolationDict, registry: TransformRegistry) -> bool:
     """Return True if the violation has a registered deterministic transform (Tier 1).
 
@@ -19,11 +33,7 @@ def is_finding_resolvable(violation: ViolationDict, registry: TransformRegistry)
     Returns:
         True if rule_id has a registered transform.
     """
-    rule_id = str(violation.get("rule_id", ""))
-    # Native validator prefixes rule IDs with "native:" — strip it for registry lookup
-    if rule_id.startswith("native:"):
-        rule_id = rule_id[len("native:") :]
-    return rule_id in registry
+    return normalize_rule_id(str(violation.get("rule_id", ""))) in registry
 
 
 def partition_violations(

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -6,7 +6,11 @@ from typing import cast
 
 from apme_engine.engine.models import ViolationDict
 from apme_engine.remediation.engine import RemediationEngine
-from apme_engine.remediation.partition import is_finding_resolvable, partition_violations
+from apme_engine.remediation.partition import (
+    is_finding_resolvable,
+    normalize_rule_id,
+    partition_violations,
+)
 from apme_engine.remediation.registry import TransformRegistry, TransformResult
 from apme_engine.remediation.transforms import build_default_registry
 from apme_engine.remediation.transforms.L007_shell_to_command import fix_shell_to_command
@@ -88,6 +92,35 @@ class TestPartition:
         reg.register("L021", lambda c, v: TransformResult(c, False))
         assert is_finding_resolvable({"rule_id": "L021"}, reg) is True
         assert is_finding_resolvable({"rule_id": "L999"}, reg) is False
+
+    def test_normalize_rule_id_strips_native_prefix(self) -> None:
+        """Verifies normalize_rule_id strips 'native:' prefix."""
+        assert normalize_rule_id("native:L021") == "L021"
+        assert normalize_rule_id("L021") == "L021"
+        assert normalize_rule_id("native:M001") == "M001"
+        assert normalize_rule_id("") == ""
+
+    def test_is_finding_resolvable_with_native_prefix(self) -> None:
+        """Verifies native:L021 is resolvable when L021 is registered."""
+        reg = TransformRegistry()
+        reg.register("L021", lambda c, v: TransformResult(c, False))
+        assert is_finding_resolvable({"rule_id": "native:L021"}, reg) is True
+        assert is_finding_resolvable({"rule_id": "native:L999"}, reg) is False
+
+    def test_partition_native_prefix_to_tier1(self) -> None:
+        """Verifies native:-prefixed violations partition into Tier 1."""
+        reg = TransformRegistry()
+        reg.register("L021", lambda c, v: TransformResult(c, False))
+
+        violations: list[ViolationDict] = [
+            {"rule_id": "native:L021"},
+            {"rule_id": "R118"},
+        ]
+        t1, t2, t3 = partition_violations(violations, reg)
+        assert len(t1) == 1
+        assert t1[0]["rule_id"] == "native:L021"
+        assert len(t2) == 1
+        assert len(t3) == 0
 
     def test_partition_three_tiers(self) -> None:
         """Verifies partition_violations splits into resolvable, AI, manual tiers."""
@@ -503,6 +536,111 @@ class TestRemediationEngine:
         assert report.fixed == 0
         assert report.passes == 1
         assert report.oscillation_detected is False
+
+    def test_resolves_relative_file_path(self, tmp_path: Path) -> None:
+        """Verifies violations with relative file paths are resolved to absolute paths.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+
+        """
+        playbook = tmp_path / "play.yml"
+        playbook.write_text(
+            textwrap.dedent("""\
+        - name: Copy file
+          ansible.builtin.copy:
+            src: /a
+            dest: /b
+        """)
+        )
+
+        def scan_fn(paths: list[str]) -> list[ViolationDict]:
+            content = playbook.read_text()
+            if "mode:" not in content:
+                return [{"rule_id": "L021", "file": "play.yml", "line": 1}]
+            return []
+
+        reg = TransformRegistry()
+        reg.register("L021", fix_missing_mode)
+        engine = RemediationEngine(reg, scan_fn, max_passes=5)
+
+        report = engine.remediate([str(playbook)], apply=True)
+        assert report.fixed >= 1
+        assert "mode:" in playbook.read_text()
+
+    def test_resolves_native_prefixed_rule_id(self, tmp_path: Path) -> None:
+        """Verifies violations with native:-prefixed rule IDs are matched to transforms.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+
+        """
+        playbook = tmp_path / "play.yml"
+        playbook.write_text(
+            textwrap.dedent("""\
+        - name: Copy file
+          ansible.builtin.copy:
+            src: /a
+            dest: /b
+        """)
+        )
+
+        def scan_fn(paths: list[str]) -> list[ViolationDict]:
+            content = playbook.read_text()
+            if "mode:" not in content:
+                return [{"rule_id": "native:L021", "file": str(playbook), "line": 1}]
+            return []
+
+        reg = TransformRegistry()
+        reg.register("L021", fix_missing_mode)
+        engine = RemediationEngine(reg, scan_fn, max_passes=5)
+
+        report = engine.remediate([str(playbook)], apply=True)
+        assert report.fixed >= 1
+        assert "mode:" in playbook.read_text()
+
+    def test_ambiguous_basename_skipped(self, tmp_path: Path) -> None:
+        """Verifies violations with ambiguous basenames are skipped, not misapplied.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+
+        """
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        play_a = dir_a / "main.yml"
+        play_b = dir_b / "main.yml"
+        play_a.write_text(
+            textwrap.dedent("""\
+        - name: Copy A
+          ansible.builtin.copy:
+            src: /a
+            dest: /b
+        """)
+        )
+        play_b.write_text(
+            textwrap.dedent("""\
+        - name: Copy B
+          ansible.builtin.copy:
+            src: /c
+            dest: /d
+        """)
+        )
+
+        def scan_fn(paths: list[str]) -> list[ViolationDict]:
+            return [{"rule_id": "L021", "file": "main.yml", "line": 1}]
+
+        reg = TransformRegistry()
+        reg.register("L021", fix_missing_mode)
+        engine = RemediationEngine(reg, scan_fn, max_passes=2)
+
+        report = engine.remediate([str(play_a), str(play_b)], apply=False)
+        assert report.fixed == 0
+        assert "mode:" not in play_a.read_text()
+        assert "mode:" not in play_b.read_text()
 
     def test_report_tiers(self, tmp_path: Path) -> None:
         """Verifies remaining_ai and remaining_manual populated from partition.


### PR DESCRIPTION
## Summary

- The `apme-scan fix` command identified fixable violations but applied **zero** transforms due to two bugs:
  1. **File path mismatch**: Violations report relative paths (`site.yml`) but the remediation engine uses absolute paths (`/tmp/.../site.yml`) as dictionary keys. The `if vf not in file_contents` check always failed, silently skipping every transform.
  2. **Rule ID prefix mismatch**: Native validator prefixes rule IDs with `native:` (e.g. `native:L046`) but transforms are registered without the prefix (`L046`). The partition function never classified native violations as Tier 1 (fixable).

- Added a basename-based file path resolver in `RemediationEngine.remediate()`
- Added `native:` prefix stripping in both `partition.py` and `engine.py`

## Test plan

- [ ] Run `apme-scan fix demo/playbook/ --apply --no-ai` on a playbook with known violations and verify transforms are applied (previously: 0 applied, now: 20 applied)
- [ ] Run existing test suite (`pytest tests/`)
- [ ] Verify `prek` passes


Made with [Cursor](https://cursor.com)