### PR TITLE
feat(formatter,cli): expand inline key=value args, force block tags, and fix role-aware gRPC scanning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ exclude_lines = [
     "raise NotImplementedError",
 ]
 show_missing = true
-fail_under = 36
+fail_under = 50
 
 [project.scripts]
 apme-scan = "apme_engine.cli:main"

--- a/src/apme_engine/cli.py
+++ b/src/apme_engine/cli.py
@@ -5,7 +5,7 @@ import json
 import os
 import sys
 import time
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import cast
 
@@ -710,6 +710,60 @@ def _run_format(args: argparse.Namespace) -> None:
         sys.stderr.write(f"\n{len(changed)} file(s) would be reformatted (use --apply to write)\n")
 
 
+_ROLE_MARKER_DIRS = frozenset({"tasks", "handlers", "defaults", "vars", "meta", "files", "templates"})
+
+
+def _find_role_root(file_path: Path) -> Path | None:
+    """Walk up from *file_path* and return the Ansible role root, if any.
+
+    A role root is a directory that directly contains at least one of the
+    standard role sub-directories (tasks/, handlers/, defaults/, …).
+
+    Args:
+        file_path: Resolved path to a YAML file.
+
+    Returns:
+        Role root Path, or None if the file is not inside a role.
+    """
+    for ancestor in file_path.parents:
+        children = {p.name for p in ancestor.iterdir() if p.is_dir()}
+        if children & _ROLE_MARKER_DIRS:
+            return ancestor
+    return None
+
+
+def _group_files_by_scan_root(file_paths: list[str]) -> dict[Path, list[Path]]:
+    """Partition resolved file paths so each group shares one scan root.
+
+    Files inside an Ansible role are grouped under the role root.
+    Remaining files are grouped under their common ancestor directory.
+
+    Args:
+        file_paths: Absolute paths to YAML files.
+
+    Returns:
+        Mapping from scan-root directory to the files that belong to it.
+    """
+    groups: dict[Path, list[Path]] = {}
+    ungrouped: list[Path] = []
+
+    for fp in file_paths:
+        p = Path(fp).resolve()
+        role_root = _find_role_root(p)
+        if role_root is not None:
+            groups.setdefault(role_root, []).append(p)
+        else:
+            ungrouped.append(p)
+
+    if ungrouped:
+        common = Path(os.path.commonpath([str(u) for u in ungrouped]))
+        if common.is_file():
+            common = common.parent
+        groups.setdefault(common, []).extend(ungrouped)
+
+    return groups
+
+
 def _scan_files_grpc(
     file_paths: list[str],
     primary_addr: str,
@@ -718,9 +772,9 @@ def _scan_files_grpc(
 ) -> list[ViolationDict]:
     """Scan files via Primary gRPC daemon (fans out to all validators including OPA).
 
-    Each file gets its own ScanStream call so only the requested files are
-    scanned — avoids pulling in unrelated siblings from a shared parent
-    directory, which would inflate violation counts in the remediation loop.
+    Files are grouped by Ansible role boundary so each role is sent as a
+    self-contained scan request.  This preserves the directory structure
+    validators need for FQCN detection, modernization rules, etc.
 
     Args:
         file_paths: Paths to YAML files to scan.
@@ -736,23 +790,76 @@ def _scan_files_grpc(
     if not yaml_files:
         return []
 
+    from apme.v1.common_pb2 import File
+    from apme.v1.primary_pb2 import ScanChunk, ScanOptions  # type: ignore[attr-defined]
+    from apme_engine.daemon.chunked_fs import CHUNK_MAX_BYTES
+
+    groups = _group_files_by_scan_root(yaml_files)
+
     all_violations: list[ViolationDict] = []
     channel = grpc.insecure_channel(primary_addr)
     stub = primary_pb2_grpc.PrimaryStub(channel)  # type: ignore[no-untyped-call]
     try:
-        for fpath in yaml_files:
-            chunks = yield_scan_chunks(
-                fpath,
-                project_root_name="project",
-                ansible_core_version=ansible_version,
-                collection_specs=collection_specs,
-            )
+        for root, paths in groups.items():
+            files: list[File] = []
+            for p in paths:
+                try:
+                    rel = str(p.relative_to(root))
+                except ValueError:
+                    rel = p.name
+                try:
+                    content = p.read_bytes()
+                except OSError:
+                    continue
+                files.append(File(path=rel, content=content))
+
+            options = ScanOptions()
+            if ansible_version:
+                options.ansible_core_version = ansible_version
+            if collection_specs:
+                options.collection_specs.extend(collection_specs)
+
+            def _chunk_iter(
+                _files: list[File] = files,
+                _options: ScanOptions = options,
+            ) -> Iterator[ScanChunk]:
+                batch: list[File] = []
+                batch_bytes = 0
+                first_chunk = True
+                for f in _files:
+                    msg_size = len(f.path.encode()) + len(f.content)
+                    if batch and batch_bytes + msg_size > CHUNK_MAX_BYTES:
+                        kwargs: dict[str, object] = {"files": batch, "last": False}
+                        if first_chunk:
+                            kwargs["scan_id"] = ""
+                            kwargs["project_root"] = "project"
+                            kwargs["options"] = _options
+                        yield ScanChunk(**kwargs)
+                        first_chunk = False
+                        batch = []
+                        batch_bytes = 0
+                    batch.append(f)
+                    batch_bytes += msg_size
+                final_kwargs: dict[str, object] = {"files": batch, "last": True}
+                if first_chunk:
+                    final_kwargs["scan_id"] = ""
+                    final_kwargs["project_root"] = "project"
+                    final_kwargs["options"] = _options
+                yield ScanChunk(**final_kwargs)
+
             try:
-                resp = stub.ScanStream(chunks, timeout=120)
+                resp = stub.ScanStream(_chunk_iter(), timeout=120)
             except grpc.RpcError as e:
-                sys.stderr.write(f"gRPC scan error for {fpath}: {e.details()}\n")
+                sys.stderr.write(f"gRPC scan error for {root}: {e.details()}\n")
                 continue
-            all_violations.extend(violation_proto_to_dict(v) for v in resp.violations)
+            for v in resp.violations:
+                vd = violation_proto_to_dict(v)
+                vf = vd.get("file", "")
+                if isinstance(vf, str) and vf and not Path(vf).is_absolute():
+                    absolute = root / vf
+                    if absolute.exists():
+                        vd["file"] = str(absolute)
+                all_violations.append(vd)
     finally:
         channel.close()
 

--- a/src/apme_engine/formatter.py
+++ b/src/apme_engine/formatter.py
@@ -250,6 +250,207 @@ def _reorder_single_task(mapping: CommentedMap) -> None:
         mapping[k] = v
 
 
+_FORMAT_META_KEYS = frozenset(
+    {
+        "name",
+        "when",
+        "changed_when",
+        "failed_when",
+        "register",
+        "notify",
+        "listen",
+        "become",
+        "become_user",
+        "become_method",
+        "become_flags",
+        "delegate_to",
+        "run_once",
+        "connection",
+        "ignore_errors",
+        "ignore_unreachable",
+        "no_log",
+        "tags",
+        "environment",
+        "vars",
+        "args",
+        "loop",
+        "loop_control",
+        "with_items",
+        "with_dict",
+        "with_fileglob",
+        "with_subelements",
+        "with_sequence",
+        "with_nested",
+        "with_first_found",
+        "block",
+        "rescue",
+        "always",
+        "any_errors_fatal",
+        "max_fail_percentage",
+        "check_mode",
+        "diff",
+        "throttle",
+        "timeout",
+        "retries",
+        "delay",
+        "until",
+        "debugger",
+        "module_defaults",
+        "collections",
+        "local_action",
+    }
+)
+
+_KV_RE = re.compile(r"(\w+)=")
+
+_COMMAND_MODULES = frozenset(
+    {
+        "command",
+        "shell",
+        "raw",
+        "script",
+        "ansible.builtin.command",
+        "ansible.builtin.shell",
+        "ansible.builtin.raw",
+        "ansible.builtin.script",
+        "ansible.legacy.command",
+        "ansible.legacy.shell",
+        "ansible.legacy.raw",
+    }
+)
+
+
+def _find_closing_quote(s: str, quote_char: str) -> int:
+    """Return index of the unescaped closing quote in *s*, or -1.
+
+    Args:
+        s: String starting with the opening quote character.
+        quote_char: The quote character to match (``"`` or ``'``).
+
+    Returns:
+        Index of the closing quote, or -1 if not found.
+    """
+    i = 1
+    while i < len(s):
+        if s[i] == "\\" and i + 1 < len(s):
+            i += 2
+            continue
+        if s[i] == quote_char:
+            return i
+        i += 1
+    return -1
+
+
+def _parse_kv_string(value: str) -> CommentedMap | None:
+    """Parse an old-style ``key=value key2=value2`` string into a CommentedMap.
+
+    Handles quoted values (double and single quotes) and values containing
+    spaces/Jinja expressions.
+
+    Args:
+        value: String containing key=value pairs (e.g. ``name="foo" gid="bar"``).
+
+    Returns:
+        CommentedMap with parsed key-value pairs, or None if the string
+        doesn't look like key=value pairs.
+    """
+    if "=" not in value:
+        return None
+
+    result = CommentedMap()
+    remaining = value.strip()
+
+    while remaining:
+        m = _KV_RE.match(remaining)
+        if m is None:
+            return None
+
+        key = m.group(1)
+        remaining = remaining[m.end() :]
+
+        if remaining.startswith('"') or remaining.startswith("'"):
+            quote_char = remaining[0]
+            end = _find_closing_quote(remaining, quote_char)
+            if end == -1:
+                return None
+            val = remaining[1:end]
+            remaining = remaining[end + 1 :].lstrip()
+        else:
+            parts = remaining.split(None, 1)
+            val = parts[0]
+            remaining = parts[1] if len(parts) > 1 else ""
+
+        result[key] = val
+
+    return result if len(result) > 0 else None
+
+
+def _expand_inline_kv_args(data: object) -> None:
+    """Walk task mappings and expand old-style ``module: key=val key2=val2`` to dict form.
+
+    Skips command/shell/raw/script modules whose string value is a command,
+    not key=value pairs.
+
+    Args:
+        data: CommentedSeq, CommentedMap, or nested structure with tasks.
+    """
+    if isinstance(data, CommentedSeq):
+        for item in data:
+            _expand_inline_kv_args(item)
+    elif isinstance(data, CommentedMap):
+        for task_list_key in ("tasks", "pre_tasks", "post_tasks", "handlers", "block", "rescue", "always"):
+            if task_list_key in data:
+                _expand_inline_kv_args(data[task_list_key])
+
+        _expand_single_task_kv(data)
+
+
+def _expand_single_task_kv(mapping: CommentedMap) -> None:
+    """Expand key=value string on a module key to a proper YAML mapping.
+
+    Args:
+        mapping: CommentedMap for a single task.
+    """
+    module_key = None
+    for k in mapping:
+        if k not in _FORMAT_META_KEYS:
+            module_key = k
+            break
+
+    if module_key is None:
+        return
+
+    if module_key in _COMMAND_MODULES:
+        return
+
+    value = mapping.get(module_key)
+    if not isinstance(value, str) or "=" not in value:
+        return
+
+    parsed = _parse_kv_string(value)
+    if parsed is not None and len(parsed) > 0:
+        mapping[module_key] = parsed
+
+
+def _force_tags_block_style(data: object) -> None:
+    """Walk task/play mappings and convert flow-style ``tags`` lists to block style.
+
+    Args:
+        data: CommentedSeq, CommentedMap, or nested structure with tasks.
+    """
+    if isinstance(data, CommentedSeq):
+        for item in data:
+            _force_tags_block_style(item)
+    elif isinstance(data, CommentedMap):
+        tags = data.get("tags")
+        if isinstance(tags, CommentedSeq) and tags.fa.flow_style():
+            tags.fa.set_block_style()
+
+        for nested_key in ("tasks", "pre_tasks", "post_tasks", "handlers", "block", "rescue", "always"):
+            if nested_key in data:
+                _force_tags_block_style(data[nested_key])
+
+
 def format_content(text: str, filename: str = "<stdin>") -> FormatResult:
     """Format a YAML string.
 
@@ -288,8 +489,12 @@ def format_content(text: str, filename: str = "<stdin>") -> FormatResult:
 
     if isinstance(data, CommentedSeq):
         for item in data:
+            _expand_inline_kv_args(item)
+            _force_tags_block_style(item)
             _reorder_task_keys(item)
     elif isinstance(data, CommentedMap):
+        _expand_inline_kv_args(data)
+        _force_tags_block_style(data)
         _reorder_task_keys(data)
 
     formatted = yaml.dumps(data)

--- a/src/apme_engine/remediation/engine.py
+++ b/src/apme_engine/remediation/engine.py
@@ -211,11 +211,11 @@ class RemediationEngine:
             if sf is not None:
                 structured[fp] = sf
 
-        # Violations may report relative filenames (e.g. "site.yml") while
-        # file_contents keys are absolute paths.  Build a reverse lookup so we
-        # can resolve either form to the canonical key.  When multiple files
-        # share a basename the entry is set to None so we skip rather than
-        # resolving to the wrong file.
+        # Violations may report relative filenames (e.g. "site.yml" or
+        # "tasks/main.yml") while file_contents keys are absolute paths.
+        # Build a reverse lookup so we can resolve either form to the
+        # canonical key.  When multiple files share a basename the entry
+        # is set to None so we skip rather than resolving to the wrong file.
         _basename_to_key: dict[str, str | None] = {}
         for fp in file_paths:
             bn = Path(fp).name
@@ -229,9 +229,18 @@ class RemediationEngine:
             if vf in file_contents:
                 return vf
             candidate = _basename_to_key.get(vf) or _basename_to_key.get(Path(vf).name)
-            if candidate is None and vf:
+            if candidate is not None:
+                return candidate
+            # Try suffix matching for relative paths (e.g. "tasks/main.yml"
+            # matching "/workspace/role/tasks/main.yml").
+            if vf and "/" in vf:
+                suffix = "/" + vf
+                matches = [fp for fp in file_paths if fp.endswith(suffix)]
+                if len(matches) == 1:
+                    return matches[0]
+            if vf:
                 self._log(f"  Skipping violation: ambiguous or unknown file '{vf}'")
-            return candidate
+            return None
 
         originals = dict(file_contents)
         all_applied_rules: dict[str, list[str]] = {fp: [] for fp in file_paths}

--- a/src/apme_engine/remediation/transforms/__init__.py
+++ b/src/apme_engine/remediation/transforms/__init__.py
@@ -56,6 +56,9 @@ def build_default_registry() -> TransformRegistry:
     reg.register("M003", structured=fix_fqcn)
     reg.register("M004", structured=fix_fqcn)
 
+    # OPA L005 also detects non-FQCN; reuse the same fixer (falls back to static map)
+    reg.register("L005", structured=fix_fqcn)
+
     # Migration rules
     reg.register("M006", structured=fix_become_unreachable)
     reg.register("M008", structured=fix_bare_include)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,9 @@ import apme_engine.cli as cli_module
 from apme_engine.ansi import strip_ansi
 from apme_engine.cli import (
     _deduplicate_violations,
+    _find_role_root,
     _fmt_ms,
+    _group_files_by_scan_root,
     _sort_violations,
 )
 from apme_engine.engine.models import ViolationDict, YAMLDict
@@ -712,3 +714,173 @@ class TestFixCommand:
         ):
             cli_module.main()
         assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# _find_role_root
+# ---------------------------------------------------------------------------
+
+
+class TestFindRoleRoot:
+    """Tests for _find_role_root()."""
+
+    def test_file_inside_role_tasks(self, tmp_path: Path) -> None:
+        """File under tasks/ returns the role root.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role = tmp_path / "my_role"
+        (role / "tasks").mkdir(parents=True)
+        (role / "defaults").mkdir()
+        yml = role / "tasks" / "main.yml"
+        yml.write_text("---\n")
+        assert _find_role_root(yml.resolve()) == role
+
+    def test_file_inside_role_handlers(self, tmp_path: Path) -> None:
+        """File under handlers/ returns the role root.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role = tmp_path / "my_role"
+        (role / "handlers").mkdir(parents=True)
+        yml = role / "handlers" / "main.yml"
+        yml.write_text("---\n")
+        assert _find_role_root(yml.resolve()) == role
+
+    def test_file_not_in_role(self, tmp_path: Path) -> None:
+        """File outside any role structure returns None.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        yml = tmp_path / "playbook.yml"
+        yml.write_text("---\n")
+        assert _find_role_root(yml.resolve()) is None
+
+    def test_nested_role(self, tmp_path: Path) -> None:
+        """Finds the nearest role root when roles are nested.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        outer = tmp_path / "roles" / "outer"
+        (outer / "tasks").mkdir(parents=True)
+        inner = outer / "tasks" / "inner_role"
+        (inner / "tasks").mkdir(parents=True)
+        yml = inner / "tasks" / "main.yml"
+        yml.write_text("---\n")
+        assert _find_role_root(yml.resolve()) == inner
+
+    def test_role_with_meta_only(self, tmp_path: Path) -> None:
+        """A directory with only meta/ is still detected as a role root.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role = tmp_path / "meta_role"
+        (role / "meta").mkdir(parents=True)
+        yml = role / "meta" / "main.yml"
+        yml.write_text("---\n")
+        assert _find_role_root(yml.resolve()) == role
+
+
+# ---------------------------------------------------------------------------
+# _group_files_by_scan_root
+# ---------------------------------------------------------------------------
+
+
+class TestGroupFilesByScanRoot:
+    """Tests for _group_files_by_scan_root()."""
+
+    def test_single_role(self, tmp_path: Path) -> None:
+        """All files in one role group under the role root.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role = tmp_path / "my_role"
+        (role / "tasks").mkdir(parents=True)
+        (role / "handlers").mkdir()
+        t = role / "tasks" / "main.yml"
+        h = role / "handlers" / "main.yml"
+        t.write_text("---\n")
+        h.write_text("---\n")
+
+        groups = _group_files_by_scan_root([str(t), str(h)])
+        assert len(groups) == 1
+        root = next(iter(groups))
+        assert root == role
+        assert set(groups[root]) == {t.resolve(), h.resolve()}
+
+    def test_two_roles(self, tmp_path: Path) -> None:
+        """Files from different roles are grouped separately.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        r1 = tmp_path / "role_a"
+        (r1 / "tasks").mkdir(parents=True)
+        r2 = tmp_path / "role_b"
+        (r2 / "tasks").mkdir(parents=True)
+        f1 = r1 / "tasks" / "main.yml"
+        f2 = r2 / "tasks" / "main.yml"
+        f1.write_text("---\n")
+        f2.write_text("---\n")
+
+        groups = _group_files_by_scan_root([str(f1), str(f2)])
+        assert len(groups) == 2
+        roots = set(groups.keys())
+        assert roots == {r1, r2}
+
+    def test_ungrouped_files_share_common_ancestor(self, tmp_path: Path) -> None:
+        """Non-role files are grouped under their common ancestor.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        d = tmp_path / "project"
+        d.mkdir()
+        a = d / "site.yml"
+        b = d / "deploy.yml"
+        a.write_text("---\n")
+        b.write_text("---\n")
+
+        groups = _group_files_by_scan_root([str(a), str(b)])
+        assert len(groups) == 1
+        root = next(iter(groups))
+        assert root == d
+
+    def test_mixed_role_and_loose_files(self, tmp_path: Path) -> None:
+        """Role files and loose playbooks are grouped separately.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role = tmp_path / "my_role"
+        (role / "tasks").mkdir(parents=True)
+        rf = role / "tasks" / "main.yml"
+        rf.write_text("---\n")
+        loose = tmp_path / "site.yml"
+        loose.write_text("---\n")
+
+        groups = _group_files_by_scan_root([str(rf), str(loose)])
+        assert len(groups) == 2
+        assert role in groups
+        resolved_loose = [p for root, paths in groups.items() if root != role for p in paths]
+        assert loose.resolve() in resolved_loose
+
+    def test_single_ungrouped_file(self, tmp_path: Path) -> None:
+        """A single non-role file is grouped under its parent directory.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        f = tmp_path / "playbook.yml"
+        f.write_text("---\n")
+
+        groups = _group_files_by_scan_root([str(f)])
+        assert len(groups) == 1
+        root = next(iter(groups))
+        assert root == tmp_path

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -578,3 +578,86 @@ class TestDiffOutput:
         result = format_content(text)
         if not result.changed:
             assert result.diff == ""
+
+
+# ---------------------------------------------------------------------------
+# Inline key=value expansion
+# ---------------------------------------------------------------------------
+
+
+class TestExpandInlineKVArgs:
+    """Tests for _expand_inline_kv_args via format_content."""
+
+    def test_simple_kv_expansion(self) -> None:
+        """Simple key=value pairs are expanded to a YAML mapping."""
+        text = '- name: Add group\n  group: name="mygroup" gid="1000"\n'
+        result = format_content(text)
+        assert "name: mygroup" in result.formatted
+        assert "gid: '1000'" in result.formatted or 'gid: "1000"' in result.formatted
+
+    def test_kv_with_jinja(self) -> None:
+        """Jinja expressions inside quoted values are preserved."""
+        text = '- name: Add group\n  group: name="{{ item.name }}" gid="{{ item.gid }}"\n'
+        result = format_content(text)
+        assert "{{ item.name }}" in result.formatted
+        assert "{{ item.gid }}" in result.formatted
+
+    def test_command_module_excluded(self) -> None:
+        """Command modules keep their string value unchanged."""
+        text = "- name: Run cmd\n  command: echo hello world\n"
+        result = format_content(text)
+        assert "echo hello world" in result.formatted
+
+    def test_shell_module_excluded(self) -> None:
+        """Shell modules keep their string value unchanged."""
+        text = "- name: Run shell\n  shell: ls -la /tmp\n"
+        result = format_content(text)
+        assert "ls -la /tmp" in result.formatted
+
+    def test_raw_module_excluded(self) -> None:
+        """Raw module keeps its string value unchanged."""
+        text = "- name: Raw cmd\n  raw: yum install -y httpd\n"
+        result = format_content(text)
+        assert "yum install -y httpd" in result.formatted
+
+    def test_script_module_excluded(self) -> None:
+        """Script module keeps its string value unchanged."""
+        text = "- name: Run script\n  script: /opt/run.sh --flag\n"
+        result = format_content(text)
+        assert "/opt/run.sh --flag" in result.formatted
+
+    def test_no_kv_string_unchanged(self) -> None:
+        """Strings without = are left as-is."""
+        text = "- name: Debug\n  ansible.builtin.debug:\n    msg: hello world\n"
+        result = format_content(text)
+        assert "msg: hello world" in result.formatted
+
+    def test_kv_expansion_idempotent(self) -> None:
+        """Applying format twice produces the same output."""
+        text = '- name: Add group\n  group: name="mygroup" gid="1000"\n'
+        r1 = format_content(text)
+        r2 = format_content(r1.formatted)
+        assert r1.formatted == r2.formatted
+
+
+# ---------------------------------------------------------------------------
+# Tags block style
+# ---------------------------------------------------------------------------
+
+
+class TestForceTagsBlockStyle:
+    """Tests for _force_tags_block_style via format_content."""
+
+    def test_flow_tags_to_block(self) -> None:
+        """Flow-style tags list is converted to block style."""
+        text = "- name: Test\n  ansible.builtin.debug:\n    msg: hi\n  tags: [users, groups]\n"
+        result = format_content(text)
+        assert "- users" in result.formatted
+        assert "- groups" in result.formatted
+
+    def test_block_tags_unchanged(self) -> None:
+        """Already block-style tags are not modified."""
+        text = "- name: Test\n  ansible.builtin.debug:\n    msg: hi\n  tags:\n    - users\n    - groups\n"
+        result = format_content(text)
+        assert "- users" in result.formatted
+        assert "- groups" in result.formatted

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -286,9 +286,10 @@ class TestDefaultRegistry:
             "M006",
             "M008",
             "M009",
+            "L005",
         ):
             assert rule_id in reg, f"{rule_id} missing from default registry"
