### PR TITLE
feat: session-scoped venvs with lifecycle management (ADR-022)

### DIFF
--- a/.sdlc/adrs/ADR-022-session-scoped-venvs.md
+++ b/.sdlc/adrs/ADR-022-session-scoped-venvs.md
@@ -1,0 +1,98 @@
+# ADR-022: Session-Scoped Venvs with Lifecycle Management
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-17
+
+## Context
+
+The Ansible validator creates Python venvs containing `ansible-core` (and optionally Ansible collections) to perform plugin introspection (FQCN resolution, redirect detection, deprecation checks). The original implementation used a shared, hash-keyed venv directory under `~/.apme-data/collection-cache/venvs/`. This had two problems:
+
+1. **Concurrency bug**: `build_venv` checked for an existing directory and then created it without holding a lock. Two concurrent requests for the same `ansible_core_version + collection_specs` hash could race, corrupting the shared venv.
+
+2. **No lifecycle management**: Venvs accumulated on disk indefinitely. There was no concept of sessions, TTLs, or cleanup. For future features (AI escalation via Abbenay, MCP tools for enterprise collection docstrings), we need venvs that persist for a known session duration and can be queried by other components.
+
+## Decision
+
+**Replace the shared hash-keyed venv pool with session-scoped venvs managed by `VenvSessionManager`.**
+
+Each session gets its own isolated directory with:
+- A file lock (`.lock`) for safe concurrent creation via `fcntl.flock()`
+- Metadata (`session.json`) tracking ansible version, collection specs, timestamps
+- A `venv/` subdirectory containing the actual virtualenv
+
+Sessions come in two flavors:
+- **Ephemeral** (default): auto-generated UUID, cleaned up on `release()`
+- **Named** (via `--session <id>`): persist for a configurable TTL, reusable across CLI invocations
+
+### Storage Layout
+
+```
+~/.apme-data/collection-cache/sessions/
+    <session_id>/
+        venv/             # the virtualenv
+        session.json      # metadata (version, specs, timestamps, ephemeral flag)
+        .lock             # flock target for creation serialization
+```
+
+### CLI Integration
+
+```bash
+# Ephemeral (default, backward compatible)
+apme-scan scan playbook.yml
+
+# Named session (reusable, VS Code extension use case)
+apme-scan scan playbook.yml --session my-project --session-ttl 7200
+
+# Session management
+apme-scan session list
+apme-scan session info my-project
+apme-scan session delete my-project
+apme-scan session reap --ttl 3600
+```
+
+## Alternatives Considered
+
+### Alternative 1: Add a Mutex to the Existing Shared Pool
+
+Add `fcntl.flock()` around `build_venv` calls in the existing hash-keyed scheme. This fixes the race condition but doesn't provide session lifecycle management needed for future AI escalation and MCP tools.
+
+**Rejected**: Solves concurrency but not lifecycle requirements.
+
+### Alternative 2: Truly Ephemeral tempdir-based Venvs
+
+Use `tempfile.mkdtemp()` for every request, deleting when done. UV cache makes creation fast (~1-2s).
+
+**Rejected**: Wasteful for repeated scans in the same session. Named sessions for VS Code extension integration require persistence.
+
+### Alternative 3: External Cache Manager (Redis/SQLite)
+
+Use an external store to coordinate venv access across processes.
+
+**Rejected**: Over-engineered. File locks are sufficient for the single-host, multi-process case. No multi-host coordination needed.
+
+## Consequences
+
+### Positive
+
+- **Concurrency safe**: File locks prevent race conditions during venv creation
+- **Backward compatible**: Default behavior (no `--session` flag) creates ephemeral venvs, matching previous semantics
+- **Future-ready**: Named sessions enable VS Code extension integration and AI escalation workflows where venvs need to persist for collection docstring queries
+- **Observable**: `session list/info/delete/reap` CLI subcommands provide visibility into venv lifecycle
+- **Atomic metadata**: `os.replace()` for metadata writes prevents corruption
+
+### Negative
+
+- **Disk usage**: Named sessions persist until TTL expiry or explicit deletion
+- **fcntl dependency**: Linux/macOS only (not Windows), acceptable for APME's container-first deployment
+- **Module-level singleton**: `_manager` in `_venv.py` means TTL is set on first use; subsequent calls with different TTL are ignored
+
+## References
+
+- `src/apme_engine/collection_cache/venv_session.py` — Implementation
+- `src/apme_engine/validators/ansible/_venv.py` — Integration layer
+- `tests/test_venv_session.py` — 20 tests covering all lifecycle operations

--- a/src/apme_engine/cli.py
+++ b/src/apme_engine/cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from typing import cast
 
@@ -46,7 +47,7 @@ from apme_engine.remediation.transforms import build_default_registry
 from apme_engine.runner import run_scan
 from apme_engine.validators.ansible import AnsibleValidator
 from apme_engine.validators.ansible._venv import DEFAULT_VERSION as ANSIBLE_DEFAULT_VERSION
