### PR TITLE
refactor(engine): replace derived violation accounting with first-class ledger

### DIFF
--- a/docs/design/DESIGN_REMEDIATION.md
+++ b/docs/design/DESIGN_REMEDIATION.md
@@ -351,6 +351,78 @@ class GraphFixReport:
     ai_proposals: list[AINodeProposal] = field(default_factory=list)
 ```
 
+## Violation Ledger
+
+### Why a Ledger, Not Derived Accounting
+
+Earlier designs stored violations on `NodeState` snapshots and derived "fixed" counts by diffing successive snapshots. This was fragile:
+
+- Double/triple-counting when multiple passes touched the same node
+- AI fixes had no distinct accounting until user approval
+- Co-fix attribution required set-difference heuristics
+
+The **violation ledger** replaces all of this with a single source of truth: each violation has an explicit lifecycle tracked as a mutable `ViolationRecord` on the node.
+
+### Data Model
+
+```python
+ViolationKey = tuple[str, str]  # (node_id, normalized_rule_id)
+
+@dataclass
+class ViolationRecord:
+    key: ViolationKey
+    violation: ViolationDict      # original validator payload
+    status: str = "open"          # "open" | "fixed" | "proposed" | "declined"
+    fixed_by: str | None = None   # "deterministic" | "ai"
+    fixed_in_pass: int | None = None
+    discovered_in_pass: int = 0
+```
+
+Each `ContentNode` has a `violation_ledger: dict[ViolationKey, ViolationRecord]`.
+
+### Lifecycle States
+
+```
+open ──→ fixed      (deterministic transform, auto-approved)
+  │
+  └──→ proposed     (AI fix applied, pending human review)
+          │
+          ├──→ fixed    (user approved)
+          │
+          └──→ declined (user rejected, violation restored)
+```
+
+| State | Meaning | In `collect_violations()`? |
+|-------|---------|---------------------------|
+| `open` | Unresolved, present in file | Yes |
+| `fixed` | Resolved (deterministic or approved AI) | No |
+| `proposed` | AI fix applied but awaiting human review | No |
+| `declined` | User rejected AI proposal, violation restored | No (queryable separately) |
+
+### Graph API
+
+| Method | Purpose |
+|--------|---------|
+| `register_violations(violations, pass_number)` | Insert new violations as `open`; re-confirm existing; reopen previously fixed |
+| `resolve_violations(node_id, remaining_ids, *, fixed_by, pass_number, status)` | Transition open violations to `fixed` or `proposed` |
+| `approve_proposed(node_id)` | Promote `proposed` → `fixed` |
+| `decline_proposed(node_id)` | Transition `proposed` → `declined` (clears attribution) |
+| `query_violations(*, status, fixed_by)` | Filter ledger entries across all nodes |
+| `collect_violations()` | Shorthand for `query_violations(status="open")` |
+
+### How It Integrates
+
+1. **Initial scan** — `_record_violations()` calls `graph.register_violations()` (all violations enter as `open`)
+2. **Tier 1 rescan** — `_rescan_and_record()` with `resolve_fixed_by="deterministic"` transitions absent violations to `fixed`
+3. **AI rescan** — `_rescan_and_record()` with `resolve_fixed_by="ai", resolve_status="proposed"` transitions absent violations to `proposed`
+4. **User approval** — `graph.approve_proposed(node_id)` promotes `proposed` → `fixed`
+5. **User rejection** — `graph.decline_proposed(node_id)` transitions `proposed` → `declined`
+6. **Report** — `GraphFixReport` counts come from `query_violations(status=...)` — no diffing
+
+### NodeState Simplification
+
+`NodeState` no longer carries `violations` or `violation_dicts`. It is a pure content snapshot (YAML text + content hash + metadata). Violation tracking is entirely the ledger's responsibility.
+
 ## Progress Streaming
 
 `GraphRemediationEngine.remediate()` is an `async def` coroutine that runs as an `asyncio.create_task` alongside a queue drain loop. Without explicit progress plumbing, the gRPC stream (and downstream WebSocket) goes silent for the entire remediation duration — often minutes for large projects with AI escalation.

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -1635,7 +1635,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             graph=graph,
             rules=rules,
             max_passes=max_passes,
-            max_ai_concurrency=int(os.environ.get("APME_AI_CONCURRENCY", "4")),
+            max_ai_concurrency=max(1, int(os.environ.get("APME_AI_CONCURRENCY", "4"))),
             progress_callback=progress_callback,
             rescan_fn=_rescan_bridge,
             ai_provider=ai_provider,  # type: ignore[arg-type]

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -73,7 +73,7 @@ from apme.v1.validate_pb2 import ValidateRequest
 from apme_engine.daemon.event_emitter import emit_fix_completed, emit_register_rules, start_sinks
 from apme_engine.daemon.session import ResourceExhaustedError, SessionState, SessionStore
 from apme_engine.daemon.violation_convert import violation_dict_to_proto, violation_proto_to_dict
-from apme_engine.engine.models import RemediationClass, ViolationDict
+from apme_engine.engine.models import RemediationClass, RemediationResolution, ViolationDict
 from apme_engine.log_bridge import attach_collector
 from apme_engine.runner import run_scan
 from apme_engine.venv_manager.session import (
@@ -247,12 +247,11 @@ def _enrich_violations_from_graph(
         v["fixed_yaml"] = approved.yaml_lines
 
         this_rule = str(v.get("rule_id", ""))
-        initial = set(node.progression[0].violations)
-        final = set(approved.violations)
-        fixed_on_node = initial - final
-        fixed_on_node.discard(this_rule)
-        if fixed_on_node:
-            v["co_fixes"] = sorted(fixed_on_node)  # type: ignore[arg-type]
+        co_fixes = sorted(
+            rec.key[1] for rec in node.violation_ledger.values() if rec.status == "fixed" and rec.key[1] != this_rule
+        )
+        if co_fixes:
+            v["co_fixes"] = co_fixes  # type: ignore[assignment]
 
 
 def _attach_snippets(violations: list[ViolationDict], files: list[File]) -> None:
@@ -1636,6 +1635,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             graph=graph,
             rules=rules,
             max_passes=max_passes,
+            max_ai_concurrency=int(os.environ.get("APME_AI_CONCURRENCY", "4")),
             progress_callback=progress_callback,
             rescan_fn=_rescan_bridge,
             ai_provider=ai_provider,  # type: ignore[arg-type]
@@ -1910,12 +1910,13 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
         has_graph_proposals = graph is not None and any(pid.startswith("ai-") for pid in session.proposals)
 
         if has_graph_proposals and graph is not None and originals is not None:
-            applied = _apply_graph_approvals(
+            applied, rejected_nodes = _apply_graph_approvals(
                 session,
                 graph,
                 originals,
                 approved_ids,
             )
+            _reconcile_after_approval(session, graph, rejected_nodes)
         else:
             applied = _apply_text_approvals(session, approved_ids)
 
@@ -2224,7 +2225,7 @@ def _apply_graph_approvals(
     graph: object,
     originals: dict[str, str],
     approved_ids: set[str],
-) -> int:
+) -> tuple[int, set[str]]:
     """Apply graph-based approvals: approve/reject nodes, re-splice files.
 
     Args:
@@ -2234,7 +2235,7 @@ def _apply_graph_approvals(
         approved_ids: Proposal IDs the user accepted.
 
     Returns:
-        Number of proposals applied.
+        Tuple of (proposals applied, rejected node IDs).
     """
     from apme_engine.engine.content_graph import ContentGraph  # noqa: PLC0415
     from apme_engine.remediation.graph_engine import (  # noqa: PLC0415
@@ -2243,7 +2244,7 @@ def _apply_graph_approvals(
     )
 
     if not isinstance(graph, ContentGraph):
-        return _apply_text_approvals(session, approved_ids)
+        return (_apply_text_approvals(session, approved_ids), set())
 
     ai_proposals: list[AINodeProposal] = [p for p in session.ai_proposals if isinstance(p, AINodeProposal)]
 
@@ -2252,6 +2253,7 @@ def _apply_graph_approvals(
         proposal_node_map[f"ai-{idx:04d}"] = anp.node_id
 
     applied = 0
+    rejected_node_ids: set[str] = set()
     all_proposal_ids = set(session.proposals.keys())
 
     for pid in all_proposal_ids:
@@ -2279,6 +2281,7 @@ def _apply_graph_approvals(
             applied += 1
         else:
             graph.reject_node(node_id)
+            rejected_node_ids.add(node_id)
 
         session.proposals.pop(pid, None)
 
@@ -2286,7 +2289,80 @@ def _apply_graph_approvals(
     for patch in patches:
         session.working_files[patch.path] = patch.patched.encode("utf-8")
 
-    return applied
+    return (applied, rejected_node_ids)
+
+
+def _reconcile_after_approval(
+    session: SessionState,
+    graph: object,
+    rejected_node_ids: set[str],
+) -> None:
+    """Reconcile session accounting after AI proposals are approved/rejected.
+
+    Promotes ``proposed`` violations on approved nodes to ``fixed``,
+    transitions ``proposed`` violations on rejected nodes to ``declined``,
+    then queries the graph ledger for authoritative counts.
+
+    Args:
+        session: Active session to reconcile.
+        graph: ContentGraph after approve/reject mutations.
+        rejected_node_ids: Node IDs whose AI proposals were rejected.
+    """
+    from apme_engine.engine.content_graph import ContentGraph  # noqa: PLC0415
+
+    if not isinstance(graph, ContentGraph):
+        return
+
+    # Promote approved proposals; decline rejected ones.
+    for node in graph.nodes():
+        nid = node.node_id
+        if nid in rejected_node_ids:
+            graph.decline_proposed(nid)
+        else:
+            graph.approve_proposed(nid)
+
+    # Remaining = open + declined (all unresolved violations).
+    # Post-approval, AI has already had its chance — everything remaining
+    # is manual review regardless of what classify_violation would say.
+    open_violations = graph.query_violations(status="open")
+    declined_violations = graph.query_violations(status="declined")
+    remaining = [dict(v) for v in open_violations + declined_violations]
+    for v in remaining:
+        v["remediation_class"] = RemediationClass.MANUAL_REVIEW
+        v["remediation_resolution"] = RemediationResolution.UNRESOLVED
+    _enrich_violations_from_graph(remaining, graph, fixed=False)
+
+    fixed = [dict(v) for v in graph.query_violations(status="fixed")]
+    for v in fixed:
+        v["remediation_class"] = RemediationClass.AUTO_FIXABLE
+    _enrich_violations_from_graph(fixed, graph, fixed=True)
+
+    session.remaining_ai = []
+    session.remaining_manual = list(remaining)
+
+    old_report = session.report or FixReport()
+
+    remaining_protos = [violation_dict_to_proto(v) for v in remaining]
+    fixed_protos = [violation_dict_to_proto(v) for v in fixed]
+
+    session.report = FixReport(
+        passes=old_report.passes,
+        fixed=len(fixed),
+        remaining_ai=0,
+        remaining_manual=len(remaining),
+        oscillation_detected=old_report.oscillation_detected,
+        remaining_violations=remaining_protos,
+        fixed_violations=fixed_protos,
+    )
+
+    logger.info(
+        "Post-approval reconciliation: %d fixed, %d remaining (%d declined), %d rejected nodes (session=%s)",
+        len(fixed),
+        len(remaining),
+        len(declined_violations),
+        len(rejected_node_ids),
+        session.session_id,
+    )
 
 
 def _apply_text_approvals(

--- a/src/apme_engine/engine/content_graph.py
+++ b/src/apme_engine/engine/content_graph.py
@@ -801,7 +801,7 @@ class ContentGraph:
                     status="open",
                     discovered_in_pass=pass_number,
                 )
-            elif existing.status == "fixed":
+            elif existing.status in ("fixed", "proposed", "declined"):
                 existing.status = "open"
                 existing.violation = v
                 existing.fixed_by = None
@@ -907,7 +907,8 @@ class ContentGraph:
         """Query violations across all nodes with optional filters.
 
         Args:
-            status: Filter by ``"open"`` or ``"fixed"`` (``None`` = all).
+            status: Filter by status: ``"open"``, ``"fixed"``,
+                ``"proposed"``, or ``"declined"`` (``None`` = all).
             fixed_by: Filter by attribution (``None`` = all).
 
         Returns:
@@ -1489,7 +1490,10 @@ def _violation_record_from_dict(d: dict[str, object]) -> ViolationRecord:
         Reconstructed ViolationRecord.
     """
     raw_key = d.get("key", ("", ""))
-    key: ViolationKey = (str(raw_key[0]), str(raw_key[1])) if isinstance(raw_key, (list, tuple)) else ("", "")
+    if isinstance(raw_key, (list, tuple)) and len(raw_key) >= 2:
+        key: ViolationKey = (str(raw_key[0]), str(raw_key[1]))
+    else:
+        key = ("", "")
     raw_violation = d.get("violation", {})
     violation: ViolationDict = dict(raw_violation) if isinstance(raw_violation, dict) else {}
     fixed_in_raw = d.get("fixed_in_pass")

--- a/src/apme_engine/engine/content_graph.py
+++ b/src/apme_engine/engine/content_graph.py
@@ -184,12 +184,14 @@ class NodeIdentity:
 
 @dataclass(frozen=True, slots=True)
 class NodeState:
-    """Immutable snapshot of a node's content at a specific pipeline phase.
+    """Immutable snapshot of a node's YAML content at a pipeline phase.
 
     Recorded at scan and transform boundaries during the convergence loop.
     Each ``ContentNode`` accumulates an ordered ``progression`` of these
-    snapshots, enabling snippet accuracy, remediation attribution, and
-    full node history.
+    snapshots, enabling snippet accuracy and remediation attribution.
+
+    Violation tracking is **not** stored here — it lives in the
+    ``ContentNode.violation_ledger`` (see ``ViolationRecord``).
 
     Attributes:
         id: Unique identifier for this progression entry
@@ -201,10 +203,6 @@ class NodeState:
             ``"transformed"``, ``"ai_transformed"``).
         yaml_lines: Raw YAML text for this node at this point in time.
         content_hash: SHA-256 hex digest of ``yaml_lines``.
-        violations: Rule IDs of violations active at this state.
-        violation_dicts: Full violation details at this state.  The
-            graph is authoritative: after convergence these are the
-            remaining violations, not a re-scan result.
         timestamp: ISO 8601 UTC timestamp when the snapshot was taken.
         approved: Whether this entry has been approved.  All entries
             start pending (``False``).  Deterministic transforms are
@@ -220,11 +218,78 @@ class NodeState:
     phase: str
     yaml_lines: str
     content_hash: str
-    violations: tuple[str, ...]
-    violation_dicts: tuple[ViolationDict, ...]
     timestamp: str
     approved: bool = False
     source: str = ""
+
+
+# ---------------------------------------------------------------------------
+# ViolationRecord — mutable violation lifecycle (ADR-044 violation ledger)
+# ---------------------------------------------------------------------------
+
+ViolationKey = tuple[str, str]
+"""Identity key for a violation: ``(node_id, normalized_rule_id)``."""
+
+
+@dataclass
+class ViolationRecord:
+    """Mutable record tracking a single violation's lifecycle on a node.
+
+    The violation ledger on each ``ContentNode`` is the single source
+    of truth for violation status.
+
+    Status transitions::
+
+        open ──→ fixed      (deterministic transform, auto-approved)
+          │
+          └──→ proposed     (AI fix applied, pending human review)
+                  │
+                  ├──→ fixed    (user approved)
+                  │
+                  └──→ declined (user rejected, violation restored)
+
+    Attributes:
+        key: ``(node_id, normalized_rule_id)`` identity.
+        violation: Original violation dict from the validator.
+        status: ``"open"``, ``"fixed"``, ``"proposed"``, or ``"declined"``.
+        fixed_by: How the violation was resolved
+            (``"deterministic"``, ``"ai"``, or ``None``).
+        fixed_in_pass: Convergence pass that resolved the violation.
+        discovered_in_pass: Convergence pass that first detected it.
+    """
+
+    key: ViolationKey
+    violation: ViolationDict
+    status: str = "open"
+    fixed_by: str | None = None
+    fixed_in_pass: int | None = None
+    discovered_in_pass: int = 0
+
+
+def _normalize_rule_id(rule_id: str) -> str:
+    """Strip legacy ``native:`` prefix from a rule ID.
+
+    Args:
+        rule_id: Raw rule ID, possibly prefixed.
+
+    Returns:
+        Bare rule ID suitable for ledger keys.
+    """
+    if rule_id.startswith("native:"):
+        return rule_id[len("native:") :]
+    return rule_id
+
+
+def _violation_key(v: ViolationDict) -> ViolationKey:
+    """Derive a ``ViolationKey`` from a violation dict.
+
+    Args:
+        v: Violation dict with ``path`` and ``rule_id`` entries.
+
+    Returns:
+        ``(path, normalized_rule_id)`` tuple.
+    """
+    return (str(v.get("path", "")), _normalize_rule_id(str(v.get("rule_id", ""))))
 
 
 def _content_hash(text: str) -> str:
@@ -339,6 +404,9 @@ class ContentNode:
         scope: Owned vs referenced content classification.
         state: Current ``NodeState`` snapshot (most recent entry in progression).
         progression: Ordered list of ``NodeState`` snapshots across pipeline phases.
+        violation_ledger: Mutable violation lifecycle records keyed by
+            ``(node_id, rule_id)``.  Single source of truth for violation
+            status and attribution.
         MAX_PROGRESSION: Upper bound on progression length per node (class-level).
     """
 
@@ -401,9 +469,12 @@ class ContentNode:
     # Scope
     scope: NodeScope = NodeScope.OWNED
 
-    # Progression (ADR-044 Phase 3) — temporal state tracking
+    # Progression (ADR-044 Phase 3) — temporal YAML state tracking
     state: NodeState | None = None
     progression: list[NodeState] = field(default_factory=list)
+
+    # Violation ledger — single source of truth for violation lifecycle
+    violation_ledger: dict[ViolationKey, ViolationRecord] = field(default_factory=dict)
 
     @property
     def node_type(self) -> NodeType:
@@ -421,14 +492,15 @@ class ContentNode:
         self,
         pass_number: int,
         phase: str,
-        violations: tuple[str, ...] = (),
-        violation_dicts: tuple[ViolationDict, ...] = (),
         source: str = "",
     ) -> NodeState:
         """Record a progression snapshot at the current pipeline phase.
 
         Creates a ``NodeState`` from the node's current ``yaml_lines``,
         appends it to ``progression``, and sets ``state`` to the new entry.
+
+        Violation tracking is handled separately via the
+        ``violation_ledger`` — this method only captures YAML content.
 
         If progression already contains ``MAX_PROGRESSION`` entries the
         oldest entry is dropped to prevent unbounded growth from bugs in
@@ -438,8 +510,6 @@ class ContentNode:
             pass_number: Convergence pass (0 = initial scan).
             phase: Pipeline phase (``"original"``, ``"scanned"``,
                 ``"transformed"``, ``"ai_transformed"``).
-            violations: Rule IDs of violations active at this state.
-            violation_dicts: Full violation details at this state.
             source: How the transform was produced (e.g.
                 ``"deterministic"``, ``"ai"``).  UI metadata only.
 
@@ -453,8 +523,6 @@ class ContentNode:
             phase=phase,
             yaml_lines=self.yaml_lines,
             content_hash=_content_hash(self.yaml_lines),
-            violations=violations,
-            violation_dicts=violation_dicts,
             timestamp=datetime.now(timezone.utc).isoformat(),
             source=source,
         )
@@ -652,37 +720,29 @@ class ContentGraph:
         self._dirty_nodes.clear()
 
     def collect_violations(self) -> list[ViolationDict]:
-        """Collect all remaining violations from the graph.
+        """Collect all remaining (open) violations from the graph.
 
-        Iterates every node and gathers ``violation_dicts`` from each
-        node's latest ``state``.  After convergence, this is the
-        authoritative violation picture — no re-scan needed.
+        Delegates to ``query_violations(status="open")``.
 
         Returns:
             Combined list of ``ViolationDict`` from all nodes.
         """
-        result: list[ViolationDict] = []
-        for node in self.nodes():
-            if node.state and node.state.violation_dicts:
-                result.extend(node.state.violation_dicts)
-        return result
+        return self.query_violations(status="open")
 
     def collect_step_diffs(self) -> list[dict[str, object]]:
-        """Collect per-step diffs from every node's progression.
+        """Collect per-step content diffs from every node's progression.
 
         Walks each node's progression and produces a diff record for
-        each consecutive pair where ``content_hash`` changed.  Each
-        record captures what the transform did and which violations
-        appeared/disappeared.
+        each consecutive pair where ``content_hash`` changed.
 
-        Violation deltas use the nearest subsequent ``scanned`` snapshot
-        (post-rescan) rather than the ``transformed`` snapshot, which is
-        recorded before the rescan and typically has empty violations.
+        Violation tracking lives in the ``violation_ledger``, not in
+        progression snapshots.  The ``violations_removed`` and
+        ``violations_added`` fields are omitted — use
+        ``query_violations()`` for authoritative violation accounting.
 
         Returns:
             List of step-diff records, each with ``node_id``,
-            ``pass_number``, ``phase``, ``diff``, ``violations_added``,
-            ``violations_removed``, and ``source``.
+            ``pass_number``, ``phase``, ``diff``, and ``source``.
         """
         steps: list[dict[str, object]] = []
         for node in self.nodes():
@@ -699,13 +759,6 @@ class ContentGraph:
                         tofile=f"pass{curr.pass_number}/{node.node_id}",
                     )
                 )
-                prev_rules = set(prev.violations)
-                post_rules = set(curr.violations)
-                if not post_rules and curr.phase == "transformed":
-                    for j in range(i + 1, len(prog)):
-                        if prog[j].phase == "scanned":
-                            post_rules = set(prog[j].violations)
-                            break
                 steps.append(
                     {
                         "node_id": node.node_id,
@@ -713,11 +766,162 @@ class ContentGraph:
                         "phase": curr.phase,
                         "source": curr.source,
                         "diff": diff,
-                        "violations_removed": sorted(prev_rules - post_rules),
-                        "violations_added": sorted(post_rules - prev_rules),
                     }
                 )
         return steps
+
+    # -- Violation ledger API --------------------------------------------------
+
+    def register_violations(
+        self,
+        violations: list[ViolationDict],
+        pass_number: int,
+    ) -> None:
+        """Register violations into the ledger of their respective nodes.
+
+        New violations are inserted with ``status="open"``.  Already-open
+        violations are no-ops (re-confirmed).  Previously-fixed violations
+        that reappear are reopened (regression).
+
+        Args:
+            violations: Violation dicts (``path`` must be a graph node ID).
+            pass_number: Convergence pass that produced these violations.
+        """
+        for v in violations:
+            node_id = str(v.get("path", ""))
+            node = self.get_node(node_id)
+            if node is None:
+                continue
+            key = _violation_key(v)
+            existing = node.violation_ledger.get(key)
+            if existing is None:
+                node.violation_ledger[key] = ViolationRecord(
+                    key=key,
+                    violation=v,
+                    status="open",
+                    discovered_in_pass=pass_number,
+                )
+            elif existing.status == "fixed":
+                existing.status = "open"
+                existing.violation = v
+                existing.fixed_by = None
+                existing.fixed_in_pass = None
+            else:
+                existing.violation = v
+
+    def resolve_violations(
+        self,
+        node_id: str,
+        remaining_rule_ids: set[str],
+        *,
+        fixed_by: str,
+        pass_number: int,
+        status: str = "fixed",
+    ) -> int:
+        """Transition open violations when absent from a rescan.
+
+        For the given node, any open ledger entry whose rule_id is
+        **not** in ``remaining_rule_ids`` transitions to *status*.
+
+        Use ``status="fixed"`` for deterministic transforms (auto-approved)
+        and ``status="proposed"`` for AI transforms (pending human review).
+
+        Args:
+            node_id: Graph node whose ledger to update.
+            remaining_rule_ids: Normalized rule IDs still present
+                after the rescan.
+            fixed_by: Attribution (``"deterministic"`` or ``"ai"``).
+            pass_number: Convergence pass of the resolution.
+            status: Target status (``"fixed"`` or ``"proposed"``).
+
+        Returns:
+            Number of violations transitioned.
+        """
+        node = self.get_node(node_id)
+        if node is None:
+            return 0
+        count = 0
+        for record in node.violation_ledger.values():
+            if record.status != "open":
+                continue
+            _, rule_id = record.key
+            if rule_id not in remaining_rule_ids:
+                record.status = status
+                record.fixed_by = fixed_by
+                record.fixed_in_pass = pass_number
+                count += 1
+        return count
+
+    def approve_proposed(self, node_id: str) -> int:
+        """Promote ``proposed`` violations to ``fixed`` on a node.
+
+        Called when the user approves an AI proposal.
+
+        Args:
+            node_id: Graph node whose proposals to approve.
+
+        Returns:
+            Number of violations promoted.
+        """
+        node = self.get_node(node_id)
+        if node is None:
+            return 0
+        count = 0
+        for record in node.violation_ledger.values():
+            if record.status == "proposed":
+                record.status = "fixed"
+                count += 1
+        return count
+
+    def decline_proposed(self, node_id: str) -> int:
+        """Transition ``proposed`` violations to ``declined`` on a node.
+
+        Called when the user rejects an AI proposal.  The node's YAML
+        should already be rolled back via ``reject_node()`` before
+        calling this.
+
+        Args:
+            node_id: Graph node whose proposals to decline.
+
+        Returns:
+            Number of violations declined.
+        """
+        node = self.get_node(node_id)
+        if node is None:
+            return 0
+        count = 0
+        for record in node.violation_ledger.values():
+            if record.status == "proposed":
+                record.status = "declined"
+                record.fixed_by = None
+                record.fixed_in_pass = None
+                count += 1
+        return count
+
+    def query_violations(
+        self,
+        *,
+        status: str | None = None,
+        fixed_by: str | None = None,
+    ) -> list[ViolationDict]:
+        """Query violations across all nodes with optional filters.
+
+        Args:
+            status: Filter by ``"open"`` or ``"fixed"`` (``None`` = all).
+            fixed_by: Filter by attribution (``None`` = all).
+
+        Returns:
+            Flat list of ``ViolationDict`` from matching records.
+        """
+        result: list[ViolationDict] = []
+        for node in self.nodes():
+            for record in node.violation_ledger.values():
+                if status is not None and record.status != status:
+                    continue
+                if fixed_by is not None and record.fixed_by != fixed_by:
+                    continue
+                result.append(record.violation)
+        return result
 
     # -- Approval tracking (ADR-044 Phase 3) --------------------------------
 
@@ -762,7 +966,11 @@ class ContentGraph:
                 node.progression[i] = replace(entry, approved=True)
                 count += 1
             if node.progression:
-                node.state = node.progression[-1]
+                last_approved = next(
+                    (s for s in reversed(node.progression) if s.approved),
+                    node.progression[-1],
+                )
+                node.state = last_approved
         return count
 
     def approve_node(self, node_id: str) -> bool:
@@ -1216,20 +1424,16 @@ def _node_state_to_dict(ns: NodeState) -> dict[str, object]:
     Returns:
         Plain dict with all NodeState fields.
     """
-    d: dict[str, object] = {
+    return {
         "id": ns.id,
         "pass_number": ns.pass_number,
         "phase": ns.phase,
         "yaml_lines": ns.yaml_lines,
         "content_hash": ns.content_hash,
-        "violations": list(ns.violations),
         "timestamp": ns.timestamp,
         "approved": ns.approved,
         "source": ns.source,
     }
-    if ns.violation_dicts:
-        d["violation_dicts"] = list(ns.violation_dicts)
-    return d
 
 
 def _node_state_from_dict(d: dict[str, object]) -> NodeState:
@@ -1241,21 +1445,61 @@ def _node_state_from_dict(d: dict[str, object]) -> NodeState:
     Returns:
         Reconstructed frozen NodeState.
     """
-    violations_raw = d.get("violations", ())
-    violations = tuple(str(v) for v in violations_raw) if isinstance(violations_raw, (list, tuple)) else ()
-    vdicts_raw = d.get("violation_dicts", ())
-    vdicts = tuple(vdicts_raw) if isinstance(vdicts_raw, (list, tuple)) else ()
     return NodeState(
         id=str(d.get("id", "")),
         pass_number=int(cast(int, d.get("pass_number", 0))),
         phase=str(d.get("phase", "")),
         yaml_lines=str(d.get("yaml_lines", "")),
         content_hash=str(d.get("content_hash", "")),
-        violations=violations,
-        violation_dicts=vdicts,
         timestamp=str(d.get("timestamp", "")),
         approved=bool(d.get("approved", False)),
         source=str(d.get("source", "")),
+    )
+
+
+def _violation_record_to_dict(rec: ViolationRecord) -> dict[str, object]:
+    """Serialize a ViolationRecord to a JSON-compatible dict.
+
+    Args:
+        rec: Violation record to serialize.
+
+    Returns:
+        Plain dict with all ViolationRecord fields.
+    """
+    d: dict[str, object] = {
+        "key": list(rec.key),
+        "violation": dict(rec.violation),
+        "status": rec.status,
+        "discovered_in_pass": rec.discovered_in_pass,
+    }
+    if rec.fixed_by is not None:
+        d["fixed_by"] = rec.fixed_by
+    if rec.fixed_in_pass is not None:
+        d["fixed_in_pass"] = rec.fixed_in_pass
+    return d
+
+
+def _violation_record_from_dict(d: dict[str, object]) -> ViolationRecord:
+    """Reconstruct a ViolationRecord from a serialized dict.
+
+    Args:
+        d: Dict produced by ``_violation_record_to_dict``.
+
+    Returns:
+        Reconstructed ViolationRecord.
+    """
+    raw_key = d.get("key", ("", ""))
+    key: ViolationKey = (str(raw_key[0]), str(raw_key[1])) if isinstance(raw_key, (list, tuple)) else ("", "")
+    raw_violation = d.get("violation", {})
+    violation: ViolationDict = dict(raw_violation) if isinstance(raw_violation, dict) else {}
+    fixed_in_raw = d.get("fixed_in_pass")
+    return ViolationRecord(
+        key=key,
+        violation=violation,
+        status=str(d.get("status", "open")),
+        fixed_by=str(d["fixed_by"]) if "fixed_by" in d else None,
+        fixed_in_pass=int(cast(int, fixed_in_raw)) if fixed_in_raw is not None else None,
+        discovered_in_pass=int(cast(int, d.get("discovered_in_pass", 0))),
     )
 
 
@@ -1287,6 +1531,8 @@ def _node_to_dict(node: ContentNode, *, slim: bool = False) -> dict[str, object]
             d["state"] = _node_state_to_dict(node.state)
         if node.progression:
             d["progression"] = [_node_state_to_dict(ns) for ns in node.progression]
+        if node.violation_ledger:
+            d["violation_ledger"] = [_violation_record_to_dict(rec) for rec in node.violation_ledger.values()]
 
     return d
 
@@ -1331,7 +1577,6 @@ def _node_from_dict(d: dict[str, object]) -> ContentNode:
 
     # Reconcile: progression is source of truth; state == progression[-1].
     if deserialized_progression:
-        # Backfill empty IDs from older serialized graphs.
         nid = str(identity.path)
         for i, entry in enumerate(deserialized_progression):
             if not entry.id:
@@ -1340,6 +1585,14 @@ def _node_from_dict(d: dict[str, object]) -> ContentNode:
         node.state = deserialized_progression[-1]
     elif deserialized_state is not None:
         node.state = deserialized_state
+
+    # Restore violation ledger.
+    raw_ledger = d.get("violation_ledger")
+    if isinstance(raw_ledger, list):
+        for entry in raw_ledger:
+            if isinstance(entry, dict):
+                rec = _violation_record_from_dict(cast(dict[str, object], entry))
+                node.violation_ledger[rec.key] = rec
 
     return node
 

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -176,7 +176,7 @@ class GraphRemediationEngine:
         self._rules = rules
         self._max_passes = max_passes
         self._max_ai_attempts = max_ai_attempts
-        self._max_ai_concurrency = max_ai_concurrency
+        self._max_ai_concurrency = max(1, max_ai_concurrency)
         self._progress_cb = progress_callback
         self._rescan_fn = rescan_fn
         self._ai_provider = ai_provider
@@ -559,7 +559,10 @@ class GraphRemediationEngine:
         proposals: list[AINodeProposal] = []
         for r in results:
             if isinstance(r, BaseException):
-                logger.exception("AI proposal failed", exc_info=r)
+                logger.error(
+                    "AI proposal failed",
+                    exc_info=(type(r), r, r.__traceback__),
+                )
                 continue
             if r is None:
                 continue

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -14,6 +14,7 @@ See :doc:`/sdlc/research/ai-as-graph-transform` for the design rationale.
 
 from __future__ import annotations
 
+import asyncio
 import difflib
 import logging
 from collections import defaultdict
@@ -68,18 +69,21 @@ class GraphFixReport:
     Callers produce patches by passing the post-convergence graph to
     :func:`splice_modifications`, then store the result here.
 
+    All violation counts are sourced from the ``ContentGraph`` violation
+    ledger — ``fixed`` and ``fixed_violations`` come from
+    ``query_violations(status="fixed")``, ``remaining_violations`` from
+    ``query_violations(status="open")``.  No snapshot diffs.
+
     Attributes:
         passes: Number of convergence passes executed.
-        fixed: Count of violations fixed by Tier 1 transforms.
+        fixed: Count of violations resolved during convergence.
         applied_patches: File patches produced by ``splice_modifications``
             (populated by the caller, not by ``remediate``).
-        remaining_violations: Violations still present after convergence,
-            collected directly from the ContentGraph (authoritative).
-        fixed_violations: Violations resolved by transforms.
+        remaining_violations: Violations still open after convergence.
+        fixed_violations: Violations resolved during convergence.
         oscillation_detected: True if the loop bailed due to oscillation.
         nodes_modified: Number of ContentNodes modified.
-        step_diffs: Per-progression-step diffs showing what each
-            transform did and which violations appeared/disappeared.
+        step_diffs: Per-progression-step content diffs.
         ai_proposals: AI-proposed node fixes pending human approval.
     """
 
@@ -141,6 +145,7 @@ class GraphRemediationEngine:
         *,
         max_passes: int = 5,
         max_ai_attempts: int = 2,
+        max_ai_concurrency: int = 4,
         progress_callback: ProgressCallback | None = None,
         rescan_fn: RescanFn | None = None,
         ai_provider: AIProvider | None = None,
@@ -153,6 +158,9 @@ class GraphRemediationEngine:
             rules: Pre-loaded GraphRule instances for re-scanning.
             max_passes: Maximum convergence passes (default 5).
             max_ai_attempts: Maximum AI resubmission rounds (default 2).
+            max_ai_concurrency: Maximum concurrent AI proposal calls
+                (default 4).  Bounds the number of simultaneous LLM
+                round-trips per AI pass.
             progress_callback: Optional ``(phase, message, fraction, level)``
                 callback for streaming progress.
             rescan_fn: Optional callback that replaces the built-in
@@ -168,6 +176,7 @@ class GraphRemediationEngine:
         self._rules = rules
         self._max_passes = max_passes
         self._max_ai_attempts = max_ai_attempts
+        self._max_ai_concurrency = max_ai_concurrency
         self._progress_cb = progress_callback
         self._rescan_fn = rescan_fn
         self._ai_provider = ai_provider
@@ -222,7 +231,6 @@ class GraphRemediationEngine:
 
         prev_count: float = float("inf")
         passes = 0
-        all_fixed: list[ViolationDict] = []
         ai_proposals: list[AINodeProposal] = []
         oscillation = False
         ai_attempts = 0
@@ -250,7 +258,6 @@ class GraphRemediationEngine:
                     graph,
                     registry,
                     tier1,
-                    all_fixed,
                     pass_num,
                 )
                 logger.debug(
@@ -261,8 +268,6 @@ class GraphRemediationEngine:
                 )
 
                 if applied_this_pass == 0:
-                    # Tier 1 stalled: transforms exist but none succeeded.
-                    # Promote stalled violations to Tier 2 so AI can attempt them.
                     tier1_stalled = True
                     tier2.extend(tier1)
                     logger.debug(
@@ -272,10 +277,12 @@ class GraphRemediationEngine:
                         len(tier2),
                     )
                 else:
-                    dirty_ids = graph.dirty_nodes
-                    rescan_violations = await self._rescan_and_record(graph, pass_num)
-                    non_dirty = [v for v in violations if str(v.get("path", "")) not in dirty_ids]
-                    violations = rescan_violations + non_dirty
+                    await self._rescan_and_record(
+                        graph,
+                        pass_num,
+                        resolve_fixed_by="deterministic",
+                    )
+                    violations = graph.collect_violations()
                     new_tier1, new_tier2, _ = partition_violations(violations, registry)
                     new_fixable = len(new_tier1)
 
@@ -317,21 +324,13 @@ class GraphRemediationEngine:
                 ai_proposals.extend(new_ai_proposals)
 
                 if graph.dirty_nodes:
-                    dirty_ids = graph.dirty_nodes
-                    rescan_violations = await self._rescan_and_record(graph, pass_num)
-
-                    rescan_keys = {
-                        (str(v.get("path", "")), normalize_rule_id(str(v.get("rule_id", ""))))
-                        for v in rescan_violations
-                    }
-                    for v in violations:
-                        if str(v.get("path", "")) in dirty_ids:
-                            key = (str(v.get("path", "")), normalize_rule_id(str(v.get("rule_id", ""))))
-                            if key not in rescan_keys:
-                                all_fixed.append(dict(v))
-
-                    non_dirty = [v for v in violations if str(v.get("path", "")) not in dirty_ids]
-                    violations = rescan_violations + non_dirty
+                    await self._rescan_and_record(
+                        graph,
+                        pass_num,
+                        resolve_fixed_by="ai",
+                        resolve_status="proposed",
+                    )
+                    violations = graph.collect_violations()
 
                     # Phase C: Post-AI Tier 1 cleanup
                     new_tier1, new_tier2, _ = partition_violations(violations, registry)
@@ -344,16 +343,16 @@ class GraphRemediationEngine:
                             graph,
                             registry,
                             new_tier1,
-                            all_fixed,
                             pass_num,
                         )
-                        dirty_ids = graph.dirty_nodes
-                        rescan_violations = await self._rescan_and_record(graph, pass_num)
-                        non_dirty = [v for v in violations if str(v.get("path", "")) not in dirty_ids]
-                        violations = rescan_violations + non_dirty
+                        await self._rescan_and_record(
+                            graph,
+                            pass_num,
+                            resolve_fixed_by="deterministic",
+                        )
+                        violations = graph.collect_violations()
                         _, new_tier2, _ = partition_violations(violations, registry)
 
-                    # Build feedback for AI resubmission
                     if new_tier2:
                         ai_feedback_by_node = _build_ai_feedback(new_tier2)
                         continue
@@ -377,14 +376,15 @@ class GraphRemediationEngine:
 
         graph.approve_pending(source_filter="deterministic")
 
-        remaining = graph.collect_violations()
+        remaining = graph.query_violations(status="open")
+        fixed_violations = graph.query_violations(status="fixed")
         step_diffs = graph.collect_step_diffs()
 
         return GraphFixReport(
             passes=passes,
-            fixed=len(all_fixed),
+            fixed=len(fixed_violations),
             remaining_violations=remaining,
-            fixed_violations=all_fixed,
+            fixed_violations=fixed_violations,
             oscillation_detected=oscillation,
             nodes_modified=_count_modified_nodes(graph),
             step_diffs=step_diffs,
@@ -396,7 +396,6 @@ class GraphRemediationEngine:
         graph: ContentGraph,
         registry: TransformRegistry,
         tier1: list[ViolationDict],
-        all_fixed: list[ViolationDict],
         pass_num: int,
     ) -> int:
         """Apply Tier 1 deterministic transforms for one pass.
@@ -405,7 +404,6 @@ class GraphRemediationEngine:
             graph: ContentGraph to transform.
             registry: Transform registry.
             tier1: Tier 1 fixable violations.
-            all_fixed: Accumulator for fixed violations.
             pass_num: Current convergence pass number.
 
         Returns:
@@ -431,7 +429,6 @@ class GraphRemediationEngine:
             applied = await graph.apply_transform(node_id, transform_fn, v)
             if applied:
                 applied_this_pass += 1
-                all_fixed.append(dict(v))
             else:
                 skipped_no_apply += 1
                 logger.debug("Tier1 transform %s on %r: not applied", rule_id, node_id)
@@ -464,6 +461,10 @@ class GraphRemediationEngine:
     ) -> list[AINodeProposal]:
         """Apply AI transforms for Tier 2 violations.
 
+        Proposals are fetched concurrently (bounded by
+        ``max_ai_concurrency``), then applied serially because
+        ``ContentGraph`` is not thread-safe.
+
         Args:
             graph: ContentGraph to transform.
             tier2: AI-candidate violations.
@@ -474,6 +475,7 @@ class GraphRemediationEngine:
             List of AI proposals applied.
         """
         from apme_engine.remediation.ai_context import build_ai_node_context
+        from apme_engine.remediation.ai_provider import AINodeFix
 
         by_node: dict[str, list[ViolationDict]] = defaultdict(list)
         for v in tier2:
@@ -487,44 +489,84 @@ class GraphRemediationEngine:
             len(by_node),
         )
 
-        proposals: list[AINodeProposal] = []
         assert self._ai_provider is not None  # noqa: S101
+        sem = asyncio.Semaphore(self._max_ai_concurrency)
 
-        for node_id, node_violations in by_node.items():
+        async def _propose_one(
+            node_id: str,
+            node_violations: list[ViolationDict],
+        ) -> tuple[str, AINodeFix, str] | None:
+            """Fetch a single AI proposal under the concurrency semaphore.
+
+            Args:
+                node_id: Graph node identifier.
+                node_violations: Violations for this node.
+
+            Returns:
+                ``(node_id, fix, before_yaml)`` on success, ``None`` if
+                the node was skipped or the AI returned no change.
+            """
+            async with sem:
+                node = graph.get_node(node_id)
+                if node is None:
+                    logger.warning("AI: node %r not found in graph — skipping", node_id)
+                    return None
+                before_yaml = node.yaml_lines
+
+                feedback = feedback_by_node.get(node_id, "")
+                context = build_ai_node_context(
+                    graph,
+                    node_id,
+                    node_violations,
+                    feedback=feedback,
+                )
+                if context is None:
+                    logger.warning("AI: context is None for node %s — skipping", node_id)
+                    return None
+
+                logger.debug(
+                    "AI: calling propose_node_fix for %s (%d violations)",
+                    node_id,
+                    len(node_violations),
+                )
+                fix = await self._ai_provider.propose_node_fix(context)  # type: ignore[union-attr]
+                logger.debug(
+                    "AI: propose_node_fix returned for %s: fix=%s",
+                    node_id,
+                    fix is not None,
+                )
+
+                if fix is None or not fix.fixed_snippet:
+                    logger.debug("AI returned no usable fix for node %s", node_id)
+                    return None
+
+                if fix.fixed_snippet.strip() == before_yaml.strip():
+                    logger.debug(
+                        "AI returned identical content for node %s (no change)",
+                        node_id,
+                    )
+                    return None
+
+                return (node_id, fix, before_yaml)
+
+        # Fan out proposals concurrently
+        results = await asyncio.gather(
+            *[_propose_one(nid, nvs) for nid, nvs in by_node.items()],
+            return_exceptions=True,
+        )
+
+        # Apply accepted fixes serially (graph mutations are not thread-safe)
+        proposals: list[AINodeProposal] = []
+        for r in results:
+            if isinstance(r, BaseException):
+                logger.exception("AI proposal failed", exc_info=r)
+                continue
+            if r is None:
+                continue
+            node_id, fix, before_yaml = r
+
             node = graph.get_node(node_id)
             if node is None:
-                logger.warning("AI: node %r not found in graph — skipping", node_id)
-                continue
-            before_yaml = node.yaml_lines
-
-            feedback = feedback_by_node.get(node_id, "")
-            context = build_ai_node_context(
-                graph,
-                node_id,
-                node_violations,
-                feedback=feedback,
-            )
-            if context is None:
-                logger.warning("AI: context is None for node %s — skipping", node_id)
-                continue
-
-            try:
-                logger.debug("AI: calling propose_node_fix for %s (%d violations)", node_id, len(node_violations))
-                fix = await self._ai_provider.propose_node_fix(context)
-                logger.debug("AI: propose_node_fix returned for %s: fix=%s", node_id, fix is not None)
-            except Exception:
-                logger.exception("AI provider failed for node %s", node_id)
-                continue
-
-            if fix is None or not fix.fixed_snippet:
-                logger.debug("AI returned no usable fix for node %s", node_id)
-                continue
-
-            if fix.fixed_snippet.strip() == before_yaml.strip():
-                logger.debug(
-                    "AI returned identical content for node %s (no change)",
-                    node_id,
-                )
                 continue
 
             node.update_from_yaml(fix.fixed_snippet)
@@ -561,12 +603,19 @@ class GraphRemediationEngine:
         self,
         graph: ContentGraph,
         pass_num: int,
+        resolve_fixed_by: str | None = None,
+        resolve_status: str = "fixed",
     ) -> list[ViolationDict]:
-        """Rescan dirty nodes and record violations.
+        """Rescan dirty nodes, register violations, and optionally resolve.
 
         Args:
             graph: ContentGraph with dirty nodes to rescan.
             pass_num: Current convergence pass number.
+            resolve_fixed_by: When set, transitions violations that
+                disappeared on dirty nodes.  Leave ``None`` to skip
+                resolution (register only).
+            resolve_status: Target status for resolved violations
+                (``"fixed"`` for deterministic, ``"proposed"`` for AI).
 
         Returns:
             Fresh violations from the rescan.
@@ -585,6 +634,17 @@ class GraphRemediationEngine:
             phase="scanned",
             dirty_node_ids=dirty,
         )
+
+        if resolve_fixed_by is not None:
+            _resolve_dirty_violations(
+                graph,
+                new_violations,
+                dirty,
+                fixed_by=resolve_fixed_by,
+                pass_number=pass_num,
+                status=resolve_status,
+            )
+
         graph.clear_dirty()
         return new_violations
 
@@ -639,7 +699,7 @@ def splice_modifications(
         if original_hash == effective.content_hash:
             continue
 
-        node_rule_ids = list(node.progression[0].violations) if node.progression[0].violations else []
+        node_rule_ids = [rec.key[1] for rec in node.violation_ledger.values()]
 
         modified_by_file[node.file_path].append(
             (node.line_start, node.line_end, effective.yaml_lines, node_rule_ids),
@@ -700,15 +760,14 @@ def _record_violations(
     phase: str,
     dirty_node_ids: frozenset[str] | None = None,
 ) -> None:
-    """Record a NodeState snapshot for nodes with violations.
+    """Record NodeState snapshots and register violations in the ledger.
 
-    Violations are grouped by ``path`` (which must already be resolved
-    to a graph ``node_id`` — validators return ``path = node_id``
-    natively via node-native serialization strategies).
+    Records a ``NodeState`` (content-only) for each node that has
+    violations, then registers all violations into the graph's
+    violation ledger.
 
     When ``dirty_node_ids`` is provided, also records a clean snapshot
-    (empty violations) for dirty nodes that are *absent* from
-    ``violations``.
+    for dirty nodes that have no violations in this batch.
 
     Args:
         graph: ContentGraph with nodes to update.
@@ -716,7 +775,7 @@ def _record_violations(
         pass_number: Convergence pass number.
         phase: Pipeline phase (``"scanned"``, ``"transformed"``).
         dirty_node_ids: When set, dirty nodes absent from violations
-            get a clean ``(phase, violations=())`` entry.
+            get a snapshot entry recorded.
     """
     by_node: dict[str, list[ViolationDict]] = defaultdict(list)
     for v in violations:
@@ -724,22 +783,60 @@ def _record_violations(
         if node_id:
             by_node[node_id].append(v)
 
-    for node_id, vdicts in by_node.items():
+    for node_id in by_node:
         node = graph.get_node(node_id)
         if node is not None:
-            rule_ids = tuple(sorted(rid for v in vdicts if (rid := str(v.get("rule_id", "")))))
-            node.record_state(
-                pass_number,
-                phase,
-                violations=rule_ids,
-                violation_dicts=tuple(vdicts),
-            )
+            node.record_state(pass_number, phase)
 
     if dirty_node_ids is not None:
         for nid in dirty_node_ids - set(by_node):
             node = graph.get_node(nid)
             if node is not None:
-                node.record_state(pass_number, phase, violations=())
+                node.record_state(pass_number, phase)
+
+    graph.register_violations(violations, pass_number)
+
+
+def _resolve_dirty_violations(
+    graph: ContentGraph,
+    rescan_violations: list[ViolationDict],
+    dirty_ids: frozenset[str],
+    *,
+    fixed_by: str,
+    pass_number: int,
+    status: str = "fixed",
+) -> None:
+    """Resolve violations on dirty nodes based on rescan results.
+
+    For each dirty node, computes which rule IDs are still present
+    and calls ``graph.resolve_violations`` so that absent violations
+    transition to *status* with the given attribution.
+
+    Args:
+        graph: ContentGraph whose ledger to update.
+        rescan_violations: Violations returned by the rescan.
+        dirty_ids: Node IDs that were rescanned.
+        fixed_by: Attribution (``"deterministic"`` or ``"ai"``).
+        pass_number: Current convergence pass number.
+        status: Target status (``"fixed"`` or ``"proposed"``).
+    """
+    remaining_by_node: dict[str, set[str]] = defaultdict(set)
+    for v in rescan_violations:
+        node_id = str(v.get("path", ""))
+        if node_id:
+            remaining_by_node[node_id].add(
+                normalize_rule_id(str(v.get("rule_id", ""))),
+            )
+
+    for nid in dirty_ids:
+        remaining = remaining_by_node.get(nid, set())
+        graph.resolve_violations(
+            nid,
+            remaining,
+            fixed_by=fixed_by,
+            pass_number=pass_number,
+            status=status,
+        )
 
 
 def _build_ai_feedback(tier2: list[ViolationDict]) -> dict[str, str]:

--- a/src/apme_gateway/db/queries.py
+++ b/src/apme_gateway/db/queries.py
@@ -920,10 +920,6 @@ async def update_ai_counts(
     scan.ai_proposed = ai_proposed
     scan.ai_declined = ai_declined
     scan.ai_accepted = ai_accepted
-    if scan.scan_type == "remediate":
-        scan.fixed_count = scan.auto_fixable + ai_accepted
-    else:
-        scan.fixed_count = 0
     await db.commit()
 
 

--- a/tests/test_graph_remediation.py
+++ b/tests/test_graph_remediation.py
@@ -351,7 +351,7 @@ class TestGraphRemediationEngine:
         assert all(s.source == "deterministic" for s in transformed)
 
     async def test_clean_state_after_rescan(self) -> None:
-        """Dirty nodes confirmed clean after rescan get an empty-violations scanned entry."""
+        """After convergence, ledger shows the violation as fixed."""
         graph = ContentGraph()
         node = _make_node(module="apt")
         graph.add_node(node)
@@ -361,12 +361,10 @@ class TestGraphRemediationEngine:
         engine = GraphRemediationEngine(registry, graph, rules)
         await engine.remediate()
 
-        scanned_states = [ns for ns in node.progression if ns.phase == "scanned"]
-        assert len(scanned_states) >= 2
-        # First scanned state has the violation
-        assert "M001" in scanned_states[0].violations
-        # Final scanned state confirms clean (empty violations)
-        assert scanned_states[-1].violations == ()
+        fixed = graph.query_violations(status="fixed")
+        assert len(fixed) >= 1
+        assert any(v["rule_id"] == "M001" for v in fixed)
+        assert graph.collect_violations() == []
 
     async def test_progress_callback(self) -> None:
         """Progress callback is invoked during remediation."""
@@ -591,8 +589,8 @@ class TestGraphRemediationEngine:
         assert report.fixed == 1
         assert len(rescan_calls) >= 1
 
-    async def test_violation_dicts_stored_on_nodestate(self) -> None:
-        """Full ViolationDicts are stored on NodeState.violation_dicts during convergence."""
+    async def test_violations_stored_in_ledger(self) -> None:
+        """Violations are registered in the node's violation_ledger during convergence."""
         graph = ContentGraph()
         node = _make_node(module="apt")
         graph.add_node(node)
@@ -603,9 +601,9 @@ class TestGraphRemediationEngine:
         report = await engine.remediate()
 
         assert report.fixed == 0
-        assert node.state is not None
-        assert len(node.state.violation_dicts) >= 1
-        assert node.state.violation_dicts[0]["rule_id"] == "M001"
+        open_violations = graph.query_violations(status="open")
+        assert len(open_violations) >= 1
+        assert any(v["rule_id"] == "M001" for v in open_violations)
 
     async def test_remaining_violations_from_graph(self) -> None:
         """remaining_violations in the report come from graph.collect_violations()."""
@@ -743,8 +741,8 @@ class TestGraphRemediationEngine:
         assert len(report.ai_proposals) >= 1
         assert report.ai_proposals[0].rule_ids == ["M001"]
 
-    async def test_ai_resolved_violations_counted_in_fixed(self) -> None:
-        """Violations resolved by AI transforms are included in report.fixed and fixed_violations."""
+    async def test_ai_resolved_violations_pending_until_approved(self) -> None:
+        """AI-resolved violations are 'proposed', not 'fixed', until approved."""
         from unittest.mock import AsyncMock
 
         from apme_engine.remediation.ai_provider import AINodeFix
@@ -787,10 +785,13 @@ class TestGraphRemediationEngine:
         )
         report = await engine.remediate(initial_violations=violations)
 
-        assert report.fixed == 1, f"expected 1 AI-resolved violation in fixed, got {report.fixed}"
-        assert len(report.fixed_violations) == 1
-        assert report.fixed_violations[0]["rule_id"] == "M001"
+        # AI fixes are "proposed" — not counted as fixed until user approves
+        assert report.fixed == 0, f"expected 0 fixed (AI pending), got {report.fixed}"
+        assert len(report.fixed_violations) == 0
+        # "proposed" is a distinct status; open violations should be empty
         assert len(report.remaining_violations) == 0
+        proposed = graph.query_violations(status="proposed")
+        assert len(proposed) == 1, "violation is in proposed state"
         assert len(report.ai_proposals) >= 1
 
     async def test_tier1_stall_no_false_convergence(self) -> None:
@@ -909,8 +910,9 @@ class TestSpliceModifications:
         )
         graph.add_node(node)
 
-        # Record initial state, transform, record transformed state
-        node.record_state(0, "scanned", ("M001",))
+        node.record_state(0, "scanned")
+        v: ViolationDict = {"rule_id": "M001", "path": node.node_id}
+        graph.register_violations([v], 0)
         node.update_from_yaml(_TASK_YAML_FQCN)
         node.record_state(1, "transformed")
         graph.approve_pending()
@@ -948,12 +950,15 @@ class TestSpliceModifications:
         graph.add_node(n1)
         graph.add_node(n2)
 
-        # Mark both as modified
-        n1.record_state(0, "scanned", ("M001",))
+        n1.record_state(0, "scanned")
+        v1: ViolationDict = {"rule_id": "M001", "path": n1.node_id}
+        graph.register_violations([v1], 0)
         n1.update_from_yaml(_TASK_YAML_FQCN)
         n1.record_state(1, "transformed")
 
-        n2.record_state(0, "scanned", ("M001",))
+        n2.record_state(0, "scanned")
+        v2: ViolationDict = {"rule_id": "M001", "path": n2.node_id}
+        graph.register_violations([v2], 0)
         n2.update_from_yaml("- name: Copy file\n  ansible.builtin.copy:\n    src: a.txt\n    dest: /tmp/a.txt\n")
         n2.record_state(1, "transformed")
         graph.approve_pending()
@@ -985,8 +990,7 @@ class TestSpliceModifications:
         node = _make_node(module="apt")
         graph.add_node(node)
 
-        # Record state twice but don't change content
-        node.record_state(0, "scanned", ("M001",))
+        node.record_state(0, "scanned")
         node.record_state(1, "scanned")
 
         patches = splice_modifications(graph, {"/workspace/site.yml": self._ORIGINAL})
@@ -1003,7 +1007,7 @@ class TestSpliceModifications:
         )
         graph.add_node(node)
 
-        node.record_state(0, "scanned", ("M001",))
+        node.record_state(0, "scanned")
         node.update_from_yaml(_TASK_YAML_FQCN)
         node.record_state(1, "transformed", source="deterministic")
         # Do NOT approve — entries remain pending
@@ -1027,7 +1031,7 @@ class TestSpliceModifications:
         graph.add_node(node)
 
         # Original → deterministic fix → AI fix
-        node.record_state(0, "scanned", ("M001",))
+        node.record_state(0, "scanned")
         node.update_from_yaml(_TASK_YAML_FQCN)
         node.record_state(1, "transformed", source="deterministic")
 
@@ -1058,7 +1062,7 @@ class TestSpliceModifications:
         )
         graph.add_node(node)
 
-        node.record_state(0, "scanned", ("M001",))
+        node.record_state(0, "scanned")
         node.update_from_yaml(_TASK_YAML_FQCN)
         node.record_state(1, "transformed", source="deterministic")
         # No approve_pending — entries are still pending

--- a/tests/test_node_state.py
+++ b/tests/test_node_state.py
@@ -17,6 +17,7 @@ from apme_engine.engine.content_graph import (
     _node_from_dict,
     _node_to_dict,
     _reindent,
+    _violation_key,
 )
 from apme_engine.engine.models import ViolationDict
 
@@ -93,8 +94,6 @@ class TestNodeState:
             phase="scanned",
             yaml_lines="- name: foo\n",
             content_hash=_content_hash("- name: foo\n"),
-            violations=("L007",),
-            violation_dicts=(),
             timestamp="2026-03-30T00:00:00+00:00",
         )
         with pytest.raises(AttributeError):
@@ -109,40 +108,6 @@ class TestNodeState:
         """Different text must produce different hashes."""
         assert _content_hash("a") != _content_hash("b")
 
-    def test_violation_dicts_default(self) -> None:
-        """Default violation_dicts is an empty tuple."""
-        ns = NodeState(
-            id="test@0",
-            pass_number=0,
-            phase="scanned",
-            yaml_lines="- name: foo\n",
-            content_hash=_content_hash("- name: foo\n"),
-            violations=(),
-            violation_dicts=(),
-            timestamp="2026-03-30T00:00:00+00:00",
-        )
-        assert ns.violation_dicts == ()
-
-    def test_violation_dicts_stored(self) -> None:
-        """Full violation dicts are stored alongside rule IDs."""
-        vdict: ViolationDict = {
-            "rule_id": "L007",
-            "path": "site.yml/plays[0]/tasks[0]",
-            "message": "test",
-        }
-        ns = NodeState(
-            id="test@0",
-            pass_number=0,
-            phase="scanned",
-            yaml_lines="- name: foo\n",
-            content_hash=_content_hash("- name: foo\n"),
-            violations=("L007",),
-            violation_dicts=(vdict,),
-            timestamp="2026-03-30T00:00:00+00:00",
-        )
-        assert len(ns.violation_dicts) == 1
-        assert ns.violation_dicts[0]["rule_id"] == "L007"
-
 
 # ---------------------------------------------------------------------------
 # record_state
@@ -155,14 +120,13 @@ class TestRecordState:
     def test_basic_record(self) -> None:
         """Recording a state appends to progression and updates state."""
         node = _make_task()
-        ns = node.record_state(0, "scanned", ("R108",))
+        ns = node.record_state(0, "scanned")
 
         assert ns is node.state
         assert len(node.progression) == 1
         assert node.progression[0] is ns
         assert ns.pass_number == 0
         assert ns.phase == "scanned"
-        assert ns.violations == ("R108",)
         assert ns.yaml_lines == node.yaml_lines
         assert ns.content_hash == _content_hash(node.yaml_lines)
         assert ns.timestamp  # non-empty
@@ -170,7 +134,7 @@ class TestRecordState:
     def test_multiple_records(self) -> None:
         """Multiple calls accumulate an ordered progression."""
         node = _make_task()
-        ns0 = node.record_state(0, "scanned", ("L007",))
+        ns0 = node.record_state(0, "scanned")
         ns1 = node.record_state(0, "transformed")
         ns2 = node.record_state(1, "scanned")
 
@@ -178,30 +142,10 @@ class TestRecordState:
         assert node.progression == [ns0, ns1, ns2]
         assert node.state is ns2
 
-    def test_empty_violations_default(self) -> None:
-        """Default violations is an empty tuple."""
-        node = _make_task()
-        ns = node.record_state(0, "original")
-        assert ns.violations == ()
-        assert ns.violation_dicts == ()
-
-    def test_violation_dicts_parameter(self) -> None:
-        """record_state stores full violation dicts."""
-        node = _make_task()
-        vdict: ViolationDict = {
-            "rule_id": "M001",
-            "path": node.node_id,
-            "message": "Use FQCN",
-        }
-        ns = node.record_state(0, "scanned", ("M001",), violation_dicts=(vdict,))
-        assert ns.violations == ("M001",)
-        assert len(ns.violation_dicts) == 1
-        assert ns.violation_dicts[0]["rule_id"] == "M001"
-
     def test_state_captures_current_yaml(self) -> None:
         """After update_from_yaml, record_state captures the new content."""
         node = _make_task()
-        node.record_state(0, "scanned", ("M001",))
+        node.record_state(0, "scanned")
 
         node.update_from_yaml(_TASK_YAML_FQCN_FIXED)
         ns = node.record_state(0, "transformed")
@@ -417,7 +361,7 @@ class TestNodeStateSerialization:
     def test_round_trip_with_progression(self) -> None:
         """Nodes with progression entries round-trip cleanly."""
         node = _make_task()
-        node.record_state(0, "scanned", ("R108", "L007"))
+        node.record_state(0, "scanned")
         node.update_from_yaml(_TASK_YAML_FQCN_FIXED)
         node.record_state(0, "transformed")
 
@@ -433,15 +377,13 @@ class TestNodeStateSerialization:
         assert restored.state.phase == "transformed"
         assert restored.state.pass_number == 0
         assert len(restored.progression) == 2
-        assert restored.progression[0].violations == ("R108", "L007")
         assert restored.progression[0].phase == "scanned"
-        assert restored.progression[1].violations == ()
         assert restored.progression[1].phase == "transformed"
 
     def test_json_serializable(self) -> None:
         """Serialized dict must be JSON-encodable."""
         node = _make_task()
-        node.record_state(0, "scanned", ("L045",))
+        node.record_state(0, "scanned")
         d = _node_to_dict(node)
         serialized = json.dumps(d)
         assert isinstance(serialized, str)
@@ -456,7 +398,7 @@ class TestNodeStateSerialization:
     def test_state_reconciled_from_progression(self) -> None:
         """When progression exists, state is reconciled to progression[-1]."""
         node = _make_task()
-        node.record_state(0, "scanned", ("L007",))
+        node.record_state(0, "scanned")
         node.record_state(0, "transformed")
         d = _node_to_dict(node)
 
@@ -468,20 +410,43 @@ class TestNodeStateSerialization:
         assert restored.state.phase == "transformed"
         assert restored.state is restored.progression[-1]
 
-    def test_tuple_violations_accepted(self) -> None:
-        """_node_state_from_dict accepts tuple violations (not just list)."""
-        from apme_engine.engine.content_graph import _node_state_from_dict
+    def test_violation_ledger_round_trip(self) -> None:
+        """Violation ledger survives serialization round-trip."""
+        graph = ContentGraph()
+        node = _make_task()
+        graph.add_node(node)
+        node.record_state(0, "scanned")
 
-        d: dict[str, object] = {
-            "pass_number": 0,
-            "phase": "scanned",
-            "yaml_lines": "",
-            "content_hash": "",
-            "violations": ("L007", "R108"),
-            "timestamp": "",
-        }
-        ns = _node_state_from_dict(d)
-        assert ns.violations == ("L007", "R108")
+        v: ViolationDict = {"rule_id": "M001", "path": node.node_id, "message": "Use FQCN"}
+        graph.register_violations([v], 0)
+
+        d = _node_to_dict(node)
+        assert "violation_ledger" in d
+
+        restored = _node_from_dict(d)
+        key = _violation_key(v)
+        assert key in restored.violation_ledger
+        rec = restored.violation_ledger[key]
+        assert rec.status == "open"
+        assert rec.violation["rule_id"] == "M001"
+
+    def test_violation_ledger_fixed_round_trip(self) -> None:
+        """Fixed violations round-trip with attribution."""
+        graph = ContentGraph()
+        node = _make_task()
+        graph.add_node(node)
+
+        v: ViolationDict = {"rule_id": "M001", "path": node.node_id}
+        graph.register_violations([v], 0)
+        graph.resolve_violations(node.node_id, set(), fixed_by="deterministic", pass_number=1)
+
+        d = _node_to_dict(node)
+        restored = _node_from_dict(d)
+        key = _violation_key(v)
+        rec = restored.violation_ledger[key]
+        assert rec.status == "fixed"
+        assert rec.fixed_by == "deterministic"
+        assert rec.fixed_in_pass == 1
 
 
 # ---------------------------------------------------------------------------
@@ -594,13 +559,12 @@ class TestApplyTransform:
         graph, nid = self._build_graph()
         node = graph.get_node(nid)
         assert node is not None
-        node.record_state(0, "scanned", ("L026",))
+        node.record_state(0, "scanned")
         await graph.apply_transform(nid, add_tag, {})
         node.record_state(0, "transformed")
 
         assert len(node.progression) == 2
         assert node.progression[0].phase == "scanned"
-        assert node.progression[0].violations == ("L026",)
         assert node.progression[1].phase == "transformed"
         assert "added" in node.progression[1].yaml_lines
 
@@ -702,7 +666,7 @@ class TestNodeStateFields:
     def test_record_state_id_unique_within_pass(self) -> None:
         """Multiple entries in the same pass get distinct IDs."""
         node = _make_task()
-        ns0 = node.record_state(0, "scanned", ("M001",))
+        ns0 = node.record_state(0, "scanned")
         ns1 = node.record_state(0, "transformed")
         assert ns0.id != ns1.id
         assert ns0.id.endswith("@0")
@@ -739,7 +703,7 @@ class TestApprovalOperations:
         graph = ContentGraph()
         node = _make_task()
         graph.add_node(node)
-        node.record_state(0, "scanned", ("M001",))
+        node.record_state(0, "scanned")
         node.update_from_yaml(_TASK_YAML_FQCN_FIXED)
         node.record_state(1, "transformed", source="deterministic")
         return graph, node
@@ -772,7 +736,7 @@ class TestApprovalOperations:
             yaml_lines=_TASK_YAML_SHORT,
         )
         graph.add_node(node2)
-        node2.record_state(0, "scanned", ("M001",))
+        node2.record_state(0, "scanned")
 
         graph.approve_pending(node1.node_id)
         assert all(s.approved for s in node1.progression)
@@ -857,31 +821,27 @@ class TestApprovalOperations:
 
 
 class TestCollectViolations:
-    """Tests for ``ContentGraph.collect_violations``."""
+    """Tests for ``ContentGraph.collect_violations`` (via violation ledger)."""
 
     def test_empty_graph(self) -> None:
         """Empty graph returns no violations."""
         graph = ContentGraph()
         assert graph.collect_violations() == []
 
-    def test_no_states_recorded(self) -> None:
-        """Nodes without recorded state contribute no violations."""
+    def test_no_violations_registered(self) -> None:
+        """Nodes without registered violations contribute nothing."""
         graph = ContentGraph()
         graph.add_node(_make_task())
         assert graph.collect_violations() == []
 
-    def test_collects_from_latest_state(self) -> None:
-        """Violations are gathered from each node's latest state."""
+    def test_collects_open_violations(self) -> None:
+        """Open violations are returned by collect_violations."""
         graph = ContentGraph()
         node = _make_task()
         graph.add_node(node)
 
-        vdict: ViolationDict = {
-            "rule_id": "M001",
-            "path": node.node_id,
-            "message": "Use FQCN",
-        }
-        node.record_state(0, "scanned", ("M001",), violation_dicts=(vdict,))
+        v: ViolationDict = {"rule_id": "M001", "path": node.node_id, "message": "Use FQCN"}
+        graph.register_violations([v], 0)
 
         result = graph.collect_violations()
         assert len(result) == 1
@@ -903,26 +863,119 @@ class TestCollectViolations:
 
         v1: ViolationDict = {"rule_id": "M001", "path": node1.node_id}
         v2: ViolationDict = {"rule_id": "L005", "path": node2.node_id}
-        node1.record_state(0, "scanned", ("M001",), violation_dicts=(v1,))
-        node2.record_state(0, "scanned", ("L005",), violation_dicts=(v2,))
+        graph.register_violations([v1, v2], 0)
 
         result = graph.collect_violations()
         assert len(result) == 2
         rule_ids = {v["rule_id"] for v in result}
         assert rule_ids == {"M001", "L005"}
 
-    def test_clean_node_contributes_nothing(self) -> None:
-        """Nodes whose latest state has no violations are excluded."""
+    def test_fixed_not_in_collect(self) -> None:
+        """Fixed violations are excluded from collect_violations."""
         graph = ContentGraph()
         node = _make_task()
         graph.add_node(node)
 
-        vdict: ViolationDict = {"rule_id": "M001", "path": node.node_id}
-        node.record_state(0, "scanned", ("M001",), violation_dicts=(vdict,))
-        node.record_state(1, "scanned")
+        v: ViolationDict = {"rule_id": "M001", "path": node.node_id}
+        graph.register_violations([v], 0)
+        graph.resolve_violations(node.node_id, set(), fixed_by="deterministic", pass_number=1)
 
-        result = graph.collect_violations()
-        assert result == []
+        assert graph.collect_violations() == []
+
+    def test_query_fixed(self) -> None:
+        """query_violations(status='fixed') returns fixed violations."""
+        graph = ContentGraph()
+        node = _make_task()
+        graph.add_node(node)
+
+        v: ViolationDict = {"rule_id": "M001", "path": node.node_id}
+        graph.register_violations([v], 0)
+        graph.resolve_violations(node.node_id, set(), fixed_by="deterministic", pass_number=1)
+
+        fixed = graph.query_violations(status="fixed")
+        assert len(fixed) == 1
+        assert fixed[0]["rule_id"] == "M001"
+
+    def test_query_by_fixed_by(self) -> None:
+        """query_violations filters by fixed_by attribution."""
+        graph = ContentGraph()
+        node = _make_task()
+        graph.add_node(node)
+
+        v1: ViolationDict = {"rule_id": "M001", "path": node.node_id}
+        v2: ViolationDict = {"rule_id": "L005", "path": node.node_id}
+        graph.register_violations([v1, v2], 0)
+        graph.resolve_violations(node.node_id, {"L005"}, fixed_by="deterministic", pass_number=1)
+
+        det = graph.query_violations(status="fixed", fixed_by="deterministic")
+        assert len(det) == 1
+        assert det[0]["rule_id"] == "M001"
+
+    def test_proposed_state(self) -> None:
+        """Proposed violations are neither in collect nor in fixed queries."""
+        graph = ContentGraph()
+        node = _make_task()
+        graph.add_node(node)
+
+        v: ViolationDict = {"rule_id": "M001", "path": node.node_id}
+        graph.register_violations([v], 0)
+        graph.resolve_violations(node.node_id, set(), fixed_by="ai", pass_number=1, status="proposed")
+
+        assert graph.collect_violations() == []
+        assert graph.query_violations(status="fixed") == []
+        proposed = graph.query_violations(status="proposed")
+        assert len(proposed) == 1
+
+    def test_approve_proposed(self) -> None:
+        """approve_proposed transitions proposed to fixed."""
+        graph = ContentGraph()
+        node = _make_task()
+        graph.add_node(node)
+
+        v: ViolationDict = {"rule_id": "M001", "path": node.node_id}
+        graph.register_violations([v], 0)
+        graph.resolve_violations(node.node_id, set(), fixed_by="ai", pass_number=1, status="proposed")
+
+        count = graph.approve_proposed(node.node_id)
+        assert count == 1
+
+        fixed = graph.query_violations(status="fixed")
+        assert len(fixed) == 1
+        assert fixed[0]["rule_id"] == "M001"
+
+    def test_decline_proposed(self) -> None:
+        """decline_proposed transitions proposed to declined."""
+        graph = ContentGraph()
+        node = _make_task()
+        graph.add_node(node)
+
+        v: ViolationDict = {"rule_id": "M001", "path": node.node_id}
+        graph.register_violations([v], 0)
+        graph.resolve_violations(node.node_id, set(), fixed_by="ai", pass_number=1, status="proposed")
+
+        count = graph.decline_proposed(node.node_id)
+        assert count == 1
+
+        declined = graph.query_violations(status="declined")
+        assert len(declined) == 1
+        key = _violation_key(v)
+        rec = node.violation_ledger[key]
+        assert rec.fixed_by is None
+        assert rec.fixed_in_pass is None
+
+    def test_reopen_regression(self) -> None:
+        """A fixed violation that reappears is reopened."""
+        graph = ContentGraph()
+        node = _make_task()
+        graph.add_node(node)
+
+        v: ViolationDict = {"rule_id": "M001", "path": node.node_id}
+        graph.register_violations([v], 0)
+        graph.resolve_violations(node.node_id, set(), fixed_by="deterministic", pass_number=1)
+        assert graph.collect_violations() == []
+
+        graph.register_violations([v], 2)
+        assert len(graph.collect_violations()) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -943,7 +996,7 @@ class TestCollectStepDiffs:
         graph = ContentGraph()
         node = _make_task()
         graph.add_node(node)
-        node.record_state(0, "scanned", ("M001",))
+        node.record_state(0, "scanned")
         node.record_state(1, "scanned")
         assert graph.collect_step_diffs() == []
 
@@ -952,7 +1005,7 @@ class TestCollectStepDiffs:
         graph = ContentGraph()
         node = _make_task()
         graph.add_node(node)
-        node.record_state(0, "scanned", ("M001",))
+        node.record_state(0, "scanned")
         node.update_from_yaml(_TASK_YAML_FQCN_FIXED)
         node.record_state(1, "transformed", source="deterministic")
 
@@ -964,28 +1017,6 @@ class TestCollectStepDiffs:
         assert d["source"] == "deterministic"
         assert isinstance(d["diff"], str)
         assert len(d["diff"]) > 0
-        removed = d["violations_removed"]
-        assert isinstance(removed, list)
-        assert "M001" in removed
-
-    def test_violation_lineage(self) -> None:
-        """Tracks violations added and removed across steps."""
-        graph = ContentGraph()
-        node = _make_task()
-        graph.add_node(node)
-        node.record_state(0, "scanned", ("L005", "M001"))
-        node.update_from_yaml(_TASK_YAML_FQCN_FIXED)
-        node.record_state(1, "scanned", ("L059",))
-
-        diffs = graph.collect_step_diffs()
-        assert len(diffs) == 1
-        d = diffs[0]
-        removed = d["violations_removed"]
-        added = d["violations_added"]
-        assert isinstance(removed, list)
-        assert isinstance(added, list)
-        assert sorted(removed) == ["L005", "M001"]
-        assert added == ["L059"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace fragile diff-based violation accounting with a first-class violation ledger on ContentNode
- Each violation has an explicit lifecycle (`open` → `fixed` | `proposed` → `fixed`/`declined`) — structurally impossible to double-count
- Post-approval remaining violations are now correctly classified as Manual (not AI)

## Changes
- **`content_graph.py`**: Add `ViolationKey`, `ViolationRecord` dataclass (4 states: open/fixed/proposed/declined), `violation_ledger` on `ContentNode`; remove `violations` and `violation_dicts` from `NodeState`; add `register_violations`, `resolve_violations`, `approve_proposed`, `decline_proposed`, `query_violations` methods; update serialization with key-length validation
- **`graph_engine.py`**: Replace snapshot-diff accounting with ledger API calls at scan/transform boundaries; AI-resolved violations enter `proposed` state (not `fixed`); concurrent AI proposals bounded by `max_ai_concurrency` (clamped >= 1); fix `logger.error` exc_info for captured exceptions
- **`primary_server.py`**: `_reconcile_after_approval` uses `approve_proposed`/`decline_proposed` instead of manual ledger manipulation; post-approval remaining violations all classified `MANUAL_REVIEW`; co-fixes derived from ledger; clamp `APME_AI_CONCURRENCY` env var to >= 1
- **`queries.py`**: Remove unused `update_ai_counts_from_scan` helper
- **`DESIGN_REMEDIATION.md`**: Document violation ledger model, lifecycle states, and graph API
- **Tests**: Rewrite `test_node_state.py` and `test_graph_remediation.py` to use ledger API; add new tests for proposed/declined states, approve/decline transitions, ledger serialization round-trips, and regression reopening

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2227 passed; 6 pre-existing venv e2e failures unrelated to this change)
- [x] Docs updated (DESIGN_REMEDIATION.md)