### PR TITLE
fix(remediation): correct summary accounting and unify remediate/check UI

### DIFF
--- a/frontend/src/components/ViolationDetailModal.tsx
+++ b/frontend/src/components/ViolationDetailModal.tsx
@@ -80,18 +80,16 @@ interface ViolationDetailModalProps {
   violation: ViolationRecord;
   diff?: string;
   getRuleDescription?: (ruleId: string) => string | undefined;
-  mergedViolations?: ViolationRecord[];
   scanId?: string;
   feedbackEnabled?: boolean;
 }
 
-export function ViolationDetailModal({ isOpen, onClose, violation, diff, getRuleDescription, mergedViolations, scanId, feedbackEnabled }: ViolationDetailModalProps) {
+export function ViolationDetailModal({ isOpen, onClose, violation, diff, getRuleDescription, scanId, feedbackEnabled }: ViolationDetailModalProps) {
   const [activeTab, setActiveTab] = useState(0);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const ruleDesc = getRuleDescription?.(violation.rule_id);
   const cls = severityClass(violation.level, violation.rule_id);
   const source = ruleSource(violation.rule_id);
-  const isCombinedFixed = !!mergedViolations;
 
   const hasSource = !!violation.original_yaml;
   const startLine = violation.node_line_start || 1;
@@ -110,7 +108,7 @@ export function ViolationDetailModal({ isOpen, onClose, violation, diff, getRule
       aria-label="Violation details"
       width="75%"
     >
-      <ModalHeader title={isCombinedFixed ? 'Fixed Violations' : 'Violation Details'} />
+      <ModalHeader title="Violation Details" />
       <ModalBody>
         <Tabs
           aria-label="Violation detail tabs"
@@ -118,37 +116,6 @@ export function ViolationDetailModal({ isOpen, onClose, violation, diff, getRule
           onSelect={(_e, key) => setActiveTab(key as number)}
         >
           <Tab eventKey={0} title={<TabTitleText>Details</TabTitleText>} aria-label="Details tab">
-            {isCombinedFixed ? (
-              <div style={{ paddingTop: 12 }}>
-                <p style={{ marginBottom: 12, opacity: 0.8 }}>
-                  {mergedViolations.length} violation{mergedViolations.length !== 1 ? 's' : ''} fixed in <strong>{violation.file}</strong>
-                </p>
-                <table className="pf-v6-c-table pf-m-compact" role="grid">
-                  <thead>
-                    <tr role="row">
-                      <th role="columnheader">Rule</th>
-                      <th role="columnheader">Severity</th>
-                      <th role="columnheader">Line</th>
-                      <th role="columnheader">Message</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {mergedViolations.map((v) => (
-                      <tr key={v.id} role="row">
-                        <td role="cell"><span className="apme-rule-id">{bareRuleId(v.rule_id)}</span></td>
-                        <td role="cell">
-                          <span className={`apme-severity ${severityClass(v.level, v.rule_id)}`}>
-                            {severityLabel(v.level, v.rule_id)}
-                          </span>
-                        </td>
-                        <td role="cell">{v.line ?? ''}</td>
-                        <td role="cell">{v.message}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ) : (
               <PageDetails>
                 <PageDetail label="Rule">
                   <span className="apme-rule-id">{bareRuleId(violation.rule_id)}</span>
@@ -191,7 +158,6 @@ export function ViolationDetailModal({ isOpen, onClose, violation, diff, getRule
                   </PageDetail>
                 )}
               </PageDetails>
-            )}
           </Tab>
           {hasSource ? (
             <Tab eventKey={1} title={<TabTitleText>Source</TabTitleText>} aria-label="Source tab">
@@ -230,7 +196,7 @@ export function ViolationDetailModal({ isOpen, onClose, violation, diff, getRule
           ) : null}
           <Tab eventKey={(hasSource ? 1 : 0) + (violationDiff ? 1 : 0) + 1} title={<TabTitleText>Data</TabTitleText>} aria-label="Data tab">
             <div className="apme-modal-diff">
-              <pre>{JSON.stringify(isCombinedFixed ? mergedViolations : violation, null, 2)}</pre>
+              <pre>{JSON.stringify(violation, null, 2)}</pre>
             </div>
           </Tab>
         </Tabs>

--- a/frontend/src/components/ViolationDetailModal.tsx
+++ b/frontend/src/components/ViolationDetailModal.tsx
@@ -50,8 +50,8 @@ function makeUnifiedDiff(original: string, fixed: string, filename: string): str
   return lines.join('\n');
 }
 
-function tierLabel(rc: number): string {
-  if (rc === 1) return 'Fixable';
+function tierLabel(rc: number, isRemediate: boolean): string {
+  if (rc === 1) return isRemediate ? 'Fixed' : 'Fixable';
   if (rc === 2) return 'AI';
   if (rc === 3) return 'Manual';
   return 'Unknown';
@@ -80,16 +80,18 @@ interface ViolationDetailModalProps {
   violation: ViolationRecord;
   diff?: string;
   getRuleDescription?: (ruleId: string) => string | undefined;
+  scanType?: string;
   scanId?: string;
   feedbackEnabled?: boolean;
 }
 
-export function ViolationDetailModal({ isOpen, onClose, violation, diff, getRuleDescription, scanId, feedbackEnabled }: ViolationDetailModalProps) {
+export function ViolationDetailModal({ isOpen, onClose, violation, diff, getRuleDescription, scanType, scanId, feedbackEnabled }: ViolationDetailModalProps) {
   const [activeTab, setActiveTab] = useState(0);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const ruleDesc = getRuleDescription?.(violation.rule_id);
   const cls = severityClass(violation.level, violation.rule_id);
   const source = ruleSource(violation.rule_id);
+  const isRemediate = scanType === 'fix' || scanType === 'remediate';
 
   const hasSource = !!violation.original_yaml;
   const startLine = violation.node_line_start || 1;
@@ -142,7 +144,7 @@ export function ViolationDetailModal({ isOpen, onClose, violation, diff, getRule
                   {violation.line}
                 </PageDetail>
                 <PageDetail label="Remediation">
-                  {tierLabel(violation.remediation_class)}
+                  {tierLabel(violation.remediation_class, isRemediate)}
                 </PageDetail>
                 <PageDetail label="Message">
                   {violation.message}

--- a/frontend/src/components/ViolationOutput.tsx
+++ b/frontend/src/components/ViolationOutput.tsx
@@ -35,15 +35,12 @@ function groupByFile(violations: ViolationRecord[]): Map<string, ViolationRecord
 }
 
 interface DisplayRow {
-  type: 'violation' | 'combined-fixed';
+  type: 'violation';
   violation: ViolationRecord;
-  /** For combined-fixed rows, the individual violations that were merged. */
-  merged?: ViolationRecord[];
 }
 
 interface ViolationOutputProps {
   violations: ViolationRecord[];
-  patchByFile: Map<string, string>;
   hasFilters: boolean;
   scanType?: string;
   getRuleDescription?: (ruleId: string) => string | undefined;
@@ -52,7 +49,7 @@ interface ViolationOutputProps {
   feedbackEnabled?: boolean;
 }
 
-export function ViolationOutput({ violations, patchByFile, hasFilters, scanType, getRuleDescription, onSectionToggle, scanId, feedbackEnabled }: ViolationOutputProps) {
+export function ViolationOutput({ violations, hasFilters, scanType, getRuleDescription, onSectionToggle, scanId, feedbackEnabled }: ViolationOutputProps) {
   const isRemediate = scanType === 'fix' || scanType === 'remediate';
   const [sectionOpen, setSectionOpen] = useState(true);
   const toggleSection = (open: boolean) => {
@@ -62,7 +59,6 @@ export function ViolationOutput({ violations, patchByFile, hasFilters, scanType,
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [allCollapsed, setAllCollapsed] = useState(false);
   const [selectedViolation, setSelectedViolation] = useState<ViolationRecord | null>(null);
-  const [selectedIsCombined, setSelectedIsCombined] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const groups = useMemo(() => groupByFile(violations), [violations]);
@@ -91,49 +87,13 @@ export function ViolationOutput({ violations, patchByFile, hasFilters, scanType,
 
   const isCollapsed = (file: string) => collapsed[file] === true;
 
-  const selectedDiff = useMemo(() => {
-    if (!selectedViolation) return undefined;
-    if (selectedIsCombined) return patchByFile.get(selectedViolation.file);
-    return undefined;
-  }, [selectedViolation, selectedIsCombined, patchByFile]);
-
   const ruleTitle = (ruleId: string) => getRuleDescription?.(ruleId) || ruleId;
 
-  const buildRows = (groupKey: string, fileViolations: ViolationRecord[]): DisplayRow[] => {
-    if (!isRemediate) {
-      const sorted = [...fileViolations].sort(
-        (a, b) => severityOrder(severityClass(a.level, a.rule_id)) - severityOrder(severityClass(b.level, b.rule_id))
-      );
-      return sorted.map(v => ({ type: 'violation', violation: v }));
-    }
-
-    const fixed = fileViolations.filter(v => v.remediation_class === 1);
-    const rest = fileViolations.filter(v => v.remediation_class !== 1);
-
-    const rows: DisplayRow[] = [];
-
-    if (fixed.length > 0) {
-      const summary: ViolationRecord = {
-        id: -1,
-        rule_id: '',
-        level: 'info',
-        message: `${fixed.length} violation${fixed.length !== 1 ? 's' : ''} fixed`,
-        file: groupKey,
-        line: null,
-        path: '',
-        remediation_class: 1,
-      };
-      rows.push({ type: 'combined-fixed', violation: summary, merged: fixed });
-    }
-
-    const sorted = [...rest].sort(
+  const buildRows = (_groupKey: string, fileViolations: ViolationRecord[]): DisplayRow[] => {
+    const sorted = [...fileViolations].sort(
       (a, b) => severityOrder(severityClass(a.level, a.rule_id)) - severityOrder(severityClass(b.level, b.rule_id))
     );
-    for (const v of sorted) {
-      rows.push({ type: 'violation', violation: v });
-    }
-
-    return rows;
+    return sorted.map(v => ({ type: 'violation', violation: v }));
   };
 
   return (
@@ -233,27 +193,6 @@ export function ViolationOutput({ violations, patchByFile, hasFilters, scanType,
                   )}
 
                   {!isCollapsed(file) && rows.map((row) => {
-                    if (row.type === 'combined-fixed') {
-                      return (
-                        <div
-                          className="apme-output-row apme-output-row-item"
-                          key="combined-fixed"
-                          role="button"
-                          tabIndex={0}
-                          onClick={() => { setSelectedViolation(row.violation); setSelectedIsCombined(true); }}
-                          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { setSelectedViolation(row.violation); setSelectedIsCombined(true); } }}
-                        >
-                          <span className="apme-output-gutter apme-output-line-num" />
-                          <span className="apme-output-content apme-output-violation-line">
-                            <span className="apme-badge passed" style={{ fontSize: 10 }}>Fixed</span>
-                            <span className="apme-output-violation-msg">
-                              {row.violation.message}
-                            </span>
-                          </span>
-                        </div>
-                      );
-                    }
-
                     const v = row.violation;
                     return (
                       <div
@@ -261,8 +200,8 @@ export function ViolationOutput({ violations, patchByFile, hasFilters, scanType,
                         key={v.id}
                         role="button"
                         tabIndex={0}
-                        onClick={() => { setSelectedViolation(v); setSelectedIsCombined(false); }}
-                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { setSelectedViolation(v); setSelectedIsCombined(false); } }}
+                        onClick={() => setSelectedViolation(v)}
+                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSelectedViolation(v); }}
                       >
                         <span className="apme-output-gutter apme-output-line-num">
                           {v.line != null ? v.line : ''}
@@ -300,11 +239,9 @@ export function ViolationOutput({ violations, patchByFile, hasFilters, scanType,
       {selectedViolation && (
         <ViolationDetailModal
           isOpen={!!selectedViolation}
-          onClose={() => { setSelectedViolation(null); setSelectedIsCombined(false); }}
+          onClose={() => setSelectedViolation(null)}
           violation={selectedViolation}
-          diff={selectedDiff}
           getRuleDescription={getRuleDescription}
-          mergedViolations={selectedIsCombined ? (groups.get(selectedViolation.file || '(unknown)')?.filter(v => v.remediation_class === 1) ?? []) : undefined}
           scanId={scanId}
           feedbackEnabled={feedbackEnabled}
         />

--- a/frontend/src/components/ViolationOutput.tsx
+++ b/frontend/src/components/ViolationOutput.tsx
@@ -242,6 +242,7 @@ export function ViolationOutput({ violations, hasFilters, scanType, getRuleDescr
           onClose={() => setSelectedViolation(null)}
           violation={selectedViolation}
           getRuleDescription={getRuleDescription}
+          scanType={scanType}
           scanId={scanId}
           feedbackEnabled={feedbackEnabled}
         />

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -125,15 +125,6 @@ export function ActivityDetailPage() {
     return violations;
   }, [projectViolations, sevFilters, ruleFilters, scopeFilters, fixFilters, searchText]);
 
-  const patchByFile = useMemo(() => {
-    if (!detail) return new Map<string, string>();
-    const map = new Map<string, string>();
-    for (const p of detail.patches) {
-      map.set(p.file, p.diff);
-    }
-    return map;
-  }, [detail]);
-
   if (loading) return <PageLayout><div style={{ padding: 48, textAlign: 'center', opacity: 0.6 }}>Loading...</div></PageLayout>;
   if (!detail) return <PageLayout><div style={{ padding: 48, textAlign: 'center', opacity: 0.6 }}>Activity not found.</div></PageLayout>;
 
@@ -260,7 +251,6 @@ export function ActivityDetailPage() {
         <div className={`apme-output-panel ${resultsOpen ? 'apme-panel-open' : 'apme-panel-closed'}`}>
           <ViolationOutput
             violations={filtered}
-            patchByFile={patchByFile}
             hasFilters={hasFilters}
             scanType={detail.scan_type}
             getRuleDescription={getRuleDescription}

--- a/src/apme_engine/cli/remediate.py
+++ b/src/apme_engine/cli/remediate.py
@@ -130,7 +130,7 @@ def run_remediate(args: argparse.Namespace) -> None:
     result_patches: list[object] = []
 
     try:
-        responses = stub.FixSession(command_iter(), timeout=600)
+        responses = stub.FixSession(command_iter(), timeout=1800)
 
         for event in responses:
             oneof = event.WhichOneof("event")

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -320,10 +320,13 @@ class GraphRemediationEngine:
                     dirty_ids = graph.dirty_nodes
                     rescan_violations = await self._rescan_and_record(graph, pass_num)
 
-                    rescan_keys = {(str(v.get("path", "")), str(v.get("rule_id", ""))) for v in rescan_violations}
+                    rescan_keys = {
+                        (str(v.get("path", "")), normalize_rule_id(str(v.get("rule_id", ""))))
+                        for v in rescan_violations
+                    }
                     for v in violations:
                         if str(v.get("path", "")) in dirty_ids:
-                            key = (str(v.get("path", "")), str(v.get("rule_id", "")))
+                            key = (str(v.get("path", "")), normalize_rule_id(str(v.get("rule_id", ""))))
                             if key not in rescan_keys:
                                 all_fixed.append(dict(v))
 

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -262,15 +262,20 @@ class GraphRemediationEngine:
 
                 if applied_this_pass == 0:
                     # Tier 1 stalled: transforms exist but none succeeded.
-                    # Fall through to Tier 2 AI instead of breaking.
+                    # Promote stalled violations to Tier 2 so AI can attempt them.
                     tier1_stalled = True
+                    tier2.extend(tier1)
                     logger.debug(
-                        "Graph remediation pass %d: tier1 stalled (0 applied); falling through to AI (tier2=%d)",
+                        "Graph remediation pass %d: tier1 stalled (0 applied); promoted %d to tier2 (total tier2=%d)",
                         pass_num,
+                        len(tier1),
                         len(tier2),
                     )
                 else:
-                    violations = await self._rescan_and_record(graph, pass_num)
+                    dirty_ids = graph.dirty_nodes
+                    rescan_violations = await self._rescan_and_record(graph, pass_num)
+                    non_dirty = [v for v in violations if str(v.get("path", "")) not in dirty_ids]
+                    violations = rescan_violations + non_dirty
                     new_tier1, new_tier2, _ = partition_violations(violations, registry)
                     new_fixable = len(new_tier1)
 
@@ -312,7 +317,18 @@ class GraphRemediationEngine:
                 ai_proposals.extend(new_ai_proposals)
 
                 if graph.dirty_nodes:
-                    violations = await self._rescan_and_record(graph, pass_num)
+                    dirty_ids = graph.dirty_nodes
+                    rescan_violations = await self._rescan_and_record(graph, pass_num)
+
+                    rescan_keys = {(str(v.get("path", "")), str(v.get("rule_id", ""))) for v in rescan_violations}
+                    for v in violations:
+                        if str(v.get("path", "")) in dirty_ids:
+                            key = (str(v.get("path", "")), str(v.get("rule_id", "")))
+                            if key not in rescan_keys:
+                                all_fixed.append(dict(v))
+
+                    non_dirty = [v for v in violations if str(v.get("path", "")) not in dirty_ids]
+                    violations = rescan_violations + non_dirty
 
                     # Phase C: Post-AI Tier 1 cleanup
                     new_tier1, new_tier2, _ = partition_violations(violations, registry)
@@ -328,7 +344,10 @@ class GraphRemediationEngine:
                             all_fixed,
                             pass_num,
                         )
-                        violations = await self._rescan_and_record(graph, pass_num)
+                        dirty_ids = graph.dirty_nodes
+                        rescan_violations = await self._rescan_and_record(graph, pass_num)
+                        non_dirty = [v for v in violations if str(v.get("path", "")) not in dirty_ids]
+                        violations = rescan_violations + non_dirty
                         _, new_tier2, _ = partition_violations(violations, registry)
 
                     # Build feedback for AI resubmission

--- a/src/apme_gateway/api/router.py
+++ b/src/apme_gateway/api/router.py
@@ -2123,7 +2123,8 @@ async def project_operate_ws(
                 patches_json = [{"file": p.path, "diff": p.diff} for p in result_patches if p.diff]
                 captured_patches.extend(patches_json)
 
-                remediated = (fixed + ai_accepted_count) if is_remediate else 0
+                remediated = fixed if is_remediate else 0
+                remaining_count = len(remaining)
                 await websocket.send_json(
                     {
                         "type": "result",
@@ -2132,7 +2133,9 @@ async def project_operate_ws(
                         "ai_proposed": ai_proposed_count,
                         "ai_declined": ai_declined_count,
                         "ai_accepted": ai_accepted_count,
-                        "manual_review": report.remaining_manual if report else 0,
+                        "manual_review": remaining_count
+                        if is_remediate
+                        else (report.remaining_manual if report else 0),
                         "remediated_count": remediated,
                         "fixed_violations": fixed_violations_json,
                         "patches": patches_json,

--- a/tests/test_graph_remediation.py
+++ b/tests/test_graph_remediation.py
@@ -691,6 +691,108 @@ class TestGraphRemediationEngine:
         assert len(report.ai_proposals) >= 1
         assert not report.oscillation_detected
 
+    async def test_tier1_stall_promotes_to_ai(self) -> None:
+        """When ALL violations are Tier 1 but transforms fail, they are promoted to Tier 2 for AI."""
+        from unittest.mock import AsyncMock
+
+        from apme_engine.remediation.ai_provider import AINodeFix
+
+        graph = ContentGraph()
+        node = _make_node(module="apt")
+        graph.add_node(node)
+        rules: list[GraphRule] = [_FQCNRule()]
+
+        def _always_fail_transform(task: CommentedMap, violation: ViolationDict) -> bool:
+            return False
+
+        registry = TransformRegistry()
+        registry.register("M001", node=_always_fail_transform)
+
+        ai_provider = AsyncMock()
+        ai_provider.propose_node_fix = AsyncMock(
+            return_value=AINodeFix(
+                fixed_snippet=_TASK_YAML_FQCN,
+                rule_ids=["M001"],
+                explanation="Fixed FQCN via AI",
+                confidence=0.9,
+            ),
+        )
+
+        violations: list[ViolationDict] = [
+            {
+                "rule_id": "M001",
+                "path": node.node_id,
+                "file": node.file_path,
+                "line": 3,
+                "message": "Use FQCN for apt",
+                "severity": "medium",
+                "source": "native",
+                "scope": "task",
+            },
+        ]
+        engine = GraphRemediationEngine(
+            registry,
+            graph,
+            rules,
+            max_passes=5,
+            ai_provider=ai_provider,
+        )
+        report = await engine.remediate(initial_violations=violations)
+
+        ai_provider.propose_node_fix.assert_called()
+        assert len(report.ai_proposals) >= 1
+        assert report.ai_proposals[0].rule_ids == ["M001"]
+
+    async def test_ai_resolved_violations_counted_in_fixed(self) -> None:
+        """Violations resolved by AI transforms are included in report.fixed and fixed_violations."""
+        from unittest.mock import AsyncMock
+
+        from apme_engine.remediation.ai_provider import AINodeFix
+
+        graph = ContentGraph()
+        node = _make_node(module="apt")
+        graph.add_node(node)
+        rules: list[GraphRule] = [_FQCNRule()]
+
+        registry = TransformRegistry()
+
+        ai_provider = AsyncMock()
+        ai_provider.propose_node_fix = AsyncMock(
+            return_value=AINodeFix(
+                fixed_snippet=_TASK_YAML_FQCN,
+                rule_ids=["M001"],
+                explanation="Fixed FQCN via AI",
+                confidence=0.9,
+            ),
+        )
+
+        violations: list[ViolationDict] = [
+            {
+                "rule_id": "M001",
+                "path": node.node_id,
+                "file": node.file_path,
+                "line": 3,
+                "message": "Use FQCN for apt",
+                "severity": "medium",
+                "source": "native",
+                "scope": "task",
+            },
+        ]
+        engine = GraphRemediationEngine(
+            registry,
+            graph,
+            rules,
+            max_passes=5,
+            ai_provider=ai_provider,
+        )
+        report = await engine.remediate(initial_violations=violations)
+
+        assert report.fixed == 1, f"expected 1 AI-resolved violation in fixed, got {report.fixed}"
+        assert len(report.fixed_violations) == 1
+        assert report.fixed_violations[0]["rule_id"] == "M001"
+        assert len(report.remaining_violations) == 0
+        assert len(report.ai_proposals) >= 1
+
     async def test_tier1_stall_no_false_convergence(self) -> None:
         """When Tier 1 stalls and no AI provider is set, the engine does not report full convergence."""
         graph = ContentGraph()


### PR DESCRIPTION
## Summary
- Fix remediation summary card showing inconsistent numbers where Remediated + Manual > Total
- AI-resolved violations are now properly tracked in the convergence loop's `all_fixed` list
- Unify the remediate view to show per-violation rows with diffs (same as check view)

## Changes
- **Convergence loop accounting** (`graph_engine.py`): After AI transforms and rescan, violations on dirty nodes that are absent from rescan results are added to `all_fixed`. Previously only Tier 1 transforms tracked their resolved violations, making `GraphFixReport.fixed` undercount by all AI-resolved violations. Uses `normalize_rule_id` for backward-compatible key comparison.
- **Non-dirty violation preservation** (`graph_engine.py`): At three rescan sites, preserve violations on unmodified nodes instead of dropping them when `_rescan_and_record` only returns dirty-node results.
- **Stall promotion** (`graph_engine.py`): When Tier 1 transforms stall (0 applied), promote stalled violations to Tier 2 so AI can attempt them.
- **Gateway summary math** (`router.py`): Use `report.fixed` directly for `remediated` instead of `fixed + ai_accepted_count` (which mixed violation counts with proposal counts). Use `len(remaining)` for `manual_review` in remediate mode since everything unfixed is effectively manual.
- **UI unification** (`ViolationOutput.tsx`, `ViolationDetailModal.tsx`, `ActivityDetailPage.tsx`): Remove the `combined-fixed` summary row from remediate view. Both check and remediate now display individual violation rows with per-violation diffs. Remove unused `patchByFile` and `mergedViolations` props.
- **Modal label consistency** (`ViolationDetailModal.tsx`): Add `scanType` prop so the Remediation field shows "Fixed" in remediate mode and "Fixable" in check mode, matching ViolationOutput pill labels.
- **Client timeout** (`remediate.py`): Increase `FixSession` gRPC timeout from 600s to 1800s to prevent `AioRpcError` during long AI processing + user review.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2231 passed, 59.81% coverage)
- [x] New test `test_ai_resolved_violations_counted_in_fixed` verifies AI-resolved violations are included in `report.fixed` and `fixed_violations`
- [x] Existing test `test_tier1_stall_promotes_to_ai` verifies stall promotion to Tier 2
- [ ] Manual verification: run `apme remediate` and confirm Total = Remediated + Manual on the result card