### PR TITLE
feat(build): add Vertex AI provider support

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -80,6 +80,9 @@ venv/
 env/
 ENV/
 
+# Host node_modules (container runs npm ci fresh)
+frontend/node_modules/
+
 # Python cache
 __pycache__/
 *.py[cod]

--- a/containers/abbenay/.env.example
+++ b/containers/abbenay/.env.example
@@ -4,6 +4,16 @@
 # Required: at least one LLM provider key matching config.yaml
 OPENROUTER_API_KEY=sk-or-v1-...
 
+# Red Hat internal Claude proxy (models.corp via apicast, Vertex AI format).
+# Your models.corp application credential goes here.
+VERTEX_ANTHROPIC_API_KEY=
+
 # Consumer token — must match what Primary sends (set in pod.yaml).
 # The default dev token works out of the box.
 APME_ABBENAY_TOKEN=apme-dev-token
+
+# Optional: absolute path to a PEM CA bundle for self-hosted model endpoints
+# that use internal or self-signed certificates. When set, the bundle is
+# mounted into the Abbenay container and NODE_EXTRA_CA_CERTS is configured
+# automatically. Leave empty/unset if your provider uses a public CA.
+# ABBENAY_CA_BUNDLE=/path/to/ca-bundle.pem

--- a/containers/abbenay/config.yaml
+++ b/containers/abbenay/config.yaml
@@ -20,7 +20,7 @@ providers:
   # vertex-anthropic:
   #   engine: vertex-anthropic
   #   base_url: "https://your-proxy.example.com:443/models"
-  #   api_key_env_var_name: "VERTEX_ANTHROPIC_API_KEY"
+  #   api_key_env: "VERTEX_ANTHROPIC_API_KEY"
   #   models:
   #     claude-sonnet-4@20250514: {}
 

--- a/containers/abbenay/config.yaml
+++ b/containers/abbenay/config.yaml
@@ -11,8 +11,18 @@ providers:
     engine: openrouter
     models:
       anthropic/claude-sonnet-4: {}
-      anthropic/claude-opus-4.6: {}    
+      anthropic/claude-opus-4.6: {}
     api_key_env: OPENROUTER_API_KEY
+
+  # Example: Vertex AI Anthropic proxy (self-hosted Claude endpoints).
+  # Uncomment and set VERTEX_ANTHROPIC_API_KEY in .env.
+  # If the endpoint uses an internal CA, set ABBENAY_CA_BUNDLE in .env.
+  # vertex-anthropic:
+  #   engine: vertex-anthropic
+  #   base_url: "https://your-proxy.example.com:443/models"
+  #   api_key_env_var_name: "VERTEX_ANTHROPIC_API_KEY"
+  #   models:
+  #     claude-sonnet-4@20250514: {}
 
 consumers:
   apme:

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -118,6 +118,8 @@ spec:
       env:
         - name: OPENROUTER_API_KEY
           value: "${OPENROUTER_API_KEY}"
+        - name: VERTEX_ANTHROPIC_API_KEY
+          value: "${VERTEX_ANTHROPIC_API_KEY}"
         - name: APME_ABBENAY_TOKEN
           value: "apme-dev-token"
         - name: XDG_RUNTIME_DIR

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -42,6 +42,14 @@ APME_FEEDBACK_GITHUB_TOKEN="${APME_FEEDBACK_GITHUB_TOKEN:-}"
 # Set ABBENAY_CA_BUNDLE to the absolute path of a PEM CA bundle file.
 ABBENAY_CA_BUNDLE="${ABBENAY_CA_BUNDLE:-}"
 if [[ -n "$ABBENAY_CA_BUNDLE" ]]; then
