### PR TITLE
fix(daemon): promote Galaxy Proxy deps to core dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
-      - run: uv sync --extra dev --extra proxy --extra gateway
+      - run: uv sync --extra dev --extra gateway
       - run: uv run pytest --cov=src/apme_engine --cov-report=term-missing --cov-fail-under=36
       - name: Fail if git reports dirty
         run: |
@@ -40,7 +40,7 @@ jobs:
             https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
           chmod +x /usr/local/bin/opa
           opa version
-      - run: uv sync --extra dev --extra proxy --extra gateway
+      - run: uv sync --extra dev --extra gateway
       - run: uv run pytest -m integration tests/integration/test_daemon_pipeline.py -v --tb=long
         env:
           OPA_USE_PODMAN: "0"
@@ -63,7 +63,7 @@ jobs:
           curl -fsSL -o /usr/local/bin/opa \
             https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
           chmod +x /usr/local/bin/opa
-      - run: uv sync --extra dev --extra proxy --extra gateway
+      - run: uv sync --extra dev --extra gateway
       - run: uv run playwright install --with-deps chromium
       - name: Build and serve UI
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,17 @@ one needs to change, write an ADR first.
     New sinks must be gRPC and pod-local — protocol translation to external
     systems (message buses, webhooks, third-party APIs) belongs in the Gateway.
 
