### PR TITLE
fix(ui,engine): PR #71 follow-up — rejection tracking, CSS variables, zero display

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -109,9 +109,9 @@ export function DashboardPage() {
                   </td>
                   <td><StatusBadge violations={scan.total_violations} scanType={scan.scan_type} /></td>
                   <td>{scan.total_violations}</td>
-                  <td><span className="apme-count-success">{scan.auto_fixable || ""}</span></td>
-                  <td>{scan.ai_candidate || ""}</td>
-                  <td><span className="apme-count-error">{scan.manual_review || ""}</span></td>
+                  <td><span className="apme-count-success">{scan.auto_fixable ?? ""}</span></td>
+                  <td>{scan.ai_candidate ?? ""}</td>
+                  <td><span className="apme-count-error">{scan.manual_review ?? ""}</span></td>
                   <td className="apme-time-ago">{timeAgo(scan.created_at)}</td>
                 </tr>
               ))}

--- a/frontend/src/pages/ScansPage.tsx
+++ b/frontend/src/pages/ScansPage.tsx
@@ -68,9 +68,9 @@ export function ScansPage() {
                   </td>
                   <td><StatusBadge violations={scan.total_violations} scanType={scan.scan_type} /></td>
                   <td>{scan.total_violations}</td>
-                  <td><span className="apme-count-success">{scan.auto_fixable || ""}</span></td>
-                  <td>{scan.ai_candidate || ""}</td>
-                  <td><span className="apme-count-error">{scan.manual_review || ""}</span></td>
+                  <td><span className="apme-count-success">{scan.auto_fixable ?? ""}</span></td>
+                  <td>{scan.ai_candidate ?? ""}</td>
+                  <td><span className="apme-count-error">{scan.manual_review ?? ""}</span></td>
                   <td className="apme-time-ago">{timeAgo(scan.created_at)}</td>
                 </tr>
               ))}

--- a/frontend/src/pages/SessionDetailPage.tsx
+++ b/frontend/src/pages/SessionDetailPage.tsx
@@ -106,9 +106,9 @@ export function SessionDetailPage() {
                   </td>
                   <td><StatusBadge violations={scan.total_violations} scanType={scan.scan_type} /></td>
                   <td>{scan.total_violations}</td>
-                  <td><span className="apme-count-success">{scan.auto_fixable || ""}</span></td>
-                  <td>{scan.ai_candidate || ""}</td>
-                  <td><span className="apme-count-error">{scan.manual_review || ""}</span></td>
+                  <td><span className="apme-count-success">{scan.auto_fixable ?? ""}</span></td>
+                  <td>{scan.ai_candidate ?? ""}</td>
+                  <td><span className="apme-count-error">{scan.manual_review ?? ""}</span></td>
                   <td className="apme-time-ago">{timeAgo(scan.created_at)}</td>
                 </tr>
               ))}

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -546,10 +546,16 @@ body,
 .apme-btn-primary {
   background-color: var(--apme-accent);
   color: #fff;
+  transition: opacity 0.15s;
 }
 
-.apme-btn-primary:hover {
+.apme-btn-primary:hover:not(:disabled) {
   background-color: var(--apme-accent-hover);
+}
+
+.apme-btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .apme-btn-secondary {
@@ -657,7 +663,7 @@ body,
 .apme-tabs {
   display: flex;
   gap: 0;
-  border-bottom: 2px solid var(--border);
+  border-bottom: 2px solid var(--apme-border);
   margin-bottom: 24px;
 }
 
@@ -669,14 +675,14 @@ body,
   margin-bottom: -2px;
   font-size: 14px;
   font-weight: 500;
-  color: var(--text-secondary);
+  color: var(--apme-text-secondary);
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .apme-tab.active {
-  color: var(--link);
-  border-bottom-color: var(--link);
+  color: var(--apme-link);
+  border-bottom-color: var(--apme-link);
 }
 
 .apme-tab.disabled {
@@ -689,7 +695,7 @@ body,
 }
 
 .apme-drop-zone {
-  border: 2px dashed var(--border);
+  border: 2px dashed var(--apme-border);
   border-radius: 8px;
   padding: 48px 24px;
   text-align: center;
@@ -699,25 +705,25 @@ body,
 
 .apme-drop-zone:hover,
 .apme-drop-zone.drag-over {
-  border-color: var(--link);
+  border-color: var(--apme-link);
   background: rgba(0, 123, 255, 0.04);
 }
 
 .apme-drop-icon {
   font-size: 36px;
-  color: var(--text-secondary);
+  color: var(--apme-text-secondary);
   margin-bottom: 8px;
 }
 
 .apme-drop-text {
   font-size: 15px;
-  color: var(--text-primary);
+  color: var(--apme-text-primary);
   margin-bottom: 4px;
 }
 
 .apme-drop-hint {
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--apme-text-secondary);
 }
 
 .apme-file-list {
@@ -727,7 +733,7 @@ body,
 .apme-file-list h3 {
   font-size: 14px;
   margin-bottom: 8px;
-  color: var(--text-primary);
+  color: var(--apme-text-primary);
 }
 
 .apme-file-list ul {
@@ -736,7 +742,7 @@ body,
   margin: 0;
   max-height: 240px;
   overflow-y: auto;
-  border: 1px solid var(--border);
+  border: 1px solid var(--apme-border);
   border-radius: 6px;
 }
 
@@ -745,7 +751,7 @@ body,
   align-items: center;
   gap: 12px;
   padding: 6px 12px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--apme-border);
   font-size: 13px;
 }
 
@@ -758,12 +764,12 @@ body,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--text-primary);
+  color: var(--apme-text-primary);
   font-family: monospace;
 }
 
 .apme-file-size {
-  color: var(--text-secondary);
+  color: var(--apme-text-secondary);
   font-size: 12px;
   white-space: nowrap;
 }
