### PR TITLE
feat: structured Tier 1 transforms with parse-once/serialize-once

### DIFF
--- a/src/apme_engine/remediation/__init__.py
+++ b/src/apme_engine/remediation/__init__.py
@@ -2,13 +2,21 @@
 
 from apme_engine.remediation.engine import FixReport, RemediationEngine
 from apme_engine.remediation.partition import is_finding_resolvable
-from apme_engine.remediation.registry import TransformFn, TransformRegistry, TransformResult
+from apme_engine.remediation.registry import (
+    StructuredTransformFn,
+    TransformFn,
+    TransformRegistry,
+    TransformResult,
+)
+from apme_engine.remediation.structured import StructuredFile
 
 __all__ = [
+    "FixReport",
+    "RemediationEngine",
+    "StructuredFile",
+    "StructuredTransformFn",
+    "TransformFn",
     "TransformRegistry",
     "TransformResult",
-    "TransformFn",
     "is_finding_resolvable",
-    "RemediationEngine",
-    "FixReport",
 ]

--- a/src/apme_engine/remediation/engine.py
+++ b/src/apme_engine/remediation/engine.py
@@ -1,8 +1,14 @@
-"""Remediation engine — convergence loop that applies Tier 1 transforms."""
+"""Remediation engine — convergence loop that applies Tier 1 transforms.
+
+Uses ``StructuredFile`` to parse each YAML file once, apply all transforms
+on the in-memory ``CommentedMap``/``CommentedSeq``, and serialize only when
+needed (once per convergence pass, for re-scanning).
+"""
 
 from __future__ import annotations
 
 import difflib
+import logging
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -15,7 +21,10 @@ from apme_engine.remediation.partition import (
     partition_violations,
 )
 from apme_engine.remediation.registry import TransformRegistry
+from apme_engine.remediation.structured import StructuredFile
 from apme_engine.remediation.transforms._helpers import violation_line_to_int
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -136,6 +145,15 @@ class RemediationEngine:
         for fp in file_paths:
             file_contents[fp] = Path(fp).read_text(encoding="utf-8")
 
+        # Build StructuredFile wrappers — parse each file once.
+        # Files that fail to parse are left in file_contents as raw strings
+        # and handled via the legacy string path in the registry.
+        structured: dict[str, StructuredFile] = {}
+        for fp, content in file_contents.items():
+            sf = StructuredFile.from_content(fp, content)
+            if sf is not None:
+                structured[fp] = sf
+
         # Violations may report relative filenames (e.g. "site.yml") while
         # file_contents keys are absolute paths.  Build a reverse lookup so we
         # can resolve either form to the canonical key.  When multiple files
@@ -188,14 +206,30 @@ class RemediationEngine:
                 if vf is None:
                     continue
 
-                result = self._registry.apply(rule_id, file_contents[vf], v)
-                if result.applied:
-                    file_contents[vf] = result.content
-                    all_applied_rules[vf].append(rule_id)
-                    applied_this_pass += 1
+                sf = structured.get(vf)
+                if sf is not None:
+                    applied = self._registry.apply_structured(rule_id, sf, v)
+                    if applied:
+                        all_applied_rules[vf].append(rule_id)
+                        applied_this_pass += 1
+                    else:
+                        v["remediation_class"] = RemediationClass.AI_CANDIDATE
+                        v["remediation_resolution"] = RemediationResolution.TRANSFORM_FAILED
                 else:
-                    v["remediation_class"] = RemediationClass.AI_CANDIDATE
-                    v["remediation_resolution"] = RemediationResolution.TRANSFORM_FAILED
+                    result = self._registry.apply(rule_id, file_contents[vf], v)
+                    if result.applied:
+                        file_contents[vf] = result.content
+                        all_applied_rules[vf].append(rule_id)
+                        applied_this_pass += 1
+                    else:
+                        v["remediation_class"] = RemediationClass.AI_CANDIDATE
+                        v["remediation_resolution"] = RemediationResolution.TRANSFORM_FAILED
+
+            # Serialize dirty structured files once per pass
+            for fp, sf in structured.items():
+                if sf.dirty:
+                    file_contents[fp] = sf.serialize()
+                    sf.reset_dirty()
 
             self._log(f"  Pass {pass_num}: applied {applied_this_pass}")
 
@@ -221,6 +255,13 @@ class RemediationEngine:
             if new_fixable == 0:
                 self._log(f"  Pass {pass_num}: fully converged (0 fixable)")
                 break
+
+            # Re-parse structured files from the serialized content
+            # so line numbers match the on-disk state for the next pass
+            for fp in list(structured):
+                sf = StructuredFile.from_content(fp, file_contents[fp])
+                if sf is not None:
+                    structured[fp] = sf
 
         # Final partition of remaining violations
         self._write_files(file_contents)

--- a/src/apme_engine/remediation/registry.py
+++ b/src/apme_engine/remediation/registry.py
@@ -1,15 +1,26 @@
-"""Transform registry — maps rule IDs to deterministic fix functions."""
+"""Transform registry — maps rule IDs to deterministic fix functions.
+
+Supports two transform signatures:
+
+- **Structured** (preferred): ``(StructuredFile, ViolationDict) -> bool``
+  — operates on the already-parsed ruamel.yaml data in-place.
+- **Legacy string**: ``(str, ViolationDict) -> TransformResult``
+  — re-parses the file on every call.  Retained for backward compat.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from apme_engine.engine.models import ViolationDict
 
+if TYPE_CHECKING:
+    from apme_engine.remediation.structured import StructuredFile
+
 
 class TransformResult(NamedTuple):
-    """Result of applying a transform to file content.
+    """Result of applying a legacy (string-based) transform.
 
     Attributes:
         content: File content (possibly modified).
@@ -21,28 +32,48 @@ class TransformResult(NamedTuple):
 
 
 TransformFn = Callable[[str, ViolationDict], TransformResult]
+StructuredTransformFn = Callable[["StructuredFile", ViolationDict], bool]
 
 
 class TransformRegistry:
     """Maps rule IDs to deterministic fix functions.
 
-    A transform receives (file_content, violation_dict) and returns a
-    TransformResult with the (possibly modified) content and a flag
-    indicating whether a change was made.
+    The registry stores both structured and legacy transforms.
+    ``apply_structured`` is preferred when a ``StructuredFile`` is
+    available; ``apply`` falls back to re-parsing.
     """
 
     def __init__(self) -> None:
         """Initialize an empty transform registry."""
         self._transforms: dict[str, TransformFn] = {}
+        self._structured: dict[str, StructuredTransformFn] = {}
 
-    def register(self, rule_id: str, fn: TransformFn) -> None:
-        """Register a transform function for a rule ID.
+    def register(
+        self,
+        rule_id: str,
+        fn: TransformFn | None = None,
+        *,
+        structured: StructuredTransformFn | None = None,
+    ) -> None:
+        """Register transform function(s) for a rule ID.
+
+        At least one of *fn* or *structured* must be provided.
 
         Args:
             rule_id: Rule identifier (e.g. L007, M001).
-            fn: Transform function (content, violation) -> TransformResult.
+            fn: Legacy transform (content, violation) -> TransformResult.
+            structured: Structured transform (StructuredFile, violation) -> bool.
+
+        Raises:
+            ValueError: If both *fn* and *structured* are None.
         """
-        self._transforms[rule_id] = fn
+        if fn is None and structured is None:
+            msg = f"register({rule_id!r}): at least one of fn or structured required"
+            raise ValueError(msg)
+        if fn is not None:
+            self._transforms[rule_id] = fn
+        if structured is not None:
+            self._structured[rule_id] = structured
 
     def __contains__(self, rule_id: str) -> bool:
         """Check if a rule has a registered transform.
@@ -51,25 +82,25 @@ class TransformRegistry:
             rule_id: Rule identifier to look up.
 
         Returns:
-            True if rule_id is registered.
+            True if rule_id is registered (structured or legacy).
         """
-        return rule_id in self._transforms
+        return rule_id in self._transforms or rule_id in self._structured
 
     def __len__(self) -> int:
