### PR TITLE
feat(daemon): populate line_start/line_end in graph-based AI proposals

### DIFF
--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -1782,6 +1782,8 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                     id=f"ai-{idx:04d}",
                     file=anp.file_path,
                     rule_id=rule_id,
+                    line_start=anp.line_start,
+                    line_end=anp.line_end,
                     before_text=anp.before_yaml,
                     after_text=anp.after_yaml,
                     diff_hunk=diff_hunk,

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -106,6 +106,8 @@ class AINodeProposal:
         rule_ids: Rule IDs addressed by this fix.
         explanation: Human-readable summary.
         confidence: AI confidence score.
+        line_start: Starting line in the original source file (0 if unknown).
+        line_end: Ending line in the original source file (0 if unknown).
     """
 
     node_id: str
@@ -115,6 +117,8 @@ class AINodeProposal:
     rule_ids: list[str] = field(default_factory=list)
     explanation: str = ""
     confidence: float = 0.85
+    line_start: int = 0
+    line_end: int = 0
 
 
 class GraphRemediationEngine:
@@ -458,6 +462,8 @@ class GraphRemediationEngine:
                     rule_ids=fix.rule_ids,
                     explanation=fix.explanation,
                     confidence=fix.confidence,
+                    line_start=node.line_start,
+                    line_end=node.line_end,
                 ),
             )
             logger.info(

--- a/tests/test_ai_graph_transform.py
+++ b/tests/test_ai_graph_transform.py
@@ -652,6 +652,8 @@ class TestUnifiedConvergence:
         assert proposal.before_yaml == original_yaml
         assert proposal.after_yaml == fixed_yaml
         assert "L013" in proposal.rule_ids
+        assert proposal.line_start == 3
+        assert proposal.line_end == 6
 
     async def test_ai_skip_unchanged_snippet(self) -> None:
         """AI returning unchanged YAML produces no proposal."""
@@ -724,3 +726,58 @@ class TestAINodeProposal:
         )
         assert p.node_id == "test"
         assert p.confidence == 0.95
+
+    def test_line_fields_default_to_zero(self) -> None:
+        """Line fields default to 0 when not specified."""
+        p = AINodeProposal(
+            node_id="n",
+            file_path="f.yml",
+            before_yaml="a",
+            after_yaml="b",
+        )
+        assert p.line_start == 0
+        assert p.line_end == 0
+
+    def test_line_fields_populated(self) -> None:
+        """Line fields are stored when explicitly provided."""
+        p = AINodeProposal(
+            node_id="site.yml/plays[0]/tasks[0]",
+            file_path="site.yml",
+            before_yaml="old",
+            after_yaml="new",
+            line_start=10,
+            line_end=15,
+        )
+        assert p.line_start == 10
+        assert p.line_end == 15
+
+
+# ---------------------------------------------------------------------------
+# _build_graph_proposals proto conversion
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGraphProposals:
+    """Proto conversion preserves line info from AINodeProposal."""
+
+    def test_line_fields_forwarded_to_proto(self) -> None:
+        """Line start/end from AINodeProposal appear on the Proposal proto."""
+        from apme_engine.daemon.primary_server import PrimaryServicer
+
+        anp = AINodeProposal(
+            node_id="site.yml/plays[0]/tasks[0]",
+            file_path="site.yml",
+            before_yaml="- name: Old\n  debug:\n    msg: hi\n",
+            after_yaml="- name: New\n  debug:\n    msg: hi\n",
+            rule_ids=["L013"],
+            confidence=0.9,
+            line_start=5,
+            line_end=8,
+        )
+        proposals = PrimaryServicer._build_graph_proposals([anp])
+
+        assert len(proposals) == 1
+        assert proposals[0].line_start == 5
+        assert proposals[0].line_end == 8
+        assert proposals[0].file == "site.yml"
+        assert proposals[0].tier == 2


### PR DESCRIPTION
## Summary
- AI proposals now include original-file line numbers, giving the CLI interactive review and UI the same source-location context that deterministic proposals have

## Changes
- **`AINodeProposal`** dataclass — added `line_start`/`line_end` fields (default 0)
- **`_apply_ai_transforms()`** — populates line fields from `ContentNode.line_start`/`line_end` (node is already loaded at that point)
- **`_build_graph_proposals()`** — forwards `anp.line_start`/`anp.line_end` to the `Proposal` proto
- **Tests** — 3 new tests (dataclass defaults, explicit values, proto forwarding) plus line assertions on existing `test_ai_proposal_contains_before_after`

No UI or CLI changes needed — both already guard on `line_start > 0`.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` — all AI graph transform and session tests pass
- [x] Verified UI `ProposalReviewPanel.tsx` and CLI `remediate.py` already handle `line_start > 0`

Closes #240

Made with [Cursor](https://cursor.com)