### PR TITLE
feat(cli): add remediation classification badges to scan output

### DIFF
--- a/.sdlc/adrs/ADR-023-per-finding-classification.md
+++ b/.sdlc/adrs/ADR-023-per-finding-classification.md
@@ -1,0 +1,197 @@
+# ADR-023: Per-Finding Remediation Classification and Resolution
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-18
+
+## Context
+
+ADR-009 established a three-tier remediation model (deterministic, AI-proposable, manual review) and described tier assignment as a static, per-rule property:
+
+```yaml
+rules:
+  L002:
+    tier: 1  # Deterministic
+  L015:
+    tier: 2  # AI-proposable
+  R101:
+    tier: 3  # Manual review
+```
+
+This model assumed a rule's tier never changes. In practice, tier assignment must be **per-finding and mutable** because:
+
+1. **Transform failures reclassify findings.** A rule with a registered transform (Tier 1) may fail to apply on a specific file — malformed YAML, unsupported structure, or edge cases the transform doesn't handle. That specific finding should escalate to Tier 2, not stay labeled "auto-fixable."
+
+2. **Oscillation reclassifies findings.** The convergence loop (scan → fix → rescan) may detect that fixes are creating new violations at the same rate. Remaining Tier 1 findings must escalate rather than loop forever.
+
+3. **AI outcomes vary per finding.** When Abbenay proposes a fix, the result differs per finding: one may succeed, another may fail validation, a third may have low confidence. The rule is the same; the resolution differs.
+
+4. **User rejection is per finding.** A user may accept an AI fix for one finding but reject another from the same rule.
+
+5. **Reporting needs per-finding granularity.** The reporting service (ADR-020) must persist what happened to each finding to show remediation funnel metrics (e.g., "60% auto-fixed, 25% AI-proposed, 10% AI-rejected, 5% manual").
+
+Two forces are in tension:
+
+- **Simplicity**: a static per-rule tier is trivial to implement and reason about.
+- **Accuracy**: the pipeline produces per-finding outcomes that a per-rule model cannot represent.
+
+## Decision
+
+**Remediation state is carried as two orthogonal fields on each finding (violation dict and proto `Violation` message), not as a static per-rule property.**
+
+### RemediationClass — "What to do next"
+
+| Value | Meaning |
+|-------|---------|
+| `auto-fixable` | A deterministic transform exists in the `TransformRegistry` |
+| `ai-candidate` | No transform, but an AI agent can propose a fix |
+| `manual-review` | Requires human judgment; not AI-proposable |
+
+Initial assignment: the `TransformRegistry` is authoritative. If a rule ID has a registered transform, the finding starts as `auto-fixable`. Otherwise, it falls to `ai-candidate` or `manual-review` based on the `ai_proposable` flag.
+
+Classification can change: `auto-fixable` → `ai-candidate` (on transform failure or oscillation), `ai-candidate` → `manual-review` (on repeated AI failure).
+
+### RemediationResolution — "What happened"
+
+| Value | Meaning |
+|-------|---------|
+| `unresolved` | Initial state — no remediation attempted yet |
+| `transform-failed` | Deterministic transform returned `applied=False` |
+| `oscillation` | Convergence loop detected oscillation and bailed |
+| `ai-proposed` | AI proposed a fix (pending validation or user review) |
+| `ai-failed` | AI call failed or returned no usable result |
+| `ai-low-confidence` | AI returned a proposal below the confidence threshold |
+| `user-rejected` | User explicitly rejected the proposed fix |
+
+Resolution is write-once per remediation attempt — once a finding is resolved, the value captures the terminal state of that attempt.
+
+### State Flow
+
+```
+Finding created (scan)
+  │
+  ├─ class = auto-fixable, resolution = unresolved
+  │   │
+  │   ├─ transform succeeds → finding removed from violations
+  │   ├─ transform fails → class = ai-candidate, resolution = transform-failed
+  │   └─ oscillation detected → class = ai-candidate, resolution = oscillation
+  │
+  ├─ class = ai-candidate, resolution = unresolved
+  │   │
+  │   ├─ AI proposes fix → resolution = ai-proposed
+  │   │   ├─ validation passes → finding removed (or re-scanned)
+  │   │   ├─ validation fails → resolution = ai-failed
+  │   │   ├─ below threshold → resolution = ai-low-confidence
+  │   │   └─ user rejects → resolution = user-rejected
+  │   │
+  │   └─ AI call fails → resolution = ai-failed
+  │
+  └─ class = manual-review, resolution = unresolved
+      └─ (remains for human action)
+```
+
+### Wire Format
+
+Both fields are carried on the proto `Violation` message:
+
+```protobuf
+enum RemediationClass { ... }      // field 8
+enum RemediationResolution { ... } // field 9
+```
+
+### Single Source of Truth
+
+Classification happens server-side in `primary_server.py` before proto serialization. CLI clients consuming gRPC responses receive pre-classified violations and do not re-classify. The local (in-process) scan path classifies via the same `add_classification_to_violations` function.
+
+## Alternatives Considered
+
+### Alternative 1: Static Per-Rule Config
+
+**Description**: Assign tiers in a YAML config file keyed by rule ID, as originally sketched in ADR-009.
+
+**Pros**:
+- Simple to implement and reason about
+- Easy to override per-project
+
+**Cons**:
+- Cannot represent transform failures, AI outcomes, or user rejection
+- A rule with a registered transform is always labeled "auto-fixable" even when the transform fails on specific files
+- No data for reporting service funnel metrics
+
+**Why not chosen**: The pipeline produces per-finding outcomes that a per-rule model cannot represent. Real-world usage showed that transform failures and edge cases make static assignment inaccurate.
+
+### Alternative 2: Separate Resolution Tracking
+
+**Description**: Findings carry only `remediation_class`. Resolution state is stored in a separate data structure (e.g., a dict keyed by `(rule_id, file, line)`).
+
+**Pros**:
+- Keeps the violation dict lean
+- Resolution tracking is opt-in
+
+**Cons**:
+- Adds indirection — consumers must join two data structures
+- Harder to serialize over gRPC (resolution must be a separate repeated field or a side-channel)
+- Easy to lose sync between the finding and its resolution
+
+**Why not chosen**: Carrying both fields on the finding is simpler, serializes naturally in protobuf, and keeps the data co-located.
+
+### Alternative 3: Single Combined Enum
+
+**Description**: Merge class and resolution into one field (e.g., `AUTO_FIXABLE_UNRESOLVED`, `AUTO_FIXABLE_TRANSFORM_FAILED`, `AI_CANDIDATE_PROPOSED`, ...).
+
+**Pros**:
+- Single field to read
+
+**Cons**:
+- Combinatorial explosion (3 classes x 7 resolutions = 21 values, growing with each new state)
+- Loses the semantic distinction between "what to do next" and "what happened"
+- Harder to query (e.g., "count all AI_CANDIDATE regardless of resolution")
+
+**Why not chosen**: Two orthogonal dimensions are clearer than one combined enum with 21+ values.
+
+## Consequences
+
+### Positive
+
+- Findings accurately reflect their remediation state at every stage of the pipeline
+- The reporting service (ADR-020) can build funnel metrics from per-finding data without inference
+- AI integration (Abbenay) has a clear contract: set `remediation_resolution` on each finding it processes
+- The proto wire format carries all state needed for dashboard visualization
+- Transform failures are visible to users (previously silent)
+
+### Negative
+
+- Every violation dict now carries two extra fields (`remediation_class`, `remediation_resolution`)
+- Code that processes violations must handle mutable classification (not a static lookup)
+- The `RemediationEngine` convergence loop must update resolution on failures, adding complexity to the loop
+
+### Neutral
+
+- The `TransformRegistry` remains the initial authority for `auto-fixable` — this decision does not change how transforms are registered, only how their outcomes are tracked
+- AI resolution states (`ai-proposed`, `ai-failed`, `ai-low-confidence`, `user-rejected`) are defined now but only populated when the Abbenay integration is wired
+
+## Implementation Notes
+
+- `RemediationClass` and `RemediationResolution` are `str, Enum` (not `StrEnum`) for Python 3.10 compatibility
+- `add_classification_to_violations()` mutates the violation list in place and returns `None` — callers should not capture the return value
+- The `_to_str_value()` helper in `partition.py` handles both enum members and plain strings when extracting values for dict lookups (necessary because `str(enum_member)` returns `"ClassName.MEMBER"` with `str, Enum`)
+- The engine sets `TRANSFORM_FAILED` when `registry.apply()` returns `applied=False` and reclassifies to `AI_CANDIDATE`
+- The engine sets `OSCILLATION` on remaining Tier 1 violations when the convergence loop detects non-decreasing fixable counts
+
+## Related Decisions
+
+- ADR-008: Rule ID conventions — classification is orthogonal to rule IDs; the same rule can have different classification per finding
+- ADR-009: Remediation engine — this ADR refines the three-tier model from static per-rule to dynamic per-finding
+- ADR-020: Reporting service — will consume `remediation_class` and `remediation_resolution` fields for funnel metrics and trend analysis
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-18 | AI agent | Initial proposal and acceptance |

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -27,6 +27,7 @@ This directory contains the Architecture Decision Records (ADRs) for APME.
 | [ADR-019](ADR-019-dependency-governance.md) | Dependency Governance Policy | Accepted | 2026-03 |
 | [ADR-020](ADR-020-reporting-service.md) | Reporting Service and Event Delivery Model | Proposed | 2026-03 |
 | [ADR-021](ADR-021-proactive-pr-feedback.md) | Proactive PR Feedback via GitHub Actions | Accepted | 2026-03 |
+| [ADR-023](ADR-023-per-finding-classification.md) | Per-Finding Remediation Classification and Resolution | Accepted | 2026-03 |
 
 ## Categories
 
@@ -51,6 +52,7 @@ This directory contains the Architecture Decision Records (ADRs) for APME.
 ### Remediation
 - ADR-009: Remediation engine architecture
 - ADR-011: YAML formatter pre-pass
+- ADR-023: Per-finding remediation classification and resolution
 
 ### Tooling & CI
 - ADR-014: Ruff linter and prek pre-commit hooks
@@ -75,7 +77,7 @@ Original planning ADRs that were superseded by implementation decisions:
 ## Creating New ADRs
 
 1. Copy the template from `../.sdlc/templates/adr.md`
-2. Use the next available number (currently ADR-022)
+2. Use the next available number (currently ADR-024)
 3. Include:
    - Status (Proposed → Accepted)
    - Date
@@ -112,3 +114,4 @@ Original planning ADRs that were superseded by implementation decisions:
 | 019 | 2026-03 | Dependency governance policy |
 | 020 | 2026-03 | Reporting service and event delivery model (proposed) |
 | 021 | 2026-03 | Proactive PR feedback via GitHub Actions |
+| 023 | 2026-03 | Per-finding remediation classification and resolution |

--- a/proto/apme/v1/common.proto
+++ b/proto/apme/v1/common.proto
@@ -2,6 +2,26 @@ syntax = "proto3";
 
 package apme.v1;
 