-        """Return the number of registered transforms.
+        """Return the number of unique registered rule IDs.
 
         Returns:
             Count of registered rule IDs.
         """
-        return len(self._transforms)
+        return len(set(self._transforms) | set(self._structured))
 
     def __iter__(self) -> Iterator[str]:
-        """Iterate over registered rule IDs.
+        """Iterate over registered rule IDs in sorted order.
 
         Returns:
-            Iterator of rule ID strings.
+            Iterator of rule ID strings (deterministic, sorted).
         """
-        return iter(self._transforms)
+        return iter(sorted(set(self._transforms) | set(self._structured)))
 
     @property
     def rule_ids(self) -> list[str]:
@@ -78,10 +109,52 @@ class TransformRegistry:
         Returns:
             Sorted list of rule ID strings.
         """
-        return sorted(self._transforms)
+        return sorted(set(self._transforms) | set(self._structured))
+
+    def apply_structured(
+        self,
+        rule_id: str,
+        sf: StructuredFile,
+        violation: ViolationDict,
+    ) -> bool:
+        """Apply a structured transform in-place on a StructuredFile.
+
+        Falls back to the legacy string path if no structured transform
+        is registered (re-parses from ``sf.serialize()``).
+
+        Args:
+            rule_id: Rule identifier.
+            sf: StructuredFile to modify in-place.
+            violation: Violation dict for context.
+
+        Returns:
+            True if the transform was applied.
+        """
+        sfn = self._structured.get(rule_id)
+        if sfn is not None:
+            applied = sfn(sf, violation)
+            if applied:
+                sf.mark_dirty()
+            return applied
+
+        fn = self._transforms.get(rule_id)
+        if fn is None:
+            return False
+        result = fn(sf.serialize(), violation)
+        if result.applied:
+            new_sf = type(sf).from_content(sf.file_path, result.content)
+            if new_sf is None:
+                return False
+            sf.data = new_sf.data
+            sf._yaml = new_sf._yaml  # noqa: SLF001
+            sf.mark_dirty()
+            return True
+        return False
 
     def apply(self, rule_id: str, content: str, violation: ViolationDict) -> TransformResult:
-        """Apply the transform for a rule to content.
+        """Apply the legacy string-based transform for a rule.
+
+        Retained for backward compatibility; prefer ``apply_structured``.
 
         Args:
             rule_id: Rule identifier.

--- a/src/apme_engine/remediation/structured.py
+++ b/src/apme_engine/remediation/structured.py
@@ -1,0 +1,89 @@
+"""StructuredFile — parse-once wrapper for ruamel.yaml round-trip data.
+
+A StructuredFile holds the parsed CommentedMap/CommentedSeq for a single
+YAML file.  Transforms operate on the in-memory structure and the file
+is serialized only when the engine needs to write it to disk.
+"""
+
+from __future__ import annotations
+
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+
+from apme_engine.engine.yaml_utils import FormattedYAML
+
+
+class StructuredFile:
+    """Parsed YAML file with in-place mutation and deferred serialization."""
+
+    __slots__ = ("file_path", "data", "dirty", "_yaml")
+
+    def __init__(
+        self,
+        file_path: str,
+        data: CommentedMap | CommentedSeq,
+        yaml_instance: FormattedYAML,
+    ) -> None:
+        """Initialize a StructuredFile.
+
+        Args:
+            file_path: Absolute path to the source file.
+            data: Already-parsed ruamel.yaml round-trip structure.
+            yaml_instance: Configured FormattedYAML used for serialization.
+        """
+        self.file_path = file_path
+        self.data = data
+        self.dirty = False
+        self._yaml = yaml_instance
+
+    @classmethod
+    def from_content(cls, file_path: str, content: str) -> StructuredFile | None:
+        """Parse YAML content into a StructuredFile.
+
+        Args:
+            file_path: Path to associate with this file.
+            content: Raw YAML string.
+
+        Returns:
+            StructuredFile on success, None if the YAML is unparseable.
+        """
+        yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
+        try:
+            data = yaml.load(content)
+        except Exception:  # noqa: BLE001
+            return None
+        if not isinstance(data, CommentedMap | CommentedSeq):
+            return None
+        return cls(file_path, data, yaml)
+
+    def serialize(self) -> str:
+        """Serialize the in-memory structure back to a YAML string.
+
+        Returns:
+            YAML string produced by FormattedYAML.dumps.
+        """
+        return self._yaml.dumps(self.data)
+
+    def find_task(self, line: int) -> CommentedMap | None:
+        """Locate the task CommentedMap at a 1-based line number.
+
+        Defers the import of ``find_task_at_line`` to avoid a circular
+        dependency (structured -> transforms._helpers -> transforms.__init__
+        -> L007 etc. -> structured).
+
+        Args:
+            line: 1-indexed line number from a violation.
+
+        Returns:
+            Task CommentedMap or None if not found.
+        """
+        from apme_engine.remediation.transforms._helpers import find_task_at_line
+
+        return find_task_at_line(self.data, line)
+
+    def mark_dirty(self) -> None:
+        """Mark this file as having been modified by a transform."""
+        self.dirty = True
+
+    def reset_dirty(self) -> None:
+        """Clear the dirty flag (e.g. after serialization)."""
+        self.dirty = False

--- a/src/apme_engine/remediation/transforms/L007_shell_to_command.py
+++ b/src/apme_engine/remediation/transforms/L007_shell_to_command.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
+from apme_engine.remediation.structured import StructuredFile
 from apme_engine.remediation.transforms._helpers import (
-    find_task_at_line,
     get_module_key,
     rename_key,
     violation_line_to_int,
@@ -33,31 +31,23 @@ def _uses_shell_features(cmd: str) -> bool:
     return any(ch in cmd for ch in _SHELL_CHARS)
 
 
-def fix_shell_to_command(content: str, violation: ViolationDict) -> TransformResult:
+def fix_shell_to_command(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Replace shell with command when the command string uses no shell features.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_key = get_module_key(task)
     if module_key is None or module_key not in _SHELL_TO_COMMAND:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_args = task.get(module_key)
     cmd = ""
@@ -67,9 +57,8 @@ def fix_shell_to_command(content: str, violation: ViolationDict) -> TransformRes
         cmd = module_args.get("cmd", "")
 
     if cmd and _uses_shell_features(cmd):
-        return TransformResult(content=content, applied=False)
+        return False
 
     new_key = _SHELL_TO_COMMAND[module_key]
     rename_key(task, module_key, new_key)
-
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/L008_local_action.py
+++ b/src/apme_engine/remediation/transforms/L008_local_action.py
@@ -5,36 +5,27 @@ from __future__ import annotations
 from ruamel.yaml.comments import CommentedMap
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import violation_line_to_int
 
 
-def fix_local_action(content: str, violation: ViolationDict) -> TransformResult:
+def fix_local_action(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Convert local_action to the module key + delegate_to: localhost.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     la_value = task.get("local_action")
     if la_value is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     if isinstance(la_value, str):
         parts = la_value.split(None, 1)
@@ -51,13 +42,13 @@ def fix_local_action(content: str, violation: ViolationDict) -> TransformResult:
     elif isinstance(la_value, CommentedMap):
         module_name = la_value.pop("module", None)
         if not module_name:
-            return TransformResult(content=content, applied=False)
+            return False
 
         del task["local_action"]
         task[module_name] = la_value if la_value else CommentedMap()
         task["delegate_to"] = "localhost"
 
     else:
-        return TransformResult(content=content, applied=False)
+        return False
 
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/L009_empty_string.py
+++ b/src/apme_engine/remediation/transforms/L009_empty_string.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import re
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import violation_line_to_int
 
 _PATTERNS = [
     (re.compile(r'\b(\w+)\s*==\s*""'), r"\1 | length == 0"),
@@ -17,38 +16,30 @@ _PATTERNS = [
 ]
 
 
-def fix_empty_string(content: str, violation: ViolationDict) -> TransformResult:
+def fix_empty_string(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Replace `var == ""` with `var | length == 0` and similar.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     when_val = task.get("when")
     if not isinstance(when_val, str):
-        return TransformResult(content=content, applied=False)
+        return False
 
     new_when = when_val
     for pat, repl in _PATTERNS:
         new_when = pat.sub(repl, new_when)
 
     if new_when == when_val:
-        return TransformResult(content=content, applied=False)
+        return False
 
     task["when"] = new_when
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/L011_literal_bool.py
+++ b/src/apme_engine/remediation/transforms/L011_literal_bool.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import re
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import violation_line_to_int
 
 _REPLACEMENTS = [
     # Equality — simplify to bare variable (or negation)
@@ -23,38 +22,30 @@ _REPLACEMENTS = [
 ]
 
 
-def fix_literal_bool(content: str, violation: ViolationDict) -> TransformResult:
+def fix_literal_bool(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Remove literal true/false comparisons from when clause.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     when_val = task.get("when")
     if not isinstance(when_val, str):
-        return TransformResult(content=content, applied=False)
+        return False
 
     new_when = when_val
     for pat, repl in _REPLACEMENTS:
         new_when = pat.sub(repl, new_when)
 
     if new_when == when_val:
-        return TransformResult(content=content, applied=False)
+        return False
 
     task["when"] = new_when
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/L012_latest.py
+++ b/src/apme_engine/remediation/transforms/L012_latest.py
@@ -3,40 +3,31 @@
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import get_module_key, violation_line_to_int
 
 
-def fix_latest(content: str, violation: ViolationDict) -> TransformResult:
+def fix_latest(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Replace ``state: latest`` with ``state: present``.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_key = get_module_key(task)
     if module_key is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_args = task.get(module_key)
     if isinstance(module_args, dict) and module_args.get("state") == "latest":
         module_args["state"] = "present"
-        return TransformResult(content=yaml.dumps(data), applied=True)
+        return True
 
-    return TransformResult(content=content, applied=False)
+    return False

--- a/src/apme_engine/remediation/transforms/L013_changed_when.py
+++ b/src/apme_engine/remediation/transforms/L013_changed_when.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import get_module_key, violation_line_to_int
 
 _CMD_MODULES = frozenset(
     {
@@ -22,41 +21,33 @@ _CMD_MODULES = frozenset(
 )
 
 
-def fix_changed_when(content: str, violation: ViolationDict) -> TransformResult:
+def fix_changed_when(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Add ``changed_when: false`` to command/shell/raw tasks.
 
     This is a conservative default — the task may actually change state,
     but the user should audit and adjust the condition.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_key = get_module_key(task)
     if module_key is None or module_key not in _CMD_MODULES:
-        return TransformResult(content=content, applied=False)
+        return False
 
     if "changed_when" in task:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_args = task.get(module_key)
     if isinstance(module_args, dict) and ("creates" in module_args or "removes" in module_args):
-        return TransformResult(content=content, applied=False)
+        return False
 
     task["changed_when"] = False
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/L015_jinja_when.py
+++ b/src/apme_engine/remediation/transforms/L015_jinja_when.py
@@ -5,43 +5,34 @@ from __future__ import annotations
 import re
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import violation_line_to_int
 
 _JINJA_EXPR = re.compile(r"\{\{\s*(.+?)\s*\}\}")
 
 
-def fix_jinja_when(content: str, violation: ViolationDict) -> TransformResult:
+def fix_jinja_when(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Replace ``{{ var }}`` in when with bare ``var``.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     when_val = task.get("when")
     if not isinstance(when_val, str):
-        return TransformResult(content=content, applied=False)
+        return False
 
     new_when = _JINJA_EXPR.sub(r"\1", when_val)
 
     if new_when == when_val:
-        return TransformResult(content=content, applied=False)
+        return False
 
     task["when"] = new_when
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/L018_become.py
+++ b/src/apme_engine/remediation/transforms/L018_become.py
@@ -3,38 +3,29 @@
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import violation_line_to_int
 
 
-def fix_become(content: str, violation: ViolationDict) -> TransformResult:
+def fix_become(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Add ``become: true`` when ``become_user`` is set.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     if "become_user" not in task:
-        return TransformResult(content=content, applied=False)
+        return False
 
     if "become" in task:
-        return TransformResult(content=content, applied=False)
+        return False
 
     items = list(task.items())
     task.clear()
@@ -43,4 +34,4 @@ def fix_become(content: str, violation: ViolationDict) -> TransformResult:
         if k == "become_user":
             task["become"] = True
 
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/L021_missing_mode.py
+++ b/src/apme_engine/remediation/transforms/L021_missing_mode.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import get_module_key, violation_line_to_int
 
 _FILE_MODULES = frozenset(
     {
@@ -31,42 +30,34 @@ _FILE_MODULES = frozenset(
 )
 
 
-def fix_missing_mode(content: str, violation: ViolationDict) -> TransformResult:
+def fix_missing_mode(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Add mode: '0644' to file-related tasks that lack an explicit mode.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_key = get_module_key(task)
     if module_key is None or module_key not in _FILE_MODULES:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_args = task.get(module_key)
 
     if isinstance(module_args, dict):
         if "mode" in module_args:
-            return TransformResult(content=content, applied=False)
+            return False
         module_args["mode"] = "0644"
     else:
         if "mode" not in task:
             task["mode"] = "0644"
         else:
-            return TransformResult(content=content, applied=False)
+            return False
 
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/L022_pipefail.py
+++ b/src/apme_engine/remediation/transforms/L022_pipefail.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import get_module_key, violation_line_to_int
 
 _SHELL_MODULES = frozenset(
     {
@@ -16,49 +15,41 @@ _SHELL_MODULES = frozenset(
 )
 
 
-def fix_pipefail(content: str, violation: ViolationDict) -> TransformResult:
+def fix_pipefail(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Prepend ``set -o pipefail &&`` to a piped shell command.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_key = get_module_key(task)
     if module_key is None or module_key not in _SHELL_MODULES:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_args = task.get(module_key)
 
     if isinstance(module_args, str):
         if "|" not in module_args or "pipefail" in module_args:
-            return TransformResult(content=content, applied=False)
+            return False
         task[module_key] = "set -o pipefail && " + module_args
 
     elif isinstance(module_args, dict):
         cmd = module_args.get("cmd", "")
         executable = module_args.get("executable", "")
         if "|" not in cmd:
-            return TransformResult(content=content, applied=False)
+            return False
         if "pipefail" in cmd or "pipefail" in executable:
-            return TransformResult(content=content, applied=False)
+            return False
         module_args["cmd"] = "set -o pipefail && " + cmd
 
     else:
-        return TransformResult(content=content, applied=False)
+        return False
 
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/L025_name_casing.py
+++ b/src/apme_engine/remediation/transforms/L025_name_casing.py
@@ -3,39 +3,30 @@
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import violation_line_to_int
 
 
-def fix_name_casing(content: str, violation: ViolationDict) -> TransformResult:
+def fix_name_casing(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Capitalize the first letter of a task or play name.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     name = task.get("name")
     if not isinstance(name, str) or not name:
-        return TransformResult(content=content, applied=False)
+        return False
 
     if name[0].isupper():
-        return TransformResult(content=content, applied=False)
+        return False
 
     task["name"] = name[0].upper() + name[1:]
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/L043_bare_vars.py
+++ b/src/apme_engine/remediation/transforms/L043_bare_vars.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import re
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import violation_line_to_int
 
 _BARE_VAR = re.compile(r"^([a-zA-Z_]\w*)$")
 
@@ -22,27 +21,19 @@ _LOOP_KEYS = (
 )
 
 
-def fix_bare_vars(content: str, violation: ViolationDict) -> TransformResult:
+def fix_bare_vars(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Wrap bare variable references in Jinja delimiters: ``foo`` -> ``{{ foo }}``.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     applied = False
     for key in _LOOP_KEYS:
@@ -51,7 +42,4 @@ def fix_bare_vars(content: str, violation: ViolationDict) -> TransformResult:
             task[key] = "{{ " + val + " }}"
             applied = True
 
-    if not applied:
-        return TransformResult(content=content, applied=False)
-
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return applied

--- a/src/apme_engine/remediation/transforms/L046_no_free_form.py
+++ b/src/apme_engine/remediation/transforms/L046_no_free_form.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from ruamel.yaml.comments import CommentedMap
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, get_module_key, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import get_module_key, violation_line_to_int
 
 _FREE_FORM_MODULES = frozenset(
     {
@@ -26,38 +25,30 @@ _FREE_FORM_MODULES = frozenset(
 )
 
 
-def fix_free_form(content: str, violation: ViolationDict) -> TransformResult:
+def fix_free_form(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Convert ``command: echo hi`` to ``command: { cmd: echo hi }``.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_key = get_module_key(task)
     if module_key is None or module_key not in _FREE_FORM_MODULES:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_args = task.get(module_key)
     if not isinstance(module_args, str):
-        return TransformResult(content=content, applied=False)
+        return False
 
     new_args = CommentedMap()
     new_args["cmd"] = module_args
     task[module_key] = new_args
 
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/M001_fqcn.py
+++ b/src/apme_engine/remediation/transforms/M001_fqcn.py
@@ -7,10 +7,8 @@ Falls back to a static builtin map when resolved_fqcn is not available.
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
+from apme_engine.remediation.structured import StructuredFile
 from apme_engine.remediation.transforms._helpers import (
-    find_task_at_line,
     get_module_key,
     rename_key,
     violation_line_to_int,
@@ -91,36 +89,27 @@ def _resolve_fqcn(violation: ViolationDict, current_key: str) -> str | None:
     return _BUILTIN_FQCN.get(current_key)
 
 
-def fix_fqcn(content: str, violation: ViolationDict) -> TransformResult:
+def fix_fqcn(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Rename a short module name to its FQCN.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line and optional resolved_fqcn.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     module_key = get_module_key(task)
     if module_key is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     fqcn = _resolve_fqcn(violation, module_key)
     if fqcn is None or fqcn == module_key:
-        return TransformResult(content=content, applied=False)
+        return False
 
     rename_key(task, module_key, fqcn)
-
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/M006_become_unreachable.py
+++ b/src/apme_engine/remediation/transforms/M006_become_unreachable.py
@@ -3,38 +3,29 @@
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import violation_line_to_int
 
 
-def fix_become_unreachable(content: str, violation: ViolationDict) -> TransformResult:
+def fix_become_unreachable(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Add ``ignore_unreachable: true`` to tasks with become + ignore_errors.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     if "ignore_unreachable" in task:
-        return TransformResult(content=content, applied=False)
+        return False
 
     if not (task.get("become") and task.get("ignore_errors")):
-        return TransformResult(content=content, applied=False)
+        return False
 
     items = list(task.items())
     task.clear()
@@ -43,4 +34,4 @@ def fix_become_unreachable(content: str, violation: ViolationDict) -> TransformR
         if k == "ignore_errors":
             task["ignore_unreachable"] = True
 
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/M008_bare_include.py
+++ b/src/apme_engine/remediation/transforms/M008_bare_include.py
@@ -3,36 +3,26 @@
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, rename_key, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import rename_key, violation_line_to_int
 
 
-def fix_bare_include(content: str, violation: ViolationDict) -> TransformResult:
+def fix_bare_include(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Replace ``include:`` with ``ansible.builtin.include_tasks:``.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     if "include" not in task:
-        return TransformResult(content=content, applied=False)
+        return False
 
     rename_key(task, "include", "ansible.builtin.include_tasks")
-
-    return TransformResult(content=yaml.dumps(data), applied=True)
+    return True

--- a/src/apme_engine/remediation/transforms/M009_with_to_loop.py
+++ b/src/apme_engine/remediation/transforms/M009_with_to_loop.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from apme_engine.engine.models import ViolationDict
-from apme_engine.engine.yaml_utils import FormattedYAML
-from apme_engine.remediation.registry import TransformResult
-from apme_engine.remediation.transforms._helpers import find_task_at_line, violation_line_to_int
+from apme_engine.remediation.structured import StructuredFile
+from apme_engine.remediation.transforms._helpers import violation_line_to_int
 
 _WITH_SIMPLE = frozenset(
     {
@@ -16,7 +15,7 @@ _WITH_SIMPLE = frozenset(
 )
 
 
-def fix_with_to_loop(content: str, violation: ViolationDict) -> TransformResult:
+def fix_with_to_loop(sf: StructuredFile, violation: ViolationDict) -> bool:
     """Convert simple ``with_items`` to ``loop:``.
 
     Only handles the straightforward cases (with_items, with_list,
@@ -24,35 +23,27 @@ def fix_with_to_loop(content: str, violation: ViolationDict) -> TransformResult:
     with_subelements) need manual review or AI.
 
     Args:
