### PR TITLE
build: add pytest-xdist for parallel unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "grpc-stubs",
     "grpcio-tools>=1.78.0",
     "pytest-playwright",
+    "pytest-xdist>=3.5",
 ]
 
 [tool.pytest.ini_options]

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,10 @@ commands = prek run --all-files {posargs}
 # ── Test suites ──────────────────────────────────────────────────────
 
 [testenv:unit]
-description = Unit tests with coverage
+description = Unit tests with coverage (parallel via pytest-xdist)
 extras = dev, gateway
 commands =
-    pytest --cov=src/apme_engine --cov-report=term-missing --cov-fail-under=36 {posargs}
+    pytest -n auto --dist loadfile --cov=src/apme_engine --cov-report=term-missing --cov-fail-under=36 {posargs}
 
 [testenv:integration]
 description = Integration tests (requires OPA binary on PATH)

--- a/uv.lock
+++ b/uv.lock
@@ -104,6 +104,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-playwright" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-protobuf" },
     { name = "types-pyyaml" },
@@ -136,6 +137,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-mock", marker = "extra == 'dev'" },
     { name = "pytest-playwright", marker = "extra == 'dev'" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
     { name = "python-multipart", marker = "extra == 'gateway'", specifier = ">=0.0.6" },
     { name = "pyyaml" },
     { name = "rapidfuzz" },
@@ -429,6 +431,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1258,6 +1269,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/6b/913e36aa421b35689ec95ed953ff7e8df3f2ee1c7b8ab2a3f1fd39d95faf/pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770", size = 16928, upload-time = "2025-11-24T03:43:22.53Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/61/4d333d8354ea2bea2c2f01bad0a4aa3c1262de20e1241f78e73360e9b620/pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38", size = 16881, upload-time = "2025-11-24T03:43:24.423Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add pytest-xdist to dev extras and enable parallel test execution by default in `tox -e unit`, cutting wall time in half

## Changes

- **`pyproject.toml`** — added `pytest-xdist>=3.5` to `dev` extras
- **`tox.ini`** — `tox -e unit` now runs with `-n auto --dist loadfile`
- **`uv.lock`** — lockfile updated

## Benchmark (8-core machine)

| Strategy | Wall time | Speedup |
|----------|-----------|---------|
| Sequential (before) | 243s (4m03s) | — |
| xdist `loadfile` (after) | 119s (1m58s) | **2.03x** |

Same 1873 tests pass, same 55.86% coverage. `loadfile` distribution groups tests by file to keep module-level fixtures local and avoid cross-process state issues.

Sequential fallback: `tox -e unit -- -n0`

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (1873 passed, 55.86% coverage, ~2min)
- [x] Sequential override works: `tox -e unit -- -n0`

Made with [Cursor](https://cursor.com)