### PR TITLE
feat(skills): add rfe-capture and branch-align skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -11,6 +11,7 @@ Agent skills for development workflow and spec-driven development.
 | `submit-pr` | Prepare and submit a pull request | — |
 | `pr-review` | Handle PR review feedback | — |
 | `review-contributor-pr` | Review and prepare a contributor's PR (upstream/fork) | — |
+| `branch-align` | Rename branch to match artifact ID after renumbering | `[new-branch-name]` |
 
 ### Spec-Driven Development (SDLC)
 
@@ -19,6 +20,7 @@ Agent skills for development workflow and spec-driven development.
 | `sdlc-status` | Show project status and blockers | `[phase or req]` |
 | `workflow` | Get workflow guidance | `[next\|blockers\|start\|resume\|decision\|import]` |
 | `prd-import` | Import PRD, create artifacts | `[path or URL]` |
+| `rfe-capture` | Capture external RFE with research-first approach | `[Jira key or description]` |
 | `phase-new` | Create delivery phase | `[Phase Name]` |
 | `req-new` | Create requirement spec | `[Feature] [--phase X]` |
 | `task-new` | Create implementation tasks | `[REQ-NNN] [Task Name]` |
@@ -38,6 +40,10 @@ skills/
 ├── pr-review/
 │   └── SKILL.md
 ├── review-contributor-pr/
+│   └── SKILL.md
+├── branch-align/
+│   └── SKILL.md
+├── rfe-capture/
 │   └── SKILL.md
 ├── sdlc-status/
 │   ├── SKILL.md

--- a/.agents/skills/branch-align/SKILL.md
+++ b/.agents/skills/branch-align/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: branch-align
+description: >-
+  Align branch name with artifact ID when they mismatch. Use when: renumbering
+  a REQ/DR/ADR after branch creation, "branch name is wrong", "rename branch
+  to match", or when PR review flags branch/artifact mismatch. Handles the git
+  branch rename and remote update.
+argument-hint: "[new-branch-name]"
+user-invocable: true
+metadata:
+  author: APME Team
+  version: 1.0.0
+---
+
+# Branch Align
+
+Rename a git branch to match its artifact ID after renumbering.
+
+## Why This Skill Exists
+
+During PR review, artifact IDs sometimes get renumbered (e.g., REQ-005 → REQ-011 to avoid conflicts). The branch name then mismatches the artifact, causing confusion:
+
+```
+Branch: docs/req-005-aa-deprecated-reporting
+Artifact: REQ-011-aa-deprecated-reporting
+```
+
+This skill renames the branch locally and on the remote fork.
+
+## Arguments
+
+- `[new-branch-name]` — target branch name (e.g., `docs/req-011-aa-deprecated-reporting`)
+- `--dry-run` — show what would happen without executing
+
+## Workflow
+
+### 1. Detect Current State
+
+```
+Current branch: docs/req-005-aa-deprecated-reporting
+Tracks remote: fork/docs/req-005-aa-deprecated-reporting
+
+Open PR: #102 (https://github.com/ansible/apme/pull/102)
+PR head: ffirg:docs/req-005-aa-deprecated-reporting
+```
+
+### 2. Confirm New Name
+
+If argument provided, use it. Otherwise:
+```
+New branch name? (current: docs/req-005-aa-deprecated-reporting)
+> docs/req-011-aa-deprecated-reporting
+```
+
+Validate format:
+- Matches artifact ID in branch (e.g., `req-011` matches `REQ-011`)
+- Follows naming convention (`type/id-slug`)
+
+### 3. Execute Rename
+
+```bash
+# Rename local branch
+git branch -m docs/req-005-aa-deprecated-reporting docs/req-011-aa-deprecated-reporting
+
+# Push new branch to remote
+git push -u fork docs/req-011-aa-deprecated-reporting
+
+# Delete old remote branch
+git push fork --delete docs/req-005-aa-deprecated-reporting
+```
+
+### 4. Update PR (if exists)
+
+GitHub PRs automatically track renamed branches if the new branch is pushed before deleting the old one. Verify:
+
+```
+PR #102 now tracks: ffirg:docs/req-011-aa-deprecated-reporting
+```
+
+If PR doesn't update automatically, provide manual fix:
+```bash
+gh pr edit 102 --head ffirg:docs/req-011-aa-deprecated-reporting
+```
+
+### 5. Summary
+
+```
+Done!
+- Renamed: docs/req-005-aa-deprecated-reporting → docs/req-011-aa-deprecated-reporting
+- Remote updated: fork
+- PR #102: Now tracks new branch
+
+Old branch deleted from remote.
+```
+
+## Edge Cases
+
+| Situation | Handling |
+|-----------|----------|
+| Uncommitted changes | Stash before rename, restore after |
+| Not on the branch to rename | Prompt to checkout or specify branch |
+| No open PR | Skip PR update step |
+| Multiple remotes | Prompt which remote to update |
+| Protected branch | Warn and abort |
+
+## Safety Checks
+
+1. **Never rename `main` or `master`** — abort with error
+2. **Check for uncommitted changes** — stash or abort
+3. **Verify remote exists** — fail gracefully if fork not configured
+4. **Confirm before deleting old remote branch** — show what will be deleted
+
+## Example Session
+
+```
+/branch-align docs/req-011-aa-deprecated-reporting
+
+Current branch: docs/req-005-aa-deprecated-reporting
+Target branch: docs/req-011-aa-deprecated-reporting
+
+This will:
+1. Rename local branch
+2. Push new branch to 'fork'
+3. Delete old branch from 'fork'
+4. PR #102 will track new branch
+
+Proceed? (Y/N) Y
+
+Renaming local branch... done
+Pushing to fork... done
+Deleting old remote branch... done
+Verifying PR #102... tracks new branch ✓
+
+Done! Branch aligned with REQ-011.
+```
+
+## Integration with submit-pr
+
+The `submit-pr` skill should:
+1. Check if branch name matches artifact IDs being committed
+2. Warn if mismatch detected
+3. Offer to invoke `branch-align` before pushing
+
+Add to submit-pr pre-flight checks:
+```
+Checking branch/artifact alignment...
+- Branch: docs/req-005-aa-deprecated-reporting
+- Artifacts: REQ-011, DR-013
+⚠️  Branch name contains 'req-005' but artifacts use REQ-011
+
+Run /branch-align to fix? (Y/N)
+```