-from apme_engine.validators.ansible._venv import resolve_venv_root
+from apme_engine.validators.ansible._venv import release_session, resolve_session, resolve_venv_root
 from apme_engine.validators.native import NativeValidator
 from apme_engine.validators.opa import OpaValidator
 
@@ -430,7 +431,9 @@ def _run_scan(args: argparse.Namespace) -> None:
         validators.append(("Native", NativeValidator()))
     if not getattr(args, "no_ansible", False):
         av = getattr(args, "ansible_version", None) or ANSIBLE_DEFAULT_VERSION
-        venv_root = resolve_venv_root(av)
+        collections = getattr(args, "collections", None)
+        sid = getattr(args, "session", None)
+        venv_root = resolve_venv_root(av, collection_specs=collections, session_id=sid)
         if venv_root is not None:
             validators.append(("Ansible", AnsibleValidator(venv_root)))
         else:
@@ -615,6 +618,8 @@ def _scan_files_local(
     repo_root: str,
     opa_bundle: str | None,
     ansible_version: str | None = None,
+    collection_specs: list[str] | None = None,
+    session_id: str | None = None,
 ) -> list[ViolationDict]:
     """In-process scan: engine + OPA + native + ansible validators. Returns violation dicts.
 
@@ -623,6 +628,8 @@ def _scan_files_local(
         repo_root: Project root path for engine context.
         opa_bundle: Optional path to OPA bundle; None uses built-in.
         ansible_version: ansible-core version for plugin introspection; None uses default.
+        collection_specs: Optional collection specifiers for venv.
+        session_id: Optional session ID for venv reuse across invocations.
 
     Returns:
         Deduplicated, sorted list of violation dicts.
@@ -634,7 +641,11 @@ def _scan_files_local(
     if not yaml_files:
         return []
 
-    venv_root = resolve_venv_root(ansible_version or ANSIBLE_DEFAULT_VERSION)
+    venv_root = resolve_venv_root(
+        ansible_version or ANSIBLE_DEFAULT_VERSION,
+        collection_specs=collection_specs,
+        session_id=session_id,
+    )
     ansible_validator: AnsibleValidator | None = None
     if venv_root is not None:
         ansible_validator = AnsibleValidator(venv_root)
@@ -735,9 +746,26 @@ def _run_fix(args: argparse.Namespace) -> None:
     repo_root = str(Path(__file__).resolve().parent.parent)
     opa_bundle = getattr(args, "opa_bundle", None)
     ansible_version = getattr(args, "ansible_version", None)
+    collection_specs = getattr(args, "collections", None)
+    session_id = getattr(args, "session", None)
+
+    # Acquire a session venv up-front so the scan closure reuses it
+    session = resolve_session(
+        ansible_version or ANSIBLE_DEFAULT_VERSION,
+        collection_specs=collection_specs,
+        session_id=session_id,
+    )
+    active_session_id = session.session_id if session else None
 
     def scan_fn(paths: list[str]) -> list[ViolationDict]:
-        return _scan_files_local(paths, repo_root, opa_bundle, ansible_version=ansible_version)
+        return _scan_files_local(
+            paths,
+            repo_root,
+            opa_bundle,
+            ansible_version=ansible_version,
+            collection_specs=collection_specs,
+            session_id=active_session_id,
+        )
 
     registry = build_default_registry()
     engine = RemediationEngine(
@@ -769,10 +797,75 @@ def _run_fix(args: argparse.Namespace) -> None:
     if report.oscillation_detected:
         sys.stderr.write("  WARNING: oscillation detected, stopped early\n")
 
+    # Release ephemeral session venvs (named sessions persist for TTL)
+    if active_session_id is not None:
+        release_session(active_session_id)
+
     if not apply_changes and report.applied_patches:
         sys.stderr.write(f"\n{len(report.applied_patches)} file(s) would be patched (use --apply to write):\n")
         for p in report.applied_patches:
             sys.stdout.write(p.diff)
+
+
+def _run_session(args: argparse.Namespace) -> None:
+    """Manage named venv sessions (list, info, delete, reap).
+
+    Args:
+        args: Parsed CLI namespace with session_command and optional session_id/ttl.
+    """
+    from datetime import datetime, timezone
+
+    from apme_engine.collection_cache.venv_session import VenvSessionManager
+
+    cmd = args.session_command
+    ttl = getattr(args, "ttl", 3600)
+    mgr = VenvSessionManager(ttl_seconds=ttl)
+
+    if cmd == "list":
+        sessions = mgr.list_sessions()
+        if not sessions:
+            print("No active sessions.")
+            return
+        print(f"{'SESSION ID':<20} {'ANSIBLE':<10} {'COLLECTIONS':<30} {'AGE':<12} {'TYPE':<10}")
+        print("-" * 82)
+        now = time.time()
+        for s in sessions:
+            age_s = int(now - s.created_at)
+            if age_s < 60:
+                age = f"{age_s}s"
+            elif age_s < 3600:
+                age = f"{age_s // 60}m"
+            else:
+                age = f"{age_s // 3600}h {(age_s % 3600) // 60}m"
+            colls = ", ".join(s.collection_specs) if s.collection_specs else "-"
+            kind = "ephemeral" if s.ephemeral else "named"
+            print(f"{s.session_id:<20} {s.ansible_version:<10} {colls:<30} {age:<12} {kind:<10}")
+
+    elif cmd == "info":
+        session = mgr.get(args.session_id)
+        if session is None:
+            sys.stderr.write(f"Session not found: {args.session_id}\n")
+            sys.exit(1)
+        created = datetime.fromtimestamp(session.created_at, tz=timezone.utc).isoformat()
+        last_used = datetime.fromtimestamp(session.last_used_at, tz=timezone.utc).isoformat()
+        print(f"Session ID:     {session.session_id}")
+        print(f"Ansible:        {session.ansible_version}")
+        print(f"Collections:    {', '.join(session.collection_specs) or '-'}")
+        print(f"Venv root:      {session.venv_root}")
+        print(f"Created:        {created}")
+        print(f"Last used:      {last_used}")
+        print(f"Type:           {'ephemeral' if session.ephemeral else 'named'}")
+
+    elif cmd == "delete":
+        if mgr.delete(args.session_id):
+            print(f"Deleted session: {args.session_id}")
+        else:
+            sys.stderr.write(f"Session not found: {args.session_id}\n")
+            sys.exit(1)
+
+    elif cmd == "reap":
+        count = mgr.reap_expired()
+        print(f"Reaped {count} expired session(s).")
 
 
 def _run_health_check(args: argparse.Namespace) -> None:
@@ -865,6 +958,17 @@ def main() -> None:
         help="Collection specs to make available (e.g. community.general:9.0.0 amazon.aws)",
     )
     scan_parser.add_argument(
+        "--session",
+        default=None,
+        help="Named session ID for venv reuse across invocations (omit for ephemeral)",
+    )
+    scan_parser.add_argument(
+        "--session-ttl",
+        type=int,
+        default=3600,
+        help="TTL in seconds for named sessions before auto-expiry (default: 3600)",
+    )
+    scan_parser.add_argument(
         "-v",
         "--verbose",
         action="count",
@@ -929,6 +1033,44 @@ def main() -> None:
         default=None,
         help="ansible-core version for plugin introspection (e.g. 2.18, 2.20). Default: 2.20",
     )
+    fix_parser.add_argument(
+        "--collections",
+        nargs="*",
+        default=None,
+        help="Collection specs to make available (e.g. community.general:9.0.0 amazon.aws)",
+    )
+    fix_parser.add_argument(
+        "--session",
+        default=None,
+        help="Named session ID for venv reuse across invocations (omit for ephemeral)",
+    )
+    fix_parser.add_argument(
+        "--session-ttl",
+        type=int,
+        default=3600,
+        help="TTL in seconds for named sessions before auto-expiry (default: 3600)",
+    )
+
+    # ── session ──
+    session_parser = subparsers.add_parser(
+        "session",
+        parents=[global_opts],
+        help="Manage named venv sessions (list, info, delete, reap)",
+    )
+    session_sub = session_parser.add_subparsers(dest="session_command", required=True)
+
+    session_sub.add_parser("list", help="List all active sessions")
+    session_info = session_sub.add_parser("info", help="Show details for a session")
+    session_info.add_argument("session_id", help="Session ID to inspect")
+    session_del = session_sub.add_parser("delete", help="Delete a session and its venv")
+    session_del.add_argument("session_id", help="Session ID to delete")
+    session_reap = session_sub.add_parser("reap", help="Delete all expired sessions")
+    session_reap.add_argument(
+        "--ttl",
+        type=int,
+        default=3600,
+        help="TTL in seconds; sessions unused longer than this are reaped (default: 3600)",
+    )
 
     # ── health-check ──
     health_parser = subparsers.add_parser(
@@ -963,12 +1105,21 @@ def main() -> None:
 
         force_no_color()
 
+    # Set session TTL if provided
+    ttl = getattr(args, "session_ttl", 3600)
+    if ttl != 3600:
+        from apme_engine.validators.ansible._venv import get_session_manager  # noqa: PLC0415
+
+        get_session_manager(ttl_seconds=ttl)
+
     if args.command == "scan":
         _run_scan(args)
     elif args.command == "format":
         _run_format(args)
     elif args.command == "fix":
         _run_fix(args)
+    elif args.command == "session":
+        _run_session(args)
     elif args.command == "health-check":
         _run_health_check(args)
     else:

--- a/src/apme_engine/collection_cache/venv_session.py
+++ b/src/apme_engine/collection_cache/venv_session.py
@@ -1,0 +1,313 @@
+"""Session-scoped venvs with file locking, TTL expiry, and reaping.
+
+Each session gets its own isolated venv directory, eliminating the concurrency
+bugs present in the old shared hash-keyed approach.  Sessions can be ephemeral
+(auto-cleaned on release) or named (persist for ``ttl_seconds`` after last use).
+
+Concurrency safety:
+    Creation is serialized per session via ``fcntl.flock`` on a ``.lock`` file.
+    Once created, the venv is read-only and safe for concurrent subprocess calls
+    (e.g. multiple ``ansible-doc`` invocations).
+
+Storage layout::
+
+    $CACHE_ROOT/sessions/
+        <session_id>/
+            venv/             # the actual virtualenv
+            session.json      # metadata
+            .lock             # flock target
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import shutil
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from apme_engine.collection_cache.config import get_cache_root
+from apme_engine.collection_cache.venv_builder import build_venv
+
+_DEFAULT_TTL = 3600
+
+
+@dataclass
+class VenvSession:
+    """Metadata for a session-scoped venv.
+
+    Attributes:
+        session_id: Unique identifier (user-provided or auto-generated).
+        venv_root: Path to the venv directory.
+        ansible_version: ansible-core version installed in the venv.
+        collection_specs: Collection specifiers symlinked into the venv.
+        created_at: Unix timestamp of creation.
+        last_used_at: Unix timestamp of last touch or acquire.
+        ephemeral: If True, venv is deleted on release.
+    """
+
+    session_id: str
+    venv_root: Path
+    ansible_version: str
+    collection_specs: list[str] = field(default_factory=list)
+    created_at: float = 0.0
+    last_used_at: float = 0.0
+    ephemeral: bool = False
+
+
+class VenvSessionManager:
+    """Manage session-scoped venvs with locking, TTL, and reaping."""
+
+    def __init__(
+        self,
+        sessions_root: Path | None = None,
+        ttl_seconds: int = _DEFAULT_TTL,
+    ) -> None:
+        """Initialize the session manager.
+
+        Args:
+            sessions_root: Directory under which session directories are created.
+                Defaults to ``$CACHE_ROOT/sessions/``.
+            ttl_seconds: How long an unused named session persists before reaping.
+        """
+        self._root = sessions_root or (get_cache_root() / "sessions")
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._ttl = ttl_seconds
+
+    @property
+    def sessions_root(self) -> Path:
+        """Root directory containing all session directories."""
+        return self._root
+
+    def acquire(
+        self,
+        ansible_version: str,
+        collection_specs: list[str] | None = None,
+        session_id: str | None = None,
+    ) -> VenvSession:
+        """Get or create a session venv.  Thread/process safe via file lock.
+
+        If ``session_id`` is None, an ephemeral session is created with a random
+        UUID that will be cleaned up on release.
+
+        If a session with the given ID already exists and its ansible version and
+        collection specs match, it is reused instantly (warm hit).
+
+        Args:
+            ansible_version: e.g. "2.20.0" or "2.20".
+            collection_specs: Collection specifiers to symlink into the venv.
+            session_id: Optional reusable session identifier.
+
+        Returns:
+            A VenvSession with a ready-to-use venv.
+        """
+        specs = collection_specs or []
+        ephemeral = session_id is None
+        sid = session_id or uuid.uuid4().hex[:12]
+        session_dir = self._root / sid
+        session_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = session_dir / ".lock"
+        meta_path = session_dir / "session.json"
+        venv_dir = session_dir / "venv"
+
+        parts = ansible_version.split(".")
+        pip_version = ".".join(parts[:2]) + ".0" if len(parts) < 3 else ansible_version
+
+        with open(lock_path, "w") as lock_fd:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            try:
+                existing = self._read_meta(meta_path)
+                if (
+                    existing is not None
+                    and existing.ansible_version == pip_version
+                    and sorted(existing.collection_specs) == sorted(specs)
+                    and venv_dir.is_dir()
+                ):
+                    existing.last_used_at = time.time()
+                    existing.ephemeral = ephemeral
+                    self._write_meta(meta_path, existing)
+                    return existing
+
+                # Version or specs changed, or venv missing — rebuild
+                if venv_dir.is_dir():
+                    shutil.rmtree(venv_dir)
+
+                venv_root = build_venv(
+                    ansible_core_version=pip_version,
+                    collection_specs=specs,
+                    venvs_root=session_dir,
+                )
+                # build_venv uses a hash-based subdir name; normalize to "venv"
+                if venv_root.name != "venv":
+                    target = session_dir / "venv"
+                    if target.exists():
+                        shutil.rmtree(target)
+                    venv_root.rename(target)
+                    venv_root = target
+
+                now = time.time()
+                session = VenvSession(
+                    session_id=sid,
+                    venv_root=venv_root,
+                    ansible_version=pip_version,
+                    collection_specs=specs,
+                    created_at=now,
+                    last_used_at=now,
+                    ephemeral=ephemeral,
+                )
+                self._write_meta(meta_path, session)
+                return session
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
+    def touch(self, session_id: str) -> bool:
+        """Update last_used_at to prevent expiry.
+
+        Args:
+            session_id: Session to touch.
+
+        Returns:
+            True if session exists and was touched, False otherwise.
+        """
+        meta_path = self._root / session_id / "session.json"
+        if not meta_path.is_file():
+            return False
+        session = self._read_meta(meta_path)
+        if session is None:
+            return False
+        session.last_used_at = time.time()
+        self._write_meta(meta_path, session)
+        return True
+
+    def release(self, session_id: str) -> bool:
+        """Release a session.  Ephemeral sessions are deleted immediately.
+
+        Named sessions remain on disk until they expire (reaped by reap_expired).
+
+        Args:
+            session_id: Session to release.
+
+        Returns:
+            True if session was found (and possibly deleted), False otherwise.
+        """
+        session_dir = self._root / session_id
+        if not session_dir.is_dir():
+            return False
+        meta = self._read_meta(session_dir / "session.json")
+        if meta is not None and meta.ephemeral:
+            shutil.rmtree(session_dir, ignore_errors=True)
+        return True
+
+    def get(self, session_id: str) -> VenvSession | None:
+        """Look up a session by ID without creating or modifying it.
+
+        Args:
+            session_id: Session to look up.
+
+        Returns:
+            The session if it exists, None otherwise.
+        """
+        meta_path = self._root / session_id / "session.json"
+        return self._read_meta(meta_path)
+
+    def list_sessions(self) -> list[VenvSession]:
+        """List all sessions with valid metadata.
+
+        Returns:
+            List of VenvSession objects, sorted by last_used_at descending.
+        """
+        sessions: list[VenvSession] = []
+        if not self._root.is_dir():
+            return sessions
+        for child in self._root.iterdir():
+            if not child.is_dir():
+                continue
+            meta = self._read_meta(child / "session.json")
+            if meta is not None:
+                sessions.append(meta)
+        sessions.sort(key=lambda s: s.last_used_at, reverse=True)
+        return sessions
+
+    def delete(self, session_id: str) -> bool:
+        """Forcefully delete a session and its venv.
+
+        Args:
+            session_id: Session to delete.
+
+        Returns:
+            True if the session directory existed and was removed.
+        """
+        session_dir = self._root / session_id
+        if not session_dir.is_dir():
+            return False
+        shutil.rmtree(session_dir, ignore_errors=True)
+        return True
+
+    def reap_expired(self) -> int:
+        """Delete sessions whose last_used_at + ttl has passed.
+
+        Ephemeral sessions that somehow were not cleaned up are also reaped.
+
+        Returns:
+            Count of sessions deleted.
+        """
+        now = time.time()
+        reaped = 0
+        if not self._root.is_dir():
+            return reaped
+        for child in self._root.iterdir():
+            if not child.is_dir():
+                continue
+            meta = self._read_meta(child / "session.json")
+            if meta is None:
+                if not any(child.iterdir()):
+                    child.rmdir()
+                continue
+            age = now - meta.last_used_at
+            if age > self._ttl or meta.ephemeral:
+                shutil.rmtree(child, ignore_errors=True)
+                reaped += 1
+        return reaped
+
+    @staticmethod
+    def _read_meta(path: Path) -> VenvSession | None:
+        """Read session metadata from JSON file.
+
+        Args:
+            path: Path to session.json.
+
+        Returns:
+            Parsed session or None if file is missing/corrupt.
+        """
+        if not path.is_file():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return VenvSession(
+                session_id=data["session_id"],
+                venv_root=Path(data["venv_root"]),
+                ansible_version=data["ansible_version"],
+                collection_specs=data.get("collection_specs", []),
+                created_at=data.get("created_at", 0.0),
+                last_used_at=data.get("last_used_at", 0.0),
+                ephemeral=data.get("ephemeral", False),
+            )
+        except (json.JSONDecodeError, KeyError, TypeError):
+            return None
+
+    @staticmethod
+    def _write_meta(path: Path, session: VenvSession) -> None:
+        """Write session metadata to JSON atomically.
+
+        Args:
+            path: Path to session.json.
+            session: Session to serialize.
+        """
+        data = asdict(session)
+        data["venv_root"] = str(session.venv_root)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        os.replace(tmp, path)

