### PR TITLE
fix(pod): prevent duplicate scans from container restart policy

### DIFF
--- a/containers/podman/run-cli.sh
+++ b/containers/podman/run-cli.sh
@@ -25,6 +25,7 @@ rc=0
 podman run \
   --name "$CLI_NAME" \
   --pod apme-pod \
+  --restart=no \
   -v "$(pwd)":/workspace:Z \
   -w /workspace \
   -e APME_PRIMARY_ADDRESS=127.0.0.1:50051 \

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -713,7 +713,16 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
 
         with attach_stream_sink(queue):
             try:
-                logger.info("ScanStream: start (%d files, req=%s)", len(all_files), scan_id)
+                peer = context.peer()
+                metadata = dict(context.invocation_metadata() or ())
+                user_agent = metadata.get("user-agent", "unknown")
+                logger.info(
+                    "ScanStream: start (%d files, req=%s, peer=%s, ua=%s)",
+                    len(all_files),
+                    scan_id,
+                    peer,
+                    user_agent,
+                )
 
                 if not all_files:
                     yield ScanEvent(result=ScanResponse(scan_id=scan_id, violations=[], logs=[]))
@@ -919,6 +928,14 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                     self._session_upload_append(session, chunk)
 
                     if chunk.last:
+                        peer = context.peer()
+                        logger.info(
+                            "FixSession: processing %d file(s) (session_id=%s, scan_id=%s, peer=%s)",
+                            len(session.original_files),
+                            session.session_id,
+                            scan_id,
+                            peer,
+                        )
                         async for event in self._session_process(session, scan_id):
                             yield event
 
@@ -1047,8 +1064,6 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             ansible_core_version = scan_opts.ansible_core_version
             collection_specs = list(scan_opts.collection_specs)
             fix_session_id = scan_opts.session_id
-
-        logger.info("FixSession: processing %d file(s) (session=%s)", len(all_files), scan_id)
 
         if not all_files:
             session.status = 3  # COMPLETE

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -126,6 +126,14 @@ class FakeGrpcContext:
         """
         self._details = details
 
+    def peer(self) -> str:
+        """Return a fake peer address.
+
+        Returns:
+            Fake peer identifier string.
+        """
+        return "ipv4:127.0.0.1:50051"
+
 
 class _AbortSignal(Exception):
     """Raised by FakeGrpcContext.abort to break out of the servicer.


### PR DESCRIPTION
## Summary

- Transient CLI containers joining the pod via `podman run --pod` were restarted by Podman's inherited `RestartPolicy: always` (from `podman play kube`), causing each scan/fix command to execute twice with distinct `scan_id`s
- Add `--restart=no` to `run-cli.sh` to prevent container restarts after exit
- Move FixSession peer logging from `_session_process` (where gRPC context is not in scope) to the `FixSession` method, fixing a `NameError`
- Add peer/user-agent metadata logging to `ScanStream` and `FixSession` for diagnostics
- Add `peer()` method to `FakeGrpcContext` test fixture

## Root Cause

Pods created via `podman play kube` inherit Kubernetes' default `RestartPolicy: always`. When a transient CLI container joined the pod, ran `apme-scan`, and exited (code 0), Podman restarted it — executing the scan a second time. Each execution generated a unique `scan_id`, producing duplicate database entries.

## Test plan

- [x] `pre-commit run --all-files` — all hooks pass
- [x] `pytest tests/` — 1086 passed (3 skipped, `test_formatter_cli.py` pre-existing failures excluded)
- [x] Manual pod test: single `run-cli.sh scan` produces exactly 1 `ScanStream` RPC
- [x] Manual pod test: single `run-cli.sh fix --apply` produces exactly 1 `FixSession` RPC
- [x] 10-second stability check: zero background drift in RPC count