### PR TITLE
docs(ADR-032): AI escalation for plugin violations

### DIFF
--- a/.sdlc/adrs/ADR-032-third-party-plugin-services.md
+++ b/.sdlc/adrs/ADR-032-third-party-plugin-services.md
@@ -139,7 +139,9 @@ Plugins supply AI context through the existing `Violation.metadata` map using a 
 metadata["ai_guidance"] = "This violation fires when a play is missing a department tag. To fix it, add a 'tags' key to the play with at least one tag prefixed 'dept:'. Example: tags: [dept:platform]. The department must match one from the org's approved list."
 ```
 
-The `ai_guidance` value is a free-form string containing whatever context the plugin author believes an AI agent needs to propose a fix: what the rule checks, how to resolve it, constraints, examples, or links to internal documentation. If `ai_guidance` is absent, the AI falls back to the violation's `message` and `level` fields.
+The `ai_guidance` value is a free-form string containing whatever context the plugin author believes an AI agent needs to propose a fix: what the rule checks, how to resolve it, constraints, examples, or links to internal documentation. If `ai_guidance` is absent, the AI falls back to the violation's `message` and `level` fields; Tier 2 prompt templates will be extended to include `level` alongside `rule_id`, `line`, and `message` to support this behavior.
+
+To support this end to end, the daemon's proto-to-dict conversion (see `src/apme_engine/daemon/violation_convert.py`) MUST be updated to preserve the `ai_guidance` metadata key (or all metadata for `EXT-` violations) instead of enforcing an allowlist that would drop it before Tier 2 escalation.
 
 The SDK provides a convenience parameter:
 
@@ -223,7 +225,7 @@ class MyOrgPlugin(PluginBase):
                         message="Plays must have a department tag",
                         file=node["file"],
                         line=node["line"][0],
-                        ai_guidance="Add a 'tags' key with at least one dept:-prefixed tag. "
+                        ai_guidance="Add a 'tags' key with at least one 'dept:'-prefixed tag. "
                                     "Valid departments: platform, security, network, app.",
                     ))
         return violations


### PR DESCRIPTION
## Summary

- Adds section 5 (AI escalation for plugin violations) to ADR-032
- Plugin authors supply AI context via `Violation.metadata["ai_guidance"]` — a free-form string with fix instructions, constraints, and examples the AI agent can use
- Plugin violations are **never combined** with built-in violations during AI passes — each plugin's Tier 2 violations get a separate AI pass using their own `ai_guidance`
- Updates the SDK example to demonstrate the `ai_guidance` parameter
- Adds Phase 4 (AI escalation) to the implementation roadmap

## Commits

- `0658713` — Add AI escalation section, per-plugin batching, ai_guidance metadata, updated SDK example and implementation phases
- `cedf16b` — Address Copilot review: note violation_convert.py allowlist plumbing, clarify Tier 2 prompt template extension for `level`, fix `dept:` quoting

## Motivation

APME's built-in AI prompts are tuned for built-in rules (L/M/R/P). When plugin violations reach Tier 2, the AI has no domain knowledge about the third-party check. Mixing plugin violations with built-in violations in the same AI pass dilutes both contexts. This update ensures plugin authors can provide targeted AI guidance and their violations are processed in isolation.

## Test plan

- [ ] Review new section 5 for consistency with ADR-025 (AI provider protocol) and ADR-009 (remediation tiers)
- [ ] Verify `ai_guidance` metadata key does not conflict with existing metadata usage in `common.proto`
- [ ] Confirm per-plugin batching strategy is feasible in the current `RemediationEngine` architecture
- [ ] Verify `violation_convert.py` allowlist note is accurate (implementation will update `_METADATA_KEYS`)