### PR TITLE
feat(daemon): wire AI provider into graph remediation path (ADR-044 PR 6)

### DIFF
--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -1359,6 +1359,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                 loop=loop,
                 format_content=format_content,
                 format_diffs=format_diffs,
+                fix_opts=fix_opts,
             ):
                 yield event
         else:
@@ -1499,12 +1500,14 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
         loop: asyncio.AbstractEventLoop,
         format_content: Callable[..., object],
         format_diffs: Sequence[object],
+        fix_opts: FixOptions | None = None,
     ) -> AsyncIterator[SessionEvent]:
         """Graph-engine remediation path (behind APME_USE_GRAPH_ENGINE=1).
 
         Runs ``GraphRemediationEngine`` in-memory, splices results to disk,
         then performs a final full-pipeline scan for the complete violation
-        picture.  Tier 2 AI is **not** wired in this path.
+        picture.  After Tier 1 convergence, eligible violations are escalated
+        to the AI provider using graph nodes as fixable units.
 
         Args:
             session: Active session state (mutated in place).
@@ -1523,9 +1526,10 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             loop: Running event loop.
             format_content: Formatter function for post-remediation pass.
             format_diffs: Accumulated format diffs from earlier step.
+            fix_opts: Client-provided options (controls AI enablement).
 
         Yields:
-            SessionEvent: Progress, Tier1Summary, and result events.
+            SessionEvent: Progress, Tier1Summary, ProposalsReady, and result events.
         """
         from apme_engine.engine.content_graph import ContentGraph
         from apme_engine.engine.graph_scanner import (
@@ -1746,10 +1750,172 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             ),
         )
 
