### PR TITLE
docs(adr): update ADR-045 — global server defs, 3-PR implementation plan

### DIFF
--- a/.sdlc/adrs/ADR-045-galaxy-auth-delegation.md
+++ b/.sdlc/adrs/ADR-045-galaxy-auth-delegation.md
@@ -86,15 +86,18 @@ Galaxy server configuration flows as scan metadata:
 CLI (reads ansible.cfg)  ──► gRPC ScanOptions.galaxy_servers ──► Primary
 UI  (global server defs) ──► Gateway ──► gRPC ScanOptions     ──► Primary
                                                                      │
-                                            Primary writes temp ansible.cfg
-                                            ansible-galaxy collection download
-                                                     │
-                                              tarballs on disk
-                                                     │
-                                              Proxy: tarball → wheel
-                                              PEP 503 serving
-                                                     │
-                                              pip/uv install wheel
+                                                          galaxy_servers + collection specs
+                                                                     │
+                                                                     ▼
+                                                               Galaxy Proxy
+                                                          writes temp ansible.cfg
+                                                     ansible-galaxy collection download
+                                                                     │
+                                                              tarballs on disk
+                                                              tarball → wheel
+                                                              PEP 503 serving
+                                                                     │
+                                                              pip/uv install wheel
 ```
 
 ## Alternatives Considered


### PR DESCRIPTION
## Summary
- Incorporates review feedback on ADR-045 (Galaxy auth delegation) from architectural discussion.

## Changes
- **Global, not per-project**: Galaxy server defs in the UI are global — the proxy's wheel cache is collection-scoped, so per-project credentials would create cache coherence issues and require credential-scoped cache namespaces. Updated forces, flow diagram, consequences, and implementation notes.
- **3-PR implementation plan**: Replaced the 3-phase plan with 3 concrete PRs: (1) proxy API-to-CLI switch, (2) CLI + proto plumbing, (3) Gateway + UI global server management. Each is independently reviewable and deployable in order.
- **Diagram fix**: Updated data-flow diagram to show Primary forwarding `galaxy_servers` to the proxy (which runs `ansible-galaxy collection download`), consistent with invariant 11 and the preferred architecture.
- **Revision history**: Recorded design decisions with rationale.

## Test plan
- [x] `prek run --all-files` passes
- [ ] ADR reviewed for internal consistency after edits