### PR TITLE
fix(test): move formatter CLI tests to integration suite

### DIFF
--- a/tests/integration/test_formatter_cli.py
+++ b/tests/integration/test_formatter_cli.py
@@ -1,7 +1,11 @@
 """CLI integration tests for the format and remediate subcommands.
 
 Exercises the full CLI pipeline via subprocess against a messy YAML fixture.
-No containers required — runs in the normal test suite.
+Requires the daemon infrastructure managed by the integration conftest.
+
+Run with::
+
+    pytest -m integration tests/integration/test_formatter_cli.py -v
 """
 
 import shutil
@@ -13,8 +17,10 @@ import pytest
 
 from apme_engine.cli._exit_codes import EXIT_ERROR
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-FIXTURE = REPO_ROOT / "tests" / "integration" / "test_format_playbook.yml"
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURE = Path(__file__).resolve().parent / "test_format_playbook.yml"
 
 
 def _cli(*args: str, cwd: str | None = None) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Summary
- Move `test_formatter_cli.py` from unit tests to `tests/integration/` to fix orphaned daemon processes that hold ports and break pod starts

## Changes
- Moved `tests/test_formatter_cli.py` to `tests/integration/test_formatter_cli.py`
- Added `pytestmark = pytest.mark.integration` so the integration conftest manages daemon lifecycle
- Simplified `FIXTURE` path since test now lives alongside the fixture file
- Updated `REPO_ROOT` derivation for new directory depth

## Context
The formatter CLI tests use `subprocess.run` to invoke the real CLI, which calls `ensure_daemon()` -> `start_daemon()` -> `os.fork()` + `os.setsid()`. The forked daemon detaches into its own session group and survives after tests complete. No cleanup fixture existed in the unit test suite. The integration conftest already handles this correctly via `stop_daemon()` in `pytest_sessionfinish` and sets `APME_PRIMARY_ADDRESS` so subprocesses skip auto-starting daemons.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2221 passed, 42 skipped)
- [x] `tox -e integration -- tests/integration/test_formatter_cli.py -v` — all 20 formatter CLI tests pass
- [x] Ports are clean after integration test run (no orphaned daemons)

Made with [Cursor](https://cursor.com)