### PR TITLE
chore: add slash command frontmatter to all agent skills

### DIFF
--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -4,6 +4,11 @@ description: >
   Guide for writing and modifying GitHub Actions workflows in this repository.
   Use when creating CI/CD pipelines, adding workflow jobs, modifying build steps,
   or debugging CI failures. Enforces the project's lean CI philosophy.
+argument-hint: "[workflow-name]"
+user-invocable: true
+metadata:
+  author: APME Team
+  version: 1.0.0
 ---
 
 # Lean CI

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -4,6 +4,11 @@ description: >
   Guide for handling pull request reviews, including automated (Copilot) and
   human reviewer feedback. Use when responding to PR comments, resolving
   review threads, or updating PRs after review.
+argument-hint: "<PR number>"
+user-invocable: true
+metadata:
+  author: APME Team
+  version: 1.0.0
 ---
 
 # PR Review

--- a/.agents/skills/review-contributor-pr/SKILL.md
+++ b/.agents/skills/review-contributor-pr/SKILL.md
@@ -6,6 +6,11 @@ description: >
   contributor's branch, or ensure a PR meets project standards before merge.
   Follow this skill so contributor PRs are reviewed consistently and avoid
   rework (prek failures, outdated base, weak description).
+argument-hint: "<PR number or URL>"
+user-invocable: true
+metadata:
+  author: APME Team
+  version: 1.0.0
 ---
 
 # Review Contributor PR

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: submit-pr
 description: Prepare and submit a pull request for the APME project. Syncs with upstream, creates a feature branch, runs pre-commit checks (prek/ruff), updates documentation and ADRs as needed, commits with conventional commits, then creates the PR via gh. Use when the user asks to submit, create, or open a pull request, or says "submit PR", "open PR", "create PR".
+argument-hint: "[branch-name] [--title 'PR title']"
+user-invocable: true
+metadata:
+  author: APME Team
+  version: 1.0.0
 ---
 
 # Submit PR


### PR DESCRIPTION
## Summary
- Adds `user-invocable: true`, `argument-hint`, and `metadata` fields to the 4 agent skills that were missing slash command support.

## Changes
- `pr-review` → `/pr-review <PR number>`
- `review-contributor-pr` → `/review-contributor-pr <PR number or URL>`
- `submit-pr` → `/submit-pr [branch-name] [--title 'PR title']`
- `lean-ci` → `/lean-ci [workflow-name]`

## Test plan
- [x] prek run --all-files passes
- [x] No functional changes — frontmatter additions only

Made with [Cursor](https://cursor.com)