+// RemediationClass indicates the complexity of remediating a violation.
+enum RemediationClass {
+  REMEDIATION_CLASS_UNSPECIFIED = 0;
+  REMEDIATION_CLASS_AUTO_FIXABLE = 1;  // Tier 1: deterministic transform exists
+  REMEDIATION_CLASS_AI_CANDIDATE = 2;  // Tier 2: AI can propose fix
+  REMEDIATION_CLASS_MANUAL_REVIEW = 3; // Tier 3: requires human judgment
+}
+
+// RemediationResolution tracks what happened during remediation of a finding.
+enum RemediationResolution {
+  REMEDIATION_RESOLUTION_UNSPECIFIED = 0;
+  REMEDIATION_RESOLUTION_UNRESOLVED = 1;
+  REMEDIATION_RESOLUTION_TRANSFORM_FAILED = 2;
+  REMEDIATION_RESOLUTION_OSCILLATION = 3;
+  REMEDIATION_RESOLUTION_AI_PROPOSED = 4;
+  REMEDIATION_RESOLUTION_AI_FAILED = 5;
+  REMEDIATION_RESOLUTION_AI_LOW_CONFIDENCE = 6;
+  REMEDIATION_RESOLUTION_USER_REJECTED = 7;
+}
+
 // Violation is the shared shape for a single lint/policy violation.
 message Violation {
   string rule_id = 1;
@@ -13,6 +33,8 @@ message Violation {
     LineRange line_range = 6;
   }
   string path = 7;
+  RemediationClass remediation_class = 8;
+  RemediationResolution remediation_resolution = 9;
 }
 
 message LineRange {

--- a/src/apme/v1/common_pb2.py
+++ b/src/apme/v1/common_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14\x61pme/v1/common.proto\x12\x07\x61pme.v1\"\xa0\x01\n\tViolation\x12\x0f\n\x07rule_id\x18\x01 \x01(\t\x12\r\n\x05level\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\x12\x0c\n\x04\x66ile\x18\x04 \x01(\t\x12\x0e\n\x04line\x18\x05 \x01(\x05H\x00\x12(\n\nline_range\x18\x06 \x01(\x0b\x32\x12.apme.v1.LineRangeH\x00\x12\x0c\n\x04path\x18\x07 \x01(\tB\x0c\n\nline_oneof\"\'\n\tLineRange\x12\r\n\x05start\x18\x01 \x01(\x05\x12\x0b\n\x03\x65nd\x18\x02 \x01(\x05\"%\n\x04\x46ile\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\x0c\"\x0f\n\rHealthRequest\" \n\x0eHealthResponse\x12\x0e\n\x06status\x18\x01 \x01(\t\"E\n\nRuleTiming\x12\x0f\n\x07rule_id\x18\x01 \x01(\t\x12\x12\n\nelapsed_ms\x18\x02 \x01(\x01\x12\x12\n\nviolations\x18\x03 \x01(\x05\"\xa1\x02\n\x14ValidatorDiagnostics\x12\x16\n\x0evalidator_name\x18\x01 \x01(\t\x12\x12\n\nrequest_id\x18\x02 \x01(\t\x12\x10\n\x08total_ms\x18\x03 \x01(\x01\x12\x16\n\x0e\x66iles_received\x18\x04 \x01(\x05\x12\x18\n\x10violations_found\x18\x05 \x01(\x05\x12)\n\x0crule_timings\x18\x06 \x03(\x0b\x32\x13.apme.v1.RuleTiming\x12=\n\x08metadata\x18\x07 \x03(\x0b\x32+.apme.v1.ValidatorDiagnostics.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14\x61pme/v1/common.proto\x12\x07\x61pme.v1\"\x96\x02\n\tViolation\x12\x0f\n\x07rule_id\x18\x01 \x01(\t\x12\r\n\x05level\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\x12\x0c\n\x04\x66ile\x18\x04 \x01(\t\x12\x0e\n\x04line\x18\x05 \x01(\x05H\x00\x12(\n\nline_range\x18\x06 \x01(\x0b\x32\x12.apme.v1.LineRangeH\x00\x12\x0c\n\x04path\x18\x07 \x01(\t\x12\x34\n\x11remediation_class\x18\x08 \x01(\x0e\x32\x19.apme.v1.RemediationClass\x12>\n\x16remediation_resolution\x18\t \x01(\x0e\x32\x1e.apme.v1.RemediationResolutionB\x0c\n\nline_oneof\"\'\n\tLineRange\x12\r\n\x05start\x18\x01 \x01(\x05\x12\x0b\n\x03\x65nd\x18\x02 \x01(\x05\"%\n\x04\x46ile\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\x0c\"\x0f\n\rHealthRequest\" \n\x0eHealthResponse\x12\x0e\n\x06status\x18\x01 \x01(\t\"E\n\nRuleTiming\x12\x0f\n\x07rule_id\x18\x01 \x01(\t\x12\x12\n\nelapsed_ms\x18\x02 \x01(\x01\x12\x12\n\nviolations\x18\x03 \x01(\x05\"\xa1\x02\n\x14ValidatorDiagnostics\x12\x16\n\x0evalidator_name\x18\x01 \x01(\t\x12\x12\n\nrequest_id\x18\x02 \x01(\t\x12\x10\n\x08total_ms\x18\x03 \x01(\x01\x12\x16\n\x0e\x66iles_received\x18\x04 \x01(\x05\x12\x18\n\x10violations_found\x18\x05 \x01(\x05\x12)\n\x0crule_timings\x18\x06 \x03(\x0b\x32\x13.apme.v1.RuleTiming\x12=\n\x08metadata\x18\x07 \x03(\x0b\x32+.apme.v1.ValidatorDiagnostics.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01*\xa2\x01\n\x10RemediationClass\x12!\n\x1dREMEDIATION_CLASS_UNSPECIFIED\x10\x00\x12\"\n\x1eREMEDIATION_CLASS_AUTO_FIXABLE\x10\x01\x12\"\n\x1eREMEDIATION_CLASS_AI_CANDIDATE\x10\x02\x12#\n\x1fREMEDIATION_CLASS_MANUAL_REVIEW\x10\x03*\xe1\x02\n\x15RemediationResolution\x12&\n\"REMEDIATION_RESOLUTION_UNSPECIFIED\x10\x00\x12%\n!REMEDIATION_RESOLUTION_UNRESOLVED\x10\x01\x12+\n\'REMEDIATION_RESOLUTION_TRANSFORM_FAILED\x10\x02\x12&\n\"REMEDIATION_RESOLUTION_OSCILLATION\x10\x03\x12&\n\"REMEDIATION_RESOLUTION_AI_PROPOSED\x10\x04\x12$\n REMEDIATION_RESOLUTION_AI_FAILED\x10\x05\x12,\n(REMEDIATION_RESOLUTION_AI_LOW_CONFIDENCE\x10\x06\x12(\n$REMEDIATION_RESOLUTION_USER_REJECTED\x10\x07\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,20 +33,24 @@ if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
   _globals['_VALIDATORDIAGNOSTICS_METADATAENTRY']._loaded_options = None
   _globals['_VALIDATORDIAGNOSTICS_METADATAENTRY']._serialized_options = b'8\001'
+  _globals['_REMEDIATIONCLASS']._serialized_start=809
+  _globals['_REMEDIATIONCLASS']._serialized_end=971
+  _globals['_REMEDIATIONRESOLUTION']._serialized_start=974
+  _globals['_REMEDIATIONRESOLUTION']._serialized_end=1327
   _globals['_VIOLATION']._serialized_start=34
-  _globals['_VIOLATION']._serialized_end=194
-  _globals['_LINERANGE']._serialized_start=196
-  _globals['_LINERANGE']._serialized_end=235
-  _globals['_FILE']._serialized_start=237
-  _globals['_FILE']._serialized_end=274
-  _globals['_HEALTHREQUEST']._serialized_start=276
-  _globals['_HEALTHREQUEST']._serialized_end=291
-  _globals['_HEALTHRESPONSE']._serialized_start=293
-  _globals['_HEALTHRESPONSE']._serialized_end=325
-  _globals['_RULETIMING']._serialized_start=327
-  _globals['_RULETIMING']._serialized_end=396
-  _globals['_VALIDATORDIAGNOSTICS']._serialized_start=399
-  _globals['_VALIDATORDIAGNOSTICS']._serialized_end=688
-  _globals['_VALIDATORDIAGNOSTICS_METADATAENTRY']._serialized_start=641
-  _globals['_VALIDATORDIAGNOSTICS_METADATAENTRY']._serialized_end=688
+  _globals['_VIOLATION']._serialized_end=312
+  _globals['_LINERANGE']._serialized_start=314
+  _globals['_LINERANGE']._serialized_end=353
+  _globals['_FILE']._serialized_start=355
+  _globals['_FILE']._serialized_end=392
+  _globals['_HEALTHREQUEST']._serialized_start=394
+  _globals['_HEALTHREQUEST']._serialized_end=409
+  _globals['_HEALTHRESPONSE']._serialized_start=411
+  _globals['_HEALTHRESPONSE']._serialized_end=443
+  _globals['_RULETIMING']._serialized_start=445
+  _globals['_RULETIMING']._serialized_end=514
+  _globals['_VALIDATORDIAGNOSTICS']._serialized_start=517
+  _globals['_VALIDATORDIAGNOSTICS']._serialized_end=806
+  _globals['_VALIDATORDIAGNOSTICS_METADATAENTRY']._serialized_start=759
+  _globals['_VALIDATORDIAGNOSTICS_METADATAENTRY']._serialized_end=806
 # @@protoc_insertion_point(module_scope)

--- a/src/apme_engine/ansi.py
+++ b/src/apme_engine/ansi.py
@@ -396,6 +396,33 @@ def severity_indicator(level: str) -> str:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Remediation badges
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Map remediation class to display label and style
+REMEDIATION_DISPLAY: dict[str, tuple[str, str]] = {
+    "auto-fixable": ("FIX", Style.BG_GREEN + Style.WHITE + Style.BOLD),
+    "ai-candidate": ("AI", Style.BG_BLUE + Style.WHITE),
+    "manual-review": ("MANUAL", Style.BG_MAGENTA + Style.WHITE),
+}
+
+
+def remediation_badge(classification: str) -> str:
+    """Return a colored badge for a remediation classification.
+
+    Args:
+        classification: Remediation class (auto-fixable, ai-candidate, manual-review)
+
+    Returns:
+        Styled badge like " FIX " with colored background
+    """
+    classification_lower = classification.lower() if classification else "ai-candidate"
+    label, styles = REMEDIATION_DISPLAY.get(classification_lower, ("?", Style.DIM))
+    padded = f" {label} "
+    return style(padded, styles)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Box drawing
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/apme_engine/cli.py
+++ b/src/apme_engine/cli.py
@@ -25,6 +25,7 @@ from apme_engine.ansi import (
     green,
     magenta,
     red,
+    remediation_badge,
     severity_badge,
     severity_indicator,
     table,
@@ -40,9 +41,14 @@ from apme_engine.collection_cache import (
 from apme_engine.daemon.chunked_fs import yield_scan_chunks
 from apme_engine.daemon.health_check import run_health_checks
 from apme_engine.daemon.violation_convert import violation_proto_to_dict
-from apme_engine.engine.models import ViolationDict, YAMLDict
+from apme_engine.engine.models import RemediationClass, RemediationResolution, ViolationDict, YAMLDict
 from apme_engine.formatter import format_directory, format_file
 from apme_engine.remediation.engine import RemediationEngine
+from apme_engine.remediation.partition import (
+    add_classification_to_violations,
+    count_by_remediation_class,
+    count_by_resolution,
+)
 from apme_engine.remediation.transforms import build_default_registry
 from apme_engine.runner import run_scan
 from apme_engine.validators.ansible import AnsibleValidator
@@ -67,11 +73,11 @@ def _sort_violations(violations: list[ViolationDict]) -> list[ViolationDict]:
         f = str(v.get("file") or "")
         line = v.get("line")
         resolved: int | float = 0
-        if isinstance(line, (int, float)):
+        if isinstance(line, int | float):
             resolved = line
-        elif isinstance(line, (list, tuple)) and line:
+        elif isinstance(line, list | tuple) and line:
             first = line[0]
-            resolved = first if isinstance(first, (int, float)) else 0
+            resolved = first if isinstance(first, int | float) else 0
         return (f, resolved)
 
     return sorted(violations, key=key)
@@ -91,7 +97,7 @@ def _deduplicate_violations(violations: list[ViolationDict]) -> list[ViolationDi
     out: list[ViolationDict] = []
     for v in violations:
         line: str | int | list[int] | tuple[int, ...] | bool | None = v.get("line")
-        if isinstance(line, (list, tuple)):
+        if isinstance(line, list | tuple):
             line = tuple(line)
         dedup_key = (str(v.get("rule_id", "")), str(v.get("file", "")), line)
         if dedup_key not in seen:
@@ -276,6 +282,38 @@ def _count_by_severity(violations: list[ViolationDict]) -> dict[str, int]:
     return counts
 
 
+def _format_remediation_summary(violations: list[ViolationDict]) -> str:
+    """Format remediation summary line.
+
+    Args:
+        violations: List of violations with remediation_class and remediation_resolution fields.
+
+    Returns:
+        Summary string like "3 auto-fixable, 2 AI-candidate, 1 manual-review".
+    """
+    counts = count_by_remediation_class(violations)
+    parts = []
+    if counts[RemediationClass.AUTO_FIXABLE.value]:
+        parts.append(green(f"{counts[RemediationClass.AUTO_FIXABLE.value]} auto-fixable"))
+    if counts[RemediationClass.AI_CANDIDATE.value]:
+        parts.append(cyan(f"{counts[RemediationClass.AI_CANDIDATE.value]} AI-candidate"))
+    if counts[RemediationClass.MANUAL_REVIEW.value]:
+        parts.append(magenta(f"{counts[RemediationClass.MANUAL_REVIEW.value]} manual-review"))
+
+    res_counts = count_by_resolution(violations)
+    res_parts = []
+    for res_val in RemediationResolution:
+        if res_val == RemediationResolution.UNRESOLVED:
+            continue
+        cnt = res_counts.get(res_val.value, 0)
+        if cnt:
+            res_parts.append(f"{cnt} {res_val.value}")
+    if res_parts:
+        parts.append(dim("(" + ", ".join(res_parts) + ")"))
+
+    return ", ".join(parts) if parts else "none"
+
+
 def _group_by_file(violations: list[ViolationDict]) -> dict[str, list[ViolationDict]]:
     """Group violations by file.
 
@@ -335,6 +373,9 @@ def _render_scan_results(
     else:
         summary_lines.append(green("No issues found"))
 
+    if violations:
+        summary_lines.append("Remediation: " + _format_remediation_summary(violations))
+
     if scan_time_ms is not None:
         summary_lines.append(f"Time: {_fmt_ms(scan_time_ms)}")
 
@@ -344,25 +385,27 @@ def _render_scan_results(
     if not violations:
         return
 
-    headers = ["Rule", "Severity", "Message", "Location"]
+    headers = ["Rule", "Severity", "Remediation", "Message", "Location"]
     rows = []
     for v in violations:
         rule_id = str(v.get("rule_id") or "?")
         level = str(v.get("level") or "none")
+        rem_raw = v.get("remediation_class") or RemediationClass.AI_CANDIDATE
+        rem_class = rem_raw.value if hasattr(rem_raw, "value") else str(rem_raw)
         message = str(v.get("message") or "")
         if len(message) > 50:
             message = message[:47] + "..."
 
         file_path = str(v.get("file") or "")
         line = v.get("line")
-        if isinstance(line, (list, tuple)) and len(line) >= 2:
+        if isinstance(line, list | tuple) and len(line) >= 2:
             location = f"{file_path}:{line[0]}-{line[1]}"
         elif line is not None:
             location = f"{file_path}:{line}"
         else:
             location = file_path
 
-        rows.append([rule_id, severity_badge(level), message, dim(location)])
+        rows.append([rule_id, severity_badge(level), remediation_badge(rem_class), message, dim(location)])
 
     print(bold("Issues"))
     print(table(headers, rows))
@@ -384,9 +427,9 @@ def _render_scan_results(
             v_prefix = TREE_LAST if is_last_v else TREE_MID
             indicator = severity_indicator(str(v.get("level") or "none"))
             line = v.get("line")
-            if isinstance(line, (list, tuple)) and len(line) >= 2:
+            if isinstance(line, list | tuple) and len(line) >= 2:
                 line_str = f"{line[0]}-{line[1]}"
-            elif isinstance(line, (list, tuple)):
+            elif isinstance(line, list | tuple):
                 line_str = str(line[0])
             elif line is not None:
                 line_str = str(line)
@@ -446,6 +489,10 @@ def _run_scan(args: argparse.Namespace) -> None:
         violations.extend(result)  # type: ignore[arg-type]
     violations = _deduplicate_violations(_sort_violations(violations))
 
+    # Add remediation classification to each violation
+    registry = build_default_registry()
+    add_classification_to_violations(violations, registry)
+
     if not validators:
         if args.json:
             print(json.dumps({"hierarchy_payload": context.hierarchy_payload}))
@@ -454,7 +501,24 @@ def _run_scan(args: argparse.Namespace) -> None:
         return
 
     if args.json:
-        print(json.dumps({"violations": violations, "count": len(violations)}, indent=2))
+        rem_counts = count_by_remediation_class(violations)
+        res_counts = count_by_resolution(violations)
+        unresolved = RemediationResolution.UNRESOLVED.value
+        print(
+            json.dumps(
+                {
+                    "violations": violations,
+                    "count": len(violations),
+                    "remediation_summary": {
+                        "auto_fixable": rem_counts[RemediationClass.AUTO_FIXABLE.value],
+                        "ai_candidate": rem_counts[RemediationClass.AI_CANDIDATE.value],
+                        "manual_review": rem_counts[RemediationClass.MANUAL_REVIEW.value],
+                    },
+                    "resolution_summary": {k: v for k, v in res_counts.items() if k != unresolved},
+                },
+                indent=2,
+            )
+        )
         return
 
     payload: YAMLDict = context.hierarchy_payload or {}
@@ -462,6 +526,23 @@ def _run_scan(args: argparse.Namespace) -> None:
         violations,
         scan_id=str(payload.get("scan_id", "")),
     )
+
+    # Handle --auto-fix: apply Tier 1 fixes
+    if getattr(args, "auto_fix", False):
+        rem_counts = count_by_remediation_class(violations)
+        fixable = rem_counts[RemediationClass.AUTO_FIXABLE.value]
+        if fixable > 0:
+            sys.stderr.write(f"\nApplying {fixable} auto-fixable remediation(s)...\n")
+            _apply_remediation(
+                Path(args.target).resolve(),
+                apply=True,
+                opa_bundle=getattr(args, "opa_bundle", None),
+                ansible_version=getattr(args, "ansible_version", None),
+                collection_specs=getattr(args, "collections", None),
+                session_id=getattr(args, "session", None),
+            )
+        else:
+            sys.stderr.write("\nNo auto-fixable issues found.\n")
 
 
 def _run_scan_grpc(args: argparse.Namespace, primary_addr: str) -> None:
@@ -501,7 +582,20 @@ def _run_scan_grpc(args: argparse.Namespace, primary_addr: str) -> None:
     has_diag = resp.HasField("diagnostics")
 
     if args.json:
-        out = {"violations": violations, "count": len(violations), "scan_id": resp.scan_id}
+        rem_counts = count_by_remediation_class(violations)
+        res_counts = count_by_resolution(violations)
+        unresolved = RemediationResolution.UNRESOLVED.value
+        out: dict[str, object] = {
+            "violations": violations,
+            "count": len(violations),
+            "scan_id": resp.scan_id,
+            "remediation_summary": {
+                "auto_fixable": rem_counts[RemediationClass.AUTO_FIXABLE.value],
+                "ai_candidate": rem_counts[RemediationClass.AI_CANDIDATE.value],
+                "manual_review": rem_counts[RemediationClass.MANUAL_REVIEW.value],
+            },
+            "resolution_summary": {k: v for k, v in res_counts.items() if k != unresolved},
+        }
         if verbosity and has_diag:
             out["diagnostics"] = _diag_to_dict(resp.diagnostics)
         print(json.dumps(out, indent=2))
@@ -672,6 +766,96 @@ def _scan_files_local(
     return _deduplicate_violations(_sort_violations(all_violations))
 
 
+def _apply_remediation(
+    target: Path,
+    *,
+    apply: bool = False,
+    max_passes: int = 5,
+    opa_bundle: str | None = None,
+    ansible_version: str | None = None,
+    collection_specs: list[str] | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Scan files and run the remediation convergence loop.
+
+    Args:
+        target: Resolved path to file or directory.
+        apply: If True, write fixes in place.
+        max_passes: Maximum convergence passes.
+        opa_bundle: Optional path to OPA bundle.
+        ansible_version: ansible-core version for introspection.
+        collection_specs: Optional collection specifiers for venv.
+        session_id: Optional session ID for venv reuse.
+    """
+    if target.is_file():
+        yaml_files = [str(target)]
+    else:
+        yaml_files = [
+            str(p)
+            for p in target.rglob("*")
+            if p.suffix in (".yml", ".yaml") and not any(part.startswith(".") for part in p.parts)
+        ]
+
+    if not yaml_files:
+        sys.stderr.write("  No YAML files found.\n")
+        return
+
+    repo_root = str(Path(__file__).resolve().parent.parent)
+
+    session = resolve_session(
+        ansible_version or ANSIBLE_DEFAULT_VERSION,
+        collection_specs=collection_specs,
+        session_id=session_id,
+    )
+    active_session_id = session.session_id if session else None
+
+    def scan_fn(paths: list[str]) -> list[ViolationDict]:
+        return _scan_files_local(
+            paths,
+            repo_root,
+            opa_bundle,
+            ansible_version=ansible_version,
+            collection_specs=collection_specs,
+            session_id=active_session_id,
+        )
+
+    registry = build_default_registry()
+    engine = RemediationEngine(
+        registry=registry,
+        scan_fn=scan_fn,
+        max_passes=max_passes,
+        verbose=True,
+    )
+
+    sys.stderr.write(f"  {len(yaml_files)} YAML file(s), {len(registry)} transforms registered\n")
+    sys.stderr.write(f"  Transforms: {', '.join(registry.rule_ids)}\n")
+    sys.stderr.write("  Remediating...\n")
+
+    report = engine.remediate(yaml_files, apply=apply)
+
+    if apply and report.applied_patches:
+        patched_paths = {p.path for p in report.applied_patches}
+        reformat = [format_file(Path(p)) for p in patched_paths]
+        for r in reformat:
+            if r.changed:
+                r.path.write_text(r.formatted, encoding="utf-8")
+
+    sys.stderr.write(f"  Tier 1 (deterministic):  {report.fixed} fixed\n")
+    sys.stderr.write(f"  Tier 2 (AI-proposable):  {len(report.remaining_ai)} remaining\n")
+    sys.stderr.write(f"  Tier 3 (manual review):  {len(report.remaining_manual)} remaining\n")
+    sys.stderr.write(f"  Passes:                  {report.passes}\n")
+    if report.oscillation_detected:
+        sys.stderr.write("  WARNING: oscillation detected, stopped early\n")
+
+    if active_session_id is not None:
+        release_session(active_session_id)
+
+    if not apply and report.applied_patches:
+        sys.stderr.write(f"\n{len(report.applied_patches)} file(s) would be patched (use --apply to write):\n")
+        for p in report.applied_patches:
+            sys.stdout.write(p.diff)
+
+
 def _run_fix(args: argparse.Namespace) -> None:
     """Format → idempotency check → scan → remediate (convergence loop).
 
@@ -728,83 +912,16 @@ def _run_fix(args: argparse.Namespace) -> None:
     sys.stderr.write("  Passed (zero diffs on second run)\n")
 
     # Phase 3: Scan + Remediate
-    sys.stderr.write("Phase 3: Scanning...\n")
-
-    if target.is_file():
-        yaml_files = [str(target)]
-    else:
-        yaml_files = [
-            str(p)
-            for p in target.rglob("*")
-            if p.suffix in (".yml", ".yaml") and not any(part.startswith(".") for part in p.parts)
-        ]
-
-    if not yaml_files:
-        sys.stderr.write("  No YAML files found.\n")
-        return
-
-    repo_root = str(Path(__file__).resolve().parent.parent)
-    opa_bundle = getattr(args, "opa_bundle", None)
-    ansible_version = getattr(args, "ansible_version", None)
-    collection_specs = getattr(args, "collections", None)
-    session_id = getattr(args, "session", None)
-
-    # Acquire a session venv up-front so the scan closure reuses it
-    session = resolve_session(
-        ansible_version or ANSIBLE_DEFAULT_VERSION,
-        collection_specs=collection_specs,
-        session_id=session_id,
-    )
-    active_session_id = session.session_id if session else None
-
-    def scan_fn(paths: list[str]) -> list[ViolationDict]:
-        return _scan_files_local(
-            paths,
-            repo_root,
-            opa_bundle,
-            ansible_version=ansible_version,
-            collection_specs=collection_specs,
-            session_id=active_session_id,
-        )
-
-    registry = build_default_registry()
-    engine = RemediationEngine(
-        registry=registry,
-        scan_fn=scan_fn,
+    sys.stderr.write("Phase 3: Scanning & remediating...\n")
+    _apply_remediation(
+        target,
+        apply=apply_changes,
         max_passes=max_passes,
-        verbose=True,
+        opa_bundle=getattr(args, "opa_bundle", None),
+        ansible_version=getattr(args, "ansible_version", None),
+        collection_specs=getattr(args, "collections", None),
+        session_id=getattr(args, "session", None),
     )
-
-    sys.stderr.write(f"  {len(yaml_files)} YAML file(s), {len(registry)} transforms registered\n")
-    sys.stderr.write(f"  Transforms: {', '.join(registry.rule_ids)}\n")
-
-    sys.stderr.write("Phase 4: Remediating...\n")
-    report = engine.remediate(yaml_files, apply=apply_changes)
-
-    if apply_changes and report.applied_patches:
-        patched_paths = {p.path for p in report.applied_patches}
-        reformat = [format_file(Path(p)) for p in patched_paths]
-        for r in reformat:
-            if r.changed:
-                r.path.write_text(r.formatted, encoding="utf-8")
-
-    # Phase 5: Report
-    sys.stderr.write("Phase 5: Summary\n")
-    sys.stderr.write(f"  Tier 1 (deterministic):  {report.fixed} fixed\n")
-    sys.stderr.write(f"  Tier 2 (AI-proposable):  {len(report.remaining_ai)} remaining\n")
-    sys.stderr.write(f"  Tier 3 (manual review):  {len(report.remaining_manual)} remaining\n")
-    sys.stderr.write(f"  Passes:                  {report.passes}\n")
-    if report.oscillation_detected:
-        sys.stderr.write("  WARNING: oscillation detected, stopped early\n")
-
-    # Release ephemeral session venvs (named sessions persist for TTL)
-    if active_session_id is not None:
-        release_session(active_session_id)
-
-    if not apply_changes and report.applied_patches:
-        sys.stderr.write(f"\n{len(report.applied_patches)} file(s) would be patched (use --apply to write):\n")
-        for p in report.applied_patches:
-            sys.stdout.write(p.diff)
 
 
 def _run_session(args: argparse.Namespace) -> None:
@@ -974,6 +1091,11 @@ def main() -> None:
         action="count",
         default=0,
         help="Diagnostics verbosity: -v for summary + top 10, -vv for full per-rule breakdown",
+    )
+    scan_parser.add_argument(
+        "--auto-fix",
+        action="store_true",
+        help="Apply auto-fixable (Tier 1) remediations after scan",
     )
 
     cache_parser = subparsers.add_parser(

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -64,11 +64,11 @@ def _sort_violations(violations: list[ViolationDict]) -> list[ViolationDict]:
     def key(v: ViolationDict) -> tuple[str, int | float]:
         f = str(v.get("file") or "")
         line = v.get("line")
-        if isinstance(line, (list, tuple)) and line:
+        if isinstance(line, list | tuple) and line:
             line = line[0]
-        if not isinstance(line, (int, float)):
+        if not isinstance(line, int | float):
             line = 0
-        return (f, line if isinstance(line, (int, float)) else 0)
+        return (f, line if isinstance(line, int | float) else 0)
 
     return sorted(violations, key=key)
 
@@ -86,7 +86,7 @@ def _deduplicate_violations(violations: list[ViolationDict]) -> list[ViolationDi
     out: list[ViolationDict] = []
     for v in violations:
         line: str | int | list[int] | tuple[int, ...] | bool | None = v.get("line")
-        if isinstance(line, (list, tuple)):
+        if isinstance(line, list | tuple):
             line = tuple(line)
         dedup_key = (str(v.get("rule_id", "")), str(v.get("file", "")), line)
         if dedup_key not in seen:
@@ -377,7 +377,13 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                 sys.stderr.flush()
 
             violations = _deduplicate_violations(_sort_violations(violations))
+
             from apme_engine.daemon.violation_convert import violation_dict_to_proto
+            from apme_engine.remediation.partition import add_classification_to_violations
+            from apme_engine.remediation.transforms import build_default_registry
+
+            registry = build_default_registry()
+            add_classification_to_violations(violations, registry)
 
             proto_violations = [violation_dict_to_proto(v) for v in violations]
 

--- a/src/apme_engine/daemon/violation_convert.py
+++ b/src/apme_engine/daemon/violation_convert.py
@@ -2,28 +2,83 @@
 
 from collections.abc import Mapping
 
+from apme.v1 import common_pb2
 from apme.v1.common_pb2 import LineRange, Violation
-from apme_engine.engine.models import ViolationDict
+from apme_engine.engine.models import RemediationClass, RemediationResolution, ViolationDict
+
+# Map string remediation class to proto enum (str keys for mypy compat with str,Enum)
+_REMEDIATION_CLASS_TO_PROTO: dict[str, int] = {
+    RemediationClass.AUTO_FIXABLE.value: common_pb2.REMEDIATION_CLASS_AUTO_FIXABLE,  # type: ignore[attr-defined]
+    RemediationClass.AI_CANDIDATE.value: common_pb2.REMEDIATION_CLASS_AI_CANDIDATE,  # type: ignore[attr-defined]
+    RemediationClass.MANUAL_REVIEW.value: common_pb2.REMEDIATION_CLASS_MANUAL_REVIEW,  # type: ignore[attr-defined]
+}
+
+# Map proto enum to string remediation class
+_PROTO_TO_REMEDIATION_CLASS: dict[int, str] = {
+    common_pb2.REMEDIATION_CLASS_UNSPECIFIED: RemediationClass.AI_CANDIDATE.value,  # type: ignore[attr-defined]
+    common_pb2.REMEDIATION_CLASS_AUTO_FIXABLE: RemediationClass.AUTO_FIXABLE.value,  # type: ignore[attr-defined]
+    common_pb2.REMEDIATION_CLASS_AI_CANDIDATE: RemediationClass.AI_CANDIDATE.value,  # type: ignore[attr-defined]
+    common_pb2.REMEDIATION_CLASS_MANUAL_REVIEW: RemediationClass.MANUAL_REVIEW.value,  # type: ignore[attr-defined]
+}
+
+# Map string remediation resolution to proto enum
+_RESOLUTION_TO_PROTO: dict[str, int] = {
+    RemediationResolution.UNRESOLVED.value: common_pb2.REMEDIATION_RESOLUTION_UNRESOLVED,  # type: ignore[attr-defined]
+    RemediationResolution.TRANSFORM_FAILED.value: common_pb2.REMEDIATION_RESOLUTION_TRANSFORM_FAILED,  # type: ignore[attr-defined]
+    RemediationResolution.OSCILLATION.value: common_pb2.REMEDIATION_RESOLUTION_OSCILLATION,  # type: ignore[attr-defined]
+    RemediationResolution.AI_PROPOSED.value: common_pb2.REMEDIATION_RESOLUTION_AI_PROPOSED,  # type: ignore[attr-defined]
+    RemediationResolution.AI_FAILED.value: common_pb2.REMEDIATION_RESOLUTION_AI_FAILED,  # type: ignore[attr-defined]
+    RemediationResolution.AI_LOW_CONFIDENCE.value: common_pb2.REMEDIATION_RESOLUTION_AI_LOW_CONFIDENCE,  # type: ignore[attr-defined]
+    RemediationResolution.USER_REJECTED.value: common_pb2.REMEDIATION_RESOLUTION_USER_REJECTED,  # type: ignore[attr-defined]
+}
+
+# Map proto enum to string remediation resolution
+_PROTO_TO_RESOLUTION: dict[int, str] = {
+    common_pb2.REMEDIATION_RESOLUTION_UNSPECIFIED: RemediationResolution.UNRESOLVED.value,  # type: ignore[attr-defined]
+    common_pb2.REMEDIATION_RESOLUTION_UNRESOLVED: RemediationResolution.UNRESOLVED.value,  # type: ignore[attr-defined]
+    common_pb2.REMEDIATION_RESOLUTION_TRANSFORM_FAILED: RemediationResolution.TRANSFORM_FAILED.value,  # type: ignore[attr-defined]
+    common_pb2.REMEDIATION_RESOLUTION_OSCILLATION: RemediationResolution.OSCILLATION.value,  # type: ignore[attr-defined]
+    common_pb2.REMEDIATION_RESOLUTION_AI_PROPOSED: RemediationResolution.AI_PROPOSED.value,  # type: ignore[attr-defined]
+    common_pb2.REMEDIATION_RESOLUTION_AI_FAILED: RemediationResolution.AI_FAILED.value,  # type: ignore[attr-defined]
+    common_pb2.REMEDIATION_RESOLUTION_AI_LOW_CONFIDENCE: RemediationResolution.AI_LOW_CONFIDENCE.value,  # type: ignore[attr-defined]
+    common_pb2.REMEDIATION_RESOLUTION_USER_REJECTED: RemediationResolution.USER_REJECTED.value,  # type: ignore[attr-defined]
+}
 
 
 def violation_dict_to_proto(v: ViolationDict | Mapping[str, str | int | list[int] | bool | None]) -> Violation:
     """Build a proto Violation from a dict with rule_id, level, message, file, line, path.
 
     Args:
-        v: Dict or mapping with rule_id, level, message, file, line (int or [start,end]), path.
+        v: Dict or mapping with rule_id, level, message, file, line (int or [start,end]), path,
+           and optional remediation_class / remediation_resolution.
 
     Returns:
         Violation proto populated from the dict.
     """
+    rc_raw = v.get("remediation_class") or RemediationClass.AI_CANDIDATE
+    remediation_class_str = rc_raw.value if hasattr(rc_raw, "value") else str(rc_raw)
+    remediation_class_proto = _REMEDIATION_CLASS_TO_PROTO.get(
+        remediation_class_str,
+        common_pb2.REMEDIATION_CLASS_AI_CANDIDATE,  # type: ignore[attr-defined]
+    )
+    res_raw = v.get("remediation_resolution") or RemediationResolution.UNRESOLVED
+    resolution_str = res_raw.value if hasattr(res_raw, "value") else str(res_raw)
+    resolution_proto = _RESOLUTION_TO_PROTO.get(
+        resolution_str,
+        common_pb2.REMEDIATION_RESOLUTION_UNRESOLVED,  # type: ignore[attr-defined]
+    )
+
     out = Violation(
-        rule_id=v.get("rule_id") or "",
-        level=v.get("level") or "",
-        message=v.get("message") or "",
-        file=v.get("file") or "",
-        path=v.get("path") or "",
+        rule_id=str(v.get("rule_id") or ""),
+        level=str(v.get("level") or ""),
+        message=str(v.get("message") or ""),
+        file=str(v.get("file") or ""),
+        path=str(v.get("path") or ""),
+        remediation_class=remediation_class_proto,
+        remediation_resolution=resolution_proto,
     )
     line = v.get("line")
-    if isinstance(line, (list, tuple)) and len(line) >= 2:
+    if isinstance(line, list | tuple) and len(line) >= 2:
         out.line_range.CopyFrom(LineRange(start=int(line[0]), end=int(line[1])))
     elif isinstance(line, int):
         out.line = line
@@ -37,11 +92,20 @@ def violation_proto_to_dict(v: Violation) -> ViolationDict:
         v: Violation proto to convert.
 
     Returns:
-        ViolationDict with rule_id, level, message, file, line, path.
+        ViolationDict with rule_id, level, message, file, line, path,
+        remediation_class, remediation_resolution.
     """
     line: int | list[int] | None = v.line if v.HasField("line") else None
     if v.HasField("line_range"):
         line = [v.line_range.start, v.line_range.end]
+    remediation_class = _PROTO_TO_REMEDIATION_CLASS.get(
+        v.remediation_class,  # type: ignore[attr-defined]
+        RemediationClass.AI_CANDIDATE.value,
+    )
+    resolution = _PROTO_TO_RESOLUTION.get(
+        v.remediation_resolution,  # type: ignore[attr-defined]
+        RemediationResolution.UNRESOLVED.value,
+    )
     return {
         "rule_id": v.rule_id,
         "level": v.level,
@@ -49,4 +113,6 @@ def violation_proto_to_dict(v: Violation) -> ViolationDict:
         "file": v.file,
         "line": line,
         "path": v.path,
+        "remediation_class": remediation_class,
+        "remediation_resolution": resolution,
     }

--- a/src/apme_engine/engine/annotators/ansible.builtin/unarchive.py
+++ b/src/apme_engine/engine/annotators/ansible.builtin/unarchive.py
@@ -36,11 +36,11 @@ class UnarchiveAnnotator(ModuleAnnotator):
         is_remote_src = False
         if remote_src is not None:
             raw_val = getattr(remote_src, "raw", None)
-            if isinstance(raw_val, (str, bool)):
+            if isinstance(raw_val, str | bool):
                 with contextlib.suppress(Exception):
                     is_remote_src = parse_bool(raw_val)
             templated_val = getattr(remote_src, "templated", None)
-            if not is_remote_src and isinstance(templated_val, (str, bool)):
+            if not is_remote_src and isinstance(templated_val, str | bool):
                 with contextlib.suppress(Exception):
                     is_remote_src = parse_bool(templated_val)
 

--- a/src/apme_engine/engine/cli/__init__.py
+++ b/src/apme_engine/engine/cli/__init__.py
@@ -315,7 +315,7 @@ class ARICLI:
                                                 mutated_yaml_list.append(mutated_yaml)
                                                 temp_file_path = target_file_path
                                             line_number = w007_rule["file"][1]
-                                            if isinstance(line_number, (list, tuple)) and len(line_number) >= 2:
+                                            if isinstance(line_number, list | tuple) and len(line_number) >= 2:
                                                 ln_str = f"{line_number[0]}-{line_number[1]}"
                                             elif isinstance(line_number, int):
                                                 ln_str = f"{line_number}-{line_number}"

--- a/src/apme_engine/engine/context.py
+++ b/src/apme_engine/engine/context.py
@@ -305,7 +305,7 @@ class Context:
                 current = self.var_set_history.get(key, [])
                 current.append(Variable(name=key, value=val, type=VariableType.RoleVars, setter=_spec.key))
                 self.var_set_history[key] = current
-        elif isinstance(_spec, (Collection, TaskFile)):
+        elif isinstance(_spec, Collection | TaskFile):
             self.variables.update(_spec.variables)
             self.update_flat_vars(_spec.variables)
         elif isinstance(_spec, Task):
@@ -510,9 +510,9 @@ class Context:
         lines: list[str] = []
         for chain_item in self.chain:
             obj_raw = chain_item.get("obj", None)
-            obj = obj_raw if isinstance(obj_raw, (Object, CallObject)) or obj_raw is None else None
+            obj = obj_raw if isinstance(obj_raw, Object | CallObject) or obj_raw is None else None
             depth_val = chain_item.get("depth", 0)
-            depth = int(depth_val) if isinstance(depth_val, (int, float)) else 0
+            depth = int(depth_val) if isinstance(depth_val, int | float) else 0
             indent = "  " * depth
             obj_type = type(obj).__name__ if obj else "None"
             obj_name = getattr(obj, "name", "") or getattr(obj, "key", "") if obj else ""

--- a/src/apme_engine/engine/model_loader.py
+++ b/src/apme_engine/engine/model_loader.py
@@ -80,7 +80,7 @@ def _safe_int(val: object) -> int:
     Returns:
         Integer value, or 0 if conversion fails.
     """
-    if isinstance(val, (int, float)):
+    if isinstance(val, int | float):
         return int(val)
     if isinstance(val, str):
         try:

--- a/src/apme_engine/engine/models.py
+++ b/src/apme_engine/engine/models.py
@@ -8,6 +8,7 @@ import json
 import os
 from copy import deepcopy
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
@@ -25,6 +26,43 @@ YAMLList = list[YAMLValue]
 
 # Violation dicts from validators (rule_id, level, message, file, line, path, etc.)
 ViolationDict = dict[str, str | int | list[int] | bool | None]
+
+
+class RemediationClass(str, Enum):
+    """Classification of remediation complexity for violations.
+
+    Attributes:
+        AUTO_FIXABLE: Tier 1 — deterministic transform exists.
+        AI_CANDIDATE: Tier 2 — AI can propose a fix.
+        MANUAL_REVIEW: Tier 3 — requires human judgment.
+    """
+
+    AUTO_FIXABLE = "auto-fixable"
+    AI_CANDIDATE = "ai-candidate"
+    MANUAL_REVIEW = "manual-review"
+
+
+class RemediationResolution(str, Enum):
+    """What happened during remediation of a specific finding.
+
+    Attributes:
+        UNRESOLVED: Initial state at scan time.
+        TRANSFORM_FAILED: Deterministic transform returned applied=False.
+        OSCILLATION: Convergence loop detected oscillation.
+        AI_PROPOSED: AI proposed a fix (pending validation).
+        AI_FAILED: AI call failed or returned no result.
+        AI_LOW_CONFIDENCE: AI returned a low-confidence proposal.
+        USER_REJECTED: User rejected the proposed fix.
+    """
+
+    UNRESOLVED = "unresolved"
+    TRANSFORM_FAILED = "transform-failed"
+    OSCILLATION = "oscillation"
+    AI_PROPOSED = "ai-proposed"
+    AI_FAILED = "ai-failed"
+    AI_LOW_CONFIDENCE = "ai-low-confidence"
+    USER_REJECTED = "user-rejected"
+
 
 from . import yaml as ariyaml  # noqa: E402
 from .finder import (  # noqa: E402
@@ -1183,7 +1221,7 @@ class Arguments:
         else:
             if isinstance(self.raw, dict):
                 sub_raw = self.raw.get(key, None)
-                if self.templated and isinstance(self.templated, (list, tuple)):
+                if self.templated and isinstance(self.templated, list | tuple):
                     first: YAMLValue = self.templated[0]
                     sub_templated = first.get(key, None) if isinstance(first, dict) else self.templated
             else:

--- a/src/apme_engine/engine/parser.py
+++ b/src/apme_engine/engine/parser.py
@@ -399,7 +399,7 @@ class Parser:
                 if ld.yaml_label_list:
                     yaml_labels = ld.yaml_label_list
                     for item in yaml_labels:
-                        if isinstance(item, (list, tuple)) and len(item) >= 2:
+                        if isinstance(item, list | tuple) and len(item) >= 2:
                             _fpath, _label = str(item[0]), str(item[1])
                             if _fpath == file_path:
                                 label = _label

--- a/src/apme_engine/engine/scanner.py
+++ b/src/apme_engine/engine/scanner.py
@@ -913,7 +913,7 @@ class SingleScan:
         if spec:
             d["file"] = getattr(spec, "defined_in", "") or ""
             line_num = getattr(spec, "line_num_in_file", None) or getattr(spec, "line_number", None)
-            if line_num and isinstance(line_num, (list, tuple)) and len(line_num) >= 2:
+            if line_num and isinstance(line_num, list | tuple) and len(line_num) >= 2:
                 d["line"] = [int(line_num[0]), int(line_num[1])]
             else:
                 d["line"] = None
@@ -1025,9 +1025,9 @@ class SingleScan:
         """
         if v is None:
             return None
-        if isinstance(v, (str, int, float, bool)):
+        if isinstance(v, str | int | float | bool):
             return v
-        if isinstance(v, (list, tuple)):
+        if isinstance(v, list | tuple):
             return [self._json_safe(x) for x in v]
         if isinstance(v, dict):
             return {str(k): self._json_safe(x) for k, x in v.items()}
@@ -1218,14 +1218,14 @@ class SingleScan:
             defs_dict = defs_val if isinstance(defs_val, dict) else {}
             for key, val in defs_dict.items():
                 _current = ext_counts.get(key, 0)
-                _current += len(val) if isinstance(val, (list, dict)) else 0
+                _current += len(val) if isinstance(val, list | dict) else 0
                 ext_counts[key] = _current
         root_counts: dict[str, int] = {}
         root_defs_val = self.root_definitions.get("definitions")
         root_defs_dict = root_defs_val if isinstance(root_defs_val, dict) else {}
         for key, val in root_defs_dict.items():
             _current = root_counts.get(key, 0)
-            _current += len(val) if isinstance(val, (list, dict)) else 0
+            _current += len(val) if isinstance(val, list | dict) else 0
             root_counts[key] = _current
         return dep_num, ext_counts, root_counts
 
@@ -1642,11 +1642,11 @@ class ARIScanner:
             _tf = defs_dict.get("taskfiles")
             _tk = defs_dict.get("tasks")
             _md = defs_dict.get("modules")
-            playbooks_num = len(_pb) if isinstance(_pb, (list, dict)) else 0
-            roles_num = len(_rl) if isinstance(_rl, (list, dict)) else 0
-            taskfiles_num = len(_tf) if isinstance(_tf, (list, dict)) else 0
-            tasks_num = len(_tk) if isinstance(_tk, (list, dict)) else 0
-            modules_num = len(_md) if isinstance(_md, (list, dict)) else 0
+            playbooks_num = len(_pb) if isinstance(_pb, list | dict) else 0
+            roles_num = len(_rl) if isinstance(_rl, list | dict) else 0
+            taskfiles_num = len(_tf) if isinstance(_tf, list | dict) else 0
+            tasks_num = len(_tk) if isinstance(_tk, list | dict) else 0
+            modules_num = len(_md) if isinstance(_md, list | dict) else 0
             logger.debug(
                 f"playbooks: {playbooks_num}, roles: {roles_num}, taskfiles: {taskfiles_num}, "
                 f"tasks: {tasks_num}, modules: {modules_num}"

--- a/src/apme_engine/engine/tree.py
+++ b/src/apme_engine/engine/tree.py
@@ -313,7 +313,7 @@ def _safe_list(v: object) -> list[Object | CallObject]:
     if isinstance(v, ObjectList):
         return v.items
     if isinstance(v, list):
-        return [x for x in v if isinstance(x, (Object, CallObject))]
+        return [x for x in v if isinstance(x, Object | CallObject)]
     return []
 
 
@@ -341,7 +341,7 @@ def _ram_match_object(match: object) -> Object | CallObject | None:
     if not isinstance(match, dict):
         return None
     obj = match.get("object")
-    return obj if isinstance(obj, (Object, CallObject)) else None
+    return obj if isinstance(obj, Object | CallObject) else None
 
 
 def _ram_match_defined_in(match: object) -> str:
@@ -389,7 +389,7 @@ def load_single_definition(defs: dict[str, object], key: str) -> ObjectList:
     obj_list = ObjectList()
     items = _safe_list(defs.get(key, []))
     for item in items:
-        if isinstance(item, (Object, CallObject)):
+        if isinstance(item, Object | CallObject):
             obj_list.add(item)
     return obj_list
 
@@ -885,7 +885,7 @@ class TreeLoader:
             p_defs = _safe_list(definitions.get("projects", []))
             if len(p_defs) > 0:
                 first = p_defs[0]
-                if isinstance(first, (Object, CallObject)):
+                if isinstance(first, Object | CallObject):
                     additional_objects.add(first)
         covered_taskfiles = []
         for i, mapping in enumerate(self.playbook_mappings):
@@ -1148,7 +1148,7 @@ class TreeLoader:
             matched_obj = self.ram_client.get_object_by_key(obj_key)
             if matched_obj is not None and isinstance(matched_obj, dict):
                 obj_raw = matched_obj.get("object", None)
-                if obj_raw is not None and isinstance(obj_raw, (Object, CallObject)):
+                if obj_raw is not None and isinstance(obj_raw, Object | CallObject):
                     return obj_raw
 
         return None
@@ -1219,7 +1219,7 @@ class TreeLoader:
                                 for offspr_obj in _ram_match_offspring(m0):
                                     type_str = str(offspr_obj.get("type", "")) + "s"
                                     oo_obj = offspr_obj.get("object")
-                                    if isinstance(oo_obj, (Object, CallObject)):
+                                    if isinstance(oo_obj, Object | CallObject):
                                         self.ext_definitions[type_str].add(oo_obj)
                                 if role_obj.key not in self.extra_requirement_obj_set:
                                     self.extra_requirements.append(
@@ -1233,10 +1233,10 @@ class TreeLoader:
                                     self.extra_requirement_obj_set.add(role_obj.key)
                                 for offspr_obj in _ram_match_offspring(m0):
                                     oo_obj = offspr_obj.get("object")
-                                    if isinstance(oo_obj, (Object, CallObject)) and getattr(oo_obj, "builtin", False):
+                                    if isinstance(oo_obj, Object | CallObject) and getattr(oo_obj, "builtin", False):
                                         continue
                                     if (
-                                        isinstance(oo_obj, (Object, CallObject))
+                                        isinstance(oo_obj, Object | CallObject)
                                         and oo_obj.key not in self.extra_requirement_obj_set
                                     ):
                                         self.extra_requirements.append(
@@ -1372,10 +1372,10 @@ class TreeLoader:
                                     self.extra_requirement_obj_set.add(role_obj.key)
                                 for offspr_obj in _ram_match_offspring(m0):
                                     oo_obj = offspr_obj.get("object")
-                                    if isinstance(oo_obj, (Object, CallObject)) and getattr(oo_obj, "builtin", False):
+                                    if isinstance(oo_obj, Object | CallObject) and getattr(oo_obj, "builtin", False):
                                         continue
                                     if (
-                                        isinstance(oo_obj, (Object, CallObject))
+                                        isinstance(oo_obj, Object | CallObject)
                                         and oo_obj.key not in self.extra_requirement_obj_set
                                     ):
                                         self.extra_requirements.append(
@@ -1435,10 +1435,10 @@ class TreeLoader:
                                     self.extra_requirement_obj_set.add(tf_obj.key)
                                 for offspr_obj in _ram_match_offspring(m0):
                                     oo_obj = offspr_obj.get("object")
-                                    if isinstance(oo_obj, (Object, CallObject)) and getattr(oo_obj, "builtin", False):
+                                    if isinstance(oo_obj, Object | CallObject) and getattr(oo_obj, "builtin", False):
                                         continue
                                     if (
-                                        isinstance(oo_obj, (Object, CallObject))
+                                        isinstance(oo_obj, Object | CallObject)
                                         and oo_obj.key not in self.extra_requirement_obj_set
                                     ):
                                         self.extra_requirements.append(

--- a/src/apme_engine/formatter.py
+++ b/src/apme_engine/formatter.py
@@ -277,7 +277,7 @@ def format_content(text: str, filename: str = "<stdin>") -> FormatResult:
             diff="",
         )
 
-    if data is None or not isinstance(data, (CommentedMap, CommentedSeq, list, dict)):
+    if data is None or not isinstance(data, CommentedMap | CommentedSeq | list | dict):
         return FormatResult(
             path=Path(filename),
             original=original,

--- a/src/apme_engine/remediation/engine.py
+++ b/src/apme_engine/remediation/engine.py
@@ -8,8 +8,12 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from apme_engine.engine.models import ViolationDict
-from apme_engine.remediation.partition import normalize_rule_id, partition_violations
+from apme_engine.engine.models import RemediationClass, RemediationResolution, ViolationDict
+from apme_engine.remediation.partition import (
+    add_classification_to_violations,
+    normalize_rule_id,
+    partition_violations,
+)
 from apme_engine.remediation.registry import TransformRegistry
 from apme_engine.remediation.transforms._helpers import violation_line_to_int
 
@@ -189,6 +193,9 @@ class RemediationEngine:
                     file_contents[vf] = result.content
                     all_applied_rules[vf].append(rule_id)
                     applied_this_pass += 1
+                else:
+                    v["remediation_class"] = RemediationClass.AI_CANDIDATE
+                    v["remediation_resolution"] = RemediationResolution.TRANSFORM_FAILED
 
             self._log(f"  Pass {pass_num}: applied {applied_this_pass}")
 
@@ -204,6 +211,9 @@ class RemediationEngine:
             if new_fixable >= prev_count:
                 self._log(f"  Pass {pass_num}: oscillation ({new_fixable} fixable >= {prev_count})")
                 oscillation = True
+                for v in new_tier1:
+                    v["remediation_class"] = RemediationClass.AI_CANDIDATE
+                    v["remediation_resolution"] = RemediationResolution.OSCILLATION
                 break
 
             prev_count = new_fixable
@@ -215,6 +225,7 @@ class RemediationEngine:
         # Final partition of remaining violations
         self._write_files(file_contents)
         final_violations = self._scan_fn(file_paths)
+        add_classification_to_violations(final_violations, self._registry)
         _, tier2, tier3 = partition_violations(final_violations, self._registry)
 
         # Build patches

--- a/src/apme_engine/remediation/partition.py
+++ b/src/apme_engine/remediation/partition.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from apme_engine.engine.models import ViolationDict
+from apme_engine.engine.models import RemediationClass, RemediationResolution
 from apme_engine.remediation.registry import TransformRegistry
 
 
@@ -66,3 +67,88 @@ def partition_violations(
             tier3.append(v)
 
     return tier1, tier2, tier3
+
+
+def classify_violation(violation: ViolationDict, registry: TransformRegistry) -> RemediationClass:
+    """Return remediation class: auto-fixable, ai-candidate, or manual-review.
+
+    Args:
+        violation: Violation dict with rule_id.
+        registry: Transform registry to check for deterministic transforms.
+
+    Returns:
+        One of RemediationClass.AUTO_FIXABLE, AI_CANDIDATE, or MANUAL_REVIEW.
+    """
+    if is_finding_resolvable(violation, registry):
+        return RemediationClass.AUTO_FIXABLE
+    elif violation.get("ai_proposable", True):
+        return RemediationClass.AI_CANDIDATE
+    else:
+        return RemediationClass.MANUAL_REVIEW
+
+
+def add_classification_to_violations(
+    violations: list[ViolationDict],
+    registry: TransformRegistry,
+) -> None:
+    """Add remediation_class and remediation_resolution fields to each violation (in place).
+
+    Args:
+        violations: List of violation dicts.
+        registry: Transform registry for Tier 1 lookup.
+    """
+    for v in violations:
+        v["remediation_class"] = classify_violation(v, registry)
+        v["remediation_resolution"] = RemediationResolution.UNRESOLVED
+
+
+def _to_str_value(val: object, default: str) -> str:
+    """Extract the string value from an enum member or fallback to str().
+
+    Args:
+        val: Enum member, string, or other value.
+        default: Default string if val is falsy.
+
+    Returns:
+        The underlying string value.
+    """
+    if not val:
+        return default
+    return val.value if hasattr(val, "value") else str(val)
+
+
+def count_by_remediation_class(violations: list[ViolationDict]) -> dict[str, int]:
+    """Count violations by remediation class.
+
+    Args:
+        violations: List of violations with remediation_class field.
+
+    Returns:
+        Dict with counts keyed by remediation class string value.
+    """
+    counts: dict[str, int] = {rc.value: 0 for rc in RemediationClass}
+    default = RemediationClass.AI_CANDIDATE.value
+    for v in violations:
+        rc = _to_str_value(v.get("remediation_class"), default)
+        if rc in counts:
+            counts[rc] += 1
+        else:
+            counts[default] += 1
+    return counts
+
+
+def count_by_resolution(violations: list[ViolationDict]) -> dict[str, int]:
+    """Count violations by remediation resolution.
+
+    Args:
+        violations: List of violations with remediation_resolution field.
+
+    Returns:
+        Dict with counts keyed by resolution string value.
+    """
+    default = RemediationResolution.UNRESOLVED.value
+    counts: dict[str, int] = {}
+    for v in violations:
+        res = _to_str_value(v.get("remediation_resolution"), default)
+        counts[res] = counts.get(res, 0) + 1
+    return counts

--- a/src/apme_engine/remediation/transforms/_helpers.py
+++ b/src/apme_engine/remediation/transforms/_helpers.py
@@ -17,10 +17,10 @@ def violation_line_to_int(violation: ViolationDict) -> int:
         1-indexed line number, or 0 if missing/invalid.
     """
     line = violation.get("line", 0)
-    if isinstance(line, (list, tuple)) and line:
+    if isinstance(line, list | tuple) and line:
         val = line[0]
-        return int(val) if isinstance(val, (int, float, str)) else 0
-    if isinstance(line, (int, float)):
+        return int(val) if isinstance(val, int | float | str) else 0
+    if isinstance(line, int | float):
         return int(line)
     if isinstance(line, str):
         raw = line.lstrip("L")

--- a/src/apme_engine/validators/ansible/__init__.py
+++ b/src/apme_engine/validators/ansible/__init__.py
@@ -57,13 +57,13 @@ def _extract_task_nodes(hierarchy_payload: YAMLDict | None) -> list[dict[str, ob
     if hierarchy_payload is None:
         return nodes
     hierarchy = hierarchy_payload.get("hierarchy", [])
-    if not isinstance(hierarchy, (list, tuple)):
+    if not isinstance(hierarchy, list | tuple):
         return nodes
     for tree in hierarchy:
         if not isinstance(tree, dict):
             continue
         raw_nodes = tree.get("nodes", [])
-        if not isinstance(raw_nodes, (list, tuple)):
+        if not isinstance(raw_nodes, list | tuple):
             continue
         for node in raw_nodes:
             if isinstance(node, dict) and node.get("type") == "taskcall":

--- a/src/apme_engine/validators/ansible/rules/L058_argspec_doc.py
+++ b/src/apme_engine/validators/ansible/rules/L058_argspec_doc.py
@@ -212,7 +212,7 @@ def _run_argspec_script(
         task_key = rv.get("task_key", "")
         task = task_by_key.get(task_key, {})
         line = task.get("line")
-        line_num = line[0] if isinstance(line, (list, tuple)) and line else 1
+        line_num = line[0] if isinstance(line, list | tuple) and line else 1
         violations.append(
             {
                 "rule_id": RULE_ID,

--- a/src/apme_engine/validators/ansible/rules/L059_argspec_mock.py
+++ b/src/apme_engine/validators/ansible/rules/L059_argspec_mock.py
@@ -252,7 +252,7 @@ def run(
         task_key = rv.get("task_key", "")
         task = task_by_key.get(task_key, {})
         line = task.get("line")
-        line_num = line[0] if isinstance(line, (list, tuple)) and line else 1
+        line_num = line[0] if isinstance(line, list | tuple) and line else 1
         violations.append(
             {
                 "rule_id": RULE_ID,

--- a/src/apme_engine/validators/ansible/rules/M001_M004_introspect.py
+++ b/src/apme_engine/validators/ansible/rules/M001_M004_introspect.py
@@ -146,7 +146,7 @@ def run(
 
         file_path = str(node.get("file", ""))
         line = node.get("line")
-        line_num = line[0] if isinstance(line, (list, tuple)) and line else 1
+        line_num = line[0] if isinstance(line, list | tuple) and line else 1
 
         # M004: Tombstoned / removed module
         if info.get("removed"):

--- a/src/apme_engine/validators/gitleaks/scanner.py
+++ b/src/apme_engine/validators/gitleaks/scanner.py
@@ -153,8 +153,8 @@ def _convert_findings(
 
         line_val = f.get("StartLine", 0)
         end_val = f.get("EndLine", line_val)
-        line = int(line_val) if isinstance(line_val, (int, float, str)) else 0
-        end_line = int(end_val) if isinstance(end_val, (int, float, str)) else line
+        line = int(line_val) if isinstance(line_val, int | float | str) else 0
+        end_line = int(end_val) if isinstance(end_val, int | float | str) else line
         gitleaks_rule = str(f.get("RuleID", "unknown"))
         desc = str(f.get("Description", f"Secret detected: {gitleaks_rule}"))
 

--- a/src/apme_engine/validators/native/__init__.py
+++ b/src/apme_engine/validators/native/__init__.py
@@ -83,7 +83,7 @@ def _extract_results(data_report: dict[str, object]) -> NativeRunResult:
                 detail = getattr(r, "detail", None)
                 message = detail["message"] if isinstance(detail, dict) and detail.get("message") else description
                 file_info = getattr(r, "file", None)
-                if isinstance(file_info, (list, tuple)) and len(file_info) >= 1:
+                if isinstance(file_info, list | tuple) and len(file_info) >= 1:
                     file_path = str(file_info[0]) if file_info[0] else ""
                     line = file_info[1] if len(file_info) > 1 else None
                 else:

--- a/src/apme_engine/validators/native/rules/P003_module_argument_value_validation.py
+++ b/src/apme_engine/validators/native/rules/P003_module_argument_value_validation.py
@@ -160,7 +160,7 @@ class ModuleArgumentValueValidationRule(Rule):
                             elif is_loop_var(str(raw_value), task):
                                 # if the variable is loop var, use the element type as actual type
                                 resolved_element: YAMLValue | None = None
-                                if isinstance(resolved_value, (list, tuple)) and resolved_value:
+                                if isinstance(resolved_value, list | tuple) and resolved_value:
                                     resolved_element = resolved_value[0]
                                 if resolved_element is not None:
                                     actual_type = type(resolved_element).__name__

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -222,7 +222,7 @@ class TestScanViolations:
 
         """
         raw_count = scan_result.get("count", 0)
-        count = int(raw_count) if isinstance(raw_count, (int, float, str)) else 0
+        count = int(raw_count) if isinstance(raw_count, int | float | str) else 0
         assert count > 0, f"Expected >0 violations, got {count}"
 
     # OPA rules
@@ -323,7 +323,7 @@ class TestNoDuplicates:
             key = (
                 str(v.get("rule_id", "")),
                 str(v.get("file", "")),
-                line if isinstance(line, (int, tuple)) else 0,
+                line if isinstance(line, int | tuple) else 0,
             )
             if key in seen:
                 dups.append(key)

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -16,6 +16,7 @@ from apme_engine.ansi import (
     green,
     ljust_ansi,
     red,
+    remediation_badge,
     reset_color_detection,
     rjust_ansi,
     section_header,
@@ -387,6 +388,73 @@ class TestSeverityBadge:
         indicator = severity_indicator("very_low")
         assert "i" in strip_ansi(indicator)
         assert Style.CYAN in indicator
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Remediation badge tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRemediationBadge:
+    """Test remediation badge rendering."""
+
+    def test_badge_auto_fixable(self, force_color: None) -> None:
+        """Auto-fixable shows FIX badge with green background.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
+        badge = remediation_badge("auto-fixable")
+        assert "FIX" in strip_ansi(badge)
+        assert Style.BG_GREEN in badge
+
+    def test_badge_ai_candidate(self, force_color: None) -> None:
+        """AI-candidate shows AI badge with blue background.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
+        badge = remediation_badge("ai-candidate")
+        assert "AI" in strip_ansi(badge)
+        assert Style.BG_BLUE in badge
+
+    def test_badge_manual_review(self, force_color: None) -> None:
+        """Manual-review shows MANUAL badge with magenta background.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
+        badge = remediation_badge("manual-review")
+        assert "MANUAL" in strip_ansi(badge)
+        assert Style.BG_MAGENTA in badge
+
+    def test_badge_case_insensitive(self, force_color: None) -> None:
+        """Badge lookup is case-insensitive.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
+        assert strip_ansi(remediation_badge("AUTO-FIXABLE")) == strip_ansi(remediation_badge("auto-fixable"))
+        assert strip_ansi(remediation_badge("AI-Candidate")) == strip_ansi(remediation_badge("ai-candidate"))
+
+    def test_badge_unknown_class(self, force_color: None) -> None:
+        """Unknown class shows ? badge.
+
+        Args:
+            force_color: Fixture that enables color output.
+        """
+        badge = remediation_badge("unknown")
+        assert "?" in strip_ansi(badge)
+
+    def test_badge_no_color(self, no_color: None) -> None:
+        """Badge shows label without styling when NO_COLOR.
+
+        Args:
+            no_color: Fixture that disables color output.
+        """
+        badge = remediation_badge("auto-fixable")
+        assert badge == " FIX "
+        assert "\033[" not in badge
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_formatter_cli.py
+++ b/tests/test_formatter_cli.py
@@ -332,8 +332,7 @@ class TestFixApply:
         """
         r = _cli("fix", "--apply", str(messy_file))
         assert r.returncode == 0
-        assert "phase 4: remediating" in r.stderr.lower()
-        assert "phase 5: summary" in r.stderr.lower()
+        assert "remediating" in r.stderr.lower()
         assert "tier 1" in r.stderr.lower()
 
 

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -4,9 +4,13 @@ import textwrap
 from pathlib import Path
 from typing import cast
 
-from apme_engine.engine.models import ViolationDict
+from apme_engine.engine.models import RemediationClass, RemediationResolution, ViolationDict
 from apme_engine.remediation.engine import RemediationEngine
 from apme_engine.remediation.partition import (
+    add_classification_to_violations,
+    classify_violation,
+    count_by_remediation_class,
+    count_by_resolution,
     is_finding_resolvable,
     normalize_rule_id,
     partition_violations,
@@ -139,6 +143,91 @@ class TestPartition:
         assert t2[0]["rule_id"] == "R118"
         assert len(t3) == 1
         assert t3[0]["rule_id"] == "POLICY"
+
+    def test_classify_violation_auto_fixable(self) -> None:
+        """Verifies classify_violation returns auto-fixable for registered rules."""
+        reg = TransformRegistry()
+        reg.register("L021", lambda c, v: TransformResult(c, False))
+        assert classify_violation({"rule_id": "L021"}, reg) == RemediationClass.AUTO_FIXABLE
+        assert classify_violation({"rule_id": "native:L021"}, reg) == RemediationClass.AUTO_FIXABLE
+
+    def test_classify_violation_ai_candidate(self) -> None:
+        """Verifies classify_violation returns ai-candidate for unregistered rules."""
+        reg = TransformRegistry()
+        assert classify_violation({"rule_id": "R118"}, reg) == RemediationClass.AI_CANDIDATE
+        assert classify_violation({"rule_id": "L999", "ai_proposable": True}, reg) == RemediationClass.AI_CANDIDATE
+
+    def test_classify_violation_manual_review(self) -> None:
+        """Verifies classify_violation returns manual-review when ai_proposable is False."""
+        reg = TransformRegistry()
+        assert classify_violation({"rule_id": "POLICY", "ai_proposable": False}, reg) == RemediationClass.MANUAL_REVIEW
+
+    def test_add_classification_to_violations(self) -> None:
+        """Verifies add_classification_to_violations mutates violations in place."""
+        reg = TransformRegistry()
+        reg.register("L021", lambda c, v: TransformResult(c, False))
+
+        violations: list[ViolationDict] = [
+            {"rule_id": "L021"},
+            {"rule_id": "R118"},
+            {"rule_id": "POLICY", "ai_proposable": False},
+        ]
+        add_classification_to_violations(violations, reg)
+        assert violations[0]["remediation_class"] == RemediationClass.AUTO_FIXABLE
+        assert violations[1]["remediation_class"] == RemediationClass.AI_CANDIDATE
+        assert violations[2]["remediation_class"] == RemediationClass.MANUAL_REVIEW
+        for v in violations:
+            assert v["remediation_resolution"] == RemediationResolution.UNRESOLVED
+
+    def test_count_by_remediation_class(self) -> None:
+        """Verifies count_by_remediation_class returns correct counts."""
+        violations: list[ViolationDict] = [
+            {"rule_id": "L021", "remediation_class": RemediationClass.AUTO_FIXABLE},
+            {"rule_id": "L022", "remediation_class": RemediationClass.AUTO_FIXABLE},
+            {"rule_id": "R118", "remediation_class": RemediationClass.AI_CANDIDATE},
+            {"rule_id": "POLICY", "remediation_class": RemediationClass.MANUAL_REVIEW},
+        ]
+        counts = count_by_remediation_class(violations)
+        assert counts[RemediationClass.AUTO_FIXABLE.value] == 2
+        assert counts[RemediationClass.AI_CANDIDATE.value] == 1
+        assert counts[RemediationClass.MANUAL_REVIEW.value] == 1
+
+    def test_count_by_resolution(self) -> None:
+        """Verifies count_by_resolution returns correct counts."""
+        violations: list[ViolationDict] = [
+            {"rule_id": "L021", "remediation_resolution": RemediationResolution.UNRESOLVED},
+            {"rule_id": "L022", "remediation_resolution": RemediationResolution.TRANSFORM_FAILED},
+            {"rule_id": "R118", "remediation_resolution": RemediationResolution.TRANSFORM_FAILED},
+            {"rule_id": "POLICY", "remediation_resolution": RemediationResolution.OSCILLATION},
+        ]
+        counts = count_by_resolution(violations)
+        assert counts[RemediationResolution.UNRESOLVED.value] == 1
+        assert counts[RemediationResolution.TRANSFORM_FAILED.value] == 2
+        assert counts[RemediationResolution.OSCILLATION.value] == 1
+
+    def test_remediation_class_is_str_enum(self) -> None:
+        """Verifies RemediationClass is iterable and members have string values."""
+        assert list(RemediationClass) == [
+            RemediationClass.AUTO_FIXABLE,
+            RemediationClass.AI_CANDIDATE,
+            RemediationClass.MANUAL_REVIEW,
+        ]
+        assert RemediationClass.AUTO_FIXABLE.value == "auto-fixable"
+
+    def test_remediation_resolution_is_str_enum(self) -> None:
+        """Verifies RemediationResolution members have string values."""
+        assert RemediationResolution.UNRESOLVED.value == "unresolved"
+        assert RemediationResolution.TRANSFORM_FAILED.value == "transform-failed"
+        assert len(list(RemediationResolution)) == 7
+
+    def test_all_registered_rules_classify(self) -> None:
+        """Verifies every registered rule ID classifies as AUTO_FIXABLE."""
+        reg = build_default_registry()
+        for rule_id in reg:
+            v: ViolationDict = {"rule_id": rule_id}
+            assert classify_violation(v, reg) == RemediationClass.AUTO_FIXABLE, (
+                f"Rule {rule_id} should classify as AUTO_FIXABLE"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -665,6 +754,79 @@ class TestRemediationEngine:
         assert len(report.remaining_manual) == 1
         assert report.remaining_ai[0]["rule_id"] == "UNKNOWN_AI"
         assert report.remaining_manual[0]["rule_id"] == "MANUAL"
+
+    def test_transform_failure_sets_resolution(self, tmp_path: Path) -> None:
+        """Verifies transform returning applied=False sets TRANSFORM_FAILED resolution.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        playbook = tmp_path / "play.yml"
+        playbook.write_text("- name: test\n  debug: msg=hi\n")
+
+        captured: list[ViolationDict] = []
+
+        def scan_fn(paths: list[str]) -> list[ViolationDict]:
+            return [{"rule_id": "STUB", "file": str(playbook), "line": 1}]
+
+        def noop_transform(content: str, violation: ViolationDict) -> TransformResult:
+            captured.append(violation)
+            return TransformResult(content, False)
+
+        reg = TransformRegistry()
+        reg.register("STUB", noop_transform)
+        engine = RemediationEngine(reg, scan_fn, max_passes=2)
+
+        engine.remediate([str(playbook)], apply=False)
+        assert len(captured) >= 1
+        assert captured[0].get("remediation_class") == RemediationClass.AI_CANDIDATE
+        assert captured[0].get("remediation_resolution") == RemediationResolution.TRANSFORM_FAILED
+
+    def test_oscillation_sets_resolution(self, tmp_path: Path) -> None:
+        """Verifies oscillation sets OSCILLATION resolution on remaining Tier 1 violations.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        playbook = tmp_path / "play.yml"
+        playbook.write_text("- name: test\n  debug: msg=hi\n")
+
+        def scan_fn(paths: list[str]) -> list[ViolationDict]:
+            return [{"rule_id": "FLIP", "file": str(playbook), "line": 1}]
+
+        def flip_transform(content: str, violation: ViolationDict) -> TransformResult:
+            return TransformResult(content + "\n# flipped", True)
+
+        reg = TransformRegistry()
+        reg.register("FLIP", flip_transform)
+        engine = RemediationEngine(reg, scan_fn, max_passes=3)
+
+        report = engine.remediate([str(playbook)], apply=True)
+        assert report.oscillation_detected is True
+
+    def test_remaining_violations_have_classification(self, tmp_path: Path) -> None:
+        """Verifies remaining violations carry remediation_class and remediation_resolution.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        playbook = tmp_path / "play.yml"
+        playbook.write_text("- name: test\n  debug: msg=hi\n")
+
+        def scan_fn(paths: list[str]) -> list[ViolationDict]:
+            return [
+                {"rule_id": "UNKNOWN", "file": str(playbook), "line": 1},
+                {"rule_id": "MANUAL", "file": str(playbook), "line": 2, "ai_proposable": False},
+            ]
+
+        reg = TransformRegistry()
+        engine = RemediationEngine(reg, scan_fn, max_passes=1)
+
+        report = engine.remediate([str(playbook)], apply=False)
+        for v in report.remaining_ai + report.remaining_manual:
+            assert "remediation_class" in v
+            assert "remediation_resolution" in v
+            assert v["remediation_resolution"] == RemediationResolution.UNRESOLVED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_violation_convert.py
+++ b/tests/test_violation_convert.py
@@ -1,0 +1,243 @@
+"""Tests for violation_convert: dict ↔ proto conversion."""
+# mypy: disable-error-code="attr-defined"
+
+from apme.v1 import common_pb2
+from apme.v1.common_pb2 import LineRange, Violation
+from apme_engine.daemon.violation_convert import (
+    violation_dict_to_proto,
+    violation_proto_to_dict,
+)
+from apme_engine.engine.models import RemediationClass, RemediationResolution, ViolationDict
+
+
+class TestViolationDictToProto:
+    """Tests for converting dict violations to proto."""
+
+    def test_basic_conversion(self) -> None:
+        """Dict fields map to proto fields."""
+        v: ViolationDict = {
+            "rule_id": "L021",
+            "level": "high",
+            "message": "Missing mode",
+            "file": "playbook.yml",
+            "line": 10,
+            "path": "tasks",
+        }
+        proto = violation_dict_to_proto(v)
+        assert proto.rule_id == "L021"
+        assert proto.level == "high"
+        assert proto.message == "Missing mode"
+        assert proto.file == "playbook.yml"
+        assert proto.line == 10
+        assert proto.path == "tasks"
+
+    def test_line_range_conversion(self) -> None:
+        """Line range tuple converts to LineRange proto."""
+        v: ViolationDict = {"rule_id": "L021", "line": [5, 10]}
+        proto = violation_dict_to_proto(v)
+        assert proto.HasField("line_range")
+        assert proto.line_range.start == 5
+        assert proto.line_range.end == 10
+
+    def test_remediation_class_auto_fixable(self) -> None:
+        """Auto-fixable class converts to proto enum."""
+        v = {"rule_id": "L021", "remediation_class": RemediationClass.AUTO_FIXABLE}
+        proto = violation_dict_to_proto(v)
+        assert proto.remediation_class == common_pb2.REMEDIATION_CLASS_AUTO_FIXABLE
+
+    def test_remediation_class_ai_candidate(self) -> None:
+        """AI-candidate class converts to proto enum."""
+        v = {"rule_id": "L021", "remediation_class": RemediationClass.AI_CANDIDATE}
+        proto = violation_dict_to_proto(v)
+        assert proto.remediation_class == common_pb2.REMEDIATION_CLASS_AI_CANDIDATE
+
+    def test_remediation_class_manual_review(self) -> None:
+        """Manual-review class converts to proto enum."""
+        v = {"rule_id": "L021", "remediation_class": RemediationClass.MANUAL_REVIEW}
+        proto = violation_dict_to_proto(v)
+        assert proto.remediation_class == common_pb2.REMEDIATION_CLASS_MANUAL_REVIEW
+
+    def test_missing_remediation_class_defaults_to_ai(self) -> None:
+        """Missing remediation_class defaults to AI_CANDIDATE."""
+        v = {"rule_id": "L021"}
+        proto = violation_dict_to_proto(v)
+        assert proto.remediation_class == common_pb2.REMEDIATION_CLASS_AI_CANDIDATE
+
+    def test_resolution_transform_failed(self) -> None:
+        """TRANSFORM_FAILED resolution converts to proto enum."""
+        v = {"rule_id": "L021", "remediation_resolution": RemediationResolution.TRANSFORM_FAILED}
+        proto = violation_dict_to_proto(v)
+        assert proto.remediation_resolution == common_pb2.REMEDIATION_RESOLUTION_TRANSFORM_FAILED
+
+    def test_resolution_oscillation(self) -> None:
+        """OSCILLATION resolution converts to proto enum."""
+        v = {"rule_id": "L021", "remediation_resolution": RemediationResolution.OSCILLATION}
+        proto = violation_dict_to_proto(v)
+        assert proto.remediation_resolution == common_pb2.REMEDIATION_RESOLUTION_OSCILLATION
+
+    def test_resolution_ai_values(self) -> None:
+        """AI resolution values convert to proto enums."""
+        for res, expected in [
+            (RemediationResolution.AI_PROPOSED, common_pb2.REMEDIATION_RESOLUTION_AI_PROPOSED),
+            (RemediationResolution.AI_FAILED, common_pb2.REMEDIATION_RESOLUTION_AI_FAILED),
+            (RemediationResolution.AI_LOW_CONFIDENCE, common_pb2.REMEDIATION_RESOLUTION_AI_LOW_CONFIDENCE),
+            (RemediationResolution.USER_REJECTED, common_pb2.REMEDIATION_RESOLUTION_USER_REJECTED),
+        ]:
+            v = {"rule_id": "L021", "remediation_resolution": res}
+            proto = violation_dict_to_proto(v)
+            assert proto.remediation_resolution == expected
+
+    def test_missing_resolution_defaults_to_unresolved(self) -> None:
+        """Missing remediation_resolution defaults to UNRESOLVED."""
+        v = {"rule_id": "L021"}
+        proto = violation_dict_to_proto(v)
+        assert proto.remediation_resolution == common_pb2.REMEDIATION_RESOLUTION_UNRESOLVED
+
+
+class TestViolationProtoToDict:
+    """Tests for converting proto violations to dict."""
+
+    def test_basic_conversion(self) -> None:
+        """Proto fields map to dict fields."""
+        proto = Violation(
+            rule_id="L021",
+            level="high",
+            message="Missing mode",
+            file="playbook.yml",
+            line=10,
+            path="tasks",
+        )
+        d = violation_proto_to_dict(proto)
+        assert d["rule_id"] == "L021"
+        assert d["level"] == "high"
+        assert d["message"] == "Missing mode"
+        assert d["file"] == "playbook.yml"
+        assert d["line"] == 10
+        assert d["path"] == "tasks"
+
+    def test_line_range_conversion(self) -> None:
+        """LineRange proto converts to list."""
+        proto = Violation(rule_id="L021")
+        proto.line_range.CopyFrom(LineRange(start=5, end=10))
+        d = violation_proto_to_dict(proto)
+        assert d["line"] == [5, 10]
+
+    def test_remediation_class_auto_fixable(self) -> None:
+        """Proto AUTO_FIXABLE enum converts to string."""
+        proto = Violation(
+            rule_id="L021",
+            remediation_class=common_pb2.REMEDIATION_CLASS_AUTO_FIXABLE,
+        )
+        d = violation_proto_to_dict(proto)
+        assert d["remediation_class"] == RemediationClass.AUTO_FIXABLE
+
+    def test_remediation_class_ai_candidate(self) -> None:
+        """Proto AI_CANDIDATE enum converts to string."""
+        proto = Violation(
+            rule_id="L021",
+            remediation_class=common_pb2.REMEDIATION_CLASS_AI_CANDIDATE,
+        )
+        d = violation_proto_to_dict(proto)
+        assert d["remediation_class"] == RemediationClass.AI_CANDIDATE
+
+    def test_remediation_class_manual_review(self) -> None:
+        """Proto MANUAL_REVIEW enum converts to string."""
+        proto = Violation(
+            rule_id="L021",
+            remediation_class=common_pb2.REMEDIATION_CLASS_MANUAL_REVIEW,
+        )
+        d = violation_proto_to_dict(proto)
+        assert d["remediation_class"] == RemediationClass.MANUAL_REVIEW
+
+    def test_unspecified_remediation_class_defaults_to_ai(self) -> None:
+        """Unspecified remediation_class defaults to AI_CANDIDATE."""
+        proto = Violation(
+            rule_id="L021",
+            remediation_class=common_pb2.REMEDIATION_CLASS_UNSPECIFIED,
+        )
+        d = violation_proto_to_dict(proto)
+        assert d["remediation_class"] == RemediationClass.AI_CANDIDATE
+
+    def test_resolution_transform_failed(self) -> None:
+        """Proto TRANSFORM_FAILED resolution converts to string."""
+        proto = Violation(
+            rule_id="L021",
+            remediation_resolution=common_pb2.REMEDIATION_RESOLUTION_TRANSFORM_FAILED,
+        )
+        d = violation_proto_to_dict(proto)
+        assert d["remediation_resolution"] == RemediationResolution.TRANSFORM_FAILED
+
+    def test_resolution_oscillation(self) -> None:
+        """Proto OSCILLATION resolution converts to string."""
+        proto = Violation(
+            rule_id="L021",
+            remediation_resolution=common_pb2.REMEDIATION_RESOLUTION_OSCILLATION,
+        )
+        d = violation_proto_to_dict(proto)
+        assert d["remediation_resolution"] == RemediationResolution.OSCILLATION
+
+    def test_unspecified_resolution_defaults_to_unresolved(self) -> None:
+        """Unspecified remediation_resolution defaults to UNRESOLVED."""
+        proto = Violation(
+            rule_id="L021",
+            remediation_resolution=common_pb2.REMEDIATION_RESOLUTION_UNSPECIFIED,
+        )
+        d = violation_proto_to_dict(proto)
+        assert d["remediation_resolution"] == RemediationResolution.UNRESOLVED
+
+    def test_resolution_all_ai_values(self) -> None:
+        """All AI resolution proto enums convert to strings."""
+        for proto_val, expected in [
+            (common_pb2.REMEDIATION_RESOLUTION_AI_PROPOSED, RemediationResolution.AI_PROPOSED),
+            (common_pb2.REMEDIATION_RESOLUTION_AI_FAILED, RemediationResolution.AI_FAILED),
+            (common_pb2.REMEDIATION_RESOLUTION_AI_LOW_CONFIDENCE, RemediationResolution.AI_LOW_CONFIDENCE),
+            (common_pb2.REMEDIATION_RESOLUTION_USER_REJECTED, RemediationResolution.USER_REJECTED),
+        ]:
+            proto = Violation(rule_id="L021", remediation_resolution=proto_val)
+            d = violation_proto_to_dict(proto)
+            assert d["remediation_resolution"] == expected
+
+
+class TestRoundTrip:
+    """Tests for round-trip conversion dict → proto → dict."""
+
+    def test_round_trip_preserves_values(self) -> None:
+        """Converting dict to proto and back preserves all fields."""
+        original: ViolationDict = {
+            "rule_id": "L021",
+            "level": "high",
+            "message": "Missing mode",
+            "file": "playbook.yml",
+            "line": 10,
+            "path": "tasks",
+            "remediation_class": RemediationClass.AUTO_FIXABLE,
+            "remediation_resolution": RemediationResolution.UNRESOLVED,
+        }
+        proto = violation_dict_to_proto(original)
+        result = violation_proto_to_dict(proto)
+        assert result["rule_id"] == original["rule_id"]
+        assert result["level"] == original["level"]
+        assert result["message"] == original["message"]
+        assert result["file"] == original["file"]
+        assert result["line"] == original["line"]
+        assert result["path"] == original["path"]
+        assert result["remediation_class"] == original["remediation_class"]
+        assert result["remediation_resolution"] == original["remediation_resolution"]
+
+    def test_round_trip_line_range(self) -> None:
+        """Line range round-trips correctly."""
+        original: ViolationDict = {"rule_id": "L021", "line": [5, 10]}
+        proto = violation_dict_to_proto(original)
+        result = violation_proto_to_dict(proto)
+        assert result["line"] == [5, 10]
+
+    def test_round_trip_resolution(self) -> None:
+        """All resolution values round-trip correctly."""
+        for res in RemediationResolution:
+            original: ViolationDict = {
+                "rule_id": "L021",
+                "remediation_resolution": res,
+            }
+            proto = violation_dict_to_proto(original)
+            result = violation_proto_to_dict(proto)
+            assert result["remediation_resolution"] == res, f"Failed for {res}"


### PR DESCRIPTION
## Summary
- Add 3-tier remediation classification system with colored badges in scan output
- Add per-finding `RemediationResolution` enum to track what happened during remediation (transform-failed, oscillation, ai-proposed, ai-failed, ai-low-confidence, user-rejected)
- Convert `RemediationClass` and add `RemediationResolution` as `str, Enum` for type safety and iteration
- Wire resolution tracking into `RemediationEngine`: transform failures set `TRANSFORM_FAILED`, oscillation sets `OSCILLATION`
- Move classification to server-side (`primary_server.py`) as single source of truth; remove redundant client-side re-classification
- Extract `_apply_remediation` from `_run_fix` to eliminate manual `argparse.Namespace` construction in `--auto-fix`
- Add `--auto-fix` flag to scan command for one-step fix application

## Changes
- `engine/models.py`: Add `RemediationClass` and `RemediationResolution` as `str, Enum`
- `partition.py`: Add `classify_violation()`, `add_classification_to_violations()` (mutates in place, returns None), `count_by_remediation_class()`, `count_by_resolution()`
- `ansi.py`: Add `remediation_badge()` with styled badges (FIX/green, AI/blue, MANUAL/magenta)
- `common.proto`: Add `RemediationClass` + `RemediationResolution` proto enums with fields 8-9 on Violation
- `violation_convert.py`: Bidirectional proto <-> dict mapping for both class and resolution
- `engine.py`: Wire `TRANSFORM_FAILED` and `OSCILLATION` resolution into convergence loop
- `primary_server.py`: Classify violations server-side before proto serialization
- `cli.py`: Extract `_apply_remediation`, display remediation column + resolution summary, include `resolution_summary` in JSON output
- Fix UP038 linter warnings across codebase (modern isinstance union syntax)
- Add comprehensive test coverage (924 tests pass)

## Test plan
- [x] `prek run --all-files` passes
- [x] `pytest tests/` passes (924 tests)
- [x] Visual verification of badge output with `apme-scan examples/`