### PR TITLE
Add deployment analysis ADRs (046-050)

### DIFF
--- a/.sdlc/adrs/ADR-046-single-process-core.md
+++ b/.sdlc/adrs/ADR-046-single-process-core.md
@@ -1,0 +1,171 @@
+# ADR-046: Single-Process Core Architecture
+
+## Status
+
+Proposed
+
+## Date
+
+2026-03-30
+
+## Context
+
+APME currently deploys as 6-8 containers in a Podman pod (ADR-004), with gRPC communication between all services (ADR-001). This architecture was appropriate when APME was a standalone tool. The deployment landscape has since expanded to include:
+
+1. **RHEL bootc appliance** — a single-VM appliance running the Ansible self-service portal as Podman Quadlet systemd services. Adding 7 containers for APME (Primary, Native, OPA, Ansible, Gitleaks, Galaxy Proxy, Gateway) to a single-node appliance that already runs 3 containers (portal, PostgreSQL, devtools) is disproportionate. Total memory for APME alone: ~3.5GB (7 × 512MB). Total pre-pulled images: ~2GB added to the bootc image.
+
+2. **OpenShift sidecar** — the portal runs in a RHDH pod. APME should fit as one sidecar container, like the existing ansible-devtools-server on port 8000. Adding 7 containers to the RHDH pod is not viable.
+
+3. **CI/CD pipelines** — GitHub Actions, Tekton, Jenkins need a single container that runs `apme check .` and exits. Pod orchestration in a CI step is unjustifiable overhead.
+
+4. **Developer workstation** — `pip install apme && apme check .` already works via daemon mode (ADR-024), which runs Primary + Native + OPA + Ansible + Galaxy Proxy in a single process. This proves the architecture can function in-process.
+
+### The daemon mode precedent
+
+ADR-024 implemented daemon mode: all core services run in one process on the developer's machine. Native rules are called in-process. OPA binary is invoked as a subprocess. The Ansible validator runs in-process with subprocess calls to `ansible-doc`. Galaxy Proxy runs as an in-process HTTP server.
+
+This already demonstrates that the multi-container architecture is a deployment choice, not an architectural requirement. The services share no mutable state between them — each receives a `ValidateRequest` and returns a `ValidateResponse`. The Validator Protocol can be satisfied by a function call as easily as a gRPC call.
+
+### What the multi-container model costs
+
+Per ARCHITECTURE.md, the current model requires:
+- 5 Containerfiles + build scripts
+- Proto compilation and stub generation (`scripts/gen_grpc.sh`)
+- `jsonpickle.encode()` for scandata serialization (fragile, version-coupled)
+- `json.dumps()` for hierarchy_payload serialization
+- Session volume mounts (`/sessions`) for venv sharing between Primary and Ansible
+- Health check coordination across 5+ containers
+- Port allocation and management (50051, 50053, 50054, 50055, 50056, 8765)
+
+Per DATA_FLOW.md, serialization boundaries exist solely because data crosses process boundaries:
+- hierarchy_payload: Python dict → `json.dumps()` → bytes → gRPC → bytes → `json.loads()` → Python dict
+- scandata: SingleScan object → `jsonpickle.encode()` → bytes → gRPC → bytes → `jsonpickle.decode()` → SingleScan object
+
+In a single-process model, these serialization round-trips disappear. The engine produces a Python object; validators consume it directly.
+
+### Decision drivers
+
+- Bootc appliance: 1 container is acceptable, 7 is not
+- OpenShift sidecar: 1 container is a natural fit, 7 containers in the RHDH pod is not
+- CI/CD: single container image with CLI entrypoint
+- Daemon mode (ADR-024) proves single-process viability
+- jsonpickle serialization is the most fragile boundary — removing it improves reliability
+- OPA and Gitleaks are external binaries — subprocess is the natural interface, not gRPC wrapping
+- Abbenay AI is a genuinely external service — gRPC to it is correct and unchanged
+
+## Decision
+
+**APME's core will run as a single process.** The engine, native rules, formatter, and remediation engine execute in-process. OPA and Gitleaks run as subprocesses within the same process (no gRPC wrapping). External services (Abbenay AI, PostgreSQL) retain their network protocols (gRPC, SQL).
+
+### Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│  apme (single process)                               │
+│                                                      │
+│  Engine (parse → annotate → hierarchy)               │
+│    │                                                 │
+│    ├── Native rules (in-process, library call)       │
+│    ├── OPA rules (subprocess: opa eval, batch)       │
+│    ├── Gitleaks (subprocess: gitleaks detect)         │
+│    └── Ansible checks (in-process + optional         │
+│        ansible-doc subprocess)                       │
+│                                                      │
+│  Remediation (Tier 1 transforms in-process)          │
+│  Formatter (in-process)                              │
+│  Server layer (optional: FastAPI REST API)           │
+│                                                      │
+│  External (network):                                 │
+│  └── Abbenay AI (:50057, gRPC — unchanged)           │
+└──────────────────────────────────────────────────────┘
+```
+
+### Validator interface preserved
+
+The `Validator` Protocol from DESIGN_VALIDATORS.md is preserved as a Python Protocol (not gRPC service). Each validator implements the same `validate(request) → response` interface. The engine calls validators via `asyncio.gather()` for the same parallel fan-out behavior documented in ARCHITECTURE.md:
+
+```python
+native_result, opa_result, gitleaks_result = await asyncio.gather(
+    asyncio.to_thread(native_validator.validate, request),   # CPU-bound
+    opa_validator.validate(request),                          # subprocess, async
+    gitleaks_validator.validate(request),                     # subprocess, async
+)
+```
+
+Wall-clock time remains `max(native, opa, gitleaks)`, consistent with ARCHITECTURE.md's parallel fan-out guarantee. The Ansible validator's checks are absorbed: M001-M004 use pre-built data files (ADR-048); L057-L059 are optional subprocess calls when ansible-core is available.
+
+### What remains external (gRPC/network)
+
+- **Abbenay AI** — external daemon, gRPC (ADR-025 unchanged)
+- **PostgreSQL** — when used for persistence in server mode
+- **Future plugin services** — ADR-042's third-party plugins use gRPC (external processes)
+
+gRPC is retained as the **extensibility protocol** for external services, not for internal validator communication.
+
+## Alternatives Considered
+
+### Alternative 1: Keep multi-container architecture, add daemon mode for lightweight deployments
+
+**Pros**: No changes to existing code. Daemon mode already works.
+
+**Cons**: Daemon mode is a second-class path — it lacks Gitleaks, Gateway, and UI. Maintaining two architectures (pod + daemon) doubles the test surface. The pod model doesn't fit bootc or OpenShift sidecar without major compromises.
+
+**Why not chosen**: Two deployment models with different capabilities is worse than one model that works everywhere.
+
+### Alternative 2: Single container with internal gRPC (all services in one container, localhost gRPC)
+
+**Pros**: One container image. gRPC contracts unchanged.
+
+**Cons**: Still has serialization overhead (jsonpickle, JSON round-trips). Still requires port management within the container. More complex than direct function calls for in-process communication.
+
+**Why not chosen**: If everything runs in one process, gRPC between in-process components adds overhead with no benefit. The Validator Protocol can be a Python interface.
+
+## Consequences
+
+### Positive
+
+- One container image serves all deployment targets (bootc, OpenShift sidecar, CI/CD, workstation)
+- jsonpickle serialization eliminated (fragile, version-coupled)
+- No port allocation for internal services
+- No health check coordination between containers
+- Reduced memory footprint (~256MB vs ~3.5GB for full pod)
+- Reduced container image size (~200MB vs ~2GB for 7 images)
+- Faster cold start (1 process vs 7 containers)
+- Validator Protocol preserved as testable Python interface
+
+### Negative
+
+- Lose process isolation between validators (a bug in one validator can crash the process)
+- OPA binary and Gitleaks binary must be bundled in the container image
+- Cannot independently scale individual validators (mitigated: scale by adding worker processes)
+
+### Neutral
+
+- Rule implementations unchanged (same Python code, same Rego files)
+- Transform implementations unchanged
+- Formatter unchanged
+- AI escalation unchanged (Abbenay remains external gRPC)
+- gRPC retained for external services and future plugins
+
+## Supersedes
+
+- ADR-001 (gRPC communication) — for internal validator communication only. gRPC retained for external services.
+- ADR-004 (Podman pod deployment) — as the sole deployment model. Pod deployment remains available for users who prefer process isolation.
+- ADR-005 (No service discovery) — no longer needed when all validators are in-process.
+
+## Related Decisions
+
+- [ADR-024](ADR-024-thin-cli-daemon-mode.md): Daemon mode — the precedent for single-process execution
+- [ADR-007](ADR-007-async-grpc-servers.md): Async servers — asyncio.gather() preserved for parallel fan-out
+- [ADR-009](ADR-009-remediation-engine.md): Validators read-only — separation of detection and remediation preserved
+- [ADR-012](ADR-012-scale-pods-not-services.md): Scale pods — workers are scaled units (one process each)
+- [ADR-025](ADR-025-ai-provider-protocol.md): AI provider — Abbenay gRPC unchanged
+- [ADR-042](ADR-042-third-party-plugin-services.md): Third-party plugins — gRPC for external plugin services
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-30 | Claude (proposal) | Initial proposal based on deployment target analysis |

--- a/.sdlc/adrs/ADR-047-deployment-modes.md
+++ b/.sdlc/adrs/ADR-047-deployment-modes.md
@@ -1,0 +1,192 @@
+# ADR-047: Deployment Modes
+
+## Status
+
+Proposed
+
+## Date
+
+2026-03-30
+
+## Context
+
+APME must serve four deployment targets from a single container image:
+
+1. **RHEL bootc appliance** — Podman Quadlet systemd service alongside the Ansible self-service portal. Single-node VM, air-gapped ready, pre-pulled images. Follows the same pattern as `portal-devtools.container` (port 8000). APME runs as `portal-apme.container` with REST API for portal integration.
+
+2. **OpenShift** — sidecar in the RHDH pod (Helm chart `extraContainers`), plus optional KEDA-scaled worker Deployment for batch scanning of cataloged collections (3000+ async).
+
+3. **CI/CD pipelines** — single container, CLI entrypoint, runs `apme check .` and outputs SARIF/JUnit/JSON. Must cold-start in <2 seconds (no venv creation, no service orchestration).
+
+4. **Developer workstation** — `pip install apme && apme check .`. No containers required. Interactive remediation with AI approval flow.
+
+ADR-024 (daemon mode) established the precedent for running APME as a single process. ADR-046 (single-process core) formalizes this as the primary architecture. This ADR defines the entrypoints and deployment patterns.
+
+### Async batch scanning
+
+The portal catalogs Ansible collections via `AnsibleGitContentsProvider` (Git repos) and `PAHCollectionProvider` (Automation Hub). When collections are cataloged, they should be scanned by APME for quality, security, and migration readiness. At scale, this means scanning 3000+ collections asynchronously.
+
+This is a **batch processing** problem, not a real-time problem. Each scan is completely independent. The current architecture has no built-in queue — scaling requires external orchestration regardless of whether APME uses gRPC pods or single processes.
+
+### PostgreSQL as queue
+
+The portal already deploys PostgreSQL (both in bootc and OpenShift). Using `SELECT FOR UPDATE SKIP LOCKED` as a work queue avoids adding Redis, RabbitMQ, or Celery infrastructure. This pattern is battle-tested at scale (Stripe, GitHub).
+
+## Decision
+
+**One container image, four entrypoints.** The same image serves all deployment targets by varying the command:
+
+| Entrypoint | Mode | Use case |
+|---|---|---|
+| `apme check .` | CLI | Developer workstation, CI/CD |
+| `apme fix .` | CLI | Developer workstation, CI/CD |
+| `apme format .` | CLI | Developer workstation, CI/CD |
+| `apme-server --port 8090` | REST API server | Bootc sidecar, OpenShift sidecar |
+| `apme-worker --db postgresql://...` | Queue worker | OpenShift batch scanning |
+
+### Mode 1: CLI
+
+Unchanged from today. `apme check`, `apme fix`, `apme format` with stdout/JSON/SARIF/JUnit output. Process starts, scans, prints results, exits.
+
+### Mode 2: Server (REST API)
+
+FastAPI application providing:
+
+```
+POST   /api/v1/scans/async           Queue async scan (returns scan_id)
+GET    /api/v1/scans/{scan_id}       Poll status and results
+POST   /api/v1/check                  Synchronous check (for small projects)
+GET    /api/v1/entities/{ref}/quality Quality summary for catalog entity
+WS     /api/v1/scans/{id}/stream     Real-time progress (WebSocket)
+GET    /health                        Health check
+```
+
+Persistence: PostgreSQL (shared with portal, separate schema) or SQLite (standalone).
+
+This extends Gateway (ADR-029) and implements Public Data API (ADR-038). In bootc/OpenShift sidecar mode, the server IS the gateway — there's no separate Gateway container.
+
+### Mode 3: Worker
+
+Background process that:
+1. Connects to PostgreSQL scan_queue table
+2. Claims pending jobs (`SELECT FOR UPDATE SKIP LOCKED`)
+3. Clones repo, runs `apme.check()` (in-process)
+4. Stores results in PostgreSQL
+5. Loops to next job
+
+Workers are stateless and horizontally scalable. In OpenShift, KEDA ScaledObject scales workers 0→N based on queue depth, and back to 0 when idle.
+
+### Bootc deployment
+
+One quadlet file:
+
+```ini
+[Container]
+Image=registry.redhat.io/aap/apme-rhel9:latest
+ContainerName=portal-apme
+Network=portal-network
+PublishPort=127.0.0.1:8090:8090
+Exec=apme-server --port 8090 --db postgresql://portal-postgres:5432/apme
+
+[Service]
+Restart=always
+After=postgres.service
+ConditionPathExists=/etc/portal/.setup-complete
+```
+
+### OpenShift deployment
+
+Sidecar in RHDH pod (Helm chart values.yaml):
+
+```yaml
+extraContainers:
+  - name: apme-server
+    image: registry.redhat.io/aap/apme-rhel9:latest
+    command: ["apme-server", "--port", "8090"]
+    ports: [{containerPort: 8090}]
+```
+
+Workers for batch scanning (separate Deployment):
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: apme-worker
+spec:
+  replicas: 0  # KEDA controls
+  template:
+    spec:
+      containers:
+        - name: worker
+          image: registry.redhat.io/aap/apme-rhel9:latest
+          command: ["apme-worker", "--db", "postgresql://..."]
+```
+
+### Container contents
+
+```
+/usr/bin/apme              CLI entrypoint
+/usr/bin/apme-server       REST API server (uvicorn + FastAPI)
+/usr/bin/apme-worker       Queue worker
+/usr/bin/opa               OPA binary (~50MB, static)
+/usr/bin/gitleaks          Gitleaks binary (~15MB, static)
+/data/ansible-core/        Pre-built module metadata (ADR-048)
+/opt/apme/                 Python library + rules + Rego bundle
+```
+
+## Alternatives Considered
+
+### Alternative 1: Separate images per deployment target
+
+**Pros**: Smaller images (CLI image doesn't need FastAPI). Targeted optimization.
+
+**Cons**: Multiple build pipelines, multiple registries, version drift between images. More moving parts for users.
+
+**Why not chosen**: One image is simpler to build, test, distribute, and version. The overhead of bundling FastAPI + uvicorn (~5MB) in CLI-only deployments is negligible.
+
+### Alternative 2: Celery + Redis for async scanning
+
+**Pros**: Mature, well-documented, rich ecosystem.
+
+**Cons**: Requires Redis deployment (new infrastructure). Redis persistence needs configuration for durability. Another StatefulSet in OpenShift, another container in bootc.
+
+**Why not chosen**: PostgreSQL is already deployed for the portal. `SELECT FOR UPDATE SKIP LOCKED` provides exactly-once delivery without additional infrastructure.
+
+## Consequences
+
+### Positive
+
+- One container image for all targets
+- Bootc: 1 quadlet file instead of 7
+- OpenShift: 1 sidecar + optional worker Deployment
+- CI/CD: `apme check .` with <2s cold start
+- Async batch scanning without new infrastructure (PostgreSQL queue)
+- KEDA scales workers to 0 when idle (zero cost)
+
+### Negative
+
+- FastAPI bundled in CLI image (minor size increase)
+- Worker mode requires PostgreSQL access
+- KEDA dependency for auto-scaling in OpenShift
+
+### Neutral
+
+- CLI behavior unchanged
+- AI escalation unchanged (Abbenay external)
+- Rule implementations unchanged
+
+## Related Decisions
+
+- [ADR-024](ADR-024-thin-cli-daemon-mode.md): Daemon mode — precedent for single-process execution
+- [ADR-029](ADR-029-web-gateway-architecture.md): Gateway — server mode absorbs Gateway's role
+- [ADR-038](ADR-038-public-data-api.md): Public data API — server mode implements this
+- [ADR-046](ADR-046-single-process-core.md): Single-process core — architectural foundation
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-30 | Claude (proposal) | Initial proposal |

--- a/.sdlc/adrs/ADR-048-pre-built-module-metadata.md
+++ b/.sdlc/adrs/ADR-048-pre-built-module-metadata.md
@@ -1,0 +1,195 @@
+# ADR-048: Pre-Built Module Metadata (Lite Mode)
+
+## Status
+
+Proposed
+
+## Date
+
+2026-03-30
+
+## Context
+
+APME's Ansible validator (M001-M004) detects module FQCN resolution, deprecation, redirects, and removals by running actual ansible-core plugin introspection inside session-scoped virtual environments (ADR-022). This requires:
+
+1. **VenvSessionManager** to create/manage per-session, per-ansible-core-version venvs
+2. **Galaxy Proxy** (ADR-031) to convert Galaxy tarballs to pip wheels (PEP 503/427)
+3. **Collection installation** via `uv pip install` into the venv
+4. **`find_plugin_with_context()`** calls against the installed ansible-core
+
+Per DEPLOYMENT.md, cold start (first scan with a new session) involves creating a venv and installing ansible-core + collections. This takes 30-60 seconds before the first rule runs. Per DESIGN_VALIDATORS.md, only 4 rules (M001-M004) and 3 rules (L057-L059) require this infrastructure.
+
+### Where this hurts
+
+1. **CI/CD pipelines**: A 30-60 second cold start for venv creation is unacceptable for PR gate checks. CI jobs should start scanning in <2 seconds.
+
+2. **Batch scanning (3000 collections)**: Each worker creating its own venv multiplies the cold-start penalty. 100 workers × 30s = 50 minutes wasted on venv creation.
+
+3. **90% of scans don't need custom collection modules**: Most M001-M004 violations involve `ansible.builtin.*` modules (shipped with ansible-core) and well-known collections (`community.general`, `ansible.posix`, `ansible.netcommon`). The argspec data for these is static per ansible-core version.
+
+### Content delivery: portal as the content broker
+
+The portal catalogs Ansible collections from multiple sources — Git repositories (GitHub/GitLab via `AnsibleGitContentsProvider`) and Automation Hub (`PAHCollectionProvider`). The portal already authenticates to these sources and maintains entity metadata including SCM coordinates, refs, and collection namespaces.
+
+For APME scanning, the portal — not APME — is the natural content broker:
+
+- **From Git**: The portal knows the SCM provider, organization, repository, ref, and `galaxy.yml` path (stored as `ansible.io/scm-*` annotations on catalog entities). The portal can construct archive download URLs (`https://github.com/{owner}/{repo}/archive/{ref}.tar.gz`) or clone repos directly. APME does not need independent SCM access.
+- **From Automation Hub (PAH)**: The portal queries PAH's `/api/galaxy/v3/` API for collection metadata and has authenticated access. PAH serves collection tarballs that the portal can proxy to APME.
+- **Air-gapped (bootc)**: In disconnected environments, the portal still has access to whatever content sources the operator configured (internal GitLab, on-prem Automation Hub). The portal downloads collection content from those sources and passes it to APME. APME itself does not need network access to content sources — the portal mediates.
+
+This means APME's scan API should accept **content directly** (uploaded files or a local path), not just a `repo_url` for APME to clone. The portal fetches the content and passes it to APME:
+
+```
+Portal discovers collection in catalog
+  → Portal downloads content from SCM or PAH (portal has auth)
+  → Portal sends content to APME via POST /api/v1/check (multipart upload)
+     or writes to shared workspace and calls APME with path
+  → APME scans content, returns violations
+  → Portal stores results and displays in UI
+```
+
+This is cleaner than APME independently cloning repos because:
+- APME does not need SCM tokens or PAH credentials (separation of secrets)
+- The portal already has authenticated access to all content sources
+- Air-gapped environments work without APME needing network access
+- Content is fetched once by the portal, not duplicated by each APME worker
+
+### Precedent in RESEARCH_REVIEW.md
+
+RESEARCH_REVIEW.md identifies `module_metadata.json` as valuable future work: *"machine-readable module lifecycle data (introduced, deprecated, removed, parameter renames) generated from `ansible-doc` across core versions."* This ADR implements that vision.
+
+### What the migration rules actually need
+
+Per the comprehensive rule analysis:
+
+- **M005-M030** (10 rules): 100% static text/regex/syntax analysis. Zero ansible-core dependency. These rules work today without venvs.
+- **M001-M004** (4 rules): Need module metadata (FQCN mapping, deprecated flag, redirect target, removed flag). This data CAN come from pre-built files instead of runtime introspection — for ansible.builtin and well-known collections.
+- **L057** (syntax check): Needs `ansible-playbook --syntax-check`. Genuinely requires ansible-core.
+- **L058-L059** (argspec validation): Need module argument specs. Require ansible-core for custom modules, but can use pre-built data for known modules.
+
+## Decision
+
+**Ship pre-built module metadata as versioned JSON data files, bundled in the package and container image.** M001-M004 use data files by default (lite mode). Full ansible-core introspection is available via `--with-ansible-runtime` flag.
+
+### Data files
+
+```
+data/ansible-core/
+  2.16/
+    modules.json        # {module_fqcn: {short_name, deprecated, removed, redirect_to, ...}}
+    redirects.json      # {old_fqcn: new_fqcn}
+    removed.json        # [removed_fqcn, ...]
+  2.17/
+    modules.json
+    redirects.json
+    removed.json
+  2.18/
+    ...
+  2.19/
+    ...
+```
+
+Generated by extending the existing `scripts/scrape_ansible_deprecations.py` to output full module metadata per ansible-core version. Data files are ~2-5MB per version, covering `ansible.builtin.*` plus the 20 most common collections.
+
+### Two modes
+
+| Mode | Flag | M001-M004 source | L057-L059 | Cold start | Requires |
+|------|------|---|---|---|---|
+| **Lite** (default) | (none) | Pre-built data files | Skipped | <2s | Data files only |
+| **Full** | `--with-ansible-runtime` | ansible-core plugin loader | Enabled | 30-60s | ansible-core installed or venv |
+
+### Lite mode behavior
+
+```python
+# M001: FQCN resolution
+module_data = load_module_data(target_version)
+short_name = task.module  # e.g., "shell"
+if short_name in module_data.short_to_fqcn:
+    fqcn = module_data.short_to_fqcn[short_name]
+    yield Violation("M001", f"Use FQCN: {fqcn}", metadata={"resolved_fqcn": fqcn})
+
+# M002: Deprecated module
+if task.module in module_data.deprecated:
+    yield Violation("M002", f"Module {task.module} is deprecated")
+
+# M003: Redirected module
+if task.module in module_data.redirects:
+    yield Violation("M003", f"Module redirected to {module_data.redirects[task.module]}")
+
+# M004: Removed module
+if task.module in module_data.removed:
+    yield Violation("M004", f"Module {task.module} has been removed")
+```
+
+### Full mode behavior
+
+Unchanged from today: VenvSessionManager creates venv, installs ansible-core + collections, runs `find_plugin_with_context()`. This is the authoritative source for custom collection modules not in the data files.
+
+### Unknown modules in lite mode
+
+If a module is not found in the data files (custom collection module), lite mode:
+- Does NOT flag M001-M004 violations (no false positives from missing data)
+- Emits an INFO-level note: "Module X not in pre-built data; use --with-ansible-runtime for full validation"
+
+## Alternatives Considered
+
+### Alternative 1: Always require venvs (status quo)
+
+**Pros**: Authoritative, covers all modules including custom collections.
+
+**Cons**: 30-60s cold start. Galaxy Proxy required. Air-gap complexity. Disproportionate for CI/CD and batch scanning where 90% of checks are against well-known modules.
+
+**Why not chosen**: The majority of scans don't need runtime introspection.
+
+### Alternative 2: Cache ansible-doc output per session
+
+**Pros**: Authoritative data, cached after first run.
+
+**Cons**: Still requires first-run cold start. Still requires venv infrastructure. Cache invalidation complexity.
+
+**Why not chosen**: Moves the cost but doesn't eliminate it.
+
+## Consequences
+
+### Positive
+
+- CI/CD cold start: <2s (no venv creation)
+- Batch scanning: workers start immediately, no per-worker venv creation overhead
+- Galaxy Proxy only needed in full mode (not for lite or CI/CD)
+- Data files are versioned and deterministic (same input → same output)
+- Portal-mediated content delivery: APME receives content from the portal, which already has authenticated access to SCMs and Automation Hub. APME does not need its own content source credentials.
+
+### Negative
+
+- Data files must be regenerated when new ansible-core versions release
+- Custom collection modules not covered in lite mode
+- Two code paths (lite data lookup vs full plugin introspection) for M001-M004
+
+### Neutral
+
+- Full mode behavior unchanged (venvs, Galaxy Proxy, plugin loader)
+- M005-M030 unchanged (already static)
+- L-rules unchanged
+- R-rules unchanged
+- SEC-rules unchanged
+
+## Supplements (Does Not Replace)
+
+- ADR-022 (session-scoped venvs) — venvs still used in full mode
+- ADR-031 (unified Galaxy proxy) — Galaxy Proxy still used in full mode
+
+## Related Decisions
+
+- [ADR-022](ADR-022-session-scoped-venvs.md): Session venvs — retained for full mode
+- [ADR-031](ADR-031-unified-collection-cache.md): Galaxy Proxy — retained for full mode
+- [ADR-046](ADR-046-single-process-core.md): Single-process core — lite mode enables <2s cold start
+- [ADR-047](ADR-047-deployment-modes.md): Deployment modes — CI/CD and workers default to lite mode
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-30 | Claude (proposal) | Initial proposal |
+| 2026-03-30 | Claude (proposal) | Corrected air-gap assumption: portal is the content broker (downloads from SCM/PAH), passes content to APME. Added content delivery model section. Removed incorrect claim about Galaxy Proxy being needed for air-gap. |