-12. **Built-in validator bundles are closed** (ADR-042). No volume-mounted rules,
+12. **Engine-core services are required, not optional.** The engine runtime
+    comprises Primary, Native, OPA, Ansible, and Galaxy Proxy. All five are
+    required for both the CLI daemon and the Podman pod — their dependencies
+    belong in core `dependencies` (not optional extras), and they live in
+    `_DEFAULT_PORTS`. Galaxy Proxy is the sole collection installation path
+    for session venvs; the daemon cannot scan without it. Only Gitleaks is
+    truly optional (`_OPTIONAL_SERVICES`) because it requires an external
+    binary. Gateway, UI, and Abbenay are pod-level / enterprise services
+    that the CLI daemon does not start.
+
+13. **Built-in validator bundles are closed** (ADR-042). No volume-mounted rules,
     no configurable rule directories, no external Rego files injected into the
     OPA bundle, no custom Python rule classes loaded into Native. The built-in
     rule set ships with the image and is the only rule set the built-in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Full workflow: [workflow.md](/.sdlc/context/workflow.md) | Getting started: [get
 - **Use gRPC** — all inter-service communication
 - **Async servers** — grpc.aio, not synchronous
 - **Rule IDs** — L/M/R/P/SEC convention per ADR-008
+- **Engine-core services are required** — Primary, Native, OPA, Ansible, and Galaxy Proxy are all required for both the CLI daemon and pod. Their deps are core, not optional extras. Only Gitleaks is optional (external binary). Gateway, UI, and Abbenay are pod-level/enterprise services the CLI daemon does not start.
 - Do NOT modify files outside task scope
 - Do NOT add features not in requirements
 - Ask for clarification if specs are ambiguous

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -13,11 +13,11 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-dev \
-            --extra ai --extra gateway --extra proxy
+            --extra ai --extra gateway
 
 # Full source; install the project itself (deps already cached).
 COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --extra ai --extra gateway --extra proxy
+    uv sync --frozen --no-dev --extra ai --extra gateway
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/docs/DATA_FLOW.md
+++ b/docs/DATA_FLOW.md
@@ -310,6 +310,6 @@ When running without the Podman pod, the CLI connects to a local daemon via `ens
 2. If a daemon is already running (`~/.apme-data/daemon.json`), the CLI reuses it
 3. Otherwise, the CLI auto-starts a background daemon (`apme daemon start`)
 
-The local daemon runs Primary, Native, OPA, and Ansible validators plus the Galaxy Proxy as localhost gRPC servers in a single background process. The CLI always communicates via gRPC — it never runs the engine in-process.
+The local daemon runs the Primary, Native, OPA, and Ansible validators as localhost gRPC servers, and the Galaxy Proxy as a localhost HTTP (uvicorn) server, all within a single background process. These five services are all required — Galaxy Proxy is the sole collection installation path for session venvs. The CLI always talks to the Primary service over gRPC; it never runs the engine in-process or communicates with Galaxy Proxy directly.
 
-Ansible and Gitleaks validators are optional and not started by default (they require external binaries or pre-built venvs). Pass `include_optional=True` to `start_daemon()` to enable them.
+Gitleaks is the only optional service (requires the `gitleaks` binary). Pass `include_optional=True` to `start_daemon()` to enable it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,19 +20,16 @@ dependencies = [
     "grpcio-health-checking>=1.78.0",
     "protobuf>=6.31.1,<7",
     "httpx",
+    "fastapi>=0.100",
+    "uvicorn[standard]>=0.20",
 ]
 
 [project.optional-dependencies]
 ai = [
     "abbenay-client @ https://github.com/redhat-developer/abbenay/releases/download/v2026.3.8-alpha/abbenay_client-2026.3.8a0-py3-none-any.whl#sha256=b4badd60cac70a12624febe02b791110f1bb1f7da872f10ff3992304496ae306",
 ]
-proxy = [
-    "fastapi>=0.100",
-    "uvicorn[standard]>=0.20",
-]
+proxy = []  # Deprecated: fastapi/uvicorn are now core deps. Kept for backwards compat.
 gateway = [
-    "fastapi>=0.100",
-    "uvicorn[standard]>=0.20",
     "sqlalchemy>=2.0",
     "aiosqlite>=0.20",
     "python-multipart>=0.0.6",

--- a/uv.lock
+++ b/uv.lock
@@ -70,6 +70,7 @@ name = "apme-engine"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "filelock" },
     { name = "grpcio" },
     { name = "grpcio-health-checking" },
@@ -80,6 +81,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rapidfuzz" },
     { name = "ruamel-yaml" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.optional-dependencies]
@@ -102,22 +104,15 @@ dev = [
 ]
 gateway = [
     { name = "aiosqlite" },
-    { name = "fastapi" },
     { name = "python-multipart" },
     { name = "sqlalchemy" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-proxy = [
-    { name = "fastapi" },
-    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "abbenay-client", marker = "extra == 'ai'", url = "https://github.com/redhat-developer/abbenay/releases/download/v2026.3.8-alpha/abbenay_client-2026.3.8a0-py3-none-any.whl" },
     { name = "aiosqlite", marker = "extra == 'gateway'", specifier = ">=0.20" },
-    { name = "fastapi", marker = "extra == 'gateway'", specifier = ">=0.100" },
-    { name = "fastapi", marker = "extra == 'proxy'", specifier = ">=0.100" },
+    { name = "fastapi", specifier = ">=0.100" },
     { name = "filelock" },
     { name = "grpc-stubs", marker = "extra == 'dev'" },
     { name = "grpcio", specifier = ">=1.78.0" },
@@ -142,8 +137,7 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'gateway'", specifier = ">=2.0" },
     { name = "types-protobuf", marker = "extra == 'dev'" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'gateway'", specifier = ">=0.20" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'proxy'", specifier = ">=0.20" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.20" },
 ]
 provides-extras = ["ai", "proxy", "gateway", "dev"]
 


### PR DESCRIPTION
## Summary

Galaxy Proxy's uvicorn dependency was not in core `dependencies`, causing
`ImportError` crashes when starting the daemon without `pip install apme-engine[proxy]`.
Since Galaxy Proxy is the sole collection installation path for session venvs,
it is a required service — promote its deps to core rather than making it optional.

## Changes

- Move `fastapi` and `uvicorn[standard]` from `[proxy]` optional extra to core `dependencies`
- Remove the `[proxy]` optional-dependencies group
- Remove `--extra proxy` from base Dockerfile and CI workflows (`test.yml`)
- Keep `galaxy_proxy` in `_DEFAULT_PORTS` (first-class service)
- Regenerate `uv.lock`

## Test plan

- `prek run --all-files` passes (ruff, mypy, pydoclint, uv-lock, adr-index)
- `apme daemon start` succeeds without `[proxy]` extra (deps are always present)
- CI workflows install correctly without `--extra proxy`