--- a/.agents/skills/rfe-capture/SKILL.md
+++ b/.agents/skills/rfe-capture/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: rfe-capture
+description: >-
+  Capture an external RFE (Jira, customer request, feature idea) using a
+  research-first approach. Use when: "capture this Jira", "customer RFE",
+  "feature request from X", "AAPRFE-123 should be tracked". This skill
+  researches existing capabilities BEFORE creating specs to avoid duplicating
+  what already exists. Do NOT use for internal feature ideas already discussed
+  (use req-new instead).
+argument-hint: "[Jira key or feature description]"
+user-invocable: true
+metadata:
+  author: APME Team
+  version: 1.0.0
+---
+
+# RFE Capture
+
+Capture external RFEs with a research-first approach to avoid creating specs for capabilities that already exist.
+
+## Why This Skill Exists
+
+When capturing external RFEs (Jira tickets, customer requests), AI agents often create well-formatted specs without first understanding what the project already does. This leads to:
+- Specs describing existing capabilities as new requirements
+- Missing context about static vs. runtime boundaries
+- Incorrect cross-references to related work
+- Wasted review cycles
+
+This skill enforces a **research phase before creation**.
+
+## Arguments
+
+If `$ARGUMENTS` is provided:
+- Jira key (e.g., `AAPRFE-1607`) → fetch issue details via MCP
+- Quoted description → use as feature summary
+- `--quick` → abbreviated research, trust user context
+
+## Workflow
+
+### Phase 1: Understand the Request
+
+**If Jira key provided:**
+```
+Fetching AAPRFE-1607...
+
+Title: [title]
+Description: [summary]
+Labels: [labels]
+Status: [status]
+
+Is this the correct issue? (Y/N)
+```
+
+**If description provided:**
+```
+Feature request: "[description]"
+
+What's the source? (Jira key, customer name, or "internal")
+```
+
+### Phase 2: Research Existing Capabilities
+
+**CRITICAL: Do this BEFORE creating any specs.**
+
+1. **Read CLAUDE.md** — understand project architecture, services, constraints
+2. **Search for existing rules** that might address this:
+   ```
+   Searching validators for related functionality...
+   - OPA bundle: src/apme_engine/validators/opa/bundle/
+   - Native rules: src/apme_engine/validators/native/rules/
+   - Ansible validator: src/apme_engine/validators/ansible/rules/
+   ```
+3. **Check existing specs and DRs**:
+   ```
+   Checking .sdlc/specs/README.md for REQ numbering...
+   Checking .sdlc/decisions/README.md for related DRs...
+   ```
+4. **Understand ecosystem boundaries**:
+   - APME = static analysis (scans content before runtime)
+   - AA = runtime observability (collects data during job execution)
+   - AAP = execution platform
+   - Where does this request fit?
+
+5. **Check output formats**:
+   - CLI: `apme scan --json` capabilities
+   - gRPC: `ScanResponse` proto structure
+   - What structured data already exists?
+
+### Phase 3: Gap Analysis
+
+Present findings:
+
+```
+## Research Summary
+
+### What APME Already Does
+- [Rule X]: [description of existing capability]
+- [Rule Y]: [description of existing capability]
+- Output format: [what's available today]
+
+### What the RFE Requests
+- [capability 1]
+- [capability 2]
+
+### Actual Gap
+- [specific gap, if any]
+- OR: "No gap — this capability exists via [rules/output]"
+
+### Ecosystem Consideration
+- This is a [static/runtime/integration] concern
+- Related existing work: [DR-NNN, REQ-NNN]
+```
+
+### Phase 4: Decision
+
+Based on research, recommend ONE of:
+
+| Outcome | When | Action |
+|---------|------|--------|
+| **No artifact needed** | Capability exists | Document in Jira comment, close |
+| **Bug/task on existing REQ** | Small gap in existing feature | Create task under REQ-NNN |
+| **New DR needed** | Architectural question to resolve | Use `/dr-new` |
+| **New REQ needed** | Genuine new capability | Use `/req-new` |
+| **Defer to other team** | Belongs in AA/AAP roadmap | Document and redirect |
+
+```
+## Recommendation
+
+Based on research, I recommend: [outcome]
+
+Rationale:
+- [reason 1]
+- [reason 2]
+
+Proceed? (Y to execute, N to discuss, D for different approach)
+```
+
+### Phase 5: Execute (if artifact needed)
+
+**If creating DR:**
+- Use `/dr-new` with research context pre-filled
+- Cross-reference related REQs and ADRs found in research
+
+**If creating REQ:**
+- Use `/req-new` with correct numbering from research
+- Include "Related Artifacts" section with cross-refs
+- Note existing capabilities that this builds on
+
+**If creating task:**
+- Use `/task-new` on the appropriate existing REQ
+- Reference the external RFE in task description
+
+### Phase 6: Attribution
+
+When creating artifacts from AI-assisted research:
+- "Raised By" should credit the human author
+- Add note: "AI-assisted research and drafting"
+- Include external reference (Jira key, customer ID)
+
+## Examples
+
+### Example 1: RFE for Existing Capability
+
+```
+/rfe-capture AAPRFE-1607
+
+Fetching AAPRFE-1607...
+Title: Deprecated module reports in Automation Analytics
+
+Researching existing capabilities...
+- L004 (OPA): Static deprecated modules check against curated list
+- M002 (Ansible): Runtime introspection via ansible-core's module_loader
+- M004 (Ansible): Removed/tombstoned module detection
+- Output: ScanResponse includes violations with metadata map
+
+Gap Analysis:
+- APME already detects deprecated modules comprehensively
+- CLI --json output missing metadata map (small bug)
+- AA integration is separate concern (runtime vs static)
+
+Recommendation: No new REQ needed
+- Create bug task on REQ-001 for CLI metadata gap
+- Note in Jira that APME already provides this capability
+- AA integration tracked separately in DR-004
+
+Proceed? (Y/N)
+```
+
+### Example 2: Genuine New Capability
+
+```
+/rfe-capture "Support scanning Terraform files for Ansible references"
+
+Researching existing capabilities...
+- No Terraform-related rules found
+- Parser only handles YAML/Ansible content
+- This would require new file type support
+
+Gap Analysis:
+- Genuine new capability not currently supported
+- Would need parser extension + new rule category
+
+Recommendation: New REQ needed
+- REQ-012: Terraform Integration
+- Phase: PHASE-004 or new phase
+- Depends on: REQ-001 (parser architecture)
+
+Proceed? (Y/N)
+```
+
+## Integration with Other Skills
+
+| Skill | When RFE-Capture Invokes It |
+|-------|----------------------------|
+| `/dr-new` | When architectural question needs resolution |
+| `/req-new` | When genuine new capability identified |
+| `/task-new` | When small gap in existing feature |
+| `/sdlc-status` | To check current REQ/DR numbering |
+
+## Anti-Patterns to Avoid
+
+1. **Creating specs without reading code** — always research first
+2. **Duplicating existing capabilities** — check rules before spec'ing
+3. **Ignoring ecosystem boundaries** — static vs runtime matters
+4. **Wrong numbering** — check existing specs before assigning numbers
+5. **Missing cross-references** — link to related DRs/REQs/ADRs