+  if [[ "$ABBENAY_CA_BUNDLE" != /* ]]; then
+    echo "ERROR: ABBENAY_CA_BUNDLE must be an absolute path (got: $ABBENAY_CA_BUNDLE)" >&2
+    exit 1
+  fi
+  if [[ "$ABBENAY_CA_BUNDLE" == *$'\n'* ]]; then
+    echo "ERROR: ABBENAY_CA_BUNDLE must not contain newlines" >&2
+    exit 1
+  fi
   if [[ ! -f "$ABBENAY_CA_BUNDLE" ]]; then
     echo "ERROR: ABBENAY_CA_BUNDLE points to a file that does not exist: $ABBENAY_CA_BUNDLE" >&2
     exit 1

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -32,10 +32,25 @@ if [[ -f "$ABBENAY_ENV" ]]; then
   set +a
 fi
 OPENROUTER_API_KEY="${OPENROUTER_API_KEY:-}"
+VERTEX_ANTHROPIC_API_KEY="${VERTEX_ANTHROPIC_API_KEY:-}"
 APME_AI_MODEL="${APME_AI_MODEL:-}"
 APME_FEEDBACK_ENABLED="${APME_FEEDBACK_ENABLED:-true}"
 APME_FEEDBACK_GITHUB_REPO="${APME_FEEDBACK_GITHUB_REPO:-}"
 APME_FEEDBACK_GITHUB_TOKEN="${APME_FEEDBACK_GITHUB_TOKEN:-}"
+
+# Optional: CA bundle for self-hosted model endpoints with internal/self-signed CAs.
+# Set ABBENAY_CA_BUNDLE to the absolute path of a PEM CA bundle file.
+ABBENAY_CA_BUNDLE="${ABBENAY_CA_BUNDLE:-}"
+if [[ -n "$ABBENAY_CA_BUNDLE" ]]; then
+  if [[ ! -f "$ABBENAY_CA_BUNDLE" ]]; then
+    echo "ERROR: ABBENAY_CA_BUNDLE points to a file that does not exist: $ABBENAY_CA_BUNDLE" >&2
+    exit 1
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: ABBENAY_CA_BUNDLE requires python3 to patch the pod YAML, but python3 was not found in PATH" >&2
+    exit 1
+  fi
+fi
 
 # Tear down any existing pod so we get a clean start.
 if podman pod exists apme-pod 2>/dev/null; then
@@ -48,11 +63,52 @@ fi
 # CACHE_PATH is escaped for sed since it may contain special chars;
 # everything else goes through envsubst so secrets stay out of argv.
 ESCAPED_PATH=$(printf '%s\n' "$CACHE_PATH" | sed -e 's/\\/\\\\/g' -e 's/[&|]/\\&/g')
-export OPENROUTER_API_KEY APME_AI_MODEL APME_ROOT="$ROOT"
+export OPENROUTER_API_KEY VERTEX_ANTHROPIC_API_KEY APME_AI_MODEL APME_ROOT="$ROOT"
 export APME_FEEDBACK_ENABLED APME_FEEDBACK_GITHUB_REPO APME_FEEDBACK_GITHUB_TOKEN
-sed "s|path: __APME_CACHE_PATH__|path: ${ESCAPED_PATH}|" containers/podman/pod.yaml \
-  | envsubst '$OPENROUTER_API_KEY $APME_AI_MODEL $APME_ROOT $APME_FEEDBACK_ENABLED $APME_FEEDBACK_GITHUB_REPO $APME_FEEDBACK_GITHUB_TOKEN' \
-  | podman play kube -
+
+# Build the pod YAML: substitute cache path and env vars.
+POD_YAML=$(sed "s|path: __APME_CACHE_PATH__|path: ${ESCAPED_PATH}|" containers/podman/pod.yaml \
+  | envsubst '$OPENROUTER_API_KEY $VERTEX_ANTHROPIC_API_KEY $APME_AI_MODEL $APME_ROOT $APME_FEEDBACK_ENABLED $APME_FEEDBACK_GITHUB_REPO $APME_FEEDBACK_GITHUB_TOKEN')
+
+# When a CA bundle is provided, inject NODE_EXTRA_CA_CERTS env var, volume mount,
+# and volume definition into the Abbenay container section of the pod YAML.
+if [[ -n "$ABBENAY_CA_BUNDLE" ]]; then
+  CA_MOUNT_PATH="/etc/ssl/certs/custom-ca-bundle.pem"
+  POD_YAML=$(python3 -c "
+import json, sys, os
+yaml = sys.stdin.read()
+ca_path = os.environ['ABBENAY_CA_BUNDLE']
+mount = '$CA_MOUNT_PATH'
+ca_path_yaml = json.dumps(ca_path)
+mount_yaml = json.dumps(mount)
+env_marker = '        - name: XDG_RUNTIME_DIR'
+vol_marker = '          readOnly: true\n    - name: galaxy-proxy'
+if env_marker not in yaml or vol_marker not in yaml:
+    print('ERROR: pod.yaml markers not found; CA bundle injection failed', file=sys.stderr)
+    sys.exit(1)
+yaml = yaml.replace(
+    env_marker,
+    '        - name: NODE_EXTRA_CA_CERTS\n'
+    '          value: ' + mount_yaml + '\n'
+    '        ' + env_marker.lstrip())
+yaml = yaml.replace(
+    vol_marker,
+    '          readOnly: true\n'
+    '        - name: abbenay-ca-bundle\n'
+    '          mountPath: ' + mount_yaml + '\n'
+    '          readOnly: true\n'
+    '    - name: galaxy-proxy')
+yaml = yaml.rstrip() + '\n' \
+    '    - name: abbenay-ca-bundle\n' \
+    '      hostPath:\n' \
+    '        path: ' + ca_path_yaml + '\n' \
+    '        type: File\n'
+print(yaml)
+" <<< "$POD_YAML")
+  echo "CA bundle enabled: $ABBENAY_CA_BUNDLE -> $CA_MOUNT_PATH (inside container)"
+fi
+
+echo "$POD_YAML" | podman play kube -
 
 echo "Pod apme-pod started (cache: $CACHE_PATH). Run a scan: containers/podman/run-cli.sh"
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -31,7 +31,7 @@ This builds a shared base image, nine service images, and pulls one official ima
 | `apme-gateway:latest` | `containers/gateway/Dockerfile` | REST API + gRPC Reporting service (SQLite) |
 | `apme-ui:latest` | `containers/ui/Dockerfile` | React SPA served by nginx (proxies API to Gateway) |
 | `apme-cli:latest` | `containers/cli/Dockerfile` | CLI client |
-| `ghcr.io/redhat-developer/abbenay:2026.3.7-alpha` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
+| `ghcr.io/redhat-developer/abbenay:2026.3.8-alpha` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
 
 ### Configure Abbenay AI (optional)
 
@@ -42,9 +42,19 @@ cp containers/abbenay/.env.example containers/abbenay/.env
 # Edit .env and set your LLM provider API key (e.g., OPENROUTER_API_KEY)
 ```
 
-The `.env` file is gitignored. The default `config.yaml` configures OpenRouter with the `apme-dev-token` consumer. To use a different provider or model, edit `containers/abbenay/config.yaml`.
+The `.env` file is gitignored. The default `config.yaml` configures the LLM provider and consumer token. To use a different provider or model, edit `containers/abbenay/config.yaml`.
 
 If `.env` is missing or the key is empty, the Abbenay container starts but model queries return empty results. AI remediation gracefully degrades — Tier 1 deterministic fixes still work.
+
+#### Custom CA certificates (self-hosted models)
+
+When using a self-hosted model endpoint with internal or self-signed CA certificates, set `ABBENAY_CA_BUNDLE` in your `.env` to the absolute path of a PEM CA bundle:
+
+```bash
+ABBENAY_CA_BUNDLE=/path/to/ca-bundle.pem
+```
+
+The start script (`up.sh`) automatically mounts the bundle into the Abbenay container and sets `NODE_EXTRA_CA_CERTS`. This is only needed for endpoints that use non-public CAs — public providers like OpenRouter, Anthropic, and OpenAI work without it.
 
 ### Start the pod
 
@@ -146,10 +156,12 @@ The OPA binary runs internally on `localhost:8181`; the gRPC wrapper proxies to 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENROUTER_API_KEY` | — | LLM provider API key (from `containers/abbenay/.env`) |
+| `OPENROUTER_API_KEY` | — | OpenRouter API key (from `containers/abbenay/.env`) |
+| `VERTEX_ANTHROPIC_API_KEY` | — | Vertex AI Anthropic proxy API key (from `containers/abbenay/.env`) |
 | `APME_ABBENAY_TOKEN` | `apme-dev-token` | Consumer token (must match `config.yaml` consumers section) |
+| `NODE_EXTRA_CA_CERTS` | — | CA bundle path inside container (auto-set by `up.sh` when `ABBENAY_CA_BUNDLE` is configured) |
 
-Abbenay uses the official container image (`ghcr.io/redhat-developer/abbenay`) with `containers/abbenay/config.yaml` volume-mounted at runtime. The default config uses OpenRouter as the LLM provider. To add providers or models, edit the `providers` section. API keys are injected from environment variables — never committed to the config file.
+Abbenay uses `containers/abbenay/config.yaml` volume-mounted at runtime. The config defines LLM providers and models. API keys are injected from environment variables — never committed to the config file. To add providers or models, edit the `providers` section of the config.
 
 The Abbenay daemon exposes a gRPC API on port 50057. Primary connects to it for AI model listing (`ListAIModels`) and batch remediation requests.
 

--- a/src/apme_engine/remediation/abbenay_provider.py
+++ b/src/apme_engine/remediation/abbenay_provider.py
@@ -160,6 +160,10 @@ def _parse_node_response(
     """
     data = _extract_json_object(response_text)
     if data is None:
+        logger.warning(
+            "_parse_node_response: no JSON object found in response (response_length=%d)",
+            len(response_text),
+        )
         return None
 
     fixed_snippet = data.get("fixed_snippet")

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -230,9 +230,19 @@ class GraphRemediationEngine:
 
         for pass_num in range(1, self._max_passes + 1):
             passes = pass_num
+            tier1_stalled = False
             self._progress("graph-tier1", f"Pass {pass_num}/{self._max_passes}")
 
-            tier1, tier2, _ = partition_violations(violations, registry)
+            tier1, tier2, tier3 = partition_violations(violations, registry)
+            logger.debug(
+                "Graph remediation pass %d: %d violations -> tier1=%d tier2=%d tier3=%d (ai_provider=%s)",
+                pass_num,
+                len(violations),
+                len(tier1),
+                len(tier2),
+                len(tier3),
+                self._ai_provider is not None,
+            )
 
             # Phase A: Tier 1 deterministic transforms
             if tier1:
@@ -243,32 +253,50 @@ class GraphRemediationEngine:
                     all_fixed,
                     pass_num,
                 )
+                logger.debug(
+                    "Graph remediation pass %d: tier1 applied=%d/%d",
+                    pass_num,
+                    applied_this_pass,
+                    len(tier1),
+                )
 
                 if applied_this_pass == 0:
-                    break
-
-                violations = await self._rescan_and_record(graph, pass_num)
-                new_tier1, new_tier2, _ = partition_violations(violations, registry)
-                new_fixable = len(new_tier1)
-
-                if new_fixable >= prev_count:
-                    logger.warning(
-                        "Graph remediation: oscillation at pass %d (%d >= %d)",
+                    # Tier 1 stalled: transforms exist but none succeeded.
+                    # Fall through to Tier 2 AI instead of breaking.
+                    tier1_stalled = True
+                    logger.debug(
+                        "Graph remediation pass %d: tier1 stalled (0 applied); falling through to AI (tier2=%d)",
                         pass_num,
-                        new_fixable,
-                        prev_count,
+                        len(tier2),
                     )
-                    oscillation = True
-                    break
+                else:
+                    violations = await self._rescan_and_record(graph, pass_num)
+                    new_tier1, new_tier2, _ = partition_violations(violations, registry)
+                    new_fixable = len(new_tier1)
 
-                prev_count = new_fixable
-                if new_fixable > 0:
-                    continue
+                    if new_fixable >= prev_count:
+                        logger.warning(
+                            "Graph remediation: oscillation at pass %d (%d >= %d)",
+                            pass_num,
+                            new_fixable,
+                            prev_count,
+                        )
+                        oscillation = True
+                        break
 
-                tier1, tier2 = new_tier1, new_tier2
+                    prev_count = new_fixable
+                    if new_fixable > 0:
+                        continue
 
-            # Phase B: Tier 2 AI transforms
-            if not tier1 and tier2 and self._ai_provider is not None and ai_attempts < self._max_ai_attempts:
+                    tier1, tier2 = new_tier1, new_tier2
+
+            # Phase B: Tier 2 AI transforms (also when tier1 stalled)
+            if (
+                (not tier1 or tier1_stalled)
+                and tier2
+                and self._ai_provider is not None
+                and ai_attempts < self._max_ai_attempts
+            ):
                 ai_attempts += 1
                 self._progress(
                     "graph-ai",
@@ -308,7 +336,7 @@ class GraphRemediationEngine:
                         ai_feedback_by_node = _build_ai_feedback(new_tier2)
                         continue
 
-            if not tier1 and not tier2:
+            if not tier1 and not tier1_stalled and not tier2:
                 self._progress(
                     "graph-tier1",
                     f"Fully converged at pass {pass_num}",
@@ -316,7 +344,7 @@ class GraphRemediationEngine:
                 logger.info("Graph remediation: fully converged at pass %d", pass_num)
                 break
 
-            if not tier1 and (self._ai_provider is None or ai_attempts >= self._max_ai_attempts):
+            if (not tier1 or tier1_stalled) and (self._ai_provider is None or ai_attempts >= self._max_ai_attempts):
                 logger.info(
                     "Graph remediation: Tier 1 exhausted, %d remaining AI candidates (ai_attempts=%d/%d)",
                     len(tier2),
@@ -367,18 +395,31 @@ class GraphRemediationEngine:
         )
 
         applied_this_pass = 0
+        skipped_no_transform = 0
+        skipped_no_apply = 0
         for v in tier1:
             rule_id = normalize_rule_id(str(v.get("rule_id", "")))
             node_id = str(v.get("path", ""))
 
             transform_fn = registry.get_node_transform(rule_id)
             if transform_fn is None:
+                skipped_no_transform += 1
                 continue
 
             applied = await graph.apply_transform(node_id, transform_fn, v)
             if applied:
                 applied_this_pass += 1
                 all_fixed.append(dict(v))
+            else:
+                skipped_no_apply += 1
+                logger.debug("Tier1 transform %s on %r: not applied", rule_id, node_id)
+        logger.debug(
+            "Tier1 pass %d summary: applied=%d skipped_no_transform=%d skipped_no_apply=%d",
+            pass_num,
+            applied_this_pass,
+            skipped_no_transform,
+            skipped_no_apply,
+        )
 
         for nid in graph.dirty_nodes:
             node = graph.get_node(nid)
@@ -418,12 +459,19 @@ class GraphRemediationEngine:
             if node_id:
                 by_node[node_id].append(v)
 
+        logger.debug(
+            "AI transforms: %d tier2 violations grouped into %d nodes",
+            len(tier2),
+            len(by_node),
+        )
+
         proposals: list[AINodeProposal] = []
         assert self._ai_provider is not None  # noqa: S101
 
         for node_id, node_violations in by_node.items():
             node = graph.get_node(node_id)
             if node is None:
+                logger.warning("AI: node %r not found in graph — skipping", node_id)
                 continue
             before_yaml = node.yaml_lines
 
@@ -435,18 +483,26 @@ class GraphRemediationEngine:
                 feedback=feedback,
             )
             if context is None:
+                logger.warning("AI: context is None for node %s — skipping", node_id)
                 continue
 
             try:
+                logger.debug("AI: calling propose_node_fix for %s (%d violations)", node_id, len(node_violations))
                 fix = await self._ai_provider.propose_node_fix(context)
+                logger.debug("AI: propose_node_fix returned for %s: fix=%s", node_id, fix is not None)
             except Exception:
                 logger.exception("AI provider failed for node %s", node_id)
                 continue
 
             if fix is None or not fix.fixed_snippet:
+                logger.debug("AI returned no usable fix for node %s", node_id)
                 continue
 
             if fix.fixed_snippet.strip() == before_yaml.strip():
+                logger.debug(
+                    "AI returned identical content for node %s (no change)",
+                    node_id,
+                )
                 continue
 
             node.update_from_yaml(fix.fixed_snippet)

--- a/tests/test_graph_remediation.py
+++ b/tests/test_graph_remediation.py
@@ -639,7 +639,7 @@ class TestGraphRemediationEngine:
         graph.add_node(node)
         rules: list[GraphRule] = [_FQCNRule()]
 
-        def _always_fail_transform(task: "CommentedMap", violation: ViolationDict) -> bool:
+        def _always_fail_transform(task: CommentedMap, violation: ViolationDict) -> bool:
             return False
 
         registry = TransformRegistry()
@@ -698,7 +698,7 @@ class TestGraphRemediationEngine:
         graph.add_node(node)
         rules: list[GraphRule] = [_FQCNRule()]
 
-        def _always_fail_transform(task: "CommentedMap", violation: ViolationDict) -> bool:
+        def _always_fail_transform(task: CommentedMap, violation: ViolationDict) -> bool:
             return False
 
         registry = TransformRegistry()

--- a/tests/test_graph_remediation.py
+++ b/tests/test_graph_remediation.py
@@ -622,6 +622,113 @@ class TestGraphRemediationEngine:
         assert len(report.remaining_violations) == len(graph_violations)
         assert report.remaining_violations[0]["rule_id"] == graph_violations[0]["rule_id"]
 
+    async def test_tier1_stall_falls_through_to_ai(self) -> None:
+        """When Tier 1 transforms exist but all return False, the engine falls through to Tier 2 AI.
+
+        Sets up two violations on the same node:
+        - M001 (FQCN) with a registered transform that always returns False (stall)
+        - L043 (jinja2) with no transform, classified Tier 2 AI candidate
+        When Tier 1 stalls, the engine should invoke the AI provider for L043.
+        """
+        from unittest.mock import AsyncMock
+
+        from apme_engine.remediation.ai_provider import AINodeFix
+
+        graph = ContentGraph()
+        node = _make_node(module="apt")
+        graph.add_node(node)
+        rules: list[GraphRule] = [_FQCNRule()]
+
+        def _always_fail_transform(task: "CommentedMap", violation: ViolationDict) -> bool:
+            return False
+
+        registry = TransformRegistry()
+        registry.register("M001", node=_always_fail_transform)
+
+        ai_provider = AsyncMock()
+        ai_provider.propose_node_fix = AsyncMock(
+            return_value=AINodeFix(
+                fixed_snippet=_TASK_YAML_FQCN,
+                rule_ids=["L043"],
+                explanation="Fixed jinja2 spacing",
+                confidence=0.95,
+            ),
+        )
+
+        violations: list[ViolationDict] = [
+            {
+                "rule_id": "M001",
+                "path": node.node_id,
+                "file": node.file_path,
+                "line": 3,
+                "message": "Use FQCN for apt",
+                "severity": "medium",
+                "source": "native",
+                "scope": "task",
+            },
+            {
+                "rule_id": "L043",
+                "path": node.node_id,
+                "file": node.file_path,
+                "line": 3,
+                "message": "Jinja2 spacing",
+                "severity": "medium",
+                "source": "native",
+                "scope": "task",
+            },
+        ]
+        engine = GraphRemediationEngine(
+            registry,
+            graph,
+            rules,
+            max_passes=5,
+            ai_provider=ai_provider,
+        )
+        report = await engine.remediate(initial_violations=violations)
+
+        ai_provider.propose_node_fix.assert_called()
+        assert report.passes >= 1
+        assert len(report.ai_proposals) >= 1
+        assert not report.oscillation_detected
+
+    async def test_tier1_stall_no_false_convergence(self) -> None:
+        """When Tier 1 stalls and no AI provider is set, the engine does not report full convergence."""
+        graph = ContentGraph()
+        node = _make_node(module="apt")
+        graph.add_node(node)
+        rules: list[GraphRule] = [_FQCNRule()]
+
+        def _always_fail_transform(task: "CommentedMap", violation: ViolationDict) -> bool:
+            return False
+
+        registry = TransformRegistry()
+        registry.register("M001", node=_always_fail_transform)
+
+        violations: list[ViolationDict] = [
+            {
+                "rule_id": "M001",
+                "path": node.node_id,
+                "file": node.file_path,
+                "line": 3,
+                "message": "Use FQCN for apt",
+                "severity": "medium",
+                "source": "native",
+                "scope": "task",
+            }
+        ]
+        engine = GraphRemediationEngine(
+            registry,
+            graph,
+            rules,
+            max_passes=5,
+            ai_provider=None,
+        )
+        report = await engine.remediate(initial_violations=violations)
+
+        assert report.fixed == 0
+        assert len(report.remaining_violations) >= 1
+        assert not report.oscillation_detected
+
     async def test_step_diffs_populated(self) -> None:
         """step_diffs captures per-progression diffs after convergence."""
         graph = ContentGraph()


### PR DESCRIPTION
## Summary
- Add Vertex AI Anthropic provider support and optional CA certificate trust for self-hosted model endpoints that use internal CAs.
- Fix graph remediation convergence: when Tier 1 transforms stall (0 applied), fall through to Tier 2 AI instead of breaking the loop.

## Changes

### Build & Deployment
- **`containers/podman/pod.yaml`**: Add `VERTEX_ANTHROPIC_API_KEY` env var passthrough to Abbenay container.
- **`containers/podman/up.sh`**: Add `VERTEX_ANTHROPIC_API_KEY` to envsubst. Add optional `ABBENAY_CA_BUNDLE` support — when set, dynamically injects `NODE_EXTRA_CA_CERTS` env var, volume mount, and volume definition into the Abbenay container section of the pod YAML. Includes validation (absolute path, no newlines, file existence, python3 preflight, marker checks).
- **`containers/abbenay/config.yaml`**: Add commented-out Vertex AI Anthropic provider example (default OpenRouter config unchanged). Fixed field name to `api_key_env` matching active config.
- **`containers/abbenay/.env.example`**: Document `VERTEX_ANTHROPIC_API_KEY` and `ABBENAY_CA_BUNDLE` variables.
- **`.containerignore`**: Exclude `frontend/node_modules/` from container builds.

### Remediation Engine
- **`src/apme_engine/remediation/graph_engine.py`**: When Tier 1 transforms stall (applied == 0), use `tier1_stalled` flag to fall through to Tier 2 AI instead of breaking the convergence loop. Convergence and exhaustion checks use the flag to avoid false "Fully converged" reports. Add debug-level logging for tier partitioning, transform results, and AI proposal flow.
- **`src/apme_engine/remediation/abbenay_provider.py`**: Add warning log in `_parse_node_response` when no JSON object is found (logs response_length only, not raw content).

### Tests
- **`tests/test_graph_remediation.py`**: Add `test_tier1_stall_falls_through_to_ai` and `test_tier1_stall_no_false_convergence` regression tests.

### Documentation
- **`docs/guides/DEPLOYMENT.md`**: Add CA certificate trust section, document `VERTEX_ANTHROPIC_API_KEY` and `NODE_EXTRA_CA_CERTS` env vars, update Abbenay config description.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (pre-existing failures on upstream/main only, none introduced)
- [x] Tier 1 stall regression tests pass (`test_tier1_stall_falls_through_to_ai`, `test_tier1_stall_no_false_convergence`)
- [x] Docs updated (DEPLOYMENT.md)
- [x] Verified pod starts with and without `ABBENAY_CA_BUNDLE` configured
- [x] All Copilot review comments addressed and resolved