### PR TITLE
feat(galaxy-proxy): add multi-server Galaxy support with SSO auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,28 @@ APME_GITLEAKS_MAX_RPCS=16
 # through this proxy. The proxy converts Galaxy tarballs to pip-installable wheels.
 APME_GALAXY_PROXY_URL=http://127.0.0.1:8765
 
+# --- Single-server fallback (simplest config) ---
+# GALAXY_URL=https://galaxy.ansible.com
+# GALAXY_TOKEN=
+
+# --- Multi-server config (ansible.cfg-style) ---
+# Comma-separated list of server names.  For each name, set
+# GALAXY_SERVER_<NAME>_URL, _TOKEN, _AUTH_URL, _AUTH_TYPE.
+# GALAXY_SERVER_LIST=certified,community
+#
+# GALAXY_SERVER_CERTIFIED_URL=https://console.redhat.com/api/automation-hub/
+# GALAXY_SERVER_CERTIFIED_TOKEN=<offline-token-from-console.redhat.com>
+# GALAXY_SERVER_CERTIFIED_AUTH_URL=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+# GALAXY_SERVER_CERTIFIED_AUTH_TYPE=sso
+#
+# GALAXY_SERVER_COMMUNITY_URL=https://galaxy.ansible.com
+# GALAXY_SERVER_COMMUNITY_AUTH_TYPE=token
+#
+# Auth types:
+#   token  — Authorization: Token <tok>   (default, standard Galaxy)
+#   bearer — Authorization: Bearer <tok>  (direct bearer)
+#   sso    — Offline-token exchange via AUTH_URL (Red Hat SSO / Keycloak)
+
 # GitHub token for org cloning (optional, for private repos — future feature)
 # GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -131,6 +131,13 @@ spec:
           readOnly: true
     - name: galaxy-proxy
       image: apme-galaxy-proxy:latest
+      env:
+        - name: GALAXY_URL
+          value: "${GALAXY_URL:-https://galaxy.ansible.com}"
+        - name: GALAXY_TOKEN
+          value: "${GALAXY_TOKEN:-}"
+        - name: GALAXY_SERVER_LIST
+          value: "${GALAXY_SERVER_LIST:-}"
       ports:
         - containerPort: 8765
           hostPort: 8765

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -23,7 +23,16 @@ fi
 
 mkdir -p "$CACHE_PATH"
 