-        content: YAML file content.
+        sf: Parsed YAML file to modify in-place.
         violation: Violation dict with line and optional with_key.
 
     Returns:
-        TransformResult with modified content if applied.
+        True if a change was applied.
     """
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-
-    try:
-        data = yaml.load(content)
-    except Exception:
-        return TransformResult(content=content, applied=False)
-
-    line = violation_line_to_int(violation)
-    task = find_task_at_line(data, line)
+    task = sf.find_task(violation_line_to_int(violation))
     if task is None:
-        return TransformResult(content=content, applied=False)
+        return False
 
     with_key = violation.get("with_key", "")
 
     if with_key in _WITH_SIMPLE and with_key in task:
         value = task.pop(with_key)
         task["loop"] = value
-        return TransformResult(content=yaml.dumps(data), applied=True)
+        return True
 
     for k in list(_WITH_SIMPLE):
         if k in task:
             value = task.pop(k)
             task["loop"] = value
-            return TransformResult(content=yaml.dumps(data), applied=True)
+            return True
 
-    return TransformResult(content=content, applied=False)
+    return False

--- a/src/apme_engine/remediation/transforms/__init__.py
+++ b/src/apme_engine/remediation/transforms/__init__.py
@@ -31,29 +31,31 @@ def build_default_registry() -> TransformRegistry:
     """
     reg = TransformRegistry()
 