-        # Graph engine does not support Tier 2 AI yet — go straight to result
-        session.status = 3  # COMPLETE
-        async for event in self._session_build_result(session):
-            yield event
+        # Tier 2 AI escalation — uses graph nodes as fixable units
+        ai_provider = self._resolve_ai_provider(fix_opts)
+        if ai_provider is not None and remaining_ai:
+            progress_callback("graph-tier2", f"AI escalation: {len(remaining_ai)} violation(s)", 0.0, 2)
+            ai_proposals = await self._graph_ai_escalate(
+                graph=graph,
+                remaining_ai=remaining_ai,
+                ai_provider=ai_provider,
+                temp_dir=temp_dir,
+            )
+            _t2_done = ProgressUpdate(
+                message=f"AI escalation complete: {len(ai_proposals)} proposal(s)",
+                phase="graph-tier2",
+                level=2,
+            )
+            session.progress_logs.append(_t2_done)
+            yield SessionEvent(progress=_t2_done)
+
+            if ai_proposals:
+                session.current_tier = 2
+                proposals = self._build_proposals_from_ai(ai_proposals)
+                for p in proposals:
+                    with contextlib.suppress(ValueError):
+                        p.file = str(Path(p.file).relative_to(temp_dir))
+                session.proposals = {p.id: p for p in proposals}
+                session.status = 1  # AWAITING_APPROVAL
+                yield SessionEvent(
+                    proposals=ProposalsReady(
+                        proposals=proposals,
+                        tier=2,
+                        status=1,
+                    ),
+                )
+            else:
+                session.status = 3  # COMPLETE
+                async for event in self._session_build_result(session):
+                    yield event
+        else:
+            session.status = 3  # COMPLETE
+            async for event in self._session_build_result(session):
+                yield event
+
+    @staticmethod
+    async def _graph_ai_escalate(
+        *,
+        graph: object,
+        remaining_ai: list[ViolationDict],
+        ai_provider: object,
+        temp_dir: Path,
+    ) -> list[object]:
+        """Per-node AI escalation using ContentGraph nodes as fixable units.
+
+        Groups AI-eligible violations by their graph node ID, then calls
+        ``propose_unit_fixes`` for each node using the node's YAML snippet
+        and line range as context.  Runs up to 8 concurrent LLM calls.
+
+        Args:
+            graph: ContentGraph with node data from the scan.
+            remaining_ai: AI-eligible violations from partition.
+            ai_provider: AIProvider-compatible object.
+            temp_dir: Working directory (for relativising file paths).
+
+        Returns:
+            List of AIProposal objects (one per successfully processed node).
+        """
+        from apme_engine.engine.content_graph import ContentGraph  # noqa: PLC0415
+        from apme_engine.remediation.ai_provider import (  # noqa: PLC0415
+            AIProposal,
+        )
+        from apme_engine.remediation.ai_provider import (
+            AIProvider as _AIProvider,
+        )
+
+        _graph: ContentGraph = graph  # type: ignore[assignment]
+        provider: _AIProvider = ai_provider  # type: ignore[assignment]
+
+        by_node: dict[str, list[ViolationDict]] = {}
+        for v in remaining_ai:
+            node_id = str(v.get("path", ""))
+            if node_id:
+                by_node.setdefault(node_id, []).append(v)
+
+        if not by_node:
+            return []
+
+        _MAX_CONCURRENT_AI = 8
+        sem = asyncio.Semaphore(_MAX_CONCURRENT_AI)
+
+        async def _propose_for_node(
+            node_id: str,
+            violations: list[ViolationDict],
+        ) -> AIProposal | None:
+            node = _graph.get_node(node_id)
+            if node is None or not node.yaml_lines:
+                return None
+
+            try:
+                rel_path = str(Path(node.file_path).relative_to(temp_dir))
+            except ValueError:
+                rel_path = node.file_path
+
+            async with sem:
+                try:
+                    patches, skipped = await provider.propose_unit_fixes(
+                        violations=violations,
+                        snippet=node.yaml_lines,
+                        file_path=rel_path,
+                        line_start=node.line_start,
+                        line_end=node.line_end,
+                    )
+                except Exception:
+                    logger.warning(
+                        "AI propose_unit_fixes failed for node %s",
+                        node_id,
+                        exc_info=True,
+                    )
+                    return None
+
+            if not patches:
+                if skipped:
+                    return AIProposal(
+                        file=node.file_path,
+                        original_snippet=node.yaml_lines,
+                        fixed_snippet=node.yaml_lines,
+                        diff="",
+                        skipped=list(skipped),
+                    )
+                return None
+
+            fixed_snippet = patches[0].fixed_lines
+            diff = "".join(
+                difflib.unified_diff(
+                    node.yaml_lines.splitlines(keepends=True),
+                    fixed_snippet.splitlines(keepends=True),
+                    fromfile=f"a/{Path(rel_path).name}",
+                    tofile=f"b/{Path(rel_path).name}",
+                )
+            )
+            rule_ids = list({p.rule_id for p in patches})
+            avg_confidence = sum(p.confidence for p in patches) / len(patches)
+            explanations = [p.explanation for p in patches if p.explanation]
+
+            return AIProposal(
+                file=node.file_path,
+                original_snippet=node.yaml_lines,
+                fixed_snippet=fixed_snippet,
+                diff=diff,
+                rule_ids=rule_ids,
+                confidence=avg_confidence,
+                explanation="; ".join(explanations),
+                skipped=list(skipped),
+                patches=list(patches),
+            )
+
+        tasks = [asyncio.create_task(_propose_for_node(nid, vs)) for nid, vs in by_node.items()]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        proposals: list[AIProposal] = []
+        for result in results:
+            if isinstance(result, BaseException):
+                logger.warning("AI escalation task failed", exc_info=result)
+                continue
+            if result is not None:
+                proposals.append(result)
+
+        return proposals  # type: ignore[return-value]
 
     @staticmethod
     def _resolve_ai_provider(fix_opts: FixOptions | None) -> object | None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -21,6 +21,7 @@ from apme.v1.primary_pb2 import (
     CloseRequest,
     ExtendRequest,
     FilePatch,
+    FixOptions,
     FixReport,
     Proposal,
     ProposalsReady,
@@ -1246,6 +1247,508 @@ class TestSessionRescanBridge:
         rules_dir = captured_rules_dir[0]
         assert rules_dir is not None, "load_graph_rules must be called with rules_dir"
         assert rules_dir.endswith("native/rules"), f"Expected native rules dir, got: {captured_rules_dir[0]}"
+
+
+class TestGraphAIEscalate:
+    """Tests for PrimaryServicer._graph_ai_escalate (static method, PR 6).
+
+    Exercises the per-node AI escalation that groups violations by graph
+    node and calls propose_unit_fixes on each.
+    """
+
+    async def test_groups_violations_by_node_and_proposes(self, tmp_path: Path) -> None:
+        """Violations are grouped by node_id; propose_unit_fixes called per node.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from unittest.mock import AsyncMock
+
+        from apme_engine.daemon.primary_server import PrimaryServicer
+        from apme_engine.engine.content_graph import ContentGraph, ContentNode, NodeIdentity, NodeType
+        from apme_engine.remediation.ai_provider import AIPatch, AIProposal
+
+        graph = ContentGraph()
+        node_path = "play.yml/plays[0]/tasks[0]"
+        yaml_text = "- name: Install\n  apt:\n    name: nginx\n    state: present\n"
+        fixed_text = "- name: Install\n  ansible.builtin.apt:\n    name: nginx\n    state: present\n"
+        graph.add_node(
+            ContentNode(
+                identity=NodeIdentity(path=node_path, node_type=NodeType.TASK),
+                file_path=str(tmp_path / "play.yml"),
+                line_start=1,
+                line_end=4,
+                yaml_lines=yaml_text,
+            )
+        )
+
+        mock_provider = AsyncMock()
+        mock_provider.propose_unit_fixes.return_value = (
+            [
+                AIPatch(
+                    rule_id="L001",
+                    line_start=1,
+                    line_end=4,
+                    fixed_lines=fixed_text,
+                    explanation="Use FQCN",
+                    confidence=0.95,
+                )
+            ],
+            [],
+        )
+
+        violations: list[dict[str, object]] = [
+            {"rule_id": "L001", "message": "Use FQCN", "path": node_path, "line": 2},
+        ]
+
+        proposals = await PrimaryServicer._graph_ai_escalate(
+            graph=graph,
+            remaining_ai=violations,  # type: ignore[arg-type]
+            ai_provider=mock_provider,
+            temp_dir=tmp_path,
+        )
+
+        mock_provider.propose_unit_fixes.assert_called_once()
+        call_kwargs = mock_provider.propose_unit_fixes.call_args
+        assert call_kwargs.kwargs["snippet"] == yaml_text
+        assert call_kwargs.kwargs["line_start"] == 1
+        assert call_kwargs.kwargs["line_end"] == 4
+
+        assert len(proposals) == 1
+        proposal: AIProposal = proposals[0]  # type: ignore[assignment]
+        assert proposal.fixed_snippet == fixed_text
+        assert "L001" in proposal.rule_ids
+        assert proposal.confidence == 0.95
+
+    async def test_skips_unknown_nodes(self, tmp_path: Path) -> None:
+        """Violations referencing unknown node IDs produce no proposals.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from unittest.mock import AsyncMock
+
+        from apme_engine.daemon.primary_server import PrimaryServicer
+        from apme_engine.engine.content_graph import ContentGraph
+
+        graph = ContentGraph()
+        mock_provider = AsyncMock()
+
+        violations: list[dict[str, object]] = [
+            {"rule_id": "L001", "message": "Use FQCN", "path": "nonexistent/node", "line": 2},
+        ]
+
+        proposals = await PrimaryServicer._graph_ai_escalate(
+            graph=graph,
+            remaining_ai=violations,  # type: ignore[arg-type]
+            ai_provider=mock_provider,
+            temp_dir=tmp_path,
+        )
+
+        mock_provider.propose_unit_fixes.assert_not_called()
+        assert proposals == []
+
+    async def test_handles_provider_failure(self, tmp_path: Path) -> None:
+        """Exception from propose_unit_fixes is caught; node skipped.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from unittest.mock import AsyncMock
+
+        from apme_engine.daemon.primary_server import PrimaryServicer
+        from apme_engine.engine.content_graph import ContentGraph, ContentNode, NodeIdentity, NodeType
+
+        graph = ContentGraph()
+        node_path = "play.yml/plays[0]/tasks[0]"
+        graph.add_node(
+            ContentNode(
+                identity=NodeIdentity(path=node_path, node_type=NodeType.TASK),
+                file_path=str(tmp_path / "play.yml"),
+                line_start=1,
+                line_end=2,
+                yaml_lines="- name: Test\n  debug:\n    msg: hi\n",
+            )
+        )
+
+        mock_provider = AsyncMock()
+        mock_provider.propose_unit_fixes.side_effect = RuntimeError("LLM unavailable")
+
+        violations: list[dict[str, object]] = [
+            {"rule_id": "L001", "message": "Fix me", "path": node_path, "line": 1},
+        ]
+
+        proposals = await PrimaryServicer._graph_ai_escalate(
+            graph=graph,
+            remaining_ai=violations,  # type: ignore[arg-type]
+            ai_provider=mock_provider,
+            temp_dir=tmp_path,
+        )
+
+        assert proposals == []
+
+    async def test_skipped_violations_returned_as_declined(self, tmp_path: Path) -> None:
+        """When AI skips violations, a proposal with empty diff and skipped list is returned.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from unittest.mock import AsyncMock
+
+        from apme_engine.daemon.primary_server import PrimaryServicer
+        from apme_engine.engine.content_graph import ContentGraph, ContentNode, NodeIdentity, NodeType
+        from apme_engine.remediation.ai_provider import AIProposal, AISkipped
+
+        graph = ContentGraph()
+        node_path = "play.yml/plays[0]/tasks[0]"
+        yaml_text = "- name: Test\n  debug:\n    msg: hi\n"
+        graph.add_node(
+            ContentNode(
+                identity=NodeIdentity(path=node_path, node_type=NodeType.TASK),
+                file_path=str(tmp_path / "play.yml"),
+                line_start=1,
+                line_end=3,
+                yaml_lines=yaml_text,
+            )
+        )
+
+        mock_provider = AsyncMock()
+        mock_provider.propose_unit_fixes.return_value = (
+            None,
+            [AISkipped(rule_id="L099", line=1, reason="Too complex", suggestion="Manual fix")],
+        )
+
+        violations: list[dict[str, object]] = [
+            {"rule_id": "L099", "message": "Complex issue", "path": node_path, "line": 1},
+        ]
+
+        proposals = await PrimaryServicer._graph_ai_escalate(
+            graph=graph,
+            remaining_ai=violations,  # type: ignore[arg-type]
+            ai_provider=mock_provider,
+            temp_dir=tmp_path,
+        )
+
+        assert len(proposals) == 1
+        proposal: AIProposal = proposals[0]  # type: ignore[assignment]
+        assert proposal.diff == ""
+        assert proposal.fixed_snippet == yaml_text
+        assert len(proposal.skipped) == 1
+        assert proposal.skipped[0].rule_id == "L099"
+
+    async def test_multiple_nodes_concurrent(self, tmp_path: Path) -> None:
+        """Multiple nodes are proposed concurrently; all results collected.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from unittest.mock import AsyncMock
+
+        from apme_engine.daemon.primary_server import PrimaryServicer
+        from apme_engine.engine.content_graph import ContentGraph, ContentNode, NodeIdentity, NodeType
+        from apme_engine.remediation.ai_provider import AIPatch, AIProposal
+
+        graph = ContentGraph()
+        for i in range(3):
+            node_path = f"play.yml/plays[0]/tasks[{i}]"
+            graph.add_node(
+                ContentNode(
+                    identity=NodeIdentity(path=node_path, node_type=NodeType.TASK),
+                    file_path=str(tmp_path / "play.yml"),
+                    line_start=i * 3 + 1,
+                    line_end=i * 3 + 3,
+                    yaml_lines=f"- name: Task {i}\n  debug:\n    msg: hi\n",
+                )
+            )
+
+        async def mock_propose(**kwargs: object) -> tuple[list[AIPatch], list[object]]:
+            snippet = str(kwargs.get("snippet", ""))
+            return (
+                [
+                    AIPatch(
+                        rule_id="L001",
+                        line_start=1,
+                        line_end=3,
+                        fixed_lines=snippet.replace("debug", "ansible.builtin.debug"),
+                        explanation="Use FQCN",
+                        confidence=0.9,
+                    )
+                ],
+                [],
+            )
+
+        mock_provider = AsyncMock()
+        mock_provider.propose_unit_fixes.side_effect = mock_propose
+
+        violations: list[dict[str, object]] = [
+            {"rule_id": "L001", "path": f"play.yml/plays[0]/tasks[{i}]", "line": i * 3 + 2} for i in range(3)
+        ]
+
+        proposals = await PrimaryServicer._graph_ai_escalate(
+            graph=graph,
+            remaining_ai=violations,  # type: ignore[arg-type]
+            ai_provider=mock_provider,
+            temp_dir=tmp_path,
+        )
+
+        assert len(proposals) == 3
+        assert mock_provider.propose_unit_fixes.call_count == 3
+        for p in proposals:
+            proposal: AIProposal = p  # type: ignore[assignment]
+            assert "ansible.builtin.debug" in proposal.fixed_snippet
+
+
+class TestSessionGraphAIIntegration:
+    """Integration tests for AI escalation within _session_graph_remediate (PR 6).
+
+    Verifies that _session_graph_remediate correctly wires AI escalation
+    after Tier 1 convergence when fix_opts enables AI.
+    """
+
+    async def test_ai_proposals_emitted(self, tmp_path: Path) -> None:
+        """When AI provider returns proposals, ProposalsReady event is emitted.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from unittest.mock import MagicMock
+
+        from apme_engine.daemon.primary_server import PrimaryServicer
+        from apme_engine.engine.content_graph import ContentGraph, ContentNode, NodeIdentity, NodeType
+        from apme_engine.remediation.ai_provider import AIProposal
+        from apme_engine.remediation.graph_engine import GraphFixReport
+
+        servicer = PrimaryServicer.__new__(PrimaryServicer)
+
+        yaml_content = "- name: Test\n  debug:\n    msg: hi\n"
+        play_file = tmp_path / "play.yml"
+        play_file.write_text(yaml_content)
+
+        graph = ContentGraph()
+        node_path = "play.yml/plays[0]/tasks[0]"
+        graph.add_node(
+            ContentNode(
+                identity=NodeIdentity(path=node_path, node_type=NodeType.TASK),
+                file_path=str(play_file),
+                yaml_lines=yaml_content,
+            )
+        )
+
+        session = SessionState(session_id="test-graph-ai-1")
+        session.working_files = {"play.yml": yaml_content.encode()}
+        session.original_files = dict(session.working_files)
+
+        ai_violations: list[dict[str, object]] = [
+            {"rule_id": "L042", "message": "Complex fix", "path": node_path, "line": 2},
+        ]
+
+        mock_ai_proposal = AIProposal(
+            file=str(play_file),
+            original_snippet=yaml_content,
+            fixed_snippet="- name: Test\n  ansible.builtin.debug:\n    msg: hi\n",
+            diff="--- a/play.yml\n+++ b/play.yml\n@@ -1,3 +1,3 @@\n",
+            rule_ids=["L042"],
+            confidence=0.9,
+            explanation="Use FQCN",
+        )
+
+        loop = asyncio.get_running_loop()
+        progress_queue: asyncio.Queue[ProgressUpdate | None] = asyncio.Queue()
+
+        fix_opts = FixOptions(enable_ai=True, ai_model="test-model")
+
+        with (
+            patch("apme_engine.engine.graph_scanner.load_graph_rules", return_value=[]),
+            patch("apme_engine.remediation.graph_engine.GraphRemediationEngine") as MockGRE,
+            patch("apme_engine.remediation.graph_engine.splice_modifications", return_value=[]),
+            patch("apme_engine.remediation.partition.add_classification_to_violations"),
+            patch(
+                "apme_engine.remediation.partition.partition_violations",
+                return_value=([], ai_violations, []),
+            ),
+            patch.object(
+                PrimaryServicer,
+                "_resolve_ai_provider",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                PrimaryServicer,
+                "_graph_ai_escalate",
+                return_value=[mock_ai_proposal],
+            ),
+        ):
+            MockGRE.return_value.remediate.return_value = GraphFixReport(passes=1, fixed=0)
+
+            events: list[SessionEvent] = []
+            async for event in servicer._session_graph_remediate(
+                session=session,
+                scan_id="scan-ai-1",
+                registry=MagicMock(),
+                scan_fn=lambda _paths: ai_violations,  # type: ignore[arg-type,return-value]
+                captured_graph=[graph],
+                yaml_paths=[str(play_file)],
+                temp_dir=tmp_path,
+                max_passes=5,
+                progress_queue=progress_queue,
+                progress_callback=lambda *a: None,
+                _heartbeat=_noop_heartbeat,
+                loop=loop,
+                format_content=_noop_format,
+                format_diffs=[],
+                fix_opts=fix_opts,
+            ):
+                events.append(event)
+
+        event_types = [e.WhichOneof("event") for e in events]
+        assert "proposals" in event_types, f"Expected ProposalsReady event, got: {event_types}"
+
+        proposals_event = next(e for e in events if e.HasField("proposals"))
+        assert proposals_event.proposals.tier == 2
+        assert len(proposals_event.proposals.proposals) >= 1
+
+        assert session.status == 1  # AWAITING_APPROVAL
+        assert session.current_tier == 2
+
+    async def test_no_ai_provider_goes_to_complete(self, tmp_path: Path) -> None:
+        """Without fix_opts, no AI escalation — session completes normally.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from unittest.mock import MagicMock
+
+        from apme_engine.daemon.primary_server import PrimaryServicer
+        from apme_engine.engine.content_graph import ContentGraph
+        from apme_engine.remediation.graph_engine import GraphFixReport
+
+        servicer = PrimaryServicer.__new__(PrimaryServicer)
+
+        play_file = tmp_path / "play.yml"
+        play_file.write_text("- name: Test\n  debug:\n    msg: hi\n")
+
+        session = SessionState(session_id="test-no-ai")
+        session.working_files = {"play.yml": play_file.read_bytes()}
+        session.original_files = dict(session.working_files)
+
+        ai_violations: list[dict[str, object]] = [
+            {"rule_id": "L042", "message": "Complex fix", "file": "play.yml", "line": 2},
+        ]
+
+        loop = asyncio.get_running_loop()
+        progress_queue: asyncio.Queue[ProgressUpdate | None] = asyncio.Queue()
+
+        with (
+            patch("apme_engine.engine.graph_scanner.load_graph_rules", return_value=[]),
+            patch("apme_engine.remediation.graph_engine.GraphRemediationEngine") as MockGRE,
+            patch("apme_engine.remediation.graph_engine.splice_modifications", return_value=[]),
+            patch("apme_engine.remediation.partition.add_classification_to_violations"),
+            patch(
+                "apme_engine.remediation.partition.partition_violations",
+                return_value=([], ai_violations, []),
+            ),
+        ):
+            MockGRE.return_value.remediate.return_value = GraphFixReport(passes=1, fixed=0)
+
+            events: list[SessionEvent] = []
+            async for event in servicer._session_graph_remediate(
+                session=session,
+                scan_id="scan-no-ai",
+                registry=MagicMock(),
+                scan_fn=lambda _paths: ai_violations,  # type: ignore[arg-type,return-value]
+                captured_graph=[ContentGraph()],
+                yaml_paths=[str(play_file)],
+                temp_dir=tmp_path,
+                max_passes=5,
+                progress_queue=progress_queue,
+                progress_callback=lambda *a: None,
+                _heartbeat=_noop_heartbeat,
+                loop=loop,
+                format_content=_noop_format,
+                format_diffs=[],
+            ):
+                events.append(event)
+
+        event_types = [e.WhichOneof("event") for e in events]
+        assert "proposals" not in event_types
+        assert "result" in event_types
+        assert session.status == 3  # COMPLETE
+
+    async def test_empty_proposals_goes_to_complete(self, tmp_path: Path) -> None:
+        """When AI returns no proposals, session completes normally.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from unittest.mock import MagicMock
+
+        from apme_engine.daemon.primary_server import PrimaryServicer
+        from apme_engine.engine.content_graph import ContentGraph
+        from apme_engine.remediation.graph_engine import GraphFixReport
+
+        servicer = PrimaryServicer.__new__(PrimaryServicer)
+
+        play_file = tmp_path / "play.yml"
+        play_file.write_text("- name: Test\n  debug:\n    msg: hi\n")
+
+        session = SessionState(session_id="test-ai-empty")
+        session.working_files = {"play.yml": play_file.read_bytes()}
+        session.original_files = dict(session.working_files)
+
+        ai_violations: list[dict[str, object]] = [
+            {"rule_id": "L042", "message": "Complex fix", "file": "play.yml", "line": 2},
+        ]
+
+        loop = asyncio.get_running_loop()
+        progress_queue: asyncio.Queue[ProgressUpdate | None] = asyncio.Queue()
+
+        fix_opts = FixOptions(enable_ai=True, ai_model="test-model")
+
+        with (
+            patch("apme_engine.engine.graph_scanner.load_graph_rules", return_value=[]),
+            patch("apme_engine.remediation.graph_engine.GraphRemediationEngine") as MockGRE,
+            patch("apme_engine.remediation.graph_engine.splice_modifications", return_value=[]),
+            patch("apme_engine.remediation.partition.add_classification_to_violations"),
+            patch(
+                "apme_engine.remediation.partition.partition_violations",
+                return_value=([], ai_violations, []),
+            ),
+            patch.object(
+                PrimaryServicer,
+                "_resolve_ai_provider",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                PrimaryServicer,
+                "_graph_ai_escalate",
+                return_value=[],
+            ),
+        ):
+            MockGRE.return_value.remediate.return_value = GraphFixReport(passes=1, fixed=0)
+
+            events: list[SessionEvent] = []
+            async for event in servicer._session_graph_remediate(
+                session=session,
+                scan_id="scan-ai-empty",
+                registry=MagicMock(),
+                scan_fn=lambda _paths: ai_violations,  # type: ignore[arg-type,return-value]
+                captured_graph=[ContentGraph()],
+                yaml_paths=[str(play_file)],
+                temp_dir=tmp_path,
+                max_passes=5,
+                progress_queue=progress_queue,
+                progress_callback=lambda *a: None,
+                _heartbeat=_noop_heartbeat,
+                loop=loop,
+                format_content=_noop_format,
+                format_diffs=[],
+                fix_opts=fix_opts,
+            ):
+                events.append(event)
+
+        event_types = [e.WhichOneof("event") for e in events]
+        assert "proposals" not in event_types
+        assert "result" in event_types
+        assert session.status == 3  # COMPLETE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Wire `AIProvider` into `_session_graph_remediate` so the graph engine path produces AI proposals for Tier 2 violations
- Use `ContentGraph` nodes as the natural unit for `propose_unit_fixes` — each `ContentNode` already has the YAML snippet, file path, and line range that the AI provider needs
- Replaces the legacy `NodeIndex + extract_units` approach with graph-native per-node context

## Changes

- **`_session_graph_remediate`**: Accept `fix_opts` parameter; after Tier 1 convergence + final scan, resolve AI provider and escalate remaining AI-eligible violations
- **`_graph_ai_escalate`**: New static method that groups violations by node ID, calls `propose_unit_fixes` concurrently (up to 8 parallel LLM calls via `asyncio.gather`), and builds `AIProposal` objects
- **Proposal flow**: Reuses existing `_build_proposals_from_ai` → `ProposalsReady` → `AWAITING_APPROVAL` pattern, matching the legacy engine path
- **Error handling**: Provider failures per-node are caught and logged; skipped violations produce declined proposals with AI reasoning

## Design decisions

- **Post-convergence** AI escalation (not during convergence) — AI proposals require user approval and don't fit the silent transform contract
- **Async-native**: Since `_session_graph_remediate` is an async generator, AI calls run directly on the event loop (no `asyncio.run` or executor needed, unlike the sync `RemediationEngine`)
- Violations that don't map to graph nodes (no matching `path` in graph) are silently skipped — they remain in `remaining_ai` for the client

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2083 tests, 8 new)
- New tests:
  - `TestGraphAIEscalate` (5 tests): per-node grouping, unknown node skip, provider failure handling, skipped→declined, concurrent multi-node
  - `TestSessionGraphAIIntegration` (3 tests): ProposalsReady emitted, no-provider→COMPLETE, empty proposals→COMPLETE

Made with [Cursor](https://cursor.com)