--- a/.agents/skills/submit-pr/SKILL.md
+++ b/.agents/skills/submit-pr/SKILL.md
@@ -109,7 +109,32 @@ Examples:
 - `build: add ruff linter and prek pre-commit hooks`
 - `docs: add prek section to DEVELOPMENT.md`
 
-### Step 6: Push and create the pull request
+### Step 6: Check branch/artifact alignment
+
+Before pushing, verify the branch name matches the artifact IDs being committed:
+
+```
+Checking branch/artifact alignment...
+- Branch: docs/req-005-aa-deprecated-reporting
+- SDLC artifacts in diff: REQ-011, DR-013
+```
+
+**If mismatch detected:**
+```
+⚠️  Branch name contains 'req-005' but artifacts use REQ-011
+
+Options:
+1. Rename branch to match artifacts (recommended)
+2. Continue with mismatched names (not recommended)
+
+Choice (1/2):
+```
+
+If option 1 selected, use `/branch-align` to rename before pushing.
+
+**Why this matters:** Reviewers and future contributors use branch names to find related work. A branch named `req-005` that contains `REQ-011` creates confusion.
+
+### Step 7: Push and create the pull request
 
 ```bash
 git push -u origin HEAD


### PR DESCRIPTION
## Summary
Implements PR #102 review feedback for improving AI-assisted SDLC workflow. Adds two new skills and enhances submit-pr based on @cidrblock's suggestions for research-first RFE capture.

## Changes
- **`/rfe-capture`** (new): Research-first approach for external RFEs
  - Reads CLAUDE.md, searches existing rules, checks SDLC indexes
  - Performs gap analysis before creating artifacts
  - Prevents duplicating existing capabilities
  - Proper attribution (human author + AI-assisted note)

- **`/branch-align`** (new): Renames branch to match artifact ID after renumbering
  - Handles local rename, remote push, old branch deletion
  - Verifies PR tracking updates

- **`/submit-pr`** (enhanced): Added Step 6 branch/artifact alignment check
  - Detects branch name vs artifact ID mismatches before pushing
  - Offers to invoke `/branch-align` to fix

- **README.md**: Updated skill index with new entries

## Test plan
- [x] Skills follow existing SKILL.md format
- [x] README index updated
- [x] No code changes (documentation only)

## Context
From PR #102 review: https://github.com/ansible/apme/pull/102#issuecomment-4127134540

> When you point an AI at a Jira ticket and say "create SDLC artifacts," it will dutifully produce specs — but it won't know that APME already detects deprecated modules, that AA is a runtime system while APME is static analysis, or that DR-004 already covers AAP integration.

The `/rfe-capture` skill enforces research before creation to avoid this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)