### PR TITLE
docs: add REQ-011 and DR-013 for AA deprecated module reporting

### DIFF
--- a/.sdlc/decisions/README.md
+++ b/.sdlc/decisions/README.md
@@ -101,6 +101,7 @@ Decision Requests (DRs) provide a formal mechanism for:
 
 | DR | Title | Category | Priority | Raised |
 |----|-------|----------|----------|--------|
+| [DR-013](open/DR-013-aa-integration-approach.md) | Automation Analytics Integration Approach | Architecture | High | 2026-03-25 |
 
 ### Closed: Decided
 

--- a/.sdlc/decisions/open/DR-013-aa-integration-approach.md
+++ b/.sdlc/decisions/open/DR-013-aa-integration-approach.md
@@ -1,0 +1,174 @@
+# DR-013: Automation Analytics Integration Approach
+
+## Status
+
+Open
+
+## Raised By
+
+Claude (from AAPRFE-1607 analysis) — 2026-03-25
+
+## Category
+
+Architecture
+
+## Priority
+
+High
+
+---
+
+## Question
+
+How should APME feed deprecated module detection data into Automation Analytics for reporting?
+
+## Context
+
+Customer RFE [AAPRFE-1607](https://redhat.atlassian.net/browse/AAPRFE-1607) requests deprecated module reports in Automation Analytics. The data already exists in job logs ("this module is deprecated, please upgrade it"), but requires structured collection and reporting.
+
+APME already detects deprecated modules via:
+- **L004**: Deprecated module usage
+- **M001-M004**: Modernization rules for outdated patterns
+
+The question is how to get this data from APME into Automation Analytics.
+
+## Impact of Not Deciding
+
+- Cannot proceed with REQ-011 implementation
+- Customer use case (AAPRFE-1607) remains unaddressed
+- Telco customers cannot plan ansible-core upgrades effectively
+
+---
+
+## Options Considered
+
+### Option A: AAP Event-Driven Integration
+
+**Description**: APME runs as part of AAP job execution (pre-flight or execution environment). Results flow through AAP's existing telemetry to Automation Analytics.
+
+**Pros**:
+- Uses existing AAP → AA data pipeline
+- Job context (job ID, template, inventory) automatically available
+- Minimal new infrastructure
+
+**Cons**:
+- Requires AAP integration work (EE, callback plugin, or pre-flight hook)
+- Dependent on AAP release cycle
+- May require changes to AA schema
+
+**Effort**: High
+
+### Option B: Direct AA API Integration
+
+**Description**: APME sends scan results directly to Automation Analytics via API.
+
+**Pros**:
+- Decoupled from AAP release cycle
+- Can work for standalone scanning (CI/CD, local)
+- Full control over data format
+
+**Cons**:
+- Requires AA API access and schema changes
+- Need to correlate with AAP job metadata separately
+- Additional authentication/authorization flow
+
+**Effort**: Medium
+
+### Option C: Insights Client Extension
+
+**Description**: Extend the Insights client (already on AAP) to collect APME scan results and ship to AA.
+
+**Pros**:
+- Leverages existing Insights infrastructure
+- Already handles authentication and transport
+- Familiar pattern for RHEL/AAP customers
+
+**Cons**:
+- Requires Insights client changes
+- May have data freshness limitations (batch upload)
+- Additional dependency
+
+**Effort**: Medium
+
+### Option D: Export-Only (No Direct Integration)
+
+**Description**: APME generates structured reports (JSON/SARIF) that customers manually import or feed into their own pipelines to AA.
+
+**Pros**:
+- No external dependencies
+- Works today with current APME capabilities
+- Customer controls the integration
+
+**Cons**:
+- No automatic flow to AA
+- Requires customer implementation effort
+- Doesn't fully address RFE request
+
+**Effort**: Low
+
+### Option E: Do Nothing / Defer
+
+**Description**: Leave undefined for now, revisit after v1 CLI stabilizes.
+
+**Pros**:
+- Focus on core scanning functionality
+- Avoid premature integration decisions
+- AA roadmap may clarify integration patterns (2H 2026 per Jira comments)
+
+**Cons**:
+- Customer RFE remains unaddressed
+- May miss alignment with AA roadmap work
+
+---
+
+## Recommendation
+
+**Option D (Export-Only) for v1, with Option A planning for v2.**
+
+Rationale:
+1. v1 focus is CLI scanning - export capability exists (JSON, SARIF)
+2. Jira comments indicate AA reporting capabilities coming in 2H 2026
+3. Option A (event-driven) aligns best long-term but requires AAP integration
+4. We should coordinate with AA team on schema before committing
+
+---
+
+## Related Artifacts
+
+- [REQ-011](../../specs/REQ-011-aa-deprecated-reporting/requirement.md): Automation Analytics Deprecated Module Reporting
+- [DR-004](../closed/deferred/DR-004-aap-integration.md): AAP Pre-Flight Integration (deferred)
+- [REQ-004](../../specs/REQ-004-enterprise-integration/requirement.md): Enterprise Integration
+- [AAPRFE-1607](https://redhat.atlassian.net/browse/AAPRFE-1607): Original customer RFE
+
+---
+
+## Discussion Log
+
+| Date | Participant | Input |
+|------|-------------|-------|
+| 2026-03-25 | Claude | Initial DR created from AAPRFE-1607 analysis |
+| | | AA team comment on Jira suggests 2H 2026 reporting roadmap |
+
+---
+
+## Decision
+
+**Status**: Open
+**Date**:
+**Decided By**:
+
+**Decision**:
+
+**Rationale**:
+
+**Action Items**:
+- [ ] Coordinate with AA team on reporting roadmap
+- [ ] Review AA API documentation for integration patterns
+- [ ] Determine if pre-flight or post-run scanning is preferred
+
+---
+
+## Post-Decision Updates
+
+| Date | Update |
+|------|--------|

--- a/.sdlc/specs/README.md
+++ b/.sdlc/specs/README.md
@@ -18,6 +18,7 @@ Specs answer "What does this feature do?" They provide:
 | REQ-002 | Automated Remediation | PHASE-002 | Draft |
 | REQ-003 | Security & Compliance | PHASE-003 | Draft |
 | REQ-004 | Enterprise Integration | PHASE-003 | Draft |
+| REQ-011 | AA Deprecated Module Reporting | PHASE-003 | Draft |
 
 ## Directory Structure
 
@@ -33,7 +34,8 @@ specs/
 │   └── tasks/            # Implementation tasks
 ├── REQ-002-automated-remediation/
 ├── REQ-003-security-compliance/
-└── REQ-004-enterprise-integration/
+├── REQ-004-enterprise-integration/
+└── REQ-011-aa-deprecated-reporting/
 ```
 
 ## Phase Relationship

--- a/.sdlc/specs/REQ-011-aa-deprecated-reporting/requirement.md
+++ b/.sdlc/specs/REQ-011-aa-deprecated-reporting/requirement.md
@@ -1,0 +1,121 @@
+# REQ-011: Automation Analytics Deprecated Module Reporting
+
+## Metadata
+
+- **Phase**: PHASE-003 - Enterprise Dashboard
+- **Status**: Draft
+- **Created**: 2026-03-25
+- **External Reference**: [AAPRFE-1607](https://redhat.atlassian.net/browse/AAPRFE-1607)
+
+## Overview
+
+Provide deprecated module detection data to Automation Analytics so customers can generate reports showing which Ansible jobs use deprecated modules. This enables proactive upgrade planning before ansible-core version migrations.
+
+## User Stories
+
+**As an AAP Administrator**, I want to see a report of all jobs using deprecated modules so that I can plan remediation before upgrading ansible-core.
+
+**As a Platform Engineer**, I want deprecated module warnings captured and aggregated so that I don't have to manually parse job logs.
+
+**As a Release Manager**, I want visibility into deprecated module usage across all automation so that I can assess upgrade readiness.
+
+## Acceptance Criteria
+
+### Scenario: Deprecated Module Detection
+
+- **GIVEN**: An Ansible playbook using a deprecated module (e.g., `include` instead of `include_tasks`)
+- **WHEN**: The playbook is scanned by APME
+- **THEN**: L004 (deprecated module) violations are detected with module name and deprecation details
+
+### Scenario: Data Available in Automation Analytics
+
+- **GIVEN**: APME has scanned playbooks with deprecated modules
+- **WHEN**: The scan results are reported to Automation Analytics
+- **THEN**: The deprecated module data is available for dashboard/report generation
+
+### Scenario: Report Generation
+
+- **GIVEN**: Deprecated module data is in Automation Analytics
+- **WHEN**: A user views the deprecation report
+- **THEN**: The report shows: job name, deprecated module, recommended replacement, job template location
+
+## Inputs / Outputs
+
+### Inputs
+
+| Name | Type | Description | Required |
+|------|------|-------------|----------|
+| Scan results | `ScanResponse` | APME scan results containing L004/M-rule violations | Yes |
+| Job metadata | TBD | AAP job context (job ID, template, inventory) | TBD |
+
+### Outputs
+
+| Name | Type | Description |
+|------|------|-------------|
+| Deprecation report | Dashboard/Export | Aggregated view of deprecated module usage |
+| Per-job violations | List | Deprecated modules per job with replacement guidance |
+
+## Behavior
+
+### Happy Path
+
+1. AAP job executes playbook
+2. APME scans playbook (pre-flight or post-run)
+3. L004/M001-M004 violations detected for deprecated modules
+4. Scan results sent to Automation Analytics
+5. User views deprecation report in AA dashboard
+6. Report shows jobs, modules, and remediation guidance
+
+### Edge Cases
+
+| Case | Handling |
+|------|----------|
+| Module deprecated in one ansible-core version but not another | Include version context in report |
+| No deprecated modules found | Report shows clean status |
+| Scan fails | Report indicates scan coverage gap |
+
+### Error Conditions
+
+| Error | Cause | Response |
+|-------|-------|----------|
+| AA unavailable | Network/service issue | Queue data for retry |
+| Invalid scan data | Malformed response | Log error, skip record |
+
+## Dependencies
+
+### Internal
+
+- REQ-001: Core Scanning Engine (L004, M001-M004 rules)
+- REQ-004: Enterprise Integration (AAP/AA connectivity)
+
+### External
+
+- Automation Analytics API (for data ingestion)
+- AAP job event stream or callback mechanism
+
+## Non-Functional Requirements
+
+- **Performance**: Scan overhead < 5% of job execution time
+- **Security**: Data in transit encrypted (TLS)
+- **Compatibility**: Support AAP 2.4+ and AA current version
+
+## Open Questions
+
+- [ ] What is the integration mechanism with Automation Analytics? (See DR-013)
+- [ ] Is this pre-flight scanning, post-run analysis, or both?
+- [ ] What job metadata is available from AAP for correlation?
+- [ ] Does AA have an existing schema for deprecation data?
+
+## References
+
+- [AAPRFE-1607](https://redhat.atlassian.net/browse/AAPRFE-1607) - Original customer RFE
+- [ADR-008](../../adrs/ADR-008-rule-id-conventions.md) - Rule ID conventions (L004 = deprecated module)
+- [DR-004](../../decisions/closed/deferred/DR-004-aap-integration.md) - AAP Pre-Flight Integration (deferred)
+
+---
+
+## Change History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-25 | Claude | Initial draft from AAPRFE-1607 |


### PR DESCRIPTION
## Summary
- Captures customer RFE [AAPRFE-1607](https://redhat.atlassian.net/browse/AAPRFE-1607) requesting deprecated module detection data in Automation Analytics
- Adds REQ-011 defining the requirement and acceptance criteria
- Adds DR-013 exploring integration approaches (event-driven, direct API, Insights client, export-only)

## Changes
- `.sdlc/specs/REQ-011-aa-deprecated-reporting/requirement.md` - New requirement spec
- `.sdlc/decisions/open/DR-013-aa-integration-approach.md` - Open decision request
- `.sdlc/specs/README.md` - Updated index

## Test plan
- [x] Documentation only - no code changes
- [x] SDLC artifact structure follows existing patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)