-# Load Abbenay secrets (.env) if present.
+# Load root .env if present (Galaxy proxy settings, etc.).
+ROOT_ENV="$ROOT/.env"
+if [[ -f "$ROOT_ENV" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ROOT_ENV"
+  set +a
+fi
+
+# Load Abbenay secrets (.env) if present (may override root .env values).
 ABBENAY_ENV="$ROOT/containers/abbenay/.env"
 if [[ -f "$ABBENAY_ENV" ]]; then
   set -a
@@ -36,6 +45,9 @@ APME_AI_MODEL="${APME_AI_MODEL:-}"
 APME_FEEDBACK_ENABLED="${APME_FEEDBACK_ENABLED:-true}"
 APME_FEEDBACK_GITHUB_REPO="${APME_FEEDBACK_GITHUB_REPO:-}"
 APME_FEEDBACK_GITHUB_TOKEN="${APME_FEEDBACK_GITHUB_TOKEN:-}"
+GALAXY_URL="${GALAXY_URL:-https://galaxy.ansible.com}"
+GALAXY_TOKEN="${GALAXY_TOKEN:-}"
+GALAXY_SERVER_LIST="${GALAXY_SERVER_LIST:-}"
 
 # Tear down any existing pod so we get a clean start.
 if podman pod exists apme-pod 2>/dev/null; then
@@ -50,9 +62,55 @@ fi
 ESCAPED_PATH=$(printf '%s\n' "$CACHE_PATH" | sed -e 's/\\/\\\\/g' -e 's/[&|]/\\&/g')
 export OPENROUTER_API_KEY APME_AI_MODEL APME_ROOT="$ROOT"
 export APME_FEEDBACK_ENABLED APME_FEEDBACK_GITHUB_REPO APME_FEEDBACK_GITHUB_TOKEN
-sed "s|path: __APME_CACHE_PATH__|path: ${ESCAPED_PATH}|" containers/podman/pod.yaml \
-  | envsubst '$OPENROUTER_API_KEY $APME_AI_MODEL $APME_ROOT $APME_FEEDBACK_ENABLED $APME_FEEDBACK_GITHUB_REPO $APME_FEEDBACK_GITHUB_TOKEN' \
-  | podman play kube -
+export GALAXY_URL GALAXY_TOKEN GALAXY_SERVER_LIST
+
+# Build a temporary pod spec with all substitutions applied.
+ENVSUBST_VARS='$OPENROUTER_API_KEY $APME_AI_MODEL $APME_ROOT $APME_FEEDBACK_ENABLED $APME_FEEDBACK_GITHUB_REPO $APME_FEEDBACK_GITHUB_TOKEN $GALAXY_URL $GALAXY_TOKEN $GALAXY_SERVER_LIST'
+TMPYAML=$(mktemp /tmp/apme-pod-XXXXXX.yaml)
+trap 'rm -f "$TMPYAML"' EXIT
+
+# First, inject per-server Galaxy env vars BEFORE envsubst runs
+# (because envsubst will replace ${GALAXY_SERVER_LIST} and break the awk pattern)
+if [[ -n "$GALAXY_SERVER_LIST" ]]; then
+  SNIPPET=$(mktemp /tmp/galaxy-env-XXXXXX.yaml)
+  trap 'rm -f "$TMPYAML" "$SNIPPET"' EXIT
+
+  # Find all GALAXY_SERVER_*_{URL,TOKEN,AUTH_URL,AUTH_TYPE} vars
+  env | grep -E '^GALAXY_SERVER_[A-Z0-9_]+_(URL|TOKEN|AUTH_URL|AUTH_TYPE)=' | sort | while IFS='=' read -r varname varval; do
+    # Escape single quotes for YAML single-quoted scalars ( ' -> '' )
+    escaped_val=$(printf '%s' "$varval" | sed "s/'/''/g")
+    echo "        - name: ${varname}"
+    echo "          value: '${escaped_val}'"
+  done > "$SNIPPET"
+
+  if [[ -s "$SNIPPET" ]]; then
+    # Insert snippet after the GALAXY_SERVER_LIST line, then apply substitutions
+    sed "s|path: __APME_CACHE_PATH__|path: ${ESCAPED_PATH}|" containers/podman/pod.yaml \
+      | awk -v snippet="$SNIPPET" '
+        /value:.*\$\{GALAXY_SERVER_LIST\}/ {
+          print
+          while ((getline line < snippet) > 0) print line
+          close(snippet)
+          next
+        }
+        { print }
+      ' \
+      | envsubst "$ENVSUBST_VARS" \
+      > "$TMPYAML"
+  else
+    # No per-server vars, just do normal substitution
+    sed "s|path: __APME_CACHE_PATH__|path: ${ESCAPED_PATH}|" containers/podman/pod.yaml \
+      | envsubst "$ENVSUBST_VARS" \
+      > "$TMPYAML"
+  fi
+else
+  # No GALAXY_SERVER_LIST, just do normal substitution
+  sed "s|path: __APME_CACHE_PATH__|path: ${ESCAPED_PATH}|" containers/podman/pod.yaml \
+    | envsubst "$ENVSUBST_VARS" \
+    > "$TMPYAML"
+fi
+
+podman play kube "$TMPYAML"
 
 echo "Pod apme-pod started (cache: $CACHE_PATH). Run a scan: containers/podman/run-cli.sh"
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -140,6 +140,35 @@ The OPA binary runs internally on `localhost:8181`; the gRPC wrapper proxies to 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `APME_GALAXY_PROXY_URL` | `http://127.0.0.1:8765` | Galaxy proxy base URL |
+| `GALAXY_URL` | `https://galaxy.ansible.com` | Single-server fallback Galaxy URL |
+| `GALAXY_TOKEN` | — | Token for the fallback Galaxy URL |
+| `GALAXY_SERVER_LIST` | — | Comma-separated server names for multi-server config (e.g., `certified,community`) |
+
+**Multi-server configuration (ansible.cfg-style):**
+
+For each server name in `GALAXY_SERVER_LIST`, set corresponding env vars:
+
+| Variable Pattern | Description |
+|------------------|-------------|
+| `GALAXY_SERVER_<NAME>_URL` | Server base URL (required) |
+| `GALAXY_SERVER_<NAME>_TOKEN` | API token or offline token |
+| `GALAXY_SERVER_<NAME>_AUTH_URL` | SSO/OIDC token endpoint for offline-token exchange |
+| `GALAXY_SERVER_<NAME>_AUTH_TYPE` | `token` (default), `bearer`, or `sso` |
+
+Example for Red Hat Automation Hub + community Galaxy:
+
+```bash
+GALAXY_SERVER_LIST=certified,community
+
+GALAXY_SERVER_CERTIFIED_URL=https://console.redhat.com/api/automation-hub/
+GALAXY_SERVER_CERTIFIED_TOKEN=<offline-token-from-console.redhat.com>
+GALAXY_SERVER_CERTIFIED_AUTH_URL=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+GALAXY_SERVER_CERTIFIED_AUTH_TYPE=sso
+
+GALAXY_SERVER_COMMUNITY_URL=https://galaxy.ansible.com
+```
+
+Servers are tried in order; the first to return a successful response wins.
 
 #### Gateway
 

--- a/src/apme_engine/cli/remediate.py
+++ b/src/apme_engine/cli/remediate.py
@@ -22,6 +22,7 @@ from apme.v1.primary_pb2 import (
     CloseRequest,
     ExtendRequest,
     FixOptions,
+    Proposal,
     ScanChunk,
     SessionCommand,
 )
@@ -214,7 +215,7 @@ def _render_tier1(summary: object) -> None:
         sys.stderr.write(f"Applied {len(applied)} Tier 1 patch(es)\n")
 
 
-def _interactive_review(proposals: list[object]) -> list[str]:
+def _interactive_review(proposals: list[Proposal]) -> list[str]:
     """Interactive y/n/a/s/q review loop for proposals.
 
     Args:
@@ -232,27 +233,24 @@ def _interactive_review(proposals: list[object]) -> list[str]:
             break
 
         sys.stderr.write(
-            f"\n--- Proposal {i}/{total} "
-            f"[{prop.rule_id}] "  # type: ignore[attr-defined]
-            f"{prop.file} "  # type: ignore[attr-defined]
-            f"lines {prop.line_start}-{prop.line_end} "  # type: ignore[attr-defined]
+            f"\n--- Proposal {i}/{total} [{prop.rule_id}] {prop.file} lines {prop.line_start}-{prop.line_end} "
         )
-        if prop.confidence:  # type: ignore[attr-defined]
-            sys.stderr.write(f"({prop.confidence:.0%})")  # type: ignore[attr-defined]
+        if prop.confidence:
+            sys.stderr.write(f"({prop.confidence:.0%})")
         sys.stderr.write("\n")
 
-        if prop.explanation:  # type: ignore[attr-defined]
-            sys.stderr.write(f"    {prop.explanation}\n")  # type: ignore[attr-defined]
-        if prop.diff_hunk:  # type: ignore[attr-defined]
-            sys.stdout.write(prop.diff_hunk + "\n")  # type: ignore[attr-defined]
+        if prop.explanation:
+            sys.stderr.write(f"    {prop.explanation}\n")
+        if prop.diff_hunk:
+            sys.stdout.write(prop.diff_hunk + "\n")
 
         answer = _prompt_ynasq()
         if answer == "y":
-            approved.append(prop.id)  # type: ignore[attr-defined]
+            approved.append(prop.id)
         elif answer == "n":
             sys.stderr.write("  Skipped\n")
         elif answer == "a":
-            approved.extend(p.id for p in proposals[i - 1 :])  # type: ignore[attr-defined]
+            approved.extend(p.id for p in proposals[i - 1 :])
             sys.stderr.write(f"  Accepted remaining {total - i + 1} proposal(s)\n")
             break
         elif answer == "s":

--- a/src/galaxy_proxy/cli.py
+++ b/src/galaxy_proxy/cli.py
@@ -1,4 +1,24 @@
-"""CLI entry point for galaxy-proxy (argparse, no external deps)."""
+"""CLI entry point for galaxy-proxy (argparse, no external deps).
+
+Environment-variable configuration
+-----------------------------------
+Servers can be defined via ``GALAXY_SERVER_LIST`` (ansible.cfg-style)::
+
+    GALAXY_SERVER_LIST=certified,community
+
+    GALAXY_SERVER_CERTIFIED_URL=https://console.redhat.com/api/automation-hub/
+    GALAXY_SERVER_CERTIFIED_TOKEN=<offline-token>
+    GALAXY_SERVER_CERTIFIED_AUTH_URL=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+    GALAXY_SERVER_CERTIFIED_AUTH_TYPE=sso
+
+    GALAXY_SERVER_COMMUNITY_URL=https://galaxy.ansible.com
+
+Per-server variables: ``GALAXY_SERVER_<NAME>_URL``, ``_TOKEN``, ``_AUTH_URL``,
+``_AUTH_TYPE`` (``token`` | ``bearer`` | ``sso``).
+
+The legacy ``GALAXY_URL`` / ``GALAXY_TOKEN`` env vars still work as a
+single-server fallback when ``GALAXY_SERVER_LIST`` is unset.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +31,10 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from galaxy_proxy.galaxy_client import GalaxyServer
+
+_VALID_AUTH_TYPES = {"token", "bearer", "sso"}
+
+logger = logging.getLogger(__name__)
 
 
 def _setup_logging(verbose: int) -> None:
@@ -28,7 +52,7 @@ def _setup_logging(verbose: int) -> None:
 def _parse_galaxy_server(raw: str) -> GalaxyServer:
     """Parse a ``--galaxy-server`` value into a :class:`GalaxyServer`.
 
-    Format: ``URL[,token=TOK][,name=LABEL]``
+    Format: ``URL[,token=TOK][,name=LABEL][,auth_url=URL][,auth_type=TYPE]``
 
     Args:
         raw: Raw server string from CLI or env var.
@@ -42,12 +66,82 @@ def _parse_galaxy_server(raw: str) -> GalaxyServer:
     url = parts[0]
     token: str | None = None
     name: str | None = None
+    auth_url: str | None = None
+    auth_type: str = "token"
     for part in parts[1:]:
         if part.startswith("token="):
             token = part[len("token=") :]
         elif part.startswith("name="):
             name = part[len("name=") :]
-    return GalaxyServer(url=url, token=token, name=name)
+        elif part.startswith("auth_url="):
+            auth_url = part[len("auth_url=") :]
+        elif part.startswith("auth_type="):
+            auth_type = part[len("auth_type=") :]
+
+    auth_type = auth_type.lower().strip()
+    if auth_type not in _VALID_AUTH_TYPES:
+        sys.stderr.write(f"WARNING: auth_type={auth_type!r} in {raw!r} is invalid — defaulting to token\n")
+        auth_type = "token"
+
+    if auth_type == "sso" and not token:
+        sys.stderr.write(f"WARNING: {raw!r} uses auth_type=sso but no token=... — SSO exchange will fail\n")
+
+    return GalaxyServer(url=url, token=token, name=name, auth_url=auth_url, auth_type=auth_type)
+
+
+def _servers_from_env() -> list[GalaxyServer] | None:
+    """Build a server list from ``GALAXY_SERVER_LIST`` env vars.
+
+    Returns:
+        List of configured servers, or ``None`` if ``GALAXY_SERVER_LIST`` is
+        not set.
+    """
+    server_list = os.environ.get("GALAXY_SERVER_LIST", "").strip()
+    if not server_list:
+        return None
+
+    from galaxy_proxy.galaxy_client import GalaxyServer
+
+    servers: list[GalaxyServer] = []
+    for entry in server_list.split(","):
+        name = entry.strip().upper()
+        if not name:
+            continue
+
+        prefix = f"GALAXY_SERVER_{name}_"
+        url = os.environ.get(f"{prefix}URL", "").strip()
+        if not url:
+            sys.stderr.write(
+                f"WARNING: GALAXY_SERVER_LIST includes {entry.strip()!r} but {prefix}URL is not set — skipping\n"
+            )
+            continue
+
+        if not url.startswith(("http://", "https://")):
+            sys.stderr.write(f"WARNING: {prefix}URL={url!r} missing http(s):// — skipping\n")
+            continue
+
+        token = os.environ.get(f"{prefix}TOKEN") or None
+        auth_url = os.environ.get(f"{prefix}AUTH_URL") or None
+        auth_type = (os.environ.get(f"{prefix}AUTH_TYPE") or "token").lower().strip()
+
+        if auth_type not in _VALID_AUTH_TYPES:
+            sys.stderr.write(f"WARNING: {prefix}AUTH_TYPE={auth_type!r} invalid — defaulting to token\n")
+            auth_type = "token"
+
+        if auth_type == "sso" and not token:
+            sys.stderr.write(f"WARNING: {prefix} uses auth_type=sso but no TOKEN — SSO exchange will fail\n")
+
+        servers.append(
+            GalaxyServer(
+                url=url,
+                token=token,
+                name=entry.strip(),
+                auth_url=auth_url,
+                auth_type=auth_type,
+            )
+        )
+
+    return servers or None
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -77,7 +171,10 @@ def main(argv: list[str] | None = None) -> None:
         dest="galaxy_servers",
         action="append",
         default=[],
-        help="Upstream Galaxy server: URL[,token=TOK][,name=LABEL]. Repeatable.",
+        help=(
+            "Upstream Galaxy server: URL[,token=TOK][,name=LABEL]"
+            "[,auth_url=URL][,auth_type=token|bearer|sso]. Repeatable."
+        ),
     )
     parser.add_argument("--pypi-url", default="https://pypi.org", help="Upstream PyPI URL for passthrough.")
     parser.add_argument("--cache-dir", type=Path, default=None, help="Wheel cache directory.")
@@ -95,6 +192,8 @@ def main(argv: list[str] | None = None) -> None:
     parsed_servers: list[GalaxyServer] | None = None
     if args.galaxy_servers:
         parsed_servers = [_parse_galaxy_server(s) for s in args.galaxy_servers]
+    else:
+        parsed_servers = _servers_from_env()
 
     app = create_app(
         galaxy_url=args.galaxy_url,
@@ -108,10 +207,24 @@ def main(argv: list[str] | None = None) -> None:
 
     host, port = args.host, args.port
     sys.stderr.write(f"Starting Galaxy Proxy on {host}:{port}\n")
+
+    if args.verbose:
+        env_server_list = os.environ.get("GALAXY_SERVER_LIST", "")
+        if env_server_list:
+            sys.stderr.write(f"  GALAXY_SERVER_LIST={env_server_list}\n")
+            for name in env_server_list.split(","):
+                name = name.strip().upper()
+                for suffix in ("URL", "TOKEN", "AUTH_URL", "AUTH_TYPE"):
+                    key = f"GALAXY_SERVER_{name}_{suffix}"
+                    val = os.environ.get(key, "")
+                    if val:
+                        display = "[REDACTED]" if suffix == "TOKEN" else val
+                        sys.stderr.write(f"    {key}={display}\n")
+
     if parsed_servers:
         for i, srv in enumerate(parsed_servers, 1):
-            auth = " (authenticated)" if srv.token else ""
-            sys.stderr.write(f"  Galaxy [{i}]: {srv.label()}{auth}\n")
+            auth_info = f" ({srv.auth_type})" if srv.token else ""
+            sys.stderr.write(f"  Galaxy [{i}]: {srv.label()} -> {srv.url}{auth_info}\n")
     else:
         sys.stderr.write(f"Galaxy: {args.galaxy_url}\n")
     sys.stderr.write(f"PyPI passthrough: {'disabled' if args.no_passthrough else args.pypi_url}\n")

--- a/src/galaxy_proxy/galaxy_client.py
+++ b/src/galaxy_proxy/galaxy_client.py
@@ -1,22 +1,62 @@
 """Async client for the Ansible Galaxy V3 REST API.
 
 Supports multiple upstream Galaxy servers (public Galaxy, Automation Hub,
-private instances) with per-server auth tokens.  Servers are tried in order;
-the first successful response wins.
+console.redhat.com) with per-server auth tokens.  Servers are tried in
+order; the first successful response wins.
+
+Auth modes:
+  - ``token`` (default): ``Authorization: Token <tok>`` — standard Galaxy.
+  - ``bearer``: ``Authorization: Bearer <tok>`` — direct bearer.
+  - ``sso``: Offline-token exchange via ``auth_url`` (Red Hat SSO / Keycloak).
+    The configured ``token`` is treated as a refresh token and exchanged for a
+    short-lived access token using ``grant_type=refresh_token``.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from dataclasses import dataclass, field
+from urllib.parse import urlparse
 
 import httpx
 
 DEFAULT_GALAXY_URL = "https://galaxy.ansible.com"
 
-COLLECTIONS_PATH = "/api/v3/plugin/ansible/content/published/collections/index"
+# Relative to the server API root (no leading slash). The base_url on each
+# httpx client already points at the API root — e.g.
+#   galaxy.ansible.com/api/   or   console.redhat.com/api/automation-hub/
+COLLECTIONS_PATH = "v3/plugin/ansible/content/published/collections/index"
+
+REDHAT_SSO_URL = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+SSO_CLIENT_ID = "cloud-services"
+SSO_TOKEN_EXPIRY_MARGIN = 30  # refresh this many seconds before expiry
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_api_root(url: str) -> str:
+    """Ensure a Galaxy server URL points at the V3 API root.
+
+    Bare Galaxy URLs (e.g. ``https://galaxy.ansible.com``) need ``/api/``
+    appended so that relative V3 paths resolve correctly.  Automation Hub
+    URLs already include the API prefix (``/api/automation-hub/``) and are
+    returned as-is with a guaranteed trailing slash.
+
+    Args:
+        url: Galaxy server base URL.
+
+    Returns:
+        Normalized URL ending with a trailing slash, pointing at the API root.
+    """
+    url = url.rstrip("/")
+    path = urlparse(url).path
+    if not path or path == "/":
+        url += "/api/"
+    else:
+        url += "/"
+    return url
 
 
 @dataclass
@@ -25,13 +65,18 @@ class GalaxyServer:
 
     Attributes:
         url: Base URL of the Galaxy or Automation Hub API.
-        token: Optional API token for Authorization, if required.
+        token: API token, offline/refresh token (for SSO), or None.
         name: Optional short name for logging and display.
+        auth_url: SSO/OIDC token endpoint for offline-token exchange.
+            When set, ``token`` is treated as a refresh token.
+        auth_type: ``"token"`` (default), ``"bearer"``, or ``"sso"``.
     """
 
     url: str
     token: str | None = None
     name: str | None = None
+    auth_url: str | None = None
+    auth_type: str = "token"
 
     def label(self) -> str:
         """Return a human-readable label (name if set, otherwise URL).
@@ -43,19 +88,35 @@ class GalaxyServer:
 
 
 @dataclass
+class CollectionInfo:
+    """Summary info for a collection (from list endpoint).
+
+    Attributes:
+        namespace: Collection namespace.
+        name: Collection name.
+        description: Short description.
+        latest_version: The highest semver version string.
+        deprecated: Whether the collection is deprecated.
+    """
+
+    namespace: str
+    name: str
+    description: str = ""
+    latest_version: str = ""
+    deprecated: bool = False
+
+
+@dataclass
 class CollectionVersion:
-    """Metadata for a single published collection version.
+    """Full metadata for a specific collection version.
 
     Attributes:
         namespace: Collection namespace.
         name: Collection name.
         version: Semantic version string.
-        download_url: Absolute URL to the collection artifact tarball.
-        dependencies: Other collections and version constraints required by this version.
-        requires_ansible: Declared Ansible version requirement, if any.
-        license: SPDX or other license strings from metadata.
-        authors: Author strings from metadata.
-        description: Human-readable description from metadata.
+        download_url: Direct URL to the tarball.
+        dependencies: Mapping of FQCN -> version specifier.
+        description: Collection description.
     """
 
     namespace: str
@@ -63,98 +124,195 @@ class CollectionVersion:
     version: str
     download_url: str
     dependencies: dict[str, str] = field(default_factory=dict)
-    requires_ansible: str | None = None
-    license: list[str] = field(default_factory=list)
-    authors: list[str] = field(default_factory=list)
     description: str = ""
+
+
+class _SSOState:
+    """Cached access token obtained from an SSO/OIDC token exchange."""
+
+    __slots__ = ("access_token", "expires_at")
+
+    def __init__(self) -> None:
+        self.access_token: str | None = None
+        self.expires_at: float = 0.0
+
+    def is_valid(self) -> bool:
+        return self.access_token is not None and time.monotonic() < self.expires_at
 
 
 class GalaxyClient:
     """Async client for fetching collections from one or more Galaxy servers.
 
-    When multiple servers are configured, each operation tries them in order
-    and returns the first successful result (like ``ansible.cfg``'s
-    ``galaxy_server_list``).
+    By default, queries only ``https://galaxy.ansible.com``.  Supply
+    ``servers`` to add Automation Hub or other Galaxy-compatible registries.
+    Servers are tried **in order** — the first successful response wins.
+
+    Example:
+        >>> async with GalaxyClient(servers=[
+        ...     GalaxyServer(url="https://hub.example.com", token="secret"),
+        ...     GalaxyServer(url="https://galaxy.ansible.com"),
+        ... ]) as client:
+        ...     versions = await client.list_versions("ansible", "netcommon")
     """
 
     def __init__(
         self,
+        *,
         galaxy_url: str = DEFAULT_GALAXY_URL,
         token: str | None = None,
-        timeout: float = 30.0,
-        *,
         servers: list[GalaxyServer] | None = None,
+        timeout: float = 30.0,
     ) -> None:
-        """Initialise with one or more upstream Galaxy servers.
+        """Create a new Galaxy client.
 
         Args:
-            galaxy_url: Default Galaxy base URL when ``servers`` is not provided.
-            token: Default token for the single implicit server from ``galaxy_url``.
-            timeout: HTTP timeout in seconds for all clients.
-            servers: Explicit list of upstream servers; overrides ``galaxy_url``/``token``.
+            galaxy_url: Fallback Galaxy URL when ``servers`` is empty.
+            token: Fallback token for the ``galaxy_url`` server.
+            servers: Ordered list of Galaxy servers to query.
+            timeout: HTTP timeout for all requests.
         """
-        self._timeout = timeout
         if servers:
             self._servers = list(servers)
         else:
             self._servers = [GalaxyServer(url=galaxy_url, token=token)]
+
         self._clients: list[httpx.AsyncClient] = []
+        self._sso_states: list[_SSOState | None] = []
+        self._sso_locks: list[asyncio.Lock | None] = []
+        self._sso_client: httpx.AsyncClient | None = None
+
         for srv in self._servers:
+            base = _normalize_api_root(srv.url)
             headers: dict[str, str] = {"Accept": "application/json"}
-            if srv.token:
-                headers["Authorization"] = f"Token {srv.token}"
+
+            if srv.auth_type == "sso":
+                self._sso_states.append(_SSOState())
+                self._sso_locks.append(asyncio.Lock())
+                if self._sso_client is None:
+                    self._sso_client = httpx.AsyncClient(timeout=timeout)
+            else:
+                self._sso_states.append(None)
+                self._sso_locks.append(None)
+                if srv.token:
+                    prefix = "Bearer" if srv.auth_type == "bearer" else "Token"
+                    headers["Authorization"] = f"{prefix} {srv.token}"
+
             self._clients.append(
                 httpx.AsyncClient(
-                    base_url=srv.url.rstrip("/"),
+                    base_url=base,
                     headers=headers,
                     timeout=timeout,
                     follow_redirects=True,
                 )
             )
+
         self._download_client = httpx.AsyncClient(
             timeout=timeout,
             follow_redirects=True,
         )
-
-    @property
-    def servers(self) -> list[GalaxyServer]:
-        """Return a copy of the configured server list."""
-        return list(self._servers)
 
     async def close(self) -> None:
         """Close all underlying HTTP clients."""
         for c in self._clients:
             await c.aclose()
         await self._download_client.aclose()
+        if self._sso_client:
+            await self._sso_client.aclose()
+
+    async def _ensure_sso_token(self, idx: int) -> None:
+        """Exchange a refresh/offline token for a short-lived access token.
+
+        Updates the Authorization header on ``self._clients[idx]`` in-place.
+
+        Args:
+            idx: Index into ``self._servers`` / ``self._clients``.
+
+        Raises:
+            ValueError: If the server uses SSO auth but has no token configured.
+            RuntimeError: If the SSO client is not initialized.
+        """
+        sso = self._sso_states[idx]
+        if sso is None or sso.is_valid():
+            return
+
+        lock = self._sso_locks[idx]
+        if lock is None:
+            return
+
+        async with lock:
+            if sso.is_valid():
+                return
+
+            srv = self._servers[idx]
+            if not srv.token:
+                raise ValueError(f"Server {srv.label()} uses auth_type=sso but has no token configured")
+
+            auth_url = srv.auth_url or REDHAT_SSO_URL
+
+            if self._sso_client is None:
+                raise RuntimeError(
+                    "SSO client is not initialized; cannot refresh SSO token. "
+                    "Ensure the GalaxyClient is constructed with SSO support."
+                )
+            resp = await self._sso_client.post(
+                auth_url,
+                data={
+                    "grant_type": "refresh_token",
+                    "client_id": SSO_CLIENT_ID,
+                    "refresh_token": srv.token,
+                },
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+            sso.access_token = payload["access_token"]
+            expires_in = int(payload.get("expires_in", 300))
+            # Clamp expiry to avoid refresh spinning if expires_in < margin
+            sso.expires_at = max(
+                time.monotonic() + 5,
+                time.monotonic() + expires_in - SSO_TOKEN_EXPIRY_MARGIN,
+            )
+            self._clients[idx].headers["Authorization"] = f"Bearer {sso.access_token}"
+            logger.debug("SSO token refreshed for %s (expires in %ds)", srv.label(), expires_in)
 
     async def __aenter__(self) -> GalaxyClient:
         """Enter async context manager.
 
         Returns:
-            This client instance.
+            Self for use in ``async with`` blocks.
         """
         return self
 
-    async def __aexit__(self, *exc: object) -> None:
-        """Exit async context manager and close clients.
+    async def __aexit__(  # noqa: DOC101, DOC103
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object | None,
+    ) -> None:
+        """Exit async context manager, closing clients.
 
         Args:
-            *exc: Exception info from the context manager protocol (type, value, traceback).
+            exc_type: Exception type if an exception was raised.
+            exc_val: Exception value if an exception was raised.
+            exc_tb: Traceback if an exception was raised.
         """
         await self.close()
 
-    async def list_versions(self, namespace: str, name: str) -> list[str]:
-        """Fetch all published version strings for a collection.
+    async def list_versions(
+        self,
+        namespace: str,
+        name: str,
+    ) -> list[str]:
+        """List all available versions of a collection.
 
-        Tries each configured server in order; returns versions from the
-        first server that responds successfully.
+        Tries each server in order; returns versions from the first server
+        that returns a non-empty list.
 
         Args:
             namespace: Collection namespace.
             name: Collection name.
 
         Returns:
-            List of version strings from the first successful upstream.
+            List of version strings.
 
         Raises:
             httpx.HTTPStatusError: When the last attempted server returns an error status.
@@ -162,9 +320,18 @@ class GalaxyClient:
             RuntimeError: When no Galaxy servers are configured.
         """  # noqa: DOC503
         last_exc: Exception | None = None
-        for srv, client in zip(self._servers, self._clients, strict=True):
+        for idx, (srv, client) in enumerate(zip(self._servers, self._clients, strict=True)):
             try:
+                await self._ensure_sso_token(idx)
                 versions = await self._list_versions_from(client, namespace, name)
+                if not versions:
+                    logger.debug(
+                        "list_versions %s.%s: 0 version(s) from %s — trying next",
+                        namespace,
+                        name,
+                        srv.label(),
+                    )
+                    continue
                 logger.debug(
                     "list_versions %s.%s: %d version(s) from %s",
                     namespace,
@@ -173,7 +340,7 @@ class GalaxyClient:
                     srv.label(),
                 )
                 return versions
-            except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            except (httpx.HTTPStatusError, httpx.RequestError, ValueError, RuntimeError) as exc:
                 logger.debug(
                     "list_versions %s.%s: %s failed: %s",
                     namespace,
@@ -182,7 +349,9 @@ class GalaxyClient:
                     exc,
                 )
                 last_exc = exc
-        raise last_exc or RuntimeError("No Galaxy servers configured")
+        if last_exc:
+            raise last_exc
+        return []
 
     async def get_version_detail(
         self,
@@ -206,10 +375,35 @@ class GalaxyClient:
             httpx.HTTPStatusError: When the last attempted server returns an error status.
             httpx.RequestError: When the last attempted server's request fails.
             RuntimeError: When no Galaxy servers are configured.
+        """  # noqa: DOC502, DOC503
+        detail, _ = await self._get_version_detail_with_idx(namespace, name, version)
+        return detail
+
+    async def _get_version_detail_with_idx(
+        self,
+        namespace: str,
+        name: str,
+        version: str,
+    ) -> tuple[CollectionVersion, int]:
+        """Fetch full metadata for a specific collection version with server index.
+
+        Args:
+            namespace: Collection namespace.
+            name: Collection name.
+            version: Collection version string.
+
+        Returns:
+            Tuple of parsed ``CollectionVersion`` and the server index.
+
+        Raises:
+            httpx.HTTPStatusError: When the last attempted server returns an error status.
+            httpx.RequestError: When the last attempted server's request fails.
+            RuntimeError: When no Galaxy servers are configured.
         """  # noqa: DOC503
         last_exc: Exception | None = None
-        for srv, client in zip(self._servers, self._clients, strict=True):
+        for idx, (srv, client) in enumerate(zip(self._servers, self._clients, strict=True)):
             try:
+                await self._ensure_sso_token(idx)
                 detail = await self._get_detail_from(client, namespace, name, version)
                 logger.debug(
                     "get_version_detail %s.%s:%s from %s",
@@ -218,8 +412,8 @@ class GalaxyClient:
                     version,
                     srv.label(),
                 )
-                return detail
-            except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+                return detail, idx
+            except (httpx.HTTPStatusError, httpx.RequestError, ValueError, RuntimeError) as exc:
                 logger.debug(
                     "get_version_detail %s.%s:%s: %s failed: %s",
                     namespace,
@@ -231,29 +425,37 @@ class GalaxyClient:
                 last_exc = exc
         raise last_exc or RuntimeError("No Galaxy servers configured")
 
-    async def download_tarball(self, download_url: str) -> bytes:
+    async def download_tarball(self, download_url: str, *, _server_idx: int | None = None) -> bytes:
         """Download a collection tarball by its absolute URL.
-
-        Uses a dedicated client without a base_url so it can follow the
-        download URL returned by any upstream server.
 
         Args:
             download_url: Full URL to the tarball resource.
+            _server_idx: Internal — index of the server that provided the URL.
+                When set, the server's auth headers are forwarded to the
+                download request (required by Automation Hub).
 
         Returns:
             Raw tarball bytes.
         """
-        resp = await self._download_client.get(download_url)
+        headers: dict[str, str] = {}
+        if _server_idx is not None:
+            auth = self._clients[_server_idx].headers.get("Authorization")
+            if auth:
+                headers["Authorization"] = auth
+        resp = await self._download_client.get(download_url, headers=headers)
         resp.raise_for_status()
         return resp.content  # type: ignore[no-any-return]
 
-    async def get_version_and_download(
+    async def fetch_collection(
         self,
         namespace: str,
         name: str,
         version: str,
     ) -> tuple[CollectionVersion, bytes]:
-        """Fetch version metadata and download the tarball in sequence.
+        """Fetch version metadata and download the tarball.
+
+        Convenience method that calls ``get_version_detail`` then
+        ``download_tarball``.
 
         Args:
             namespace: Collection namespace.
@@ -263,52 +465,86 @@ class GalaxyClient:
         Returns:
             Tuple of version metadata and tarball bytes.
         """
-        detail = await self.get_version_detail(namespace, name, version)
-        tarball = await self.download_tarball(detail.download_url)
+        detail, server_idx = await self._get_version_detail_with_idx(namespace, name, version)
+        tarball = await self.download_tarball(detail.download_url, _server_idx=server_idx)
         return detail, tarball
 
     # ── internal per-client helpers ──────────────────────────────────
 
-    @staticmethod
     async def _list_versions_from(
+        self,
         client: httpx.AsyncClient,
         namespace: str,
         name: str,
     ) -> list[str]:
-        versions: list[str] = []
+        """List versions from a single upstream server.
+
+        Args:
+            client: The httpx client for this server.
+            namespace: Collection namespace.
+            name: Collection name.
+
+        Returns:
+            List of version strings (sorted descending if API provides order).
+
+        Raises:
+            httpx.HTTPStatusError: On non-2xx response.
+            httpx.RequestError: On connection error.
+        """  # noqa: DOC502
         url = f"{COLLECTIONS_PATH}/{namespace}/{name}/versions/"
-        params: dict[str, str | int] = {"limit": 100, "offset": 0}
+        versions: list[str] = []
+        params: dict[str, int] | None = {"limit": 100}
         while True:
             resp = await client.get(url, params=params)
             resp.raise_for_status()
-            payload = resp.json()
-            for entry in payload.get("data", []):
-                versions.append(entry["version"])
-            if not payload.get("links", {}).get("next"):
+            data = resp.json()
+            for item in data.get("data", []):
+                v = item.get("version")
+                if v:
+                    versions.append(v)
+            links = data.get("links") or {}
+            next_url = links.get("next")
+            if not next_url:
                 break
-            params["offset"] = int(params["offset"]) + int(params["limit"])
+            url = next_url
+            params = None
         return versions
 
-    @staticmethod
     async def _get_detail_from(
+        self,
         client: httpx.AsyncClient,
         namespace: str,
         name: str,
         version: str,
     ) -> CollectionVersion:
+        """Fetch version detail from a single upstream server.
+
+        Args:
+            client: The httpx client for this server.
+            namespace: Collection namespace.
+            name: Collection name.
+            version: Collection version string.
+
+        Returns:
+            Parsed ``CollectionVersion``.
+
+        Raises:
+            httpx.HTTPStatusError: On non-2xx response.
+            httpx.RequestError: On connection error.
+            ValueError: If the response is missing download_url.
+        """  # noqa: DOC502, DOC503
         url = f"{COLLECTIONS_PATH}/{namespace}/{name}/versions/{version}/"
         resp = await client.get(url)
         resp.raise_for_status()
         data = resp.json()
-        meta = data.get("metadata", {})
+        download_url = data.get("download_url")
+        if not download_url:
+            raise ValueError(f"Collection {namespace}.{name}:{version} response missing download_url")
         return CollectionVersion(
             namespace=namespace,
             name=name,
             version=version,
-            download_url=data["download_url"],
-            dependencies=meta.get("dependencies", {}),
-            requires_ansible=data.get("requires_ansible"),
-            license=meta.get("license", []),
-            authors=meta.get("authors", []),
-            description=meta.get("description", ""),
+            download_url=download_url,
+            dependencies=data.get("metadata", {}).get("dependencies", {}),
+            description=data.get("metadata", {}).get("description", ""),
         )

--- a/src/galaxy_proxy/metadata.py
+++ b/src/galaxy_proxy/metadata.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import csv
 import hashlib
 import io
+import re
 from typing import TYPE_CHECKING, Any
 
 from galaxy_proxy.naming import fqcn_to_python
+
+_INLINE_COMMENT_RE = re.compile(r"\s+#.*$")
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -87,6 +90,9 @@ def galaxy_to_metadata_with_python_deps(
     for line in requirements_txt.splitlines():
         line = line.strip()
         if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        line = _INLINE_COMMENT_RE.sub("", line).strip()
+        if not line:
             continue
         extra_lines.append(f"Requires-Dist: {line}")
 

--- a/src/galaxy_proxy/naming.py
+++ b/src/galaxy_proxy/naming.py
@@ -36,10 +36,16 @@ def fqcn_to_python(fqcn: str) -> str:
 def python_to_fqcn(package_name: str) -> tuple[str, str]:
     """Convert a Python package name back to (namespace, name).
 
+    PEP 503 normalization collapses ``_`` to ``-``, but Galaxy names only
+    use ``[a-z0-9_]`` (no hyphens).  After splitting, hyphens in both
+    namespace and name are converted back to underscores.
+
     >>> python_to_fqcn("ansible-collection-ansible-utils")
     ('ansible', 'utils')
     >>> python_to_fqcn("ansible_collection_community_general")
     ('community', 'general')
+    >>> python_to_fqcn("ansible-collection-infra-aap-configuration")
+    ('infra', 'aap_configuration')
 
     Args:
         package_name: Python package name (normalized per PEP 503).
@@ -60,7 +66,7 @@ def python_to_fqcn(package_name: str) -> tuple[str, str]:
     if len(parts) != 2:
         msg = f"Cannot extract namespace and name from {package_name!r}"
         raise ValueError(msg)
-    return parts[0], parts[1]
+    return parts[0].replace("-", "_"), parts[1].replace("-", "_")
 
 
 def is_collection_package(package_name: str) -> bool:

--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -199,7 +199,7 @@ def create_app(
         )
 
         try:
-            _detail, tarball_data = await galaxy.get_version_and_download(ns, coll_name, version)
+            _detail, tarball_data = await galaxy.fetch_collection(ns, coll_name, version)
         except Exception as exc:
             logger.exception("Failed to fetch %s.%s %s from Galaxy", ns, coll_name, version)
             raise HTTPException(


### PR DESCRIPTION
  ## Summary
  - Add multi-server Galaxy configuration with per-server auth (ansible.cfg-style)
  - Support Red Hat SSO/offline-token exchange for Automation Hub (console.redhat.com)
  - Normalize API root paths and forward auth headers for tarball downloads
  ## Changes
  - **galaxy_client.py**: SSO token exchange via `_SSOState`, normalized API root paths, auth header forwarding
  - **cli.py**: `_servers_from_env()` parses `GALAXY_SERVER_LIST` environment variables
  - **up.sh**: Sources root `.env`, dynamically injects per-server vars into pod spec
  - **pod.yaml**: Adds `GALAXY_URL/TOKEN/SERVER_LIST` env vars to proxy container
  - **DEPLOYMENT.md**: Documents multi-server configuration with examples
  ## Known Issue
  `ansible.eda` collection fails to install due to missing `pkg-config` in the container image. The `systemd-python` dependency attempts to call `pkg-config` during build. Other certified collections work correctly. This is a container image 
  dependency issue — may require adding `pkgconf` to the base image.
  ## Test plan
  - [x] prek run --all-files passes
  - [ ] Multi-server fallback: first server returning a result wins
  - [ ] SSO token exchange: offline token -> access token for Automation Hub
  - [ ] Auth header forwarding: tarball downloads use correct server auth
  - [ ] Legacy single-server config still works