--- a/src/apme_engine/validators/ansible/_venv.py
+++ b/src/apme_engine/validators/ansible/_venv.py
@@ -1,39 +1,106 @@
 """Venv resolution and collection environment helpers for ansible validator rules.
 
-Venvs are ephemeral — created on demand via ``build_venv`` and cached by UV
-wheels so subsequent builds are near-instant.  Same code path in containers
-(UV cache pre-warmed at image build) and local developer machines.
+Venvs are session-scoped: each CLI invocation or named session gets its own
+isolated venv via ``VenvSessionManager``.  UV wheel cache (pre-warmed at
+container build time) makes fresh venv creation near-instant (~1-2s).
 """
 
 import sys
 from pathlib import Path
 
+from apme_engine.collection_cache.venv_session import VenvSession, VenvSessionManager
+
 SUPPORTED_VERSIONS = ["2.18", "2.19", "2.20"]
 DEFAULT_VERSION = "2.20"
 
+_manager: VenvSessionManager | None = None
 
-def resolve_venv_root(version: str) -> Path | None:
+
+def get_session_manager(ttl_seconds: int = 3600) -> VenvSessionManager:
+    """Return the module-level session manager, creating it on first call.
+
+    Args:
+        ttl_seconds: TTL for named sessions (default 1 hour).
+
+    Returns:
+        The singleton VenvSessionManager instance.
+    """
+    global _manager  # noqa: PLW0603
+    if _manager is None:
+        _manager = VenvSessionManager(ttl_seconds=ttl_seconds)
+    return _manager
+
+
+def resolve_venv_root(
+    version: str,
+    collection_specs: list[str] | None = None,
+    session_id: str | None = None,
+) -> Path | None:
     """Return a venv root with ansible-core for the given version.
 
-    Delegates to ``build_venv`` which reuses an existing cached venv or
-    creates a new one.  UV wheel cache makes repeated builds near-instant.
+    Uses ``VenvSessionManager`` for concurrency-safe, session-scoped venvs.
+    Without a ``session_id``, creates an ephemeral venv (cleaned up on release).
+    With a ``session_id``, the venv persists for the session TTL and can be
+    reused by subsequent calls.
 
     Args:
         version: Ansible version string (e.g. "2.20").
+        collection_specs: Optional collection specifiers to install.
+        session_id: Optional session ID for venv reuse across invocations.
 
     Returns:
         Path to venv root, or None if build fails.
     """
