### PR TITLE
fix(ui): make proposal cards expandable even without diff data

### DIFF
--- a/frontend/src/pages/NewScanPage.tsx
+++ b/frontend/src/pages/NewScanPage.tsx
@@ -465,6 +465,7 @@ function ProposalCard({
 }) {
   const [expanded, setExpanded] = useState(false);
   const hasDiff = Boolean(proposal.before_text || proposal.diff_hunk);
+  const hasDetails = Boolean(proposal.explanation || hasDiff);
   const confidencePct = Math.round(proposal.confidence * 100);
 
   return (
@@ -510,7 +511,7 @@ function ProposalCard({
           </div>
           <span className="apme-confidence-label">{confidencePct}%</span>
         </div>
-        {hasDiff && (
+        {hasDetails && (
           <button
             className="apme-btn-secondary apme-proposal-expand"
             onClick={(e) => {
@@ -518,26 +519,29 @@ function ProposalCard({
               setExpanded(!expanded);
             }}
           >
-            {expanded ? "Hide" : "Diff"}
+            {expanded ? "Hide" : hasDiff ? "Diff" : "Details"}
           </button>
         )}
       </div>
 
-      {proposal.explanation && (
-        <div className="apme-proposal-explanation">{proposal.explanation}</div>
-      )}
-
-      {expanded && hasDiff && (
-        <div className="apme-proposal-diff">
-          {proposal.diff_hunk ? (
-            <pre className="apme-diff-content">{proposal.diff_hunk}</pre>
-          ) : (
-            <DiffView
-              before={proposal.before_text}
-              after={proposal.after_text}
-            />
+      {expanded && (
+        <>
+          {proposal.explanation && (
+            <div className="apme-proposal-explanation">{proposal.explanation}</div>
           )}
-        </div>
+          {hasDiff && (
+            <div className="apme-proposal-diff">
+              {proposal.diff_hunk ? (
+                <pre className="apme-diff-content">{proposal.diff_hunk}</pre>
+              ) : (
+                <DiffView
+                  before={proposal.before_text}
+                  after={proposal.after_text}
+                />
+              )}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -1133,9 +1133,9 @@ body,
 }
 
 .apme-proposal-explanation {
-  padding: 0 16px 12px 46px;
+  padding: 8px 16px 12px 46px;
   font-size: 13px;
-  color: var(--apme-text-muted);
+  color: var(--apme-text-secondary);
   line-height: 1.5;
 }
 


### PR DESCRIPTION
## Summary

- Proposal cards in the AI review section had no expand button when `before_text`/`after_text`/`diff_hunk` are empty (the current state until Tier 2 AI is wired per ADR-025)
- The explanation text was always visible but styled as `text-muted`, making it easy to miss — cards appeared inert with no way to see what the proposal actually suggests
- Now shows a **Details** button when an explanation exists (even without a diff), and **Diff** when diff data is available
- Moved the explanation into the collapsible section so cards are compact by default and expanded on demand
- Bumped explanation color from `text-muted` to `text-secondary` for better readability

## Test plan

- [ ] Create a scan with Tier 2/3 violations — proposal cards should show a "Details" button
- [ ] Click "Details" — explanation text expands below the header
- [ ] Click "Hide" — explanation collapses
- [ ] When AI produces diffs (future), button should read "Diff" and show diff + explanation


Made with [Cursor](https://cursor.com)