### PR TITLE
feat(ADR-032): Third-party plugin services extension model

### DIFF
--- a/.sdlc/adrs/ADR-032-third-party-plugin-services.md
+++ b/.sdlc/adrs/ADR-032-third-party-plugin-services.md
@@ -125,7 +125,7 @@ During fix passes, the Primary (or Remediation Engine) routes violations by rule
 
 Plugin transforms participate in the same convergence loop: scan -> fix -> rescan -> repeat until stable. The plugin receives one `TransformRequest` per violation, returns the fixed file (or `applied=false`), and the Primary writes the result back before rescanning.
 
-If a plugin's `Transform` returns an error or `applied=false` for a given violation, the violation is classified as `REMEDIATION_CLASS_MANUAL_REVIEW` (Tier 3), consistent with the built-in behavior when a transform fails.
+If a plugin's `Transform` returns an error or `applied=false` for a given violation, the violation is reclassified as `REMEDIATION_CLASS_AI_CANDIDATE` with `REMEDIATION_RESOLUTION_TRANSFORM_FAILED` (Tier 2), matching the built-in remediation engine's handling of transform failures.
 
 ### 5. Data contract
 
@@ -139,7 +139,7 @@ Plugins receive the following data in `ValidateRequest`:
 | `collection_specs` | `repeated string` | Collection specifiers from requirements.yml |
 | `request_id` | `string` | Correlation ID |
 
-Plugins do **not** receive `scandata` (field 4 on `ValidateRequest`). This field contains Python-specific jsonpickle serialization of internal engine state and is not part of the public contract. Keeping it out preserves language-agnosticism: plugins can be written in Python, Go, Rust, or any language with gRPC support.
+The underlying `ValidateRequest` protobuf message also defines `scandata` as field 4. For calls from the Primary to plugins, the Primary **MUST** send `scandata` unset/empty, and plugin implementations **MUST** ignore any value present in this field. `scandata` contains Python-specific jsonpickle serialization of internal engine state and is **not** part of the stable, language-agnostic public contract, even though the field exists on the wire.
 
 The `hierarchy_payload` JSON schema should be documented as a versioned public contract (future work — not blocking this ADR).
 


### PR DESCRIPTION
## Summary

- Proposes ADR-032: a `Plugin` gRPC service as the public extension contract for third-party containers that combine validation and transformation
- Defines `EXT-` rule ID prefix convention (extending ADR-008) with Primary-enforced namespacing
- Includes Python SDK design (`apme-plugin-sdk` with `PluginBase` class) to lower the authoring barrier to ~20 lines of code
- Formalizes monorepo structure with shared `proto/` directory for both `apme_engine` and `apme_plugin_sdk` packages
- SDK example includes both a validate check (missing department tags) and a working transform (adds `dept:unassigned` tag)

## Commits

- `a97c77b` — Initial ADR proposal with all 8 key decisions
- `d0d411d` — Add transform example to SDK plugin sample
- `a89769d` — Address Copilot review feedback (transform failure classification, scandata field clarification)

## Status

This is a **Proposed** ADR for review and discussion. No implementation changes are included.

## Test plan

- [ ] Review ADR for completeness and consistency with existing ADRs (001, 005, 008, 009, 026)
- [ ] Validate proto sketch is compatible with existing `ValidateRequest`/`ValidateResponse`
- [ ] Confirm SDK design is feasible (PluginBase, auto-prefix, serve pattern)
- [ ] Review monorepo layout for build/release implications