@@ -771,7 +777,7 @@ body,
 .apme-file-remove {
   background: none;
   border: none;
-  color: var(--text-secondary);
+  color: var(--apme-text-secondary);
   cursor: pointer;
   font-size: 14px;
   padding: 2px 6px;
@@ -791,7 +797,7 @@ body,
 .apme-options-panel summary {
   cursor: pointer;
   font-size: 14px;
-  color: var(--text-secondary);
+  color: var(--apme-text-secondary);
   padding: 8px 0;
 }
 
@@ -802,55 +808,24 @@ body,
 .apme-form-group label {
   display: block;
   font-size: 13px;
-  color: var(--text-secondary);
+  color: var(--apme-text-secondary);
   margin-bottom: 4px;
 }
 
 .apme-form-group input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--apme-border);
   border-radius: 6px;
-  background: var(--bg-card);
-  color: var(--text-primary);
+  background: var(--apme-bg-secondary);
+  color: var(--apme-text-primary);
   font-size: 14px;
   box-sizing: border-box;
 }
 
-.apme-btn-primary {
+.apme-scan-form .apme-btn-primary {
   margin-top: 16px;
   padding: 10px 28px;
-  background: var(--link);
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: opacity 0.15s;
-}
-
-.apme-btn-primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.apme-btn-primary:hover:not(:disabled) {
-  opacity: 0.9;
-}
-
-.apme-btn-secondary {
-  padding: 6px 16px;
-  background: var(--bg-card);
-  color: var(--text-primary);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 13px;
-  cursor: pointer;
-}
-
-.apme-btn-secondary:hover {
-  border-color: var(--link);
 }
 
 /* Progress display */
@@ -874,8 +849,8 @@ body,
 .apme-spinner {
   width: 28px;
   height: 28px;
-  border: 3px solid var(--border);
-  border-top-color: var(--link);
+  border: 3px solid var(--apme-border);
+  border-top-color: var(--apme-link);
   border-radius: 50%;
   animation: apme-spin 0.8s linear infinite;
   margin-bottom: 16px;
@@ -886,7 +861,7 @@ body,
 }
 
 .apme-timeline {
-  border-left: 2px solid var(--border);
+  border-left: 2px solid var(--apme-border);
   padding-left: 16px;
   max-height: 400px;
   overflow-y: auto;
@@ -902,14 +877,14 @@ body,
 
 .apme-timeline-phase {
   font-weight: 600;
-  color: var(--link);
+  color: var(--apme-link);
   font-size: 12px;
   min-width: 70px;
   font-family: monospace;
 }
 
 .apme-timeline-message {
-  color: var(--text-primary);
+  color: var(--apme-text-primary);
 }
 
 /* Completion + error states */
@@ -930,7 +905,7 @@ body,
 }
 
 .apme-redirect-hint {
-  color: var(--text-secondary);
+  color: var(--apme-text-secondary);
   font-size: 13px;
   margin-top: 12px;
 }
@@ -945,7 +920,7 @@ body,
 }
 
 .apme-error-message {
-  color: var(--text-secondary);
+  color: var(--apme-text-secondary);
   font-family: monospace;
   font-size: 13px;
   margin-bottom: 16px;

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -1328,7 +1328,6 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             Number of proposals successfully applied.
         """
         if not approved_ids:
-            session.proposals.clear()
             session.status = 3  # COMPLETE
             return 0
 


### PR DESCRIPTION
## Summary
- Follow-up fixes for issues identified in PR #71 review.

## Changes

### Engine: preserve rejection outcomes on skip-all
- Removed `session.proposals.clear()` in `_session_apply_approved` when `approved_ids` is empty. Proposals now stay in `session.proposals` so `_build_fix_event` correctly records each as `status="rejected"` — fixes AI acceptance stats undercount.

### CSS: fix undefined variables
- Replaced 32 occurrences of bare `--border`, `--link`, `--text-primary`, `--text-secondary`, `--bg-card` with their defined `--apme-*` equivalents across the New Scan page section of `theme.css`.
- Merged duplicate `.apme-btn-primary` / `.apme-btn-secondary` definitions into single canonical blocks.

### UI: fix zero-count display
- Changed `|| ""` to `?? ""` in `DashboardPage`, `SessionDetailPage`, and `ScansPage` so numeric `0` renders as "0" instead of blank.

## Test plan
- [x] prek run --all-files passes
- [x] No logic changes beyond the three targeted fixes

Made with [Cursor](https://cursor.com)