### PR TITLE
docs(adr): SBOM as Gateway view, extend ProjectManifest, CLI→REST future

### DIFF
--- a/.sdlc/adrs/ADR-024-thin-cli-daemon-mode.md
+++ b/.sdlc/adrs/ADR-024-thin-cli-daemon-mode.md
@@ -320,7 +320,7 @@ Primary:
 |-----------|-------------|-------------|
 | `sbom` | (not implemented) | CLI → Gateway REST (`GET /api/v1/projects/{id}/sbom?format=cyclonedx`) |
 | `health-check` | CLI → gRPC Health probes | CLI → Gateway REST (aggregated health) |
-| `session list/info` | CLI → gRPC Primary | CLI → Gateway REST (persisted session data) |
+| `session list/info` | (not implemented) | CLI → Gateway REST (persisted session data) |
 
 Streaming operations (`check`, `remediate`) that require real-time progress
 and bidirectional interaction stay on gRPC to Primary (via `FixSession`).

--- a/.sdlc/adrs/ADR-040-scan-metadata-enrichment.md
+++ b/.sdlc/adrs/ADR-040-scan-metadata-enrichment.md
@@ -48,7 +48,7 @@ message CollectionRef {
   string version = 2;        // e.g. "8.0.0"
   string source = 3;         // "specified", "learned", or "dependency"
   string license = 4;        // SPDX identifier or free-text (from MANIFEST.json / galaxy.yml)
-  string supplier = 5;       // author or namespace (from galaxy.yml authors / namespace)
+  string supplier = 5;       // namespace (e.g. "community", "ansible"); from galaxy.yml namespace field
 }
 
 message PythonPackageRef {
@@ -198,9 +198,11 @@ Remaining work:
 1. Extend `list_installed_packages` — replace the `pip list` subprocess with
    `importlib.metadata` run in the venv's Python. One subprocess, returns
    name, version, license, and author in a single pass.
-2. Extend `list_installed_collections` — read `license` and `supplier` from
-   each collection's `MANIFEST.json` / `galaxy.yml` (already walking the
-   collection dirs).
+2. Extend `list_installed_collections` — after `ansible-galaxy collection list`
+   returns `(fqcn, version)` pairs, walk the collection install paths to read
+   `license` and `supplier` from each collection's `MANIFEST.json` /
+   `galaxy.yml`. This is new filesystem access — the current function only
+   parses the JSON output from `ansible-galaxy`.
 3. Update `_build_manifest` to populate the new `license`/`supplier` proto fields.
 
 ### Gateway changes


### PR DESCRIPTION
## Summary

- **ADR-040**: Extend `ProjectManifest` with `license` and `supplier` fields on `CollectionRef` and `PythonPackageRef`. Position SBOM generation as a derivative view — CycloneDX serialization is a Gateway concern, not engine. Defer roles to ADR-044 (ContentGraph). Add 3-PR implementation plan and SBOM REST endpoint specification.
- **ADR-024**: Add "Future Direction" section documenting the planned CLI → Gateway REST migration for read-heavy operations. `apme sbom` is the first case.
- These updates are the architectural groundwork for PR #133 (SBOM generation), providing clear guidance on where each piece of that work should land.

## Context

Contributor PR #133 proposes SBOM generation as a standalone engine RPC with direct CycloneDX output. After review, we've aligned the approach with ADR-040's `ProjectManifest` vision: the manifest **is** the SBOM data, and CycloneDX/SPDX/CSV are presentation formats owned by the Gateway.

### 3-PR implementation plan

1. **Engine + Proto**: Hydrate `ProjectManifest` with license/supplier data using PR #133's collectors
2. **Gateway**: DB schema, persist manifests via `ReportingServicer`, `GET /api/v1/projects/{id}/sbom?format=cyclonedx`
3. **CLI**: `apme sbom` calls Gateway REST (first CLI subcommand using REST instead of gRPC)

## Test plan

- [ ] `prek run --all-files` passes (ADR index regenerated)
- [ ] ADR-040 proto sketch includes `license` and `supplier` on both ref types
- [ ] SBOM section clearly positions serialization as Gateway-owned
- [ ] ADR-024 future direction table distinguishes streaming (gRPC) from read-heavy (REST)
- [ ] Cross-references between ADR-040, ADR-024, ADR-044, and DR-002 are consistent


Made with [Cursor](https://cursor.com)