### PR TITLE
fix(ci): move ARG before first FROM in multi-stage Dockerfiles

### DIFF
--- a/containers/gitleaks/Dockerfile
+++ b/containers/gitleaks/Dockerfile
@@ -1,8 +1,7 @@
 # Gitleaks validator: gitleaks binary + Python gRPC shim.
 # Multi-stage: copies gitleaks from the official image.
-FROM docker.io/zricethezav/gitleaks:latest AS gitleaks-bin
-
 ARG BASE_IMAGE=localhost/apme-base:latest
+FROM docker.io/zricethezav/gitleaks:latest AS gitleaks-bin
 FROM $BASE_IMAGE
 
 COPY --from=gitleaks-bin /usr/bin/gitleaks /usr/local/bin/gitleaks

--- a/containers/opa/Dockerfile
+++ b/containers/opa/Dockerfile
@@ -1,8 +1,7 @@
 # OPA validator: gRPC wrapper over OPA REST API.
 # Multi-stage: copies the OPA binary from the official image.
-FROM docker.io/openpolicyagent/opa:latest AS opa-bin
-
 ARG BASE_IMAGE=localhost/apme-base:latest
+FROM docker.io/openpolicyagent/opa:latest AS opa-bin
 FROM $BASE_IMAGE
 
 COPY --from=opa-bin /opa /usr/local/bin/opa


### PR DESCRIPTION
## Summary

- Fixes OPA and Gitleaks container image builds that fail with `base name ($BASE_IMAGE) should not be blank` in the GHCR workflow merged in #165

## Changes

In Docker multi-stage builds, an `ARG` placed **between** two `FROM` instructions is scoped to the first stage — the second `FROM` cannot see it. The `ARG BASE_IMAGE` declaration must be **before the first `FROM`** to be in the global scope.

```dockerfile
# Before (broken — ARG scoped to opa-bin stage):
FROM docker.io/openpolicyagent/opa:latest AS opa-bin
ARG BASE_IMAGE=localhost/apme-base:latest
FROM $BASE_IMAGE   # ← $BASE_IMAGE is blank here

# After (fixed — ARG in global scope):
ARG BASE_IMAGE=localhost/apme-base:latest
FROM docker.io/openpolicyagent/opa:latest AS opa-bin
FROM $BASE_IMAGE   # ← works
```

Same fix applied to both `containers/opa/Dockerfile` and `containers/gitleaks/Dockerfile`.

The 7 single-stage Dockerfiles (primary, native, ansible, galaxy-proxy, gateway, cli, ui) were not affected.

## Test plan

- [ ] GHCR workflow builds all 10 images successfully (OPA and Gitleaks no longer fail)
- [ ] Local `podman build` still works (default `BASE_IMAGE` unchanged)

Made with [Cursor](https://cursor.com)