--- a/.sdlc/adrs/ADR-049-node-identity-registry.md
+++ b/.sdlc/adrs/ADR-049-node-identity-registry.md
@@ -1,0 +1,291 @@
+# ADR-049: Node Identity Registry
+
+## Status
+
+Proposed
+
+## Date
+
+2026-03-30
+
+## Context
+
+ADR-044 correctly identifies six problems with APME's current stateless scan model. This ADR agrees with the problem statement but proposes a simpler solution.
+
+### Problems (from ADR-044, all valid)
+
+1. **Snippet accuracy**: Snippets show post-format content, not the original the user wrote.
+2. **Violation matching**: `(rule_id, file, line)` tuples break when transforms shift line numbers.
+3. **Remediation attribution**: "Which transform fixed which violation?" is inferred, not tracked.
+4. **Three representations**: ARI tree + StructuredFile + raw bytes synchronized via disk I/O.
+5. **No temporal history**: No per-node progression through the pipeline.
+6. **Inherited property mis-attribution**: R108 fires on every task inheriting `become` (50 violations) instead of once on the defining play (1 violation).
+
+### Why ADR-044's ContentGraph is more than needed
+
+ADR-044 proposes a `ContentGraph` built on `networkx.MultiDiGraph` with a 3-phase migration porting all 96 native rules to a `GraphRule` interface. After comprehensive analysis, this solution is disproportionate:
+
+**networkx is unnecessary for this graph shape.** Ansible content graphs are small (100-1000 nodes), mostly trees with a few cross-edges. The algorithms ADR-044 lists (`is_directed_acyclic_graph`, `topological_sort`, `weakly_connected_components`, `is_isomorphic`) are each implementable in <20 lines with parent/children pointers. Adding a runtime dependency for capabilities achievable with basic data structures violates ADR-019's dependency governance principle.
+
+**Porting 96 rules is the highest-risk part of the plan.** Per DESIGN_VALIDATORS.md, native rules access `ctx.current` (234 call sites), `task.spec` (50 sites), `task.file_info()` (73 sites). Changing every call site across 96 rules in Phase 2 while maintaining production stability is a large surface area with high regression risk. The ADR's "zero throwaway code" claim means the switchover is a cliff — everything changes at once.
+
+**ContentGraph doesn't eliminate the three representations.** Per DATA_FLOW.md, OPA needs JSON hierarchy_payload, Gitleaks needs raw files, transforms need ruamel.yaml mutation. These exist because different consumers need different formats, not because of a missing identity model. The ContentGraph adds a fourth representation (the graph itself) alongside the existing three.
+
+**Variable provenance, Python AST analysis, complexity metrics, topology visualization, and dependency quality scorecards** are bundled into ADR-044 but are independent concerns. Each should be a separate ADR. Bundling them inflates the implementation scope.
+
+**The highest-impact problem (#6, inherited property mis-attribution) is solvable with ~30 lines.** A parent-chain walk from any node to its root, checking where a property is first defined, gives PropertyOrigin without a graph library.
+
+### The simpler alternative
+
+A `NodeRegistry` (~200 lines) that sits on top of the existing `hierarchy_payload` output from ARI. It adds identity and progression tracking without touching the engine, rules, validators, or serialization boundaries.
+
+## Decision
+
+**Build a NodeRegistry that assigns stable identities to ARI's hierarchy nodes and tracks their progression across pipeline passes.** ARI remains the parser. Rules remain on their current interfaces. The registry is a new layer between the engine output and the remediation loop.
+
+### Core data structures
+
+```python
+@dataclass
+class NodeSnapshot:
+    """Immutable record of a node's state at a specific pipeline phase."""
+    pass_number: int
+    phase: str            # "original", "formatted", "scanned", "transformed"
+    content: str          # YAML text at this point
+    violations: list[ViolationDict]
+    transforms_applied: list[str]  # rule_ids of transforms that changed this node
+
+@dataclass
+class TrackedNode:
+    """A node with stable identity and progression history."""
+    id: str               # stable YAML path: "site.yml::play[0]#task[3]"
+    key: str              # ARI's node key (bridge to hierarchy_payload)
+    kind: str             # "playcall", "taskcall", "rolecall", "blockcall"
+    file: str             # relative file path
+    line: int             # line number (from hierarchy_payload)
+    parent_id: str | None
+    children_ids: list[str]
+    history: list[NodeSnapshot]
+
+class NodeRegistry:
+    """Stable identity and progression tracking for ARI hierarchy nodes."""
+
+    _by_id: dict[str, TrackedNode]
+    _by_key: dict[str, TrackedNode]          # ARI key → TrackedNode
+    _by_file_line: dict[tuple[str, int], TrackedNode]
+
+    @classmethod
+    def from_hierarchy_payload(cls, payload: dict) -> NodeRegistry:
+        """Build registry from ARI's hierarchy_payload output.
+
+        Walks the hierarchy trees, assigns YAML-path IDs,
+        records parent-child relationships.
+        """
+        ...
+
+    def get(self, node_id: str) -> TrackedNode | None:
+        """Look up node by stable ID."""
+        ...
+
+    def match_violation(self, violation: ViolationDict) -> TrackedNode | None:
+        """Match a violation to its node.
+
+        First tries violation['path'] (ARI key) via _by_key.
+        Falls back to (file, line) via _by_file_line.
+        """
+        ...
+
+    def inherited(self, node_id: str, key: str) -> tuple[Any, str | None]:
+        """Walk parent chain for inherited property.
+
+        Returns (value, origin_node_id) or (None, None).
+        Used by rules that need PropertyOrigin
+        (R108, M010, M022).
+        """
+        node = self._by_id.get(node_id)
+        while node:
+            # Look up property in hierarchy_payload node
+            payload_node = self._get_payload_node(node.key)
+            val = payload_node.get("options", {}).get(key)
+            if val is not None:
+                return val, node.id
+            if node.parent_id:
+                node = self._by_id.get(node.parent_id)
+            else:
+                break
+        return None, None
+
+    def snapshot(self, pass_number: int, phase: str,
+                 file_contents: dict[str, str],
+                 violations: list[ViolationDict]) -> None:
+        """Record a snapshot of all nodes at a pipeline phase.
+
+        Called at: original parse, post-format, each scan pass,
+        each transform pass.
+        """
+        for v in violations:
+            node = self.match_violation(v)
+            if node:
+                v["node_id"] = node.id  # enrich violation with stable ID
+
+        for node in self._by_id.values():
+            content = self._extract_node_content(node, file_contents)
+            node_violations = [v for v in violations
+                               if v.get("node_id") == node.id]
+            node.history.append(NodeSnapshot(
+                pass_number=pass_number,
+                phase=phase,
+                content=content,
+                violations=node_violations,
+                transforms_applied=[],
+            ))
+
+    def snippet_at(self, node_id: str, pass_number: int,
+                   context_lines: int = 10) -> str | None:
+        """Extract snippet from any historical state."""
+        node = self._by_id.get(node_id)
+        if not node:
+            return None
+        for snap in node.history:
+            if snap.pass_number == pass_number:
+                return snap.content
+        return None
+
+    def attribution(self, node_id: str) -> list[dict]:
+        """Return progression timeline for a node.
+
+        Example: [
+          {"pass": 0, "phase": "original", "violations": []},
+          {"pass": 1, "phase": "formatted", "violations": []},
+          {"pass": 2, "phase": "scanned", "violations": [V1, V2]},
+          {"pass": 3, "phase": "transformed", "violations": [V2],
+           "transforms": ["L007"]},
+        ]
+        """
+        ...
+```
+
+### Integration points
+
+**Built after ARI parse (no ARI changes):**
+```python
+# In Primary's scan pipeline (primary_server.py)
+context = run_scan(target_path, ...)  # existing ARI call
+registry = NodeRegistry.from_hierarchy_payload(context.hierarchy_payload)
+registry.snapshot(0, "original", file_contents, violations=[])
+```
+
+**Used in remediation loop (opt-in, no rule changes):**
+```python
+# In remediation engine (engine.py convergence loop)
+for pass_num in range(max_passes):
+    violations = scan()
+    registry.snapshot(pass_num, "scanned", file_contents, violations)
+
+    for v in fixable:
+        transform_registry.apply(v.rule_id, ...)
+    registry.snapshot(pass_num, "transformed", file_contents, violations)
+```
+
+**Enriches violations (transparent to validators):**
+```python
+# After merge/dedup in Primary
+for v in violations:
+    node = registry.match_violation(v)
+    if node:
+        v["node_id"] = node.id  # stable identity
+        v["snippet_original"] = registry.snippet_at(node.id, 0)
+```
+
+**PropertyOrigin for opted-in rules (no interface change):**
+```python
+# R108 can optionally use registry (if available)
+# Graph variant rules already exist (R108_graph, M010_graph, M022_graph)
+# These can call registry.inherited() instead of requiring full ContentGraph
+val, origin_id = registry.inherited(node_id, "become")
+if val and origin_id == current_node_id:
+    # This node DEFINES become, not just inherits it
+    yield Violation("R108", node_id=origin_id, ...)
+```
+
+### NodeIdentity scheme
+
+Same as ADR-044:
+```
+<file-path>::<yaml-path>
+
+Examples:
+  site.yml::play[0]#task[3]
+  roles/web/tasks/main.yml::task[0]
+  site.yml::play[1]#block[0]#task[2]
+```
+
+Derived from structural position in the hierarchy_payload, not from content. Assigned once at first parse, stable through formatting and transforms that don't restructure the document.
+
+## Alternatives Considered
+
+### Alternative 1: ADR-044 ContentGraph (networkx MultiDiGraph)
+
+**Pros**: Full graph with algorithms. Unified model for all consumers. Variable provenance, Python AST analysis, complexity metrics.
+
+**Cons**: Requires porting 96 rules to GraphRule. networkx dependency. 3-phase migration. Doesn't eliminate three representations. Bundles 7+ separate concerns into one ADR.
+
+**Why not chosen**: Disproportionate effort for the stated problems. The highest-value outcomes (identity, progression, PropertyOrigin) don't require a graph library or rule porting.
+
+### Alternative 2: Do nothing (status quo + NodeIndex)
+
+**Pros**: No changes. NodeIndex works as a workaround.
+
+**Cons**: Pain points persist. Violation matching breaks after transforms. No progression tracking. Inherited property mis-attribution generates noisy reports.
+
+**Why not chosen**: The problems are real and growing. The NodeRegistry is small enough (~200 lines) to be low-risk.
+
+## Consequences
+
+### Positive
+
+- Stable violation identity across passes (YAML-path IDs, not line numbers)
+- Snippets from any pipeline phase (original, formatted, scanned, transformed)
+- Remediation attribution: progression timeline per node
+- PropertyOrigin for inherited properties (R108 fires once on play, not 50x on tasks)
+- No rule changes required (registry enriches violations transparently)
+- No ARI engine changes
+- No networkx dependency
+- No migration phases
+- ~200 lines total, replacing ~100 lines (NodeIndex)
+
+### Negative
+
+- Does not solve "three representations" (separate concern, higher-effort refactor)
+- Variable provenance not addressed (separate concern)
+- Python AST analysis not addressed (separate concern)
+- Parent-child relationships derived from hierarchy_payload structure, not from deep include resolution
+
+### Neutral
+
+- ARI engine unchanged
+- All 100+ rules unchanged
+- All transforms unchanged
+- Validator gRPC contract unchanged (if retained) or Validator Protocol unchanged (per ADR-046)
+- OPA Rego rules unchanged
+- Gitleaks integration unchanged
+
+## Supersedes
+
+- ADR-044 (Node Identity and Progression Model) — same problem statement, simpler solution. The capabilities ADR-044 bundles beyond identity and progression (variable provenance, Python AST, complexity metrics, visualization, dependency scorecards) should be proposed as separate ADRs when needed.
+
+## Related Decisions
+
+- [ADR-044](ADR-044-node-identity-progression-model.md): ContentGraph — superseded by this simpler approach
+- [ADR-003](ADR-003-vendor-ari-engine.md): ARI engine — unchanged, registry consumes ARI's output
+- [ADR-009](ADR-009-remediation-engine.md): Remediation — convergence loop gains progression tracking
+- [ADR-023](ADR-023-per-finding-classification.md): Per-finding classification — violations gain stable node_id
+- [ADR-019](ADR-019-dependency-governance.md): Dependency governance — no new runtime dependencies
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-30 | Claude (proposal) | Initial proposal superseding ADR-044 |

--- a/.sdlc/adrs/ADR-050-portal-integration.md
+++ b/.sdlc/adrs/ADR-050-portal-integration.md
@@ -1,0 +1,374 @@
+# ADR-050: Portal and Backstage Integration
+
+## Status
+
+Proposed
+
+## Date
+
+2026-03-30
+
+## Context
+
+APME will be deployed alongside the Ansible self-service portal (Red Hat Developer Hub with Ansible Backstage plugins). The portal catalogs Ansible collections from Git repositories (`AnsibleGitContentsProvider`), Automation Hub (`PAHCollectionProvider`), and AAP (`AAPJobTemplateProvider`). When collections are cataloged, they should be scanned by APME for quality, security, and migration readiness.
+
+### Deployment targets
+
+The portal deploys in two models:
+
+1. **OpenShift** — RHDH via Helm chart (`ansible-portal-chart`). APME runs as a sidecar container in the RHDH pod (ADR-047) and as KEDA-scaled workers for batch scanning.
+
+2. **RHEL bootc appliance** — Podman Quadlet systemd services (`automation-portal-bootc-container`). APME runs as a single Quadlet container on the `portal-network` bridge, alongside `portal` (RHDH), `portal-postgres` (PostgreSQL), and `portal-devtools` (ADT).
+
+Both models use the same APME container image with the `apme-server` entrypoint (ADR-047).
+
+### Security context
+
+An audit of the portal's existing sidecar model (devtools on port 8000) reveals several security gaps that APME must not inherit:
+
+| Finding | DevTools (current) | Risk | APME approach |
+|---|---|---|---|
+| **No authentication** | Zero auth between portal and devtools. Any container on `portal-network` can call devtools APIs. | HIGH — a compromised container can invoke code generation. | Opt-in API key via `APME_API_KEY` env var. When set, all requests require `X-API-Key` header. When unset (sidecar mode), network isolation is primary boundary. |
+| **Runs as root** | DevTools container has no `User` directive — defaults to root. | HIGH — container escape gives root on host. | APME runs as non-root (`USER 1001`). All capabilities dropped. |
+| **No input validation** | Scaffolder passes user-supplied `namespace` and `collection_name` directly to devtools API without validation. | MEDIUM — potential for path traversal or injection in generated content. | APME validates all input: `repo_url` must be https/git scheme (no `file://`), `ref` must match `[a-zA-Z0-9._/-]`, `ansible_version` must be in supported set. |
+| **No TLS** | Plain HTTP between portal and devtools. | LOW for same-pod (localhost), MEDIUM for bridge network (sniffable). | Same as devtools — plain HTTP for same-pod/bridge. TLS available via reverse proxy if APME is exposed externally. |
+| **No rate limiting** | Unlimited requests. | LOW — only portal calls it. | Configurable rate limit on async scan endpoint (default: 100 scans/minute). Prevents queue flooding. |
+| **No audit logging** | No record of who called what. | MEDIUM — no forensic trail. | All API calls logged with timestamp, endpoint, source IP, scan parameters. Scan results stored in PostgreSQL with full provenance. |
+
+The devtools model is adequate for a **same-pod sidecar with a single trusted caller** but has gaps that compound with network exposure. APME improves on this baseline while remaining proportionate to the threat model.
+
+### Integration pattern
+
+The portal's existing plugins follow a consistent pattern:
+- **Backend module** (TypeScript) implements Backstage's `EntityProvider` interface for catalog sync
+- **Frontend plugin** (React) renders entity details with custom components
+- **Service client** (TypeScript) communicates with backend services via HTTP
+
+APME integration follows this same pattern: a Backstage backend module triggers scans, a frontend plugin displays results, and the APME server provides the REST API.
+
+### Relationship to existing ADRs
+
+- ADR-029 (Gateway) defined the REST API and persistence layer. In the single-process model (ADR-046), the server mode absorbs the Gateway's role.
+- ADR-038 (Public Data API, Proposed) defined the consumer contract. This ADR implements ADR-038's vision with concrete endpoints and the Backstage plugin.
+- ADR-037 (Project-centric UI) defined the dashboard model. The portal integration is complementary — the portal shows collection-level quality metadata, while the standalone dashboard (if deployed) shows detailed violation management.
+
+## Decision
+
+**APME integrates with the portal via a REST API (server mode) and a Backstage dynamic plugin.**
+
+### REST API endpoints (APME server)
+
+Extends the API defined in ADR-047's server mode:
+
+```
+# Sync scan with uploaded content (portal sends files directly)
+POST /api/v1/check
+  Body: multipart/form-data
+    files: <collection content as tar.gz or individual files>
+    ansible_version: "2.18"
+    entity_ref: "component:default/acme.webstack"
+  Returns: {scan_id, status, violations, summary}
+
+# Async scan with uploaded content (for large collections)
+POST /api/v1/scans/async
+  Body: multipart/form-data
+    files: <collection content as tar.gz or individual files>
+    ansible_version: "2.18"
+    entity_ref: "component:default/acme.webstack"
+  Returns: {"scan_id": "uuid", "status": "queued"}
+
+# Async scan with content path (shared workspace)
+POST /api/v1/scans/async
+  Body: {
+    "workspace_path": "/workspace/acme.webstack",
+    "ansible_version": "2.18",
+    "entity_ref": "component:default/acme.webstack"
+  }
+  Returns: {"scan_id": "uuid", "status": "queued"}
+
+# Poll scan status
+GET /api/v1/scans/{scan_id}
+  Returns: {
+    "status": "completed",
+    "summary": {
+      "quality_score": 82,
+      "total_violations": 14,
+      "by_severity": {"error": 2, "warning": 7, "info": 5},
+      "by_category": {"lint": 8, "security": 2, "migration": 4},
+      "migration_ready": {"2.18": true, "2.19": false}
+    },
+    "violations": [...]
+  }
+
+# Quality summary for catalog entity (consumed by Backstage plugin)
+GET /api/v1/entities/{entity_ref}/quality
+  Returns: {
+    "entity_ref": "component:default/acme.webstack",
+    "quality_score": 82,
+    "security_issues": 2,
+    "migration_status": {"2.18": "ready", "2.19": "needs_work"},
+    "last_scan": "2026-03-30T10:15:00Z",
+    "scan_id": "uuid"
+  }
+```
+
+**Content delivery model**: The portal is the content broker, not APME. The portal already has authenticated access to all content sources (GitHub, GitLab, Automation Hub). The portal downloads collection content and passes it to APME via:
+
+1. **Multipart upload** (POST /api/v1/check or /api/v1/scans/async) — portal sends files directly. Works in all deployments including air-gapped.
+2. **Shared workspace** (POST /api/v1/scans/async with `workspace_path`) — portal writes content to a shared volume, APME reads from it. Efficient for large collections; avoids copying over HTTP.
+
+This eliminates the need for APME to have SCM tokens, PAH credentials, or network access to external content sources. APME receives content; the portal handles acquisition and authentication.
+
+### Backstage dynamic plugin
+
+A new plugin package `@ansible/backstage-plugin-apme` with two components:
+
+**Backend module** (`catalog-backend-module-apme`):
+- Implements Backstage `EntityProvider` interface
+- Listens for catalog entity change events
+- When a new Ansible collection entity appears, triggers `POST /api/v1/scans/async` to the APME server
+- Configurable scan schedule (default: on catalog sync, configurable interval)
+
+**Frontend plugin** (`plugin-apme`):
+- **APMEQualityCard**: Entity detail page card showing quality score, security status, migration readiness
+- **APMEViolationsTab**: Detailed violation list with rule IDs, severity badges, file/line references, and snippets
+- Fetches data from APME server via `GET /api/v1/entities/{entity_ref}/quality`
+
+### Configuration
+
+In RHDH `app-config.yaml`:
+
+```yaml
+ansible:
+  apme:
+    baseUrl: ${APME_HOST:-portal-apme}
+    port: '8090'
+
+catalog:
+  providers:
+    apme:
+      schedule:
+        frequency: { minutes: 60 }
+        timeout: { minutes: 30 }
+```
+
+### Bootc integration
+
+The `portal-setup` wizard (or cloud-init config) includes APME configuration:
+
+```yaml
+# /run/cloud-init/portal-config.yaml
+apme:
+  enabled: true
+  ansible_version: "2.18"
+```
+
+The APME container starts after PostgreSQL and the portal, joins the `portal-network`, and is reachable at `portal-apme:8090`.
+
+### Security model
+
+#### Threat model by deployment
+
+**Bootc appliance (single VM):**
+- Trust boundary: the VM itself. The operator controls all containers.
+- APME port 8090 is bound to the bridge network only (`PublishPort=127.0.0.1:8090:8090`), NOT exposed to the host's external interfaces.
+- Attack path: an attacker must first compromise the portal or another container on `portal-network` — at which point they already have access to PostgreSQL credentials and AAP tokens. APME is not the meaningful security boundary.
+- Network isolation is the primary defense. Opt-in API key adds defense-in-depth.
+
+**OpenShift sidecar (same pod):**
+- Trust boundary: the pod. All containers share localhost (127.0.0.1).
+- APME port 8090 is not exposed via Service or Route. Only containers in the same pod can reach it.
+- Other pods in the namespace cannot reach APME unless a Service is explicitly created.
+- NetworkPolicy on worker Deployment denies all inbound traffic (workers only connect outbound to PostgreSQL).
+
+**Workers (separate Deployment):**
+- Workers have no inbound ports. They connect outbound to PostgreSQL only.
+- PostgreSQL authentication: password via Kubernetes Secret, separate `apme` schema (cannot read/write portal tables).
+- Workers receive content via the scan queue (portal uploaded content to shared workspace or inline in the queue row). Workers do not need SCM tokens or PAH credentials — the portal handles content acquisition.
+
+#### APME-specific attack surface
+
+APME has attack surface beyond what devtools has:
+
+| Capability | Risk | Mitigation |
+|---|---|---|
+| **Content ingestion** (receives files from portal or CLI) | Path traversal — a malicious archive could contain `../../etc/passwd` paths. Zip bomb — large decompressed content exhausting disk. | Archive extraction uses `tarfile.data_filter` (Python 3.12+) or manual path validation rejecting absolute paths and `..` components. Extraction to isolated temp directory with size quota (2 GiB). Cleanup in `finally` block. When receiving `workspace_path`, validate it's within the allowed workspace root. |
+| **YAML parsing** (processes untrusted Ansible content) | Billion-laughs (YAML bomb), excessive memory from deeply nested structures. | ruamel.yaml safe loader (no arbitrary Python object instantiation). Max file size 2 MiB (existing DATA_FLOW.md constraint). Max node depth limit. |
+| **OPA subprocess** (runs `opa eval` with hierarchy payload) | Command injection if payload is interpolated into shell command. | Payload passed via stdin (`subprocess.run(input=...)`, not shell interpolation). No `shell=True`. |
+| **Gitleaks subprocess** (runs `gitleaks detect`) | Limited — gitleaks reads files, doesn't execute them. | Subprocess with timeout. Non-zero exit code is informational (secrets found), not an error. |
+| **PostgreSQL writes** (stores scan results) | SQL injection if violations are interpolated into queries. | SQLAlchemy parameterized queries only. No raw string interpolation. |
+| **AI escalation** (sends content to Abbenay) | Content leakage to external AI provider. | AI is opt-in (`--ai` flag). Abbenay connection via gRPC with bearer token. Content sent only for Tier 2 violations, not entire repos. |
+
+#### Container hardening
+
+```ini
+# apme.container (Quadlet)
+[Container]
+Image=registry.redhat.io/aap/apme-rhel9:latest
+ContainerName=portal-apme
+Network=portal-network
+PublishPort=127.0.0.1:8090:8090
+User=1001:0
+
+# Read-only root filesystem
+ReadOnly=true
+# Writable tmpfs for scan workspace
+Tmpfs=/tmp:rw,size=512m,noexec
+Volume=/var/lib/apme/workspace:/workspace:Z
+
+# Secrets (never in env files, never in image)
+Secret=portal_apme_db_password,type=env,target=APME_DB_PASSWORD
+
+# No extra capabilities
+DropCapability=ALL
+
+[Service]
+Restart=always
+RestartSec=10
+After=postgres.service
+ConditionPathExists=/etc/portal/.setup-complete
+```
+
+OpenShift equivalent:
+
+```yaml
+containers:
+  - name: apme-server
+    image: registry.redhat.io/aap/apme-rhel9:latest
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: [ALL]
+    volumeMounts:
+      - name: tmp
+        mountPath: /tmp
+      - name: workspace
+        mountPath: /workspace
+volumes:
+  - name: tmp
+    emptyDir:
+      sizeLimit: 512Mi
+  - name: workspace
+    emptyDir:
+      sizeLimit: 2Gi
+```
+
+#### Opt-in API key
+
+When `APME_API_KEY` env var is set, all non-health endpoints require the key:
+
+```python
+@app.middleware("http")
+async def check_api_key(request: Request, call_next):
+    api_key = os.environ.get("APME_API_KEY")
+    if api_key and request.url.path != "/health":
+        provided = request.headers.get("X-API-Key", "")
+        if not hmac.compare_digest(provided, api_key):
+            return JSONResponse(
+                status_code=401,
+                content={"error": "invalid or missing API key"},
+            )
+    return await call_next(request)
+```
+
+When `APME_API_KEY` is not set: no auth enforced (sidecar mode where network isolation is sufficient). This is the default for bootc and OpenShift sidecar deployments.
+
+When `APME_API_KEY` is set: required for all requests. Used when APME is exposed outside the pod boundary (e.g., shared APME server for multiple teams, CI/CD calling from external clusters).
+
+The API key is stored as a Podman secret (bootc) or Kubernetes Secret (OpenShift), injected at runtime. It is never in configuration files, container images, or environment file templates.
+
+#### Database isolation
+
+APME uses a **separate PostgreSQL schema** from the portal:
+
+```
+Portal:  postgresql://portal-postgres:5432/backstage   (portal schema)
+APME:    postgresql://portal-postgres:5432/apme         (apme schema)
+```
+
+The APME database user has `CONNECT` and `CREATE` on the `apme` database only. It cannot read or write portal tables (`backstage` database). This is enforced by PostgreSQL's native database-level isolation — no additional configuration needed beyond creating a separate database and user.
+
+#### Secrets inventory
+
+| Secret | Purpose | Who needs it | Rotation |
+|---|---|---|---|
+| `APME_DB_PASSWORD` | PostgreSQL auth for `apme` database | Server, Workers | On credential rotation; restart containers |
+| `APME_API_KEY` | Optional API authentication | Server (validates), Portal plugin (sends) | On rotation; update both server and client |
+| `APME_ABBENAY_TOKEN` | AI provider auth (Abbenay) | Server (if AI enabled) | Per Abbenay token lifecycle |
+
+APME does **not** need and must **not** receive: `AAP_TOKEN`, `OAUTH_CLIENT_SECRET`, `POSTGRESQL_ADMIN_PASSWORD`, SCM tokens (`GITHUB_TOKEN`, `GITLAB_TOKEN`), or any portal-level secrets.
+
+The portal is the content broker — it downloads collection content from SCMs and Automation Hub using its own credentials, then passes the content to APME. APME never contacts external content sources directly. This separation means:
+- A compromised APME container cannot access AAP, Git repositories, or the portal's database
+- APME needs only 2-3 secrets (database password, optional API key, optional AI token) vs the portal's 6+
+- Air-gapped environments work without APME needing any network egress beyond the internal bridge
+
+## Alternatives Considered
+
+### Alternative 1: AAP job template integration
+
+**Description**: Create an AAP job template that calls APME, expose via portal's existing job template catalog.
+
+**Pros**: No new Backstage plugin. Uses existing portal infrastructure.
+
+**Cons**: Requires AAP Controller deployment. Scans run as Ansible jobs (heavy). Results not integrated into catalog entity metadata. No quality badges on collection pages.
+
+**Why not chosen**: APME is a lightweight scanning tool, not an Ansible job. Running it through AAP Controller adds unnecessary infrastructure.
+
+### Alternative 2: Webhook-only integration
+
+**Description**: APME server sends webhook on scan completion. Portal receives and stores results.
+
+**Pros**: Decoupled. APME doesn't need to know about Backstage.
+
+**Cons**: Requires webhook receiver in portal. More complex than direct API polling. Webhook delivery is not guaranteed (needs retry logic).
+
+**Why not chosen**: Direct REST API polling is simpler and more reliable for the portal sidecar model where APME is on localhost.
+
+## Consequences
+
+### Positive
+
+- Collections in the portal catalog automatically scanned for quality/security/migration
+- Quality scores visible on collection detail pages
+- Security issues surfaced before collections are used in automation
+- Migration readiness visible per ansible-core version
+- Same pattern as existing portal plugins (consistent DX)
+- No new infrastructure (PostgreSQL shared with portal, separate schema)
+- Security model improves on devtools baseline (non-root, input validation, opt-in API key, audit logging, read-only filesystem)
+- Secret separation limits blast radius (APME cannot access AAP or portal secrets)
+
+### Negative
+
+- New Backstage plugin to maintain (TypeScript)
+- APME server must be co-deployed with portal
+- Quality scores may lag behind code changes (scan schedule dependent)
+- Separate PostgreSQL database/user requires provisioning during setup
+
+### Neutral
+
+- APME's core scanning unchanged
+- CI/CD integration unchanged (CLI mode)
+- Standalone dashboard (if deployed) unchanged
+- No mTLS between portal and APME (consistent with portal's existing sidecar model; network isolation is primary boundary)
+
+## Related Decisions
+
+- [ADR-029](ADR-029-web-gateway-architecture.md): Gateway — server mode absorbs Gateway's role
+- [ADR-038](ADR-038-public-data-api.md): Public data API — this ADR implements it
+- [ADR-046](ADR-046-single-process-core.md): Single-process core — server runs in one container
+- [ADR-047](ADR-047-deployment-modes.md): Deployment modes — server mode and worker mode
+- [ADR-048](ADR-048-pre-built-module-metadata.md): Lite mode — workers use lite mode for fast scanning
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-30 | Claude (proposal) | Initial proposal |
+| 2026-03-30 | Claude (proposal) | Added security model: threat analysis, devtools audit findings, container hardening, input validation, opt-in API key, database isolation, secrets inventory |
+| 2026-03-30 | Claude (proposal) | Corrected content delivery model: portal is the content broker (downloads from SCM/PAH and passes to APME). APME does not clone repos or need SCM/PAH credentials. Removed GIT_TOKEN from secrets inventory. Updated API to accept multipart uploads and shared workspace paths. Updated attack surface (content ingestion replaces git clone SSRF). |


### PR DESCRIPTION
Five proposed ADRs based on comprehensive analysis of APME's deployment targets (OpenShift Helm, RHEL bootc appliance, CI/CD, developer workstation) and portal integration requirements:

- ADR-046: Single-process core architecture (supersedes ADR-001/004/005 for internal validator communication)
- ADR-047: Deployment modes (CLI, server, worker from one image)
- ADR-048: Pre-built module metadata (lite mode for fast cold start)
- ADR-049: Node identity registry (supersedes ADR-044 ContentGraph)
- ADR-050: Portal and Backstage integration with security model