### PR TITLE
fix(remediation): path-based task lookup, FQCN fallback, free-form quoting, handler traversal

### DIFF
--- a/src/apme_engine/daemon/violation_convert.py
+++ b/src/apme_engine/daemon/violation_convert.py
@@ -86,6 +86,16 @@ def violation_dict_to_proto(v: ViolationDict | Mapping[str, str | int | list[int
         out.line_range.CopyFrom(LineRange(start=int(line[0]), end=int(line[1])))
     elif isinstance(line, int):
         out.line = line
+    elif isinstance(line, str) and line:
+        raw = line.lstrip("L")
+        parts = raw.split("-")
+        try:
+            if len(parts) >= 2:
+                out.line_range.CopyFrom(LineRange(start=int(parts[0]), end=int(parts[1])))
+            else:
+                out.line = int(parts[0])
+        except (ValueError, IndexError):
+            pass
     return out
 
 

--- a/src/apme_engine/engine/tree.py
+++ b/src/apme_engine/engine/tree.py
@@ -783,6 +783,7 @@ class TreeLoader:
         self.root_definitions = load_all_definitions(root_definitions)
         self.ext_definitions = load_all_definitions(ext_definitions)
         self.add_builtin_modules()
+        self._register_handler_taskfiles()
 
         self.dicts = make_dicts(self.root_definitions, self.ext_definitions)
 
@@ -1160,6 +1161,32 @@ class TreeLoader:
         obj_list = ObjectList(items=[cast(Object | CallObject, m) for m in builtin_modules])
         self.ext_definitions["modules"].merge(obj_list)
 
+    def _register_handler_taskfiles(self) -> None:
+        """Add handler TaskFiles (and their tasks) from roles into root_definitions.
+
+        The ARI engine stores handler files in ``role.handlers`` but excludes
+        them from the definitions dict that the tree walker uses.  This method
+        copies them into ``root_definitions["taskfiles"]`` (and their child
+        tasks into ``root_definitions["tasks"]``) so that ``get_object()`` can
+        resolve handler keys during tree traversal.
+        """
+        taskfiles_list = self.root_definitions.get("taskfiles", ObjectList())
+        tasks_list = self.root_definitions.get("tasks", ObjectList())
+        if not isinstance(taskfiles_list, ObjectList) or not isinstance(tasks_list, ObjectList):
+            return
+        roles_list = self.root_definitions.get("roles", ObjectList())
+        if not isinstance(roles_list, ObjectList):
+            return
+        for obj in roles_list.items:
+            if not isinstance(obj, Role):
+                continue
+            for h in obj.handlers:
+                if isinstance(h, TaskFile) and h.key:
+                    taskfiles_list.add(cast(Object | CallObject, h))
+                    for task in h.tasks:
+                        if hasattr(task, "key") and task.key:
+                            tasks_list.add(cast(Object | CallObject, task))
+
     def _get_children_keys(
         self,
         obj: Object | CallObject,
@@ -1282,6 +1309,10 @@ class TreeLoader:
                 if tf_str.split(key_delimiter)[-1].split("/")[-1] in target_taskfiles and "/handlers/" not in tf_str
             ]
             children_keys.extend(target_taskfile_key)
+            for h in obj.handlers:
+                h_key = h.key if isinstance(h, TaskFile) else str(h)
+                if h_key:
+                    children_keys.append(h_key)
         elif isinstance(obj, TaskFile):
             children_keys = [t.key if isinstance(t, Task) else str(t) for t in obj.tasks]
         elif isinstance(obj, Task):

--- a/src/apme_engine/engine/yaml_utils.py
+++ b/src/apme_engine/engine/yaml_utils.py
@@ -619,7 +619,8 @@ class FormattedYAML(YAML):  # type: ignore[misc]
             data = None
             logger.error("Invalid yaml, verify the file contents and try again. %s", ex)  # noqa: TRY400
         except Exception as ex:
-            print(ex)
+            data = None
+            logger.error("YAML load error: %s", ex)  # noqa: TRY400
         if preamble_comment is not None and isinstance(
             data,
             CommentedMap | CommentedSeq,

--- a/src/apme_engine/formatter.py
+++ b/src/apme_engine/formatter.py
@@ -104,6 +104,64 @@ def _fix_tabs(text: str) -> str:
     return text.replace("\t", "  ")
 
 
+_FREE_FORM_MODULE_NAMES = frozenset(
+    {
+        "ansible.builtin.command",
+        "ansible.builtin.shell",
+        "ansible.builtin.raw",
+        "ansible.builtin.script",
+        "ansible.legacy.command",
+        "ansible.legacy.shell",
+        "ansible.legacy.raw",
+        "command",
+        "shell",
+        "raw",
+        "script",
+    }
+)
+
+_FREE_FORM_LINE_RE = re.compile(
+    r"^(?P<indent>\s*-?\s*)(?P<module>"
+    + "|".join(re.escape(m) for m in sorted(_FREE_FORM_MODULE_NAMES, key=len, reverse=True))
+    + r"):\s+(?P<value>.+)$"
+)
+
+
+def _quote_free_form_args(text: str) -> str:
+    """Quote free-form module arguments that contain YAML-unsafe characters.
+
+    Runs before ``yaml.load()`` to prevent parse failures on lines like::
+
+        ansible.builtin.shell: cat /etc/passwd | cut -d: -f1
+
+    The colon inside the value is valid for Ansible but invalid YAML.
+    This wraps such values in double quotes so ruamel can parse the file.
+
+    Args:
+        text: Raw YAML content.
+
+    Returns:
+        Text with free-form values quoted where necessary.
+    """
+    lines = text.split("\n")
+    changed = False
+    for i, line in enumerate(lines):
+        m = _FREE_FORM_LINE_RE.match(line)
+        if m is None:
+            continue
+        value = m.group("value")
+        if value.startswith(('"', "'")):
+            continue
+        if ":" not in value:
+            continue
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        lines[i] = f'{m.group("indent")}{m.group("module")}: "{escaped}"'
+        changed = True
+    if not changed:
+        return text
+    return "\n".join(lines)
+
+
 def _strip_stray_blanks(text: str) -> str:
     """Remove interior blank lines inserted by ruamel round-trip dumping.
 
@@ -464,6 +522,7 @@ def format_content(text: str, filename: str = "<stdin>") -> FormatResult:
     original = text
 
     text = _fix_tabs(text)
+    text = _quote_free_form_args(text)
 
     yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
 

--- a/src/apme_engine/remediation/structured.py
+++ b/src/apme_engine/remediation/structured.py
@@ -63,22 +63,41 @@ class StructuredFile:
         """
         return self._yaml.dumps(self.data)
 
-    def find_task(self, line: int) -> CommentedMap | None:
-        """Locate the task CommentedMap at a 1-based line number.
+    def find_task(
+        self,
+        line: int,
+        violation: dict[str, str | int | list[int] | bool | None] | None = None,
+    ) -> CommentedMap | None:
+        """Locate the task CommentedMap by line number or violation path index.
 
-        Defers the import of ``find_task_at_line`` to avoid a circular
-        dependency (structured -> transforms._helpers -> transforms.__init__
-        -> L007 etc. -> structured).
+        Tries the 1-based ``line`` first.  When that fails (e.g. ``line=0``
+        because the validator didn't supply one), falls back to extracting
+        a ``task:[N]`` index from the violation's ``path`` field.
 
         Args:
             line: 1-indexed line number from a violation.
+            violation: Optional full violation dict for path-based fallback.
 
         Returns:
             Task CommentedMap or None if not found.
         """
-        from apme_engine.remediation.transforms._helpers import find_task_at_line
+        from apme_engine.remediation.transforms._helpers import (
+            find_task_at_line,
+            find_task_by_index,
+            violation_task_index,
+        )
 
-        return find_task_at_line(self.data, line)
+        if line > 0:
+            result = find_task_at_line(self.data, line)
+            if result is not None:
+                return result
+
+        if violation is not None:
+            idx = violation_task_index(violation)
+            if idx is not None:
+                return find_task_by_index(self.data, idx)
+
+        return None
 
     def mark_dirty(self) -> None:
         """Mark this file as having been modified by a transform."""

--- a/src/apme_engine/remediation/transforms/L007_shell_to_command.py
+++ b/src/apme_engine/remediation/transforms/L007_shell_to_command.py
@@ -41,7 +41,7 @@ def fix_shell_to_command(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L008_local_action.py
+++ b/src/apme_engine/remediation/transforms/L008_local_action.py
@@ -19,7 +19,7 @@ def fix_local_action(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L009_empty_string.py
+++ b/src/apme_engine/remediation/transforms/L009_empty_string.py
@@ -26,7 +26,7 @@ def fix_empty_string(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L011_literal_bool.py
+++ b/src/apme_engine/remediation/transforms/L011_literal_bool.py
@@ -32,7 +32,7 @@ def fix_literal_bool(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L012_latest.py
+++ b/src/apme_engine/remediation/transforms/L012_latest.py
@@ -17,7 +17,7 @@ def fix_latest(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L013_changed_when.py
+++ b/src/apme_engine/remediation/transforms/L013_changed_when.py
@@ -34,7 +34,7 @@ def fix_changed_when(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L015_jinja_when.py
+++ b/src/apme_engine/remediation/transforms/L015_jinja_when.py
@@ -21,7 +21,7 @@ def fix_jinja_when(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L018_become.py
+++ b/src/apme_engine/remediation/transforms/L018_become.py
@@ -17,7 +17,7 @@ def fix_become(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L021_missing_mode.py
+++ b/src/apme_engine/remediation/transforms/L021_missing_mode.py
@@ -40,7 +40,7 @@ def fix_missing_mode(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L022_pipefail.py
+++ b/src/apme_engine/remediation/transforms/L022_pipefail.py
@@ -25,7 +25,7 @@ def fix_pipefail(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L025_name_casing.py
+++ b/src/apme_engine/remediation/transforms/L025_name_casing.py
@@ -17,7 +17,7 @@ def fix_name_casing(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L043_bare_vars.py
+++ b/src/apme_engine/remediation/transforms/L043_bare_vars.py
@@ -31,7 +31,7 @@ def fix_bare_vars(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/L046_no_free_form.py
+++ b/src/apme_engine/remediation/transforms/L046_no_free_form.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
 from apme_engine.engine.models import ViolationDict
 from apme_engine.remediation.structured import StructuredFile
 from apme_engine.remediation.transforms._helpers import get_module_key, violation_line_to_int
+
+_YAML_UNSAFE_RE_CHARS = frozenset(":{}[]|>&*!%#`@,")
 
 _FREE_FORM_MODULES = frozenset(
     {
@@ -35,7 +38,7 @@ def fix_free_form(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 
@@ -48,7 +51,10 @@ def fix_free_form(sf: StructuredFile, violation: ViolationDict) -> bool:
         return False
 
     new_args = CommentedMap()
-    new_args["cmd"] = module_args
+    cmd_val: str | DoubleQuotedScalarString = module_args
+    if any(c in module_args for c in _YAML_UNSAFE_RE_CHARS):
+        cmd_val = DoubleQuotedScalarString(module_args)
+    new_args["cmd"] = cmd_val
     task[module_key] = new_args
 
     return True

--- a/src/apme_engine/remediation/transforms/M001_fqcn.py
+++ b/src/apme_engine/remediation/transforms/M001_fqcn.py
@@ -99,7 +99,7 @@ def fix_fqcn(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/M006_become_unreachable.py
+++ b/src/apme_engine/remediation/transforms/M006_become_unreachable.py
@@ -17,7 +17,7 @@ def fix_become_unreachable(sf: StructuredFile, violation: ViolationDict) -> bool
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/M008_bare_include.py
+++ b/src/apme_engine/remediation/transforms/M008_bare_include.py
@@ -17,7 +17,7 @@ def fix_bare_include(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/M009_with_to_loop.py
+++ b/src/apme_engine/remediation/transforms/M009_with_to_loop.py
@@ -29,7 +29,7 @@ def fix_with_to_loop(sf: StructuredFile, violation: ViolationDict) -> bool:
     Returns:
         True if a change was applied.
     """
-    task = sf.find_task(violation_line_to_int(violation))
+    task = sf.find_task(violation_line_to_int(violation), violation)
     if task is None:
         return False
 

--- a/src/apme_engine/remediation/transforms/_helpers.py
+++ b/src/apme_engine/remediation/transforms/_helpers.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import re
+
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from apme_engine.engine.models import ViolationDict
+
+_TASK_INDEX_RE = re.compile(r"task:\[(\d+)\]")
 
 
 def violation_line_to_int(violation: ViolationDict) -> int:
@@ -30,6 +34,54 @@ def violation_line_to_int(violation: ViolationDict) -> int:
         except ValueError:
             return 0
     return 0
+
+
+def violation_task_index(violation: ViolationDict) -> int | None:
+    """Extract the task index from the violation ``path`` field.
+
+    The native validator encodes the task position as ``task:[N]`` in the
+    hierarchy node key.  This is useful when ``line`` is ``None``.
+
+    Args:
+        violation: Violation dict with optional path field.
+
+    Returns:
+        0-based task index, or None if not present.
+    """
+    path = violation.get("path", "")
+    if not isinstance(path, str):
+        return None
+    m = _TASK_INDEX_RE.search(path)
+    return int(m.group(1)) if m else None
+
+
+def find_task_by_index(data: CommentedMap | CommentedSeq, index: int) -> CommentedMap | None:
+    """Return the Nth task from a top-level task list.
+
+    Works on bare task lists (CommentedSeq) and play mappings that contain
+    a ``tasks``, ``pre_tasks``, ``post_tasks``, or ``handlers`` key.
+
+    Args:
+        data: Playbook root (CommentedMap or CommentedSeq).
+        index: 0-based task index.
+
+    Returns:
+        Task CommentedMap, or None if index is out of range.
+    """
+    seq: CommentedSeq | None = None
+    if isinstance(data, CommentedSeq):
+        seq = data
+    elif isinstance(data, CommentedMap):
+        for key in ("tasks", "pre_tasks", "post_tasks", "handlers"):
+            candidate = data.get(key)
+            if isinstance(candidate, CommentedSeq):
+                seq = candidate
+                break
+    if seq is not None and 0 <= index < len(seq):
+        item = seq[index]
+        if isinstance(item, CommentedMap):
+            return item
+    return None
 
 
 def find_task_at_line(data: CommentedMap | CommentedSeq, line: int) -> CommentedMap | None:

--- a/src/apme_engine/validators/ansible/rules/M001_M004_introspect.py
+++ b/src/apme_engine/validators/ansible/rules/M001_M004_introspect.py
@@ -20,6 +20,7 @@ import json, sys
 
 data = json.loads(sys.stdin.read())
 module_names = data.get("modules", [])
+fallback_map = data.get("fallback_fqcn", {})
 results = {}
 
 from ansible.plugins.loader import module_loader
@@ -48,6 +49,9 @@ for name in module_names:
             info["removed"] = True
             info["removal_msg"] = str(e)
 
+    if not info["fqcn"] and not info["removed"] and name in fallback_map:
+        info["fqcn"] = fallback_map[name]
+
     results[name] = info
 
 json.dump(results, sys.stdout)
@@ -55,7 +59,10 @@ json.dump(results, sys.stdout)
 
 
 def _run_introspection(
-    module_names: list[str], venv_root: Path, env_extra: dict[str, str] | None = None
+    module_names: list[str],
+    venv_root: Path,
+    env_extra: dict[str, str] | None = None,
+    fallback_fqcn: dict[str, str] | None = None,
 ) -> dict[str, object]:
     """Run plugin introspection in the venv's Python. Returns {name: info_dict}.
 
@@ -63,6 +70,9 @@ def _run_introspection(
         module_names: List of module names to introspect.
         venv_root: Path to ansible venv root.
         env_extra: Optional extra environment variables.
+        fallback_fqcn: Static short-name-to-FQCN map used when the venv's
+            ``find_plugin_with_context`` fails to resolve (e.g. ``yum`` on
+            ansible-core >= 2.17 where the module routing throws).
 
     Returns:
         Dict mapping module name to info dict (fqcn, deprecated, etc.).
@@ -79,10 +89,14 @@ def _run_introspection(
     if env_extra:
         env.update(env_extra)
 
+    payload: dict[str, object] = {"modules": module_names}
+    if fallback_fqcn:
+        payload["fallback_fqcn"] = fallback_fqcn
+
     try:
         result = subprocess.run(
             [str(python), "-c", _SCRIPT],
-            input=json.dumps({"modules": module_names}),
+            input=json.dumps(payload),
             capture_output=True,
             text=True,
             timeout=30,
@@ -129,7 +143,12 @@ def run(
     if not unique_modules:
         return []
 
-    intro = _run_introspection(unique_modules, venv_root, env_extra)
+    from apme_engine.remediation.transforms.M001_fqcn import _BUILTIN_FQCN
+
+    short_names = {m for m in unique_modules if "." not in m}
+    fallback = {name: _BUILTIN_FQCN[name] for name in short_names if name in _BUILTIN_FQCN}
+
+    intro = _run_introspection(unique_modules, venv_root, env_extra, fallback_fqcn=fallback or None)
     if not intro:
         return []
 
@@ -163,7 +182,6 @@ def run(
             continue
 
         # M001: FQCN resolution
-        fqcn = info.get("fqcn", "")
         fqcn = str(info.get("fqcn", ""))
         if fqcn and fqcn != module_name and str(module_name).count(".") < 2:
             violations.append(

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -661,3 +661,45 @@ class TestForceTagsBlockStyle:
         result = format_content(text)
         assert "- users" in result.formatted
         assert "- groups" in result.formatted
+
+
+# ---------------------------------------------------------------------------
+# Free-form quoting
+# ---------------------------------------------------------------------------
+
+
+class TestQuoteFreeFormArgs:
+    """Tests for _quote_free_form_args via format_content."""
+
+    def test_colon_in_shell_value_quoted(self) -> None:
+        """Shell args with colons are quoted to avoid YAML parse errors."""
+        text = "- name: Extract users\n  ansible.builtin.shell: cat /etc/passwd | cut -d: -f1\n"
+        result = format_content(text)
+        assert result.formatted is not None
+        assert "cut -d" in result.formatted
+
+    def test_shell_without_colon_unchanged(self) -> None:
+        """Shell args without colons are left alone."""
+        text = "- name: List files\n  ansible.builtin.shell: ls -la /tmp\n"
+        result = format_content(text)
+        assert "ls -la /tmp" in result.formatted
+
+    def test_already_quoted_unchanged(self) -> None:
+        """Already-quoted values are not double-quoted."""
+        text = '- name: Test\n  shell: "echo hello: world"\n'
+        result = format_content(text)
+        assert "echo hello: world" in result.formatted
+
+    def test_list_item_form_matched(self) -> None:
+        """The ``- shell: ...`` list-item form is also matched."""
+        text = "- shell: cat /etc/passwd | cut -d: -f1\n"
+        result = format_content(text)
+        assert result.formatted is not None
+        assert "cut -d" in result.formatted
+
+    def test_free_form_quoting_idempotent(self) -> None:
+        """Applying format twice produces the same output."""
+        text = "- name: Extract\n  ansible.builtin.shell: cat /etc/passwd | cut -d: -f1\n"
+        r1 = format_content(text)
+        r2 = format_content(r1.formatted)
+        assert r1.formatted == r2.formatted

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -19,6 +19,7 @@ from apme_engine.remediation.partition import (
 from apme_engine.remediation.registry import TransformRegistry, TransformResult
 from apme_engine.remediation.structured import StructuredFile
 from apme_engine.remediation.transforms import build_default_registry
+from apme_engine.remediation.transforms._helpers import find_task_by_index, violation_task_index
 from apme_engine.remediation.transforms.L007_shell_to_command import fix_shell_to_command
 from apme_engine.remediation.transforms.L008_local_action import fix_local_action
 from apme_engine.remediation.transforms.L009_empty_string import fix_empty_string
@@ -1643,3 +1644,103 @@ class TestM009WithToLoop:
         r1 = _apply(fix_with_to_loop, content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
         r2 = _apply(fix_with_to_loop, r1.content, {"rule_id": "M009", "line": 1, "with_key": "with_items"})
         assert r2.applied is False
+
+
+# ---------------------------------------------------------------------------
+# violation_task_index / find_task_by_index
+# ---------------------------------------------------------------------------
+
+
+class TestViolationTaskIndex:
+    """Tests for violation_task_index()."""
+
+    def test_extracts_index_from_path(self) -> None:
+        """Extracts task index from a native validator path field."""
+        v: ViolationDict = {"rule_id": "L007", "path": "task:playbook.yml#task:[2]"}
+        assert violation_task_index(v) == 2
+
+    def test_returns_none_without_path(self) -> None:
+        """Returns None when violation has no path field."""
+        v: ViolationDict = {"rule_id": "L007"}
+        assert violation_task_index(v) is None
+
+    def test_returns_none_for_non_task_path(self) -> None:
+        """Returns None when path does not contain task:[N]."""
+        v: ViolationDict = {"rule_id": "L007", "path": "playbook.yml"}
+        assert violation_task_index(v) is None
+
+    def test_returns_none_for_non_string_path(self) -> None:
+        """Returns None when path is not a string."""
+        v: ViolationDict = {"rule_id": "L007", "path": 42}
+        assert violation_task_index(v) is None
+
+
+class TestFindTaskByIndex:
+    """Tests for find_task_by_index()."""
+
+    def test_finds_task_in_seq(self) -> None:
+        """Finds a task by index in a bare CommentedSeq."""
+        sf = StructuredFile.from_content(
+            "tasks.yml",
+            textwrap.dedent("""\
+            - name: First
+              ansible.builtin.debug:
+                msg: one
+            - name: Second
+              ansible.builtin.debug:
+                msg: two
+            """),
+        )
+        assert sf is not None
+        task = find_task_by_index(sf.data, 1)
+        assert task is not None
+        assert task["name"] == "Second"
+
+    def test_finds_task_in_play_tasks(self) -> None:
+        """Finds a task by index in a play's tasks list."""
+        sf = StructuredFile.from_content(
+            "play.yml",
+            textwrap.dedent("""\
+            tasks:
+              - name: First
+                ansible.builtin.debug:
+                  msg: one
+              - name: Second
+                ansible.builtin.debug:
+                  msg: two
+            """),
+        )
+        assert sf is not None
+        task = find_task_by_index(sf.data, 0)
+        assert task is not None
+        assert task["name"] == "First"
+
+    def test_returns_none_for_out_of_range(self) -> None:
+        """Returns None when index is out of range."""
+        sf = StructuredFile.from_content(
+            "tasks.yml",
+            textwrap.dedent("""\
+            - name: Only task
+              ansible.builtin.debug:
+                msg: hi
+            """),
+        )
+        assert sf is not None
+        assert find_task_by_index(sf.data, 5) is None
+
+    def test_finds_task_in_handlers(self) -> None:
+        """Finds a task by index in a play's handlers list."""
+        sf = StructuredFile.from_content(
+            "play.yml",
+            textwrap.dedent("""\
+            handlers:
+              - name: Restart service
+                ansible.builtin.service:
+                  name: httpd
+                  state: restarted
+            """),
+        )
+        assert sf is not None
+        task = find_task_by_index(sf.data, 0)
+        assert task is not None
+        assert task["name"] == "Restart service"

--- a/tests/test_violation_convert.py
+++ b/tests/test_violation_convert.py
@@ -241,3 +241,36 @@ class TestRoundTrip:
             proto = violation_dict_to_proto(original)
             result = violation_proto_to_dict(proto)
             assert result["remediation_resolution"] == res, f"Failed for {res}"
+
+
+class TestStringLineParsing:
+    """Tests for string line format parsing in violation_dict_to_proto."""
+
+    def test_string_line_range(self) -> None:
+        """String line 'L15-19' is parsed as a LineRange."""
+        v: ViolationDict = {"rule_id": "L007", "line": "L15-19"}
+        proto = violation_dict_to_proto(v)
+        assert proto.HasField("line_range")
+        assert proto.line_range.start == 15
+        assert proto.line_range.end == 19
+
+    def test_string_single_line(self) -> None:
+        """String line 'L42' is parsed as a single line number."""
+        v: ViolationDict = {"rule_id": "L007", "line": "L42"}
+        proto = violation_dict_to_proto(v)
+        assert proto.line == 42
+
+    def test_string_line_without_prefix(self) -> None:
+        """String line '10-20' (no L prefix) is parsed as a range."""
+        v: ViolationDict = {"rule_id": "L007", "line": "10-20"}
+        proto = violation_dict_to_proto(v)
+        assert proto.HasField("line_range")
+        assert proto.line_range.start == 10
+        assert proto.line_range.end == 20
+
+    def test_invalid_string_line_ignored(self) -> None:
+        """Non-numeric string line is silently ignored."""
+        v: ViolationDict = {"rule_id": "L007", "line": "unknown"}
+        proto = violation_dict_to_proto(v)
+        assert proto.line == 0
+        assert not proto.HasField("line_range")


### PR DESCRIPTION
## Summary

- **Remediation:** add path-based task lookup fallback for native validator violations with `line=None`, using `task:[N]` index from violation path field
- **Introspection:** add `fallback_fqcn` mechanism so modules that fail dynamic resolution (e.g. `yum` on ansible-core >= 2.17) still get FQCN detection via static map
- **Formatter:** pre-parse quoting for YAML-unsafe free-form module args (e.g. `shell: cut -d: -f1`) and fix for list-item form matching
- **Hierarchy engine:** register handler TaskFiles/tasks so validators can detect issues in handler files
- **Violation serialization:** parse string line formats (`L15-19`) to prevent silent line number loss causing remediation oscillation

## Changes

### Path-based task lookup (`_helpers.py`, `structured.py`, 17 transforms)
- Add `violation_task_index()` to extract `task:[N]` index from native violation path field
- Add `find_task_by_index()` supporting `tasks`, `pre_tasks`, `post_tasks`, and `handlers` lists
- Extend `StructuredFile.find_task()` to fall back from line lookup to path-index lookup
- Update all 17 structured transform callsites to pass full violation dict

### FQCN introspection fallback (`M001_M004_introspect.py`)
- Add `fallback_fqcn` parameter to `_run_introspection()` using the static `_BUILTIN_FQCN` map
- When `find_plugin_with_context()` throws `ModuleNotFoundError` (ansible-core >= 2.17 collection routing), fall back to static map

### Pre-parse free-form quoting (`formatter.py`)
- Add `_quote_free_form_args()` to wrap YAML-unsafe free-form args in double quotes before `yaml.load()`
- Fix `_FREE_FORM_LINE_RE` to match both indented and `- module: ...` list-item forms (Copilot review feedback)

### Handler file traversal (`tree.py`)
- Add `_register_handler_taskfiles()` to inject handler TaskFiles and tasks into `root_definitions`
- Include handler keys in Role `_get_children_keys()` for tree traversal

### String line parsing (`violation_convert.py`)
- Parse `"L15-19"` string line format into `LineRange` proto
- Parse `"L42"` into single line number

### Minor fixes
- `yaml_utils.py`: replace `print()` with `logger.error()` in YAML load exception handler, return `None` consistently
- `L046_no_free_form.py`: wrap YAML-unsafe command strings with `DoubleQuotedScalarString` to prevent re-parse failures

## Test plan

- [x] `pytest` — 1111 passed, 0 failures
- [x] Coverage gate met (50.86% >= 50%)
- [x] No linter errors
- [x] 17 new tests: free-form quoting (5), violation_task_index (4), find_task_by_index (4), string line parsing (4)
- [x] Free-form quoting is idempotent (verified by test)
- [x] List-item form (`- shell: ...`) now matched (Copilot fix, verified by test)