### PR TITLE
feat(remediation,ui): surface AI abstain reason/suggestion and add AI Tried filter

### DIFF
--- a/frontend/src/components/ViolationDetailModal.tsx
+++ b/frontend/src/components/ViolationDetailModal.tsx
@@ -76,6 +76,8 @@ export interface ViolationRecord {
   fixed_yaml?: string;
   co_fixes?: string[];
   node_line_start?: number;
+  ai_reason?: string;
+  ai_suggestion?: string;
 }
 
 interface ViolationDetailModalProps {
@@ -163,6 +165,16 @@ export function ViolationDetailModal({ isOpen, onClose, violation, diff, getRule
                     {ruleDesc}
                   </PageDetail>
                 )}
+                {violation.ai_reason ? (
+                  <PageDetail label="AI Reason">
+                    {violation.ai_reason}
+                  </PageDetail>
+                ) : null}
+                {violation.ai_suggestion ? (
+                  <PageDetail label="Suggestion">
+                    {violation.ai_suggestion}
+                  </PageDetail>
+                ) : null}
               </PageDetails>
           </Tab>
           {hasSource ? (

--- a/frontend/src/components/severity.ts
+++ b/frontend/src/components/severity.ts
@@ -107,11 +107,14 @@ export function scopeLabel(scope: number | undefined): string {
 // Fix tier (remediation_class)
 // ---------------------------------------------------------------------------
 
+/** Synthetic filter value for AI-abstained violations (not a real remediation_class). */
+export const FIX_AI_TRIED = 4;
+
 export const FIX_LABELS: Record<number, string> = {
-  1: 'Fixable', 2: 'AI', 3: 'Manual',
+  1: 'Fixable', 2: 'AI', 3: 'Manual', [FIX_AI_TRIED]: 'AI Tried',
 };
 
-export const FIX_ORDER = [1, 2, 3] as const;
+export const FIX_ORDER = [1, 2, 3, FIX_AI_TRIED] as const;
 
 /** Human-readable label for a remediation_class value. */
 export function fixLabel(rc: number | undefined): string {

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { PageLayout, PageHeader } from '@ansible/ansible-ui-framework';
 import { ViolationStatusBar } from '../components/ViolationStatusBar';
-import { severityClass } from '../components/severity';
+import { severityClass, FIX_AI_TRIED } from '../components/severity';
+import { RESOLUTION_AI_ABSTAINED } from '../types/constants';
 import { SeverityStatusBar } from '../components/SeverityStatusBar';
 import { ViolationOutputToolbar } from '../components/ViolationOutputToolbar';
 import { ViolationOutput } from '../components/ViolationOutput';
@@ -93,7 +94,9 @@ export function ActivityDetailPage() {
   const fixCounts = useMemo(() => {
     const counts = new Map<number, number>();
     for (const v of projectViolations) {
-      if (v.remediation_class > 0) {
+      if (v.remediation_resolution === RESOLUTION_AI_ABSTAINED) {
+        counts.set(FIX_AI_TRIED, (counts.get(FIX_AI_TRIED) ?? 0) + 1);
+      } else if (v.remediation_class > 0) {
         counts.set(v.remediation_class, (counts.get(v.remediation_class) ?? 0) + 1);
       }
     }
@@ -112,7 +115,12 @@ export function ActivityDetailPage() {
       violations = violations.filter((v) => v.scope != null && scopeFilters.has(v.scope));
     }
     if (fixFilters.size > 0) {
-      violations = violations.filter((v) => fixFilters.has(v.remediation_class));
+      violations = violations.filter((v) => {
+        if (v.remediation_resolution === RESOLUTION_AI_ABSTAINED) {
+          return fixFilters.has(FIX_AI_TRIED);
+        }
+        return fixFilters.has(v.remediation_class);
+      });
     }
     if (searchText.trim()) {
       const q = searchText.toLowerCase();

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -14,6 +14,8 @@ export interface ViolationDetail {
   fixed_yaml?: string;
   co_fixes?: string[];
   node_line_start?: number;
+  ai_reason?: string;
+  ai_suggestion?: string;
 }
 
 export interface LogEntry {

--- a/src/apme_engine/daemon/violation_convert.py
+++ b/src/apme_engine/daemon/violation_convert.py
@@ -49,6 +49,8 @@ _METADATA_KEYS = frozenset(
         "dep_package",
         "dep_installed_version",
         "dep_fix_versions",
+        "ai_reason",
+        "ai_suggestion",
     }
 )
 

--- a/src/apme_engine/engine/content_graph.py
+++ b/src/apme_engine/engine/content_graph.py
@@ -259,6 +259,8 @@ class ViolationRecord:
             (``"deterministic"``, ``"ai"``, or ``None``).
         fixed_in_pass: Convergence pass that resolved the violation.
         discovered_in_pass: Convergence pass that first detected it.
+        ai_reason: Why the AI could not fix this violation (``ai_abstained`` only).
+        ai_suggestion: Manual remediation guidance from the AI (``ai_abstained`` only).
     """
 
     key: ViolationKey
@@ -267,6 +269,8 @@ class ViolationRecord:
     fixed_by: str | None = None
     fixed_in_pass: int | None = None
     discovered_in_pass: int = 0
+    ai_reason: str | None = None
+    ai_suggestion: str | None = None
 
 
 def _normalize_rule_id(rule_id: str) -> str:
@@ -861,6 +865,8 @@ class ContentGraph:
         self,
         node_id: str,
         rule_ids: frozenset[str],
+        *,
+        reasons: dict[str, tuple[str, str]] | None = None,
     ) -> int:
         """Transition ``open`` violations to ``ai_abstained`` on a node.
 
@@ -878,6 +884,8 @@ class ContentGraph:
         Args:
             node_id: Graph node whose violations to mark.
             rule_ids: Set of normalized rule IDs the AI abstained from.
+            reasons: Optional mapping of ``normalized_rule_id`` to
+                ``(reason, suggestion)`` from the AI provider.
 
         Returns:
             Number of violations transitioned to ``ai_abstained``.
@@ -892,6 +900,10 @@ class ContentGraph:
             _, rule_id = record.key
             if rule_id in rule_ids:
                 record.status = "ai_abstained"
+                if reasons is not None:
+                    reason_pair = reasons.get(rule_id)
+                    if reason_pair is not None:
+                        record.ai_reason, record.ai_suggestion = reason_pair
                 count += 1
         return count
 
@@ -984,6 +996,10 @@ class ContentGraph:
                 mapped = _status_resolution.get(record.status)
                 if mapped is not None:
                     vdict["remediation_resolution"] = mapped
+                if record.ai_reason:
+                    vdict["ai_reason"] = record.ai_reason
+                if record.ai_suggestion:
+                    vdict["ai_suggestion"] = record.ai_suggestion
                 result.append(vdict)
         return result
 
@@ -1540,6 +1556,10 @@ def _violation_record_to_dict(rec: ViolationRecord) -> dict[str, object]:
         d["fixed_by"] = rec.fixed_by
     if rec.fixed_in_pass is not None:
         d["fixed_in_pass"] = rec.fixed_in_pass
+    if rec.ai_reason is not None:
+        d["ai_reason"] = rec.ai_reason
+    if rec.ai_suggestion is not None:
+        d["ai_suggestion"] = rec.ai_suggestion
     return d
 
 
@@ -1567,6 +1587,8 @@ def _violation_record_from_dict(d: dict[str, object]) -> ViolationRecord:
         fixed_by=str(d["fixed_by"]) if "fixed_by" in d else None,
         fixed_in_pass=int(cast(int, fixed_in_raw)) if fixed_in_raw is not None else None,
         discovered_in_pass=int(cast(int, d.get("discovered_in_pass", 0))),
+        ai_reason=str(d["ai_reason"]) if "ai_reason" in d else None,
+        ai_suggestion=str(d["ai_suggestion"]) if "ai_suggestion" in d else None,
     )
 
 

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -605,8 +605,12 @@ class GraphRemediationEngine:
             )
 
             if fix.skipped:
-                skipped_ids = frozenset(normalize_rule_id(s.rule_id) for s in fix.skipped)
-                graph.abstain_violations(node_id, skipped_ids)
+                skipped_reasons = {normalize_rule_id(s.rule_id): (s.reason, s.suggestion) for s in fix.skipped}
+                graph.abstain_violations(
+                    node_id,
+                    frozenset(skipped_reasons),
+                    reasons=skipped_reasons,
+                )
 
             logger.info(
                 "AI transform applied to %s (rules: %s, confidence: %.2f)",

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -608,7 +608,7 @@ class GraphRemediationEngine:
                 skipped_reasons = {normalize_rule_id(s.rule_id): (s.reason, s.suggestion) for s in fix.skipped}
                 graph.abstain_violations(
                     node_id,
-                    frozenset(skipped_reasons),
+                    frozenset(skipped_reasons.keys()),
                     reasons=skipped_reasons,
                 )
 

--- a/src/apme_gateway/api/router.py
+++ b/src/apme_gateway/api/router.py
@@ -724,6 +724,8 @@ async def list_project_violations(
             fixed_yaml=v.fixed_yaml,
             co_fixes=[r for r in v.co_fixes.split(",") if r],
             node_line_start=v.node_line_start,
+            ai_reason=v.ai_reason,
+            ai_suggestion=v.ai_suggestion,
         )
         for v in violations
     ]
@@ -1305,6 +1307,8 @@ async def get_activity_detail(activity_id: str) -> ActivityDetail:
                 fixed_yaml=v.fixed_yaml,
                 co_fixes=[r for r in v.co_fixes.split(",") if r],
                 node_line_start=v.node_line_start,
+                ai_reason=v.ai_reason,
+                ai_suggestion=v.ai_suggestion,
             )
             for v in scan.violations
         ],

--- a/src/apme_gateway/api/schemas.py
+++ b/src/apme_gateway/api/schemas.py
@@ -78,6 +78,8 @@ class ViolationDetail(BaseModel):  # type: ignore[misc]
         fixed_yaml: Node YAML after transforms (fixed violations only).
         co_fixes: Other rule IDs whose fixes are included in this node's diff.
         node_line_start: File line where the node starts.
+        ai_reason: Why the AI could not fix this violation (ai_abstained only).
+        ai_suggestion: Manual remediation guidance from the AI (ai_abstained only).
     """
 
     id: int
@@ -95,6 +97,8 @@ class ViolationDetail(BaseModel):  # type: ignore[misc]
     fixed_yaml: str = ""
     co_fixes: list[str] = []
     node_line_start: int = 0
+    ai_reason: str = ""
+    ai_suggestion: str = ""
 
 
 class ProposalDetail(BaseModel):  # type: ignore[misc]

--- a/src/apme_gateway/db/__init__.py
+++ b/src/apme_gateway/db/__init__.py
@@ -56,6 +56,10 @@ def _migrate_violations_table(conn: object) -> None:
         migrations.append("ALTER TABLE violations ADD COLUMN node_line_start INTEGER NOT NULL DEFAULT 0")
     if "remediation_resolution" not in existing:
         migrations.append("ALTER TABLE violations ADD COLUMN remediation_resolution INTEGER NOT NULL DEFAULT 0")
+    if "ai_reason" not in existing:
+        migrations.append("ALTER TABLE violations ADD COLUMN ai_reason TEXT NOT NULL DEFAULT ''")
+    if "ai_suggestion" not in existing:
+        migrations.append("ALTER TABLE violations ADD COLUMN ai_suggestion TEXT NOT NULL DEFAULT ''")
 
     for stmt in migrations:
         conn.execute(text(stmt))

--- a/src/apme_gateway/db/models.py
+++ b/src/apme_gateway/db/models.py
@@ -160,6 +160,8 @@ class Violation(Base):
         fixed_yaml: Node YAML after transforms (fixed violations only).
         co_fixes: Comma-separated other rule IDs whose fixes are included.
         node_line_start: File line where the node starts.
+        ai_reason: Why the AI could not fix this violation (ai_abstained only).
+        ai_suggestion: Manual remediation guidance from the AI (ai_abstained only).
         scan: Back-reference to owning Scan.
     """
 
@@ -181,6 +183,8 @@ class Violation(Base):
     fixed_yaml: Mapped[str] = mapped_column(Text, nullable=False, default="")
     co_fixes: Mapped[str] = mapped_column(Text, nullable=False, default="")
     node_line_start: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    ai_reason: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    ai_suggestion: Mapped[str] = mapped_column(Text, nullable=False, default="")
 
     scan: Mapped[Scan] = relationship(back_populates="violations")
 

--- a/src/apme_gateway/grpc_reporting/servicer.py
+++ b/src/apme_gateway/grpc_reporting/servicer.py
@@ -273,6 +273,8 @@ def _add_violations(db: AsyncSession, scan_id: str, violations: Sequence[object]
                 fixed_yaml=v.fixed_yaml,  # type: ignore[attr-defined]
                 co_fixes=",".join(v.co_fixes),  # type: ignore[attr-defined]
                 node_line_start=v.node_line_start,  # type: ignore[attr-defined]
+                ai_reason=v.metadata.get("ai_reason", ""),  # type: ignore[attr-defined]
+                ai_suggestion=v.metadata.get("ai_suggestion", ""),  # type: ignore[attr-defined]
             )
         )
 


### PR DESCRIPTION
## Summary
- Wire `AISkipped.reason` and `AISkipped.suggestion` from the AI provider through the full stack (engine ledger, proto metadata, gateway DB, REST API) to the UI
- Add "AI Tried" as a filterable category in the Fix toolbar so users can isolate violations where AI attempted but could not produce a fix

## Changes
- **Engine (`content_graph.py`)**: Add `ai_reason`/`ai_suggestion` fields to `ViolationRecord`; extend `abstain_violations()` to accept per-rule reason pairs; stamp fields in `query_violations()`; round-trip in serialization helpers
- **Engine (`graph_engine.py`)**: Build reasons dict from `AISkipped` objects and pass to `abstain_violations()`
- **Proto transport (`violation_convert.py`)**: Add `ai_reason`/`ai_suggestion` to `_METADATA_KEYS` for transport via existing `metadata` map (no proto schema change)
- **Gateway DB (`models.py`, `__init__.py`)**: Add `ai_reason`/`ai_suggestion` columns with migration for existing SQLite databases
- **Gateway reporting (`servicer.py`)**: Extract from proto metadata when persisting violations
- **Gateway API (`schemas.py`, `router.py`)**: Add fields to `ViolationDetail` schema and both violation endpoints
- **Frontend (`api.ts`, `ViolationDetailModal.tsx`)**: Add fields to TypeScript interface; display conditional "AI Reason" and "Suggestion" rows in the Details tab
- **Frontend (`severity.ts`, `ActivityDetailPage.tsx`)**: Add synthetic `FIX_AI_TRIED` filter value; update counting and filtering logic to bucket AI-abstained violations separately

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2242 passed)
- [ ] Manual: run `apme remediate` against a project with AI-candidate violations, verify "AI Tried" pill shows in results
- [ ] Manual: click an AI Tried violation, verify "AI Reason" and "Suggestion" appear in the Details tab
- [ ] Manual: use the Fix filter toolbar, verify "AI Tried" checkbox appears and correctly filters

Made with [Cursor](https://cursor.com)