### PR TITLE
docs(adrs): propose ADR-043 default severity assignment for rule catalog

### DIFF
--- a/.sdlc/adrs/ADR-043-default-severity-assignment.md
+++ b/.sdlc/adrs/ADR-043-default-severity-assignment.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -156,7 +156,7 @@ enum Severity {
 
 The ambiguous legacy strings (`error`, `warning`) cannot be mechanically mapped because they were assigned inconsistently — OPA's `error` means different things for L004 (deprecated module → High) vs. L003 (missing play name → Low). These are resolved by the per-rule assignment table, not by string mapping.
 
-**Retire the engine `Severity` class.** The `Severity` class and `_severity_level_mapping` in `engine/models.py` are replaced by the proto enum. Native rule classes update their `severity` field to use the new enum values. OPA rules update their `"level"` strings. The old vocabulary is removed — no compatibility shim, since the legacy strings were never exposed to external consumers.
+**Retire the engine `Severity` class.** The `Severity` class and `_severity_level_mapping` in `engine/models.py` are replaced by the proto enum. Native rule classes update their `severity` field to use the new enum values. OPA rules update their `"level"` strings. The old vocabulary is removed. Note that legacy level strings are currently visible to consumers — the UI renders `Violation.level`, the CLI displays it, and the REST API exposes it. The migration to the enum is a coordinated breaking change across engine, Gateway, CLI, and UI; all components must be deployed together.
 
 ### 6. Static assignment table
 
@@ -256,7 +256,7 @@ Third-party plugins ([ADR-042](ADR-042-third-party-plugin-services.md)) provide 
 
 ### Neutral
 
-- ADR-041's `default_severity` field semantics are unchanged — this ADR defines how the values are determined, not how they flow
+- ADR-041's `default_severity` field and override flow are unchanged — this ADR extends the enum from 5 to 6 values (adding Error) and defines the assignment criteria. ADR-041's registration table should be updated to reference the 6-value enum when this ADR is implemented
 - Override mechanism (ADR-041 §4) is unaffected — admins can still override any rule's severity regardless of the default
 - Plugin authors use the same enum and criteria but own their own assignments
 

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -51,6 +51,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-012](ADR-012-scale-pods-not-services.md) | Scale Pods, Not Services Within a Pod | 2026-02 |
 | [ADR-016](ADR-016-single-branch-main.md) | Single-branch `main` Strategy | 2026-03 |
 | [ADR-040](ADR-040-scan-metadata-enrichment.md) | Scan Metadata Enrichment | 2026-03-25 |
+| [ADR-043](ADR-043-default-severity-assignment.md) | Default Severity Assignment for Rule Catalog | 2026-03-26 |
 
 ## Proposed
 
@@ -64,7 +65,6 @@ Decisions under consideration — not yet accepted or implemented.
 | [ADR-038](ADR-038-public-data-api.md) | Public Data API for Platform Consumers | 2026-03-25 |
 | [ADR-041](ADR-041-rule-catalog-override-architecture.md) | Rule Catalog & Override Architecture | 2026-03-25 |
 | [ADR-042](ADR-042-third-party-plugin-services.md) | Third-Party Plugin Services | 2026-03-20 |
-| [ADR-043](ADR-043-default-severity-assignment.md) | Default Severity Assignment for Rule Catalog | 2026-03-26 |
 
 ## Superseded
 


### PR DESCRIPTION
## Summary

- Proposes ADR-043: a criteria-based framework for assigning default severities to all rules in the APME rule catalog
- Fills the gap left by ADR-041, which defined the `default_severity` field and catalog infrastructure but not the assignment policy

## Changes

- **New 6-level severity enum**: Critical (security only), Error (runtime breakage), High (behavioral risk), Medium (correctness smell), Low (best practice), Info (advisory)
- **Impact-class decision tree**: principled criteria for assigning severity based on consequence of ignoring the finding, not rule category prefix
- **Vocabulary normalization**: replaces the dual vocabulary (native `very_high`/`very_low`/`none` + OPA/Ansible ad-hoc `error`/`warning`/`info`) with a single proto `Severity` enum
- **Static assignment table**: per-rule default severity maintained as a single authoritative file shipping with the engine image
- **Representative assignments**: examples across all 6 levels drawn from real rules (SEC:\*, L057, M001-M004, R101, L026, R501, etc.)

### Files changed
- `.sdlc/adrs/ADR-043-default-severity-assignment.md` — new ADR
- `.sdlc/adrs/README.md` — index updated

## Test plan

- [x] `prek run --all-files` passes
- [x] ADR index updated and consistent
- [ ] Review: severity levels and criteria are clear and complete
- [ ] Review: representative assignments are reasonable
- [ ] Review: normalization mapping from legacy strings is correct

Made with [Cursor](https://cursor.com)