-    # OPA lint rules
-    reg.register("L007", fix_shell_to_command)
-    reg.register("L008", fix_local_action)
-    reg.register("L009", fix_empty_string)
-    reg.register("L011", fix_literal_bool)
-    reg.register("L012", fix_latest)
-    reg.register("L013", fix_changed_when)
-    reg.register("L015", fix_jinja_when)
-    reg.register("L018", fix_become)
+    # Structured transforms (parse-once, modify in-place)
+    reg.register("L007", structured=fix_shell_to_command)
+    reg.register("L008", structured=fix_local_action)
+    reg.register("L009", structured=fix_empty_string)
+    reg.register("L011", structured=fix_literal_bool)
+    reg.register("L012", structured=fix_latest)
+    reg.register("L013", structured=fix_changed_when)
+    reg.register("L015", structured=fix_jinja_when)
+    reg.register("L018", structured=fix_become)
+    reg.register("L021", structured=fix_missing_mode)
+    reg.register("L022", structured=fix_pipefail)
+    reg.register("L025", structured=fix_name_casing)
+    reg.register("L043", structured=fix_bare_vars)
+    reg.register("L046", structured=fix_free_form)
+
+    # L020 operates on raw lines (YAML 1.1 octal ambiguity) — legacy string path
     reg.register("L020", fix_octal_mode)
-    reg.register("L021", fix_missing_mode)
-    reg.register("L022", fix_pipefail)
-    reg.register("L025", fix_name_casing)
-    reg.register("L043", fix_bare_vars)
-    reg.register("L046", fix_free_form)
 
     # Ansible validator rules (carry resolved_fqcn from ansible-core)
-    reg.register("M001", fix_fqcn)
-    reg.register("M003", fix_fqcn)
+    reg.register("M001", structured=fix_fqcn)
+    reg.register("M003", structured=fix_fqcn)
 
     # Migration rules
-    reg.register("M006", fix_become_unreachable)
-    reg.register("M008", fix_bare_include)
-    reg.register("M009", fix_with_to_loop)
+    reg.register("M006", structured=fix_become_unreachable)
+    reg.register("M008", structured=fix_bare_include)
+    reg.register("M009", structured=fix_with_to_loop)
 
     return reg

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -1,6 +1,7 @@
 """Tests for the remediation engine: registry, partition, transforms, convergence."""
 
 import textwrap
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -16,6 +17,7 @@ from apme_engine.remediation.partition import (
     partition_violations,
 )
 from apme_engine.remediation.registry import TransformRegistry, TransformResult
+from apme_engine.remediation.structured import StructuredFile
 from apme_engine.remediation.transforms import build_default_registry
 from apme_engine.remediation.transforms.L007_shell_to_command import fix_shell_to_command
 from apme_engine.remediation.transforms.L008_local_action import fix_local_action
@@ -35,6 +37,29 @@ from apme_engine.remediation.transforms.M001_fqcn import fix_fqcn
 from apme_engine.remediation.transforms.M006_become_unreachable import fix_become_unreachable
 from apme_engine.remediation.transforms.M008_bare_include import fix_bare_include
 from apme_engine.remediation.transforms.M009_with_to_loop import fix_with_to_loop
+
+
+def _apply(
+    fn: Callable[[StructuredFile, ViolationDict], bool],
+    content: str,
+    violation: ViolationDict,
+) -> TransformResult:
+    """Adapter: call a structured transform using the old (content, violation) interface.
+
+    Args:
+        fn: Structured transform function.
+        content: YAML file content string.
+        violation: Violation dict.
+
+    Returns:
+        TransformResult with serialized content and applied flag.
+    """
+    sf = StructuredFile.from_content("test.yml", content)
+    if sf is None:
+        return TransformResult(content, False)
+    applied = fn(sf, violation)
+    return TransformResult(sf.serialize() if applied else content, applied)
+
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -282,7 +307,7 @@ class TestL021MissingMode:
             src: /tmp/foo
             dest: /tmp/bar
         """)
-        result = fix_missing_mode(content, {"rule_id": "L021", "line": 1})
+        result = _apply(fix_missing_mode, content, {"rule_id": "L021", "line": 1})
         assert result.applied is True
         assert "mode:" in result.content
         assert "0644" in result.content
@@ -296,7 +321,7 @@ class TestL021MissingMode:
             dest: /tmp/bar
             mode: "0755"
         """)
-        result = fix_missing_mode(content, {"rule_id": "L021", "line": 1})
+        result = _apply(fix_missing_mode, content, {"rule_id": "L021", "line": 1})
         assert result.applied is False
 
     def test_no_change_for_non_file_module(self) -> None:
@@ -305,7 +330,7 @@ class TestL021MissingMode:
         - name: Run command
           ansible.builtin.command: echo hello
         """)
-        result = fix_missing_mode(content, {"rule_id": "L021", "line": 1})
+        result = _apply(fix_missing_mode, content, {"rule_id": "L021", "line": 1})
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -316,14 +341,14 @@ class TestL021MissingMode:
             src: foo.j2
             dest: /etc/foo.conf
         """)
-        r1 = fix_missing_mode(content, {"rule_id": "L021", "line": 1})
+        r1 = _apply(fix_missing_mode, content, {"rule_id": "L021", "line": 1})
         assert r1.applied is True
-        r2 = fix_missing_mode(r1.content, {"rule_id": "L021", "line": 1})
+        r2 = _apply(fix_missing_mode, r1.content, {"rule_id": "L021", "line": 1})
         assert r2.applied is False
 
     def test_handles_invalid_yaml(self) -> None:
         """Verifies invalid YAML returns applied False without raising."""
-        result = fix_missing_mode("{{{{invalid", {"rule_id": "L021", "line": 1})
+        result = _apply(fix_missing_mode, "{{{{invalid", {"rule_id": "L021", "line": 1})
         assert result.applied is False
 
 
@@ -341,7 +366,7 @@ class TestL007ShellToCommand:
         - name: List files
           ansible.builtin.shell: ls -la /tmp
         """)
-        result = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
+        result = _apply(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is True
         assert "ansible.builtin.command" in result.content
         assert "ansible.builtin.shell" not in result.content
@@ -352,7 +377,7 @@ class TestL007ShellToCommand:
         - name: Grep output
           ansible.builtin.shell: cat /tmp/log | grep error
         """)
-        result = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
+        result = _apply(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
     def test_no_change_when_and_present(self) -> None:
@@ -362,7 +387,7 @@ class TestL007ShellToCommand:
           ansible.builtin.shell:
             cmd: mkdir /tmp/foo && touch /tmp/foo/bar
         """)
-        result = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
+        result = _apply(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
     def test_no_change_when_redirect_present(self) -> None:
@@ -371,7 +396,7 @@ class TestL007ShellToCommand:
         - name: Write output
           ansible.builtin.shell: echo hello > /tmp/out
         """)
-        result = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
+        result = _apply(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
     def test_no_change_for_command_module(self) -> None:
@@ -380,7 +405,7 @@ class TestL007ShellToCommand:
         - name: Already command
           ansible.builtin.command: echo hello
         """)
-        result = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
+        result = _apply(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -389,9 +414,9 @@ class TestL007ShellToCommand:
         - name: Simple command
           ansible.builtin.shell: whoami
         """)
-        r1 = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
+        r1 = _apply(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert r1.applied is True
-        r2 = fix_shell_to_command(r1.content, {"rule_id": "L007", "line": 1})
+        r2 = _apply(fix_shell_to_command, r1.content, {"rule_id": "L007", "line": 1})
         assert r2.applied is False
 
     def test_dict_form_cmd(self) -> None:
@@ -401,7 +426,7 @@ class TestL007ShellToCommand:
           ansible.builtin.shell:
             cmd: whoami
         """)
-        result = fix_shell_to_command(content, {"rule_id": "L007", "line": 1})
+        result = _apply(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is True
         assert "ansible.builtin.command" in result.content
 
@@ -430,7 +455,7 @@ class TestFQCNTransform:
                 "original_module": "debug",
             },
         )
-        result = fix_fqcn(content, violation)
+        result = _apply(fix_fqcn, content, violation)
         assert result.applied is True
         assert "ansible.builtin.debug" in result.content
         assert "\n  debug:" not in result.content
@@ -444,7 +469,7 @@ class TestFQCNTransform:
             dest: /b
         """)
         violation = cast(ViolationDict, {"rule_id": "M001", "line": 1})
-        result = fix_fqcn(content, violation)
+        result = _apply(fix_fqcn, content, violation)
         assert result.applied is True
         assert "ansible.builtin.copy" in result.content
 
@@ -456,7 +481,7 @@ class TestFQCNTransform:
             msg: hello
         """)
         violation = cast(ViolationDict, {"rule_id": "M001", "line": 1})
-        result = fix_fqcn(content, violation)
+        result = _apply(fix_fqcn, content, violation)
         assert result.applied is False
 
     def test_no_change_for_unknown_short_name(self) -> None:
@@ -467,7 +492,7 @@ class TestFQCNTransform:
             param: value
         """)
         violation = cast(ViolationDict, {"rule_id": "M001", "line": 1})
-        result = fix_fqcn(content, violation)
+        result = _apply(fix_fqcn, content, violation)
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -478,9 +503,9 @@ class TestFQCNTransform:
             name: httpd
             state: present
         """)
-        r1 = fix_fqcn(content, cast(ViolationDict, {"rule_id": "M001", "line": 1}))
+        r1 = _apply(fix_fqcn, content, cast(ViolationDict, {"rule_id": "M001", "line": 1}))
         assert r1.applied is True
-        r2 = fix_fqcn(r1.content, cast(ViolationDict, {"rule_id": "M001", "line": 1}))
+        r2 = _apply(fix_fqcn, r1.content, cast(ViolationDict, {"rule_id": "M001", "line": 1}))
         assert r2.applied is False
 
     def test_m003_redirect_uses_resolved_fqcn(self) -> None:
@@ -500,7 +525,7 @@ class TestFQCNTransform:
                 "redirect_chain": ["ansible.builtin.yum", "ansible.builtin.dnf"],
             },
         )
-        result = fix_fqcn(content, violation)
+        result = _apply(fix_fqcn, content, violation)
         assert result.applied is True
         assert "ansible.builtin.dnf" in result.content
 
@@ -537,7 +562,7 @@ class TestRemediationEngine:
             return []
 
         reg = TransformRegistry()
-        reg.register("L021", fix_missing_mode)
+        reg.register("L021", structured=fix_missing_mode)
         engine = RemediationEngine(reg, scan_fn, max_passes=5)
 
         report = engine.remediate([str(playbook)], apply=True)
@@ -568,7 +593,7 @@ class TestRemediationEngine:
             return []
 
         reg = TransformRegistry()
-        reg.register("L021", fix_missing_mode)
+        reg.register("L021", structured=fix_missing_mode)
         engine = RemediationEngine(reg, scan_fn, max_passes=5)
 
         report = engine.remediate([str(playbook)], apply=False)
@@ -649,7 +674,7 @@ class TestRemediationEngine:
             return []
 
         reg = TransformRegistry()
-        reg.register("L021", fix_missing_mode)
+        reg.register("L021", structured=fix_missing_mode)
         engine = RemediationEngine(reg, scan_fn, max_passes=5)
 
         report = engine.remediate([str(playbook)], apply=True)
@@ -680,7 +705,7 @@ class TestRemediationEngine:
             return []
 
         reg = TransformRegistry()
-        reg.register("L021", fix_missing_mode)
+        reg.register("L021", structured=fix_missing_mode)
         engine = RemediationEngine(reg, scan_fn, max_passes=5)
 
         report = engine.remediate([str(playbook)], apply=True)
@@ -722,7 +747,7 @@ class TestRemediationEngine:
             return [{"rule_id": "L021", "file": "main.yml", "line": 1}]
 
         reg = TransformRegistry()
-        reg.register("L021", fix_missing_mode)
+        reg.register("L021", structured=fix_missing_mode)
         engine = RemediationEngine(reg, scan_fn, max_passes=2)
 
         report = engine.remediate([str(play_a), str(play_b)], apply=False)
@@ -843,7 +868,7 @@ class TestL008LocalAction:
         - name: Run locally
           local_action: command echo hello
         """)
-        result = fix_local_action(content, {"rule_id": "L008", "line": 1})
+        result = _apply(fix_local_action, content, {"rule_id": "L008", "line": 1})
         assert result.applied is True
         assert "local_action" not in result.content
         assert "delegate_to: localhost" in result.content
@@ -857,7 +882,7 @@ class TestL008LocalAction:
             module: ansible.builtin.debug
             msg: hi
         """)
-        result = fix_local_action(content, {"rule_id": "L008", "line": 1})
+        result = _apply(fix_local_action, content, {"rule_id": "L008", "line": 1})
         assert result.applied is True
         assert "local_action" not in result.content
         assert "delegate_to: localhost" in result.content
@@ -870,7 +895,7 @@ class TestL008LocalAction:
           ansible.builtin.debug:
             msg: hi
         """)
-        result = fix_local_action(content, {"rule_id": "L008", "line": 1})
+        result = _apply(fix_local_action, content, {"rule_id": "L008", "line": 1})
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -879,9 +904,9 @@ class TestL008LocalAction:
         - name: Run locally
           local_action: command whoami
         """)
-        r1 = fix_local_action(content, {"rule_id": "L008", "line": 1})
+        r1 = _apply(fix_local_action, content, {"rule_id": "L008", "line": 1})
         assert r1.applied is True
-        r2 = fix_local_action(r1.content, {"rule_id": "L008", "line": 1})
+        r2 = _apply(fix_local_action, r1.content, {"rule_id": "L008", "line": 1})
         assert r2.applied is False
 
 
@@ -901,7 +926,7 @@ class TestL009EmptyString:
             msg: empty
           when: myvar == ""
         """)
-        result = fix_empty_string(content, {"rule_id": "L009", "line": 1})
+        result = _apply(fix_empty_string, content, {"rule_id": "L009", "line": 1})
         assert result.applied is True
         assert "myvar | length == 0" in result.content
 
@@ -913,7 +938,7 @@ class TestL009EmptyString:
             msg: not empty
           when: myvar != ''
         """)
-        result = fix_empty_string(content, {"rule_id": "L009", "line": 1})
+        result = _apply(fix_empty_string, content, {"rule_id": "L009", "line": 1})
         assert result.applied is True
         assert "myvar | length > 0" in result.content
 
@@ -925,7 +950,7 @@ class TestL009EmptyString:
             msg: ok
           when: myvar is defined
         """)
-        result = fix_empty_string(content, {"rule_id": "L009", "line": 1})
+        result = _apply(fix_empty_string, content, {"rule_id": "L009", "line": 1})
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -936,8 +961,8 @@ class TestL009EmptyString:
             msg: empty
           when: myvar == ""
         """)
-        r1 = fix_empty_string(content, {"rule_id": "L009", "line": 1})
-        r2 = fix_empty_string(r1.content, {"rule_id": "L009", "line": 1})
+        r1 = _apply(fix_empty_string, content, {"rule_id": "L009", "line": 1})
+        r2 = _apply(fix_empty_string, r1.content, {"rule_id": "L009", "line": 1})
         assert r2.applied is False
 
 
@@ -957,7 +982,7 @@ class TestL011LiteralBool:
             msg: hi
           when: enabled == true
         """)
-        result = fix_literal_bool(content, {"rule_id": "L011", "line": 1})
+        result = _apply(fix_literal_bool, content, {"rule_id": "L011", "line": 1})
         assert result.applied is True
         assert "enabled" in result.content
         assert "== true" not in result.content
@@ -970,7 +995,7 @@ class TestL011LiteralBool:
             msg: hi
           when: enabled == false
         """)
-        result = fix_literal_bool(content, {"rule_id": "L011", "line": 1})
+        result = _apply(fix_literal_bool, content, {"rule_id": "L011", "line": 1})
         assert result.applied is True
         assert "not enabled" in result.content
 
@@ -982,7 +1007,7 @@ class TestL011LiteralBool:
             msg: hi
           when: enabled is true
         """)
-        result = fix_literal_bool(content, {"rule_id": "L011", "line": 1})
+        result = _apply(fix_literal_bool, content, {"rule_id": "L011", "line": 1})
         assert result.applied is True
         assert "is true" not in result.content
 
@@ -994,7 +1019,7 @@ class TestL011LiteralBool:
             msg: hi
           when: enabled == True
         """)
-        result = fix_literal_bool(content, {"rule_id": "L011", "line": 1})
+        result = _apply(fix_literal_bool, content, {"rule_id": "L011", "line": 1})
         assert result.applied is True
 
     def test_no_change_without_pattern(self) -> None:
@@ -1005,7 +1030,7 @@ class TestL011LiteralBool:
             msg: hi
           when: enabled
         """)
-        result = fix_literal_bool(content, {"rule_id": "L011", "line": 1})
+        result = _apply(fix_literal_bool, content, {"rule_id": "L011", "line": 1})
         assert result.applied is False
 
 
@@ -1025,7 +1050,7 @@ class TestL015JinjaWhen:
             msg: hi
           when: "{{ my_var }}"
         """)
-        result = fix_jinja_when(content, {"rule_id": "L015", "line": 1})
+        result = _apply(fix_jinja_when, content, {"rule_id": "L015", "line": 1})
         assert result.applied is True
         assert "{{" not in result.content
         assert "}}" not in result.content
@@ -1039,7 +1064,7 @@ class TestL015JinjaWhen:
             msg: hi
           when: my_var is defined
         """)
-        result = fix_jinja_when(content, {"rule_id": "L015", "line": 1})
+        result = _apply(fix_jinja_when, content, {"rule_id": "L015", "line": 1})
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -1050,8 +1075,8 @@ class TestL015JinjaWhen:
             msg: hi
           when: "{{ some_flag }}"
         """)
-        r1 = fix_jinja_when(content, {"rule_id": "L015", "line": 1})
-        r2 = fix_jinja_when(r1.content, {"rule_id": "L015", "line": 1})
+        r1 = _apply(fix_jinja_when, content, {"rule_id": "L015", "line": 1})
+        r2 = _apply(fix_jinja_when, r1.content, {"rule_id": "L015", "line": 1})
         assert r2.applied is False
 
 
@@ -1126,7 +1151,7 @@ class TestL025NameCasing:
           ansible.builtin.debug:
             msg: hi
         """)
-        result = fix_name_casing(content, {"rule_id": "L025", "line": 1})
+        result = _apply(fix_name_casing, content, {"rule_id": "L025", "line": 1})
         assert result.applied is True
         assert "Install packages" in result.content
 