-        assert len(reg) == 21
+        assert len(reg) == 22
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Formatter:** expand old-style inline `key=value` module args (e.g. `group: name="foo" gid="1000"`) into proper YAML mappings; force flow-style `tags` lists to block style
- **CLI:** refactor `_scan_files_grpc` to group files by Ansible role boundary, preserving directory structure validators need for FQCN/modernization detection
- **Remediation:** register `fix_fqcn` for OPA `L005` rule so FQCN fixes work without the Ansible validator; improve violation file-path resolution with suffix matching

## Changes

### Formatter (`src/apme_engine/formatter.py`)
- Add `_parse_kv_string()` and `_expand_inline_kv_args()` to convert legacy `module: key=val key2=val2` strings into proper YAML mappings during Phase 1 formatting
- Use `_find_closing_quote()` for robust quoted-value parsing (handles backslash escapes, Jinja expressions)
- Exclude command/shell/raw/script modules (both short and FQCN forms) since their string values are commands, not key=value pairs
- Add `_force_tags_block_style()` to normalize `tags: [a, b]` to block-style list

### CLI scanning (`src/apme_engine/cli.py`)
- Add `_find_role_root()` to detect Ansible role boundaries by walking up for standard marker directories (tasks/, handlers/, defaults/, etc.)
- Add `_group_files_by_scan_root()` to partition files so each role is sent as a self-contained gRPC scan request
- Implement proper gRPC message chunking using `CHUNK_MAX_BYTES` (1 MiB) to avoid exceeding message size limits on large projects
- Resolve relative violation paths back to absolute paths after each per-role scan

### Remediation (`src/apme_engine/remediation/`)
- Register existing `fix_fqcn` transform for OPA `L005` rule — falls back to static `_BUILTIN_FQCN` map covering all common builtins
- Improve `_resolve_file` with suffix matching for relative paths (e.g. `tasks/main.yml` matching `/workspace/role/tasks/main.yml`)

### Tests & coverage
- 10 formatter tests: KV expansion, Jinja preservation, command module exclusions, idempotency, tags block style conversion
- 10 CLI tests: `_find_role_root` (tasks, handlers, not-in-role, nested, meta-only) and `_group_files_by_scan_root` (single role, two roles, ungrouped, mixed, single file)
- Coverage threshold bumped from 36% → 50% (actual: 50.69%)

## Test plan

- [x] `pytest` — 1094 passed, 0 failures
- [x] Coverage gate met (50.69% >= 50%)
- [x] No linter errors
- [x] Formatter changes are idempotent (verified by test)
- [x] Command/shell/raw/script modules excluded from KV expansion (verified by tests)