-    from apme_engine.collection_cache.venv_builder import build_venv
-
-    parts = version.split(".")
-    pip_version = ".".join(parts[:2]) + ".0" if len(parts) < 3 else version
+    mgr = get_session_manager()
     try:
-        return build_venv(pip_version, collection_specs=[])
+        session = mgr.acquire(
+            ansible_version=version,
+            collection_specs=collection_specs,
+            session_id=session_id,
+        )
+        return session.venv_root
     except Exception as exc:
         sys.stderr.write(f"Ansible venv build failed for {version}: {exc}\n")
         sys.stderr.flush()
         return None
+
+
+def resolve_session(
+    version: str,
+    collection_specs: list[str] | None = None,
+    session_id: str | None = None,
+) -> VenvSession | None:
+    """Resolve a full VenvSession (includes session_id for later release/touch).
+
+    Args:
+        version: Ansible version string.
+        collection_specs: Optional collection specifiers.
+        session_id: Optional session ID for reuse.
+
+    Returns:
+        VenvSession or None if build fails.
+    """
+    mgr = get_session_manager()
+    try:
+        return mgr.acquire(
+            ansible_version=version,
+            collection_specs=collection_specs,
+            session_id=session_id,
+        )
+    except Exception as exc:
+        sys.stderr.write(f"Ansible venv build failed for {version}: {exc}\n")
+        sys.stderr.flush()
+        return None
+
+
+def release_session(session_id: str) -> None:
+    """Release a session (ephemeral sessions are deleted immediately).
+
+    Args:
+        session_id: Session to release.
+    """
+    mgr = get_session_manager()
+    mgr.release(session_id)
 
 
 def resolve_ansible_playbook(version: str) -> Path | None:

--- a/tests/test_venv_session.py
+++ b/tests/test_venv_session.py
@@ -1,0 +1,348 @@
+"""Tests for session-scoped venv manager."""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apme_engine.collection_cache.venv_session import VenvSessionManager
+
+
+@pytest.fixture()  # type: ignore[untyped-decorator]
+def sessions_root(tmp_path: Path) -> Path:
+    """Provide a temporary sessions root directory.
+
+    Args:
+        tmp_path: Pytest built-in temporary directory fixture.
+
+    Returns:
+        Path to a fresh ``sessions/`` directory.
+    """
+    root = tmp_path / "sessions"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture()  # type: ignore[untyped-decorator]
+def manager(sessions_root: Path) -> VenvSessionManager:
+    """Provide a VenvSessionManager with a temporary root.
+
+    Args:
+        sessions_root: Temporary sessions root directory fixture.
+
+    Returns:
+        A VenvSessionManager configured for testing.
+    """
+    return VenvSessionManager(sessions_root=sessions_root, ttl_seconds=60)
+
+
+def _mock_build_venv(
+    ansible_core_version: str,
+    collection_specs: list[str],
+    venvs_root: Path | None = None,
+    **kwargs: object,
+) -> Path:
+    """Create a minimal venv directory structure for testing.
+
+    Args:
+        ansible_core_version: Version string written to pyvenv.cfg.
+        collection_specs: Ignored (present for API compat with build_venv).
+        venvs_root: Directory in which to create the fake venv.
+        **kwargs: Absorbed additional keyword arguments.
+
+    Returns:
+        Path to the created fake venv directory.
+    """
+    assert venvs_root is not None
+    venv_dir = venvs_root / "fakehash"
+    venv_dir.mkdir(parents=True, exist_ok=True)
+    (venv_dir / "pyvenv.cfg").write_text(f"version = {ansible_core_version}\n")
+    lib = venv_dir / "lib" / "python3.12" / "site-packages" / "ansible_collections"
+    lib.mkdir(parents=True)
+    bindir = venv_dir / "bin"
+    bindir.mkdir()
+    (bindir / "python").touch()
+    (bindir / "ansible-doc").touch()
+    return venv_dir
+
+
+class TestAcquireEphemeral:
+    """Tests for ephemeral (no session_id) venv acquisition."""
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_creates_venv(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Creates venv.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        session = manager.acquire(ansible_version="2.20")
+        assert session.venv_root.is_dir()
+        assert session.ansible_version == "2.20.0"
+        assert session.ephemeral is True
+        assert session.session_id  # non-empty
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_each_call_gets_unique_id(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Each call gets unique id.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        s1 = manager.acquire(ansible_version="2.20")
+        s2 = manager.acquire(ansible_version="2.20")
+        assert s1.session_id != s2.session_id
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_release_deletes_ephemeral(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Release deletes ephemeral.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        session = manager.acquire(ansible_version="2.20")
+        session_dir = manager.sessions_root / session.session_id
+        assert session_dir.is_dir()
+        manager.release(session.session_id)
+        assert not session_dir.exists()
+
+
+class TestAcquireNamed:
+    """Tests for named (session_id provided) venv acquisition."""
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_creates_named_session(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Creates named session.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        session = manager.acquire(ansible_version="2.20", session_id="my-project")
+        assert session.session_id == "my-project"
+        assert session.ephemeral is False
+        assert session.venv_root.is_dir()
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_reuses_existing_session(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Reuses existing session.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        s1 = manager.acquire(ansible_version="2.20", session_id="reuse-me")
+        s2 = manager.acquire(ansible_version="2.20", session_id="reuse-me")
+        assert s1.venv_root == s2.venv_root
+        assert mock_bv.call_count == 1  # only built once
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_rebuilds_on_version_change(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Rebuilds on version change.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        manager.acquire(ansible_version="2.20", session_id="version-test")
+        manager.acquire(ansible_version="2.18", session_id="version-test")
+        assert mock_bv.call_count == 2
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_release_keeps_named(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Release keeps named.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        manager.acquire(ansible_version="2.20", session_id="keep-me")
+        session_dir = manager.sessions_root / "keep-me"
+        manager.release("keep-me")
+        assert session_dir.is_dir()
+
+
+class TestTouch:
+    """Tests for session touch (TTL refresh)."""
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_touch_updates_last_used(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Touch updates last used.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        session = manager.acquire(ansible_version="2.20", session_id="touch-test")
+        old_ts = session.last_used_at
+        time.sleep(0.05)
+        manager.touch("touch-test")
+        updated = manager.get("touch-test")
+        assert updated is not None
+        assert updated.last_used_at > old_ts
+
+    def test_touch_nonexistent_returns_false(self, manager: VenvSessionManager) -> None:
+        """Verify Touch nonexistent returns false.
+
+        Args:
+            manager: VenvSessionManager fixture.
+        """
+        assert manager.touch("nonexistent") is False
+
+
+class TestListAndGet:
+    """Tests for listing and getting sessions."""
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_list_sessions(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify List sessions.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        manager.acquire(ansible_version="2.20", session_id="first")
+        time.sleep(0.05)
+        manager.acquire(ansible_version="2.20", session_id="second")
+        sessions = manager.list_sessions()
+        assert len(sessions) == 2
+        assert sessions[0].session_id == "second"
+        assert sessions[1].session_id == "first"
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_get_existing(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Get existing.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        manager.acquire(ansible_version="2.20", session_id="get-me")
+        session = manager.get("get-me")
+        assert session is not None
+        assert session.session_id == "get-me"
+
+    def test_get_nonexistent(self, manager: VenvSessionManager) -> None:
+        """Verify Get nonexistent.
+
+        Args:
+            manager: VenvSessionManager fixture.
+        """
+        assert manager.get("nope") is None
+
+
+class TestDeleteAndReap:
+    """Tests for session deletion and expiry reaping."""
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_delete(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Delete.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        manager.acquire(ansible_version="2.20", session_id="delete-me")
+        assert manager.delete("delete-me") is True
+        assert manager.get("delete-me") is None
+
+    def test_delete_nonexistent(self, manager: VenvSessionManager) -> None:
+        """Verify Delete nonexistent.
+
+        Args:
+            manager: VenvSessionManager fixture.
+        """
+        assert manager.delete("nope") is False
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_reap_expired(self, mock_bv: MagicMock, sessions_root: Path) -> None:
+        """Verify Reap expired.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            sessions_root: Temporary sessions root fixture.
+        """
+        mgr = VenvSessionManager(sessions_root=sessions_root, ttl_seconds=0)
+        mgr.acquire(ansible_version="2.20", session_id="old-session")
+        time.sleep(0.05)
+        count = mgr.reap_expired()
+        assert count == 1
+        assert mgr.get("old-session") is None
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_reap_keeps_fresh(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Reap keeps fresh.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        manager.acquire(ansible_version="2.20", session_id="fresh-session")
+        count = manager.reap_expired()
+        assert count == 0
+        assert manager.get("fresh-session") is not None
+
+
+class TestCollectionSpecs:
+    """Tests for collection spec handling."""
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_specs_stored_in_metadata(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Specs stored in metadata.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        specs = ["community.general:9.0.0", "amazon.aws"]
+        manager.acquire(ansible_version="2.20", collection_specs=specs, session_id="with-colls")
+        session = manager.get("with-colls")
+        assert session is not None
+        assert sorted(session.collection_specs) == sorted(specs)
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_spec_change_triggers_rebuild(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Spec change triggers rebuild.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        manager.acquire(ansible_version="2.20", collection_specs=["a.b"], session_id="spec-test")
+        manager.acquire(ansible_version="2.20", collection_specs=["a.b", "c.d"], session_id="spec-test")
+        assert mock_bv.call_count == 2
+
+
+class TestMetadataPersistence:
+    """Tests for JSON metadata read/write."""
+
+    @patch("apme_engine.collection_cache.venv_session.build_venv", side_effect=_mock_build_venv)
+    def test_metadata_file_exists(self, mock_bv: MagicMock, manager: VenvSessionManager) -> None:
+        """Verify Metadata file exists.
+
+        Args:
+            mock_bv: Patched build_venv function.
+            manager: VenvSessionManager fixture.
+        """
+        manager.acquire(ansible_version="2.20", session_id="meta-test")
+        meta_path = manager.sessions_root / "meta-test" / "session.json"
+        assert meta_path.is_file()
+        data = json.loads(meta_path.read_text())
+        assert data["session_id"] == "meta-test"
+        assert data["ansible_version"] == "2.20.0"
+
+    def test_corrupt_metadata_returns_none(self, manager: VenvSessionManager) -> None:
+        """Verify Corrupt metadata returns none.
+
+        Args:
+            manager: VenvSessionManager fixture.
+        """
+        session_dir = manager.sessions_root / "corrupt"
+        session_dir.mkdir()
+        (session_dir / "session.json").write_text("not json")
+        assert manager.get("corrupt") is None


### PR DESCRIPTION
## Summary

- **Adds `VenvSessionManager`** (`src/apme_engine/collection_cache/venv_session.py`) — session-scoped venvs with `fcntl.flock()` concurrency safety, TTL expiry, and reaping. Fixes a race condition in the old shared hash-keyed `build_venv` approach where concurrent requests could corrupt venvs.
- **Updates `_venv.py`** to use the session manager. `resolve_venv_root()` gains `collection_specs` and `session_id` params while remaining backward-compatible (defaults to ephemeral sessions).
- **Adds CLI flags** `--session`, `--session-ttl` to `scan` and `fix` commands, plus `--collections` to `fix`. Named sessions persist for the TTL and are reusable across invocations (VS Code extension use case).
- **Adds `session` subcommand** with `list`, `info`, `delete`, `reap` operations for session lifecycle management.
- **ADR-022** documents the architectural decision, alternatives considered, and consequences.
- **20 new tests** covering ephemeral/named acquire, reuse, rebuild-on-change, touch, release, list, get, delete, reap, collection specs, and metadata persistence.

## Test plan

- [x] All 883 existing tests pass (0 failures)
- [x] 20 new `test_venv_session.py` tests pass
- [x] prek (ruff + mypy + pydoclint) all green
- [x] CI passes on PR
- [x] Manual: `apme-scan scan playbook.yml --session test-session` creates and reuses a named session
- [x] Manual: `apme-scan session list` shows active sessions
- [x] Manual: `apme-scan session reap` cleans up expired sessions