@@ -1137,7 +1162,7 @@ class TestL025NameCasing:
           ansible.builtin.debug:
             msg: hi
         """)
-        result = fix_name_casing(content, {"rule_id": "L025", "line": 1})
+        result = _apply(fix_name_casing, content, {"rule_id": "L025", "line": 1})
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -1147,8 +1172,8 @@ class TestL025NameCasing:
           ansible.builtin.debug:
             msg: hi
         """)
-        r1 = fix_name_casing(content, {"rule_id": "L025", "line": 1})
-        r2 = fix_name_casing(r1.content, {"rule_id": "L025", "line": 1})
+        r1 = _apply(fix_name_casing, content, {"rule_id": "L025", "line": 1})
+        r2 = _apply(fix_name_casing, r1.content, {"rule_id": "L025", "line": 1})
         assert r2.applied is False
 
 
@@ -1166,7 +1191,7 @@ class TestL046FreeForm:
         - name: Run it
           ansible.builtin.command: echo hello
         """)
-        result = fix_free_form(content, {"rule_id": "L046", "line": 1})
+        result = _apply(fix_free_form, content, {"rule_id": "L046", "line": 1})
         assert result.applied is True
         assert "cmd:" in result.content
         assert "echo hello" in result.content
@@ -1178,7 +1203,7 @@ class TestL046FreeForm:
           ansible.builtin.command:
             cmd: echo hello
         """)
-        result = fix_free_form(content, {"rule_id": "L046", "line": 1})
+        result = _apply(fix_free_form, content, {"rule_id": "L046", "line": 1})
         assert result.applied is False
 
     def test_no_change_for_non_command_module(self) -> None:
@@ -1188,7 +1213,7 @@ class TestL046FreeForm:
           ansible.builtin.debug:
             msg: hi
         """)
-        result = fix_free_form(content, {"rule_id": "L046", "line": 1})
+        result = _apply(fix_free_form, content, {"rule_id": "L046", "line": 1})
         assert result.applied is False
 
     def test_shell_module(self) -> None:
@@ -1197,7 +1222,7 @@ class TestL046FreeForm:
         - name: Run shell
           ansible.builtin.shell: cat /etc/hosts | grep localhost
         """)
-        result = fix_free_form(content, {"rule_id": "L046", "line": 1})
+        result = _apply(fix_free_form, content, {"rule_id": "L046", "line": 1})
         assert result.applied is True
         assert "cmd:" in result.content
 
@@ -1218,7 +1243,7 @@ class TestL043BareVars:
             msg: "{{ item }}"
           with_items: packages
         """)
-        result = fix_bare_vars(content, {"rule_id": "L043", "line": 1})
+        result = _apply(fix_bare_vars, content, {"rule_id": "L043", "line": 1})
         assert result.applied is True
         assert "{{ packages }}" in result.content
 
@@ -1230,7 +1255,7 @@ class TestL043BareVars:
             msg: "{{ item }}"
           with_items: "{{ packages }}"
         """)
-        result = fix_bare_vars(content, {"rule_id": "L043", "line": 1})
+        result = _apply(fix_bare_vars, content, {"rule_id": "L043", "line": 1})
         assert result.applied is False
 
     def test_no_change_without_loop(self) -> None:
@@ -1240,7 +1265,7 @@ class TestL043BareVars:
           ansible.builtin.debug:
             msg: hi
         """)
-        result = fix_bare_vars(content, {"rule_id": "L043", "line": 1})
+        result = _apply(fix_bare_vars, content, {"rule_id": "L043", "line": 1})
         assert result.applied is False
 
 
@@ -1258,7 +1283,7 @@ class TestL013ChangedWhen:
         - name: Check version
           ansible.builtin.command: python --version
         """)
-        result = fix_changed_when(content, {"rule_id": "L013", "line": 1})
+        result = _apply(fix_changed_when, content, {"rule_id": "L013", "line": 1})
         assert result.applied is True
         assert "changed_when:" in result.content
 
@@ -1270,7 +1295,7 @@ class TestL013ChangedWhen:
             cmd: touch /tmp/foo
             creates: /tmp/foo
         """)
-        result = fix_changed_when(content, {"rule_id": "L013", "line": 1})
+        result = _apply(fix_changed_when, content, {"rule_id": "L013", "line": 1})
         assert result.applied is False
 
     def test_no_change_when_already_set(self) -> None:
@@ -1280,7 +1305,7 @@ class TestL013ChangedWhen:
           ansible.builtin.command: echo test
           changed_when: false
         """)
-        result = fix_changed_when(content, {"rule_id": "L013", "line": 1})
+        result = _apply(fix_changed_when, content, {"rule_id": "L013", "line": 1})
         assert result.applied is False
 
     def test_no_change_for_non_command_module(self) -> None:
@@ -1290,7 +1315,7 @@ class TestL013ChangedWhen:
           ansible.builtin.debug:
             msg: hi
         """)
-        result = fix_changed_when(content, {"rule_id": "L013", "line": 1})
+        result = _apply(fix_changed_when, content, {"rule_id": "L013", "line": 1})
         assert result.applied is False
 
 
@@ -1309,7 +1334,7 @@ class TestL018Become:
           ansible.builtin.command: whoami
           become_user: postgres
         """)
-        result = fix_become(content, {"rule_id": "L018", "line": 1})
+        result = _apply(fix_become, content, {"rule_id": "L018", "line": 1})
         assert result.applied is True
         assert "become: true" in result.content or "become: True" in result.content
 
@@ -1321,7 +1346,7 @@ class TestL018Become:
           become: true
           become_user: postgres
         """)
-        result = fix_become(content, {"rule_id": "L018", "line": 1})
+        result = _apply(fix_become, content, {"rule_id": "L018", "line": 1})
         assert result.applied is False
 
     def test_no_change_without_become_user(self) -> None:
@@ -1331,7 +1356,7 @@ class TestL018Become:
           ansible.builtin.debug:
             msg: hi
         """)
-        result = fix_become(content, {"rule_id": "L018", "line": 1})
+        result = _apply(fix_become, content, {"rule_id": "L018", "line": 1})
         assert result.applied is False
 
     def test_become_inserted_after_become_user(self) -> None:
@@ -1341,7 +1366,7 @@ class TestL018Become:
           ansible.builtin.command: whoami
           become_user: postgres
         """)
-        result = fix_become(content, {"rule_id": "L018", "line": 1})
+        result = _apply(fix_become, content, {"rule_id": "L018", "line": 1})
         assert result.applied is True
         lines = result.content.splitlines()
         bu_line = next(i for i, line in enumerate(lines) if "become_user" in line)
@@ -1363,7 +1388,7 @@ class TestL022Pipefail:
         - name: Grep logs
           ansible.builtin.shell: cat /var/log/syslog | grep error
         """)
-        result = fix_pipefail(content, {"rule_id": "L022", "line": 1})
+        result = _apply(fix_pipefail, content, {"rule_id": "L022", "line": 1})
         assert result.applied is True
         assert "set -o pipefail &&" in result.content
 
@@ -1374,7 +1399,7 @@ class TestL022Pipefail:
           ansible.builtin.shell:
             cmd: cat /var/log/syslog | grep error
         """)
-        result = fix_pipefail(content, {"rule_id": "L022", "line": 1})
+        result = _apply(fix_pipefail, content, {"rule_id": "L022", "line": 1})
         assert result.applied is True
         assert "set -o pipefail &&" in result.content
 
@@ -1384,7 +1409,7 @@ class TestL022Pipefail:
         - name: Simple
           ansible.builtin.shell: echo hello
         """)
-        result = fix_pipefail(content, {"rule_id": "L022", "line": 1})
+        result = _apply(fix_pipefail, content, {"rule_id": "L022", "line": 1})
         assert result.applied is False
 
     def test_no_change_when_already_set(self) -> None:
@@ -1393,7 +1418,7 @@ class TestL022Pipefail:
         - name: Grep logs
           ansible.builtin.shell: set -o pipefail && cat /var/log/syslog | grep error
         """)
-        result = fix_pipefail(content, {"rule_id": "L022", "line": 1})
+        result = _apply(fix_pipefail, content, {"rule_id": "L022", "line": 1})
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -1402,8 +1427,8 @@ class TestL022Pipefail:
         - name: Grep
           ansible.builtin.shell: cat log | grep err
         """)
-        r1 = fix_pipefail(content, {"rule_id": "L022", "line": 1})
-        r2 = fix_pipefail(r1.content, {"rule_id": "L022", "line": 1})
+        r1 = _apply(fix_pipefail, content, {"rule_id": "L022", "line": 1})
+        r2 = _apply(fix_pipefail, r1.content, {"rule_id": "L022", "line": 1})
         assert r2.applied is False
 
 
@@ -1423,7 +1448,7 @@ class TestL012Latest:
             name: httpd
             state: latest
         """)
-        result = fix_latest(content, {"rule_id": "L012", "line": 1})
+        result = _apply(fix_latest, content, {"rule_id": "L012", "line": 1})
         assert result.applied is True
         assert "state: present" in result.content
         assert "state: latest" not in result.content
@@ -1436,7 +1461,7 @@ class TestL012Latest:
             name: httpd
             state: present
         """)
-        result = fix_latest(content, {"rule_id": "L012", "line": 1})
+        result = _apply(fix_latest, content, {"rule_id": "L012", "line": 1})
         assert result.applied is False
 
     def test_no_change_for_absent(self) -> None:
@@ -1447,7 +1472,7 @@ class TestL012Latest:
             name: httpd
             state: absent
         """)
-        result = fix_latest(content, {"rule_id": "L012", "line": 1})
+        result = _apply(fix_latest, content, {"rule_id": "L012", "line": 1})
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -1458,8 +1483,8 @@ class TestL012Latest:
             name: nginx
             state: latest
         """)
-        r1 = fix_latest(content, {"rule_id": "L012", "line": 1})
-        r2 = fix_latest(r1.content, {"rule_id": "L012", "line": 1})
+        r1 = _apply(fix_latest, content, {"rule_id": "L012", "line": 1})
+        r2 = _apply(fix_latest, r1.content, {"rule_id": "L012", "line": 1})
         assert r2.applied is False
 
 
@@ -1479,7 +1504,7 @@ class TestM006BecomeUnreachable:
           become: true
           ignore_errors: true
         """)
-        result = fix_become_unreachable(content, {"rule_id": "M006", "line": 1})
+        result = _apply(fix_become_unreachable, content, {"rule_id": "M006", "line": 1})
         assert result.applied is True
         assert "ignore_unreachable: true" in result.content or "ignore_unreachable: True" in result.content
 
@@ -1492,7 +1517,7 @@ class TestM006BecomeUnreachable:
           ignore_errors: true
           ignore_unreachable: true
         """)
-        result = fix_become_unreachable(content, {"rule_id": "M006", "line": 1})
+        result = _apply(fix_become_unreachable, content, {"rule_id": "M006", "line": 1})
         assert result.applied is False
 
     def test_no_change_without_become(self) -> None:
@@ -1502,7 +1527,7 @@ class TestM006BecomeUnreachable:
           ansible.builtin.command: whoami
           ignore_errors: true
         """)
-        result = fix_become_unreachable(content, {"rule_id": "M006", "line": 1})
+        result = _apply(fix_become_unreachable, content, {"rule_id": "M006", "line": 1})
         assert result.applied is False
 
     def test_inserted_after_ignore_errors(self) -> None:
@@ -1513,7 +1538,7 @@ class TestM006BecomeUnreachable:
           become: true
           ignore_errors: true
         """)
-        result = fix_become_unreachable(content, {"rule_id": "M006", "line": 1})
+        result = _apply(fix_become_unreachable, content, {"rule_id": "M006", "line": 1})
         lines = result.content.splitlines()
         ie_line = next(i for i, line in enumerate(lines) if "ignore_errors" in line)
         iu_line = next(i for i, line in enumerate(lines) if "ignore_unreachable" in line)
@@ -1533,7 +1558,7 @@ class TestM008BareInclude:
         content = textwrap.dedent("""\
         - include: tasks/setup.yml
         """)
-        result = fix_bare_include(content, {"rule_id": "M008", "line": 1})
+        result = _apply(fix_bare_include, content, {"rule_id": "M008", "line": 1})
         assert result.applied is True
         assert "ansible.builtin.include_tasks" in result.content
         assert "\n- include:" not in result.content
@@ -1543,7 +1568,7 @@ class TestM008BareInclude:
         content = textwrap.dedent("""\
         - ansible.builtin.include_tasks: tasks/setup.yml
         """)
-        result = fix_bare_include(content, {"rule_id": "M008", "line": 1})
+        result = _apply(fix_bare_include, content, {"rule_id": "M008", "line": 1})
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -1551,8 +1576,8 @@ class TestM008BareInclude:
         content = textwrap.dedent("""\
         - include: tasks/setup.yml
         """)
-        r1 = fix_bare_include(content, {"rule_id": "M008", "line": 1})
-        r2 = fix_bare_include(r1.content, {"rule_id": "M008", "line": 1})
+        r1 = _apply(fix_bare_include, content, {"rule_id": "M008", "line": 1})
+        r2 = _apply(fix_bare_include, r1.content, {"rule_id": "M008", "line": 1})
         assert r2.applied is False
 
 
@@ -1575,7 +1600,7 @@ class TestM009WithToLoop:
             - httpd
             - nginx
         """)
-        result = fix_with_to_loop(content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
+        result = _apply(fix_with_to_loop, content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
         assert result.applied is True
         assert "loop:" in result.content
         assert "with_items" not in result.content
@@ -1591,7 +1616,7 @@ class TestM009WithToLoop:
             - httpd
             - nginx
         """)
-        result = fix_with_to_loop(content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
+        result = _apply(fix_with_to_loop, content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
         assert result.applied is False
 
     def test_with_dict_not_handled(self) -> None:
@@ -1602,7 +1627,7 @@ class TestM009WithToLoop:
             name: "{{ item.key }}"
           with_dict: "{{ users }}"
         """)
-        result = fix_with_to_loop(content, {"rule_id": "M009", "line": 1, "with_key": "with_dict"})
+        result = _apply(fix_with_to_loop, content, {"rule_id": "M009", "line": 1, "with_key": "with_dict"})
         assert result.applied is False
 
     def test_idempotent(self) -> None:
@@ -1614,6 +1639,6 @@ class TestM009WithToLoop:
           with_items:
             - httpd
         """)
-        r1 = fix_with_to_loop(content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
-        r2 = fix_with_to_loop(r1.content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
+        r1 = _apply(fix_with_to_loop, content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
+        r2 = _apply(fix_with_to_loop, r1.content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
         assert r2.applied is False


### PR DESCRIPTION
## Summary

- Introduces `StructuredFile` wrapper around ruamel.yaml's `CommentedMap`/`CommentedSeq` for parse-once, mutate in-place, serialize-once semantics
- Refactors all 17 AST-based transforms from `(str, ViolationDict) -> TransformResult` to `(StructuredFile, ViolationDict) -> bool`, eliminating per-transform parse/serialize overhead
- Adds `StructuredTransformFn` type alias and `apply_structured()` to `TransformRegistry` with automatic fallback to legacy string path
- Engine convergence loop now parses files once at pass start, applies all transforms in-memory, and serializes dirty files once per pass
- L020 (octal mode) intentionally remains a legacy string-based transform due to its regex line-level approach

## Files changed

- `src/apme_engine/remediation/structured.py` (new) — `StructuredFile` class
- `src/apme_engine/remediation/registry.py` — dual-path registry with `apply_structured()`
- `src/apme_engine/remediation/engine.py` — parse-once/serialize-once convergence loop
- `src/apme_engine/remediation/transforms/*.py` — 17 transforms refactored to structured signature
- `src/apme_engine/remediation/transforms/__init__.py` — registration updated to use `structured=` kwarg
- `tests/test_remediation.py` — `_apply()` adapter, all 107 tests updated

## Test plan

- [x] All 107 remediation tests pass with new structured API
- [x] Full suite: 924 passed, 4 skipped, 0 failures
- [x] ruff lint clean
- [x] mypy type check clean
- [x] L020 legacy path verified separately
- [x] Engine convergence, oscillation detection, and resolution tracking verified


Made with [Cursor](https://cursor.com)