### PR TITLE
feat(ansible): add collection-version-aware LRU cache for plugin introspection

### DIFF
--- a/src/apme_engine/daemon/ansible_validator_server.py
+++ b/src/apme_engine/daemon/ansible_validator_server.py
@@ -201,6 +201,11 @@ class AnsibleValidatorServicer(validate_pb2_grpc.ValidatorServicer):
                     )
                     for rt in result.run_result.rule_timings
                 ]
+                diag_metadata: dict[str, str] = {
+                    "ansible_core_version": result.ansible_core_version,
+                }
+                for mk, mv in result.run_result.metadata.items():
+                    diag_metadata[mk] = str(mv)
                 diag = ValidatorDiagnostics(
                     validator_name="ansible",
                     request_id=req_id,
@@ -208,9 +213,7 @@ class AnsibleValidatorServicer(validate_pb2_grpc.ValidatorServicer):
                     files_received=len(request.files),
                     violations_found=len(result.run_result.violations),
                     rule_timings=rule_timings,
-                    metadata={
-                        "ansible_core_version": result.ansible_core_version,
-                    },
+                    metadata=diag_metadata,
                 )
 
                 for v in result.run_result.violations:

--- a/src/apme_engine/validators/ansible/__init__.py
+++ b/src/apme_engine/validators/ansible/__init__.py
@@ -14,6 +14,7 @@ from typing import cast
 from apme_engine.engine.models import YAMLDict
 from apme_engine.validators.base import ScanContext
 
+from .cache import plugin_cache
 from .rules import L057_syntax, L058_argspec_doc, L059_argspec_mock, M001_M004_introspect
 
 NodeLookup = dict[str, list[tuple[int, int, str]]]
@@ -41,10 +42,12 @@ class AnsibleRunResult:
     Attributes:
         violations: List of violation dicts.
         rule_timings: Per-rule timing data.
+        metadata: Extra metadata (e.g. cache hit/miss stats).
     """
 
     violations: list[dict[str, object]] = field(default_factory=list)
     rule_timings: list[AnsibleRuleTiming] = field(default_factory=list)
+    metadata: dict[str, int] = field(default_factory=dict)
 
 
 def _extract_task_nodes(hierarchy_payload: YAMLDict | None) -> list[dict[str, object]]:
@@ -278,6 +281,19 @@ class AnsibleValidator:
         rule_timings.append(AnsibleRuleTiming(rule_id="L059", elapsed_ms=elapsed, violations=len(l059)))
         sys.stderr.write(f"  L059 (argspec-mock): {len(l059)} issue(s) in {elapsed:.1f}ms\n")
 
-        sys.stderr.write(f"Ansible validator: total {len(violations)} violation(s)\n")
+        cache_stats = plugin_cache.stats()
+        sys.stderr.write(
+            f"Ansible validator: total {len(violations)} violation(s), "
+            f"cache introspect={cache_stats.get('cache_introspect_hits', 0)}h/"
+            f"{cache_stats.get('cache_introspect_misses', 0)}m, "
+            f"docspec={cache_stats.get('cache_docspec_hits', 0)}h/"
+            f"{cache_stats.get('cache_docspec_misses', 0)}m, "
+            f"mockspec={cache_stats.get('cache_mockspec_hits', 0)}h/"
+            f"{cache_stats.get('cache_mockspec_misses', 0)}m\n"
+        )
         sys.stderr.flush()
-        return AnsibleRunResult(violations=violations, rule_timings=rule_timings)
+        return AnsibleRunResult(
+            violations=violations,
+            rule_timings=rule_timings,
+            metadata=cache_stats,
+        )

--- a/src/apme_engine/validators/ansible/cache.py
+++ b/src/apme_engine/validators/ansible/cache.py
@@ -24,6 +24,7 @@ CacheType = Literal["introspect", "docspec", "mockspec"]
 CacheKey = tuple[str, str, str]  # (collection_fqcn, version, plugin_name)
 
 _MAX_ENTRIES = 1024
+_MAX_VERSION_ENTRIES = 256
 
 
 def _collection_version(venv_root: str, namespace: str, name: str) -> str:
@@ -107,8 +108,8 @@ class PluginCache:
         }
         self._hits: dict[CacheType, int] = {"introspect": 0, "docspec": 0, "mockspec": 0}
         self._misses: dict[CacheType, int] = {"introspect": 0, "docspec": 0, "mockspec": 0}
-        self._version_cache: dict[tuple[str, str, str], str] = {}
-        self._core_version_cache: dict[str, str] = {}
+        self._version_cache: OrderedDict[tuple[str, str, str], str] = OrderedDict()
+        self._core_version_cache: OrderedDict[str, str] = OrderedDict()
         self._lock = threading.Lock()
 
     def _resolve_version(self, venv_root: str, namespace: str, name: str) -> str:
@@ -125,15 +126,22 @@ class PluginCache:
         memo_key = (venv_root, namespace, name)
         cached = self._version_cache.get(memo_key)
         if cached is not None:
+            self._version_cache.move_to_end(memo_key)
             return cached
         if namespace == "ansible" and name == "builtin":
             version = self._core_version_cache.get(venv_root)
             if version is None:
                 version = _ansible_core_version(venv_root)
                 self._core_version_cache[venv_root] = version
+                while len(self._core_version_cache) > _MAX_VERSION_ENTRIES:
+                    self._core_version_cache.popitem(last=False)
+            else:
+                self._core_version_cache.move_to_end(venv_root)
         else:
             version = _collection_version(venv_root, namespace, name)
         self._version_cache[memo_key] = version
+        while len(self._version_cache) > _MAX_VERSION_ENTRIES:
+            self._version_cache.popitem(last=False)
         return version
 
     def _make_key(self, venv_root: str, plugin_name: str) -> CacheKey | None:
@@ -254,7 +262,8 @@ class PluginCache:
         """Return hit/miss counts for diagnostics.
 
         Returns:
-            Dict with keys like ``introspect_hits``, ``introspect_misses``, etc.
+            Dict with keys like ``cache_introspect_hits``,
+            ``cache_introspect_misses``, etc.
         """
         with self._lock:
             stores: list[CacheType] = ["introspect", "docspec", "mockspec"]

--- a/src/apme_engine/validators/ansible/cache.py
+++ b/src/apme_engine/validators/ansible/cache.py
@@ -1,0 +1,272 @@
+"""Collection-version-aware LRU cache for Ansible plugin introspection.
+
+Caches expensive subprocess results (plugin resolution, docstring specs,
+mock argspecs) keyed by ``(collection_fqcn, collection_version, plugin_name)``
+so that repeat scans and cross-venv calls with identical collection versions
+avoid redundant subprocess invocations.
+
+The cache is in-memory only — it lives in the Ansible validator daemon
+process and dies with it.
+"""
+
+from __future__ import annotations
+
+import glob as _glob
+import json
+import logging
+import threading
+from collections import OrderedDict
+from pathlib import Path
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+CacheType = Literal["introspect", "docspec", "mockspec"]
+CacheKey = tuple[str, str, str]  # (collection_fqcn, version, plugin_name)
+
+_MAX_ENTRIES = 1024
+
+
+def _collection_version(venv_root: str, namespace: str, name: str) -> str:
+    """Read a collection's installed version from its MANIFEST.json.
+
+    Args:
+        venv_root: Path to the venv root directory.
+        namespace: Collection namespace (e.g. ``community``).
+        name: Collection name (e.g. ``general``).
+
+    Returns:
+        Version string, or ``""`` if the manifest cannot be read.
+    """
+    pattern = (
+        f"{venv_root}/lib/python*/site-packages/"
+        f"ansible_collections/{namespace}/{name}/MANIFEST.json"
+    )
+    for path in sorted(_glob.glob(pattern)):
+        try:
+            with open(path) as fh:
+                manifest = json.load(fh)
+            return str(manifest.get("collection_info", {}).get("version", ""))
+        except (OSError, json.JSONDecodeError, KeyError):
+            continue
+    return ""
+
+
+def _ansible_core_version(venv_root: str) -> str:
+    """Read the ansible-core version installed in a venv.
+
+    Args:
+        venv_root: Path to the venv root directory.
+
+    Returns:
+        Version string, or ``""`` if it cannot be determined.
+    """
+    pattern = f"{venv_root}/lib/python*/site-packages/ansible/release.py"
+    for path in sorted(_glob.glob(pattern)):
+        try:
+            with open(path) as fh:
+                for line in fh:
+                    if line.startswith("__version__"):
+                        return line.split("=", 1)[1].strip().strip("'\"")
+        except OSError:
+            continue
+    return ""
+
+
+def _parse_fqcn(plugin_name: str) -> tuple[str, str, str] | None:
+    """Parse a FQCN into (namespace, collection_name, plugin_short_name).
+
+    Returns ``None`` for short-form names (fewer than 3 dot-separated parts).
+
+    Args:
+        plugin_name: Fully qualified collection name or short-form name.
+
+    Returns:
+        ``(namespace, name, short_name)`` or ``None``.
+    """
+    parts = plugin_name.split(".")
+    if len(parts) < 3:
+        return None
+    return (parts[0], parts[1], ".".join(parts[2:]))
+
+
+class PluginCache:
+    """In-memory LRU cache for plugin introspection results.
+
+    Thread-safe — guarded by a single lock since the validator daemon
+    may serve concurrent RPCs.
+    """
+
+    def __init__(self, max_entries: int = _MAX_ENTRIES) -> None:
+        """Initialize the cache.
+
+        Args:
+            max_entries: Maximum entries per LRU store before eviction.
+        """
+        self._max = max_entries
+        self._stores: dict[CacheType, OrderedDict[CacheKey, object]] = {
+            "introspect": OrderedDict(),
+            "docspec": OrderedDict(),
+            "mockspec": OrderedDict(),
+        }
+        self._hits: dict[CacheType, int] = {"introspect": 0, "docspec": 0, "mockspec": 0}
+        self._misses: dict[CacheType, int] = {"introspect": 0, "docspec": 0, "mockspec": 0}
+        self._version_cache: dict[tuple[str, str, str], str] = {}
+        self._core_version_cache: dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def _resolve_version(self, venv_root: str, namespace: str, name: str) -> str:
+        """Resolve collection version with an internal memo cache.
+
+        Args:
+            venv_root: Venv root path.
+            namespace: Collection namespace.
+            name: Collection name.
+
+        Returns:
+            Version string.
+        """
+        memo_key = (venv_root, namespace, name)
+        cached = self._version_cache.get(memo_key)
+        if cached is not None:
+            return cached
+        if namespace == "ansible" and name == "builtin":
+            version = self._core_version_cache.get(venv_root)
+            if version is None:
+                version = _ansible_core_version(venv_root)
+                self._core_version_cache[venv_root] = version
+        else:
+            version = _collection_version(venv_root, namespace, name)
+        self._version_cache[memo_key] = version
+        return version
+
+    def _make_key(self, venv_root: str, plugin_name: str) -> CacheKey | None:
+        """Build a cache key from a plugin name.
+
+        Returns ``None`` for short-form names that can't be resolved to
+        a collection without subprocess help.
+
+        Args:
+            venv_root: Venv root path.
+            plugin_name: FQCN or short-form module name.
+
+        Returns:
+            Cache key tuple or ``None``.
+        """
+        parsed = _parse_fqcn(plugin_name)
+        if parsed is None:
+            return None
+        namespace, name, _ = parsed
+        version = self._resolve_version(venv_root, namespace, name)
+        if not version:
+            return None
+        collection_fqcn = f"{namespace}.{name}"
+        return (collection_fqcn, version, plugin_name)
+
+    def get(self, store: CacheType, venv_root: str, plugin_name: str) -> object | None:
+        """Look up a cached result.
+
+        Args:
+            store: Which cache store to query.
+            venv_root: Venv root path.
+            plugin_name: Module FQCN or short-form name.
+
+        Returns:
+            Cached result or ``None`` on miss.
+        """
+        with self._lock:
+            key = self._make_key(venv_root, plugin_name)
+            if key is None:
+                self._misses[store] += 1
+                return None
+            lru = self._stores[store]
+            result = lru.get(key)
+            if result is not None:
+                lru.move_to_end(key)
+                self._hits[store] += 1
+                return result
+            self._misses[store] += 1
+            return None
+
+    def put(
+        self,
+        store: CacheType,
+        venv_root: str,
+        plugin_name: str,
+        result: object,
+        *,
+        resolved_fqcn: str = "",
+    ) -> None:
+        """Store a result in the cache.
+
+        If ``resolved_fqcn`` is provided and differs from ``plugin_name``,
+        the result is also stored under the FQCN key so that later lookups
+        by FQCN (e.g. from L058/L059 after M001 resolves short names) hit.
+
+        Args:
+            store: Which cache store to use.
+            venv_root: Venv root path.
+            plugin_name: Module name as provided to the subprocess.
+            result: Subprocess result to cache.
+            resolved_fqcn: Resolved FQCN if different from plugin_name.
+        """
+        with self._lock:
+            lru = self._stores[store]
+
+            key = self._make_key(venv_root, plugin_name)
+            if key is not None:
+                lru[key] = result
+                lru.move_to_end(key)
+
+            if resolved_fqcn and resolved_fqcn != plugin_name:
+                fqcn_key = self._make_key(venv_root, resolved_fqcn)
+                if fqcn_key is not None:
+                    lru[fqcn_key] = result
+                    lru.move_to_end(fqcn_key)
+
+            while len(lru) > self._max:
+                lru.popitem(last=False)
+
+    def partition(
+        self,
+        store: CacheType,
+        venv_root: str,
+        modules: list[str],
+    ) -> tuple[dict[str, object], list[str]]:
+        """Split a module list into cached results and uncached names.
+
+        Args:
+            store: Which cache store to query.
+            venv_root: Venv root path.
+            modules: Module names to check.
+
+        Returns:
+            ``(cached_results, uncached_modules)`` where cached_results maps
+            module name to its cached result.
+        """
+        cached: dict[str, object] = {}
+        uncached: list[str] = []
+        for module in modules:
+            result = self.get(store, venv_root, module)
+            if result is not None:
+                cached[module] = result
+            else:
+                uncached.append(module)
+        return cached, uncached
+
+    def stats(self) -> dict[str, int]:
+        """Return hit/miss counts for diagnostics.
+
+        Returns:
+            Dict with keys like ``introspect_hits``, ``introspect_misses``, etc.
+        """
+        with self._lock:
+            stores: list[CacheType] = ["introspect", "docspec", "mockspec"]
+            result: dict[str, int] = {}
+            for store_name in stores:
+                result[f"cache_{store_name}_hits"] = self._hits[store_name]
+                result[f"cache_{store_name}_misses"] = self._misses[store_name]
+            return result
+
+
+plugin_cache = PluginCache()

--- a/src/apme_engine/validators/ansible/cache.py
+++ b/src/apme_engine/validators/ansible/cache.py
@@ -16,7 +16,6 @@ import json
 import logging
 import threading
 from collections import OrderedDict
-from pathlib import Path
 from typing import Literal
 
 logger = logging.getLogger(__name__)
@@ -38,10 +37,7 @@ def _collection_version(venv_root: str, namespace: str, name: str) -> str:
     Returns:
         Version string, or ``""`` if the manifest cannot be read.
     """
-    pattern = (
-        f"{venv_root}/lib/python*/site-packages/"
-        f"ansible_collections/{namespace}/{name}/MANIFEST.json"
-    )
+    pattern = f"{venv_root}/lib/python*/site-packages/ansible_collections/{namespace}/{name}/MANIFEST.json"
     for path in sorted(_glob.glob(pattern)):
         try:
             with open(path) as fh:

--- a/src/apme_engine/validators/ansible/rules/L058_argspec_doc.py
+++ b/src/apme_engine/validators/ansible/rules/L058_argspec_doc.py
@@ -10,15 +10,17 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import cast
+
+from apme_engine.validators.ansible.cache import plugin_cache
 
 RULE_ID = "L058"
 
-_SCRIPT = textwrap.dedent("""\
+_SPEC_SCRIPT = textwrap.dedent("""\
 import json, sys
 
 data = json.loads(sys.stdin.read())
 module_names = data.get("modules", [])
-tasks = data.get("tasks", [])
 
 specs = {}
 try:
@@ -37,82 +39,127 @@ try:
         if not doc:
             continue
         options = doc.get("options") or {}
-        specs[name] = {
+        entry = {
             "options": options,
             "required_together": doc.get("required_together", []),
             "mutually_exclusive": doc.get("mutually_exclusive", []),
             "required_one_of": doc.get("required_one_of", []),
         }
+        specs[name] = entry
         fqcn = getattr(ctx, "resolved_fqcn", "") or ""
         if fqcn and fqcn != name:
-            specs[fqcn] = specs[name]
+            specs[fqcn] = entry
 except Exception as e:
     sys.stderr.write(f"L058: failed to load specs: {e}\\n")
 
-violations = []
-for task in tasks:
-    module = task.get("module", "")
-    module_options = task.get("module_options", {})
-    if not module or not isinstance(module_options, dict):
-        continue
-
-    spec = specs.get(module)
-    if not spec:
-        continue
-
-    options = spec.get("options", {})
-    user_keys = set(module_options.keys())
-    if "free_form" in options:
-        continue
-    if any("{{" in str(v) for v in module_options.values()):
-        continue
-
-    valid_params = set(options.keys())
-    valid_params.update({
-        "_raw_params", "_ansible_check_mode", "_ansible_debug",
-        "_ansible_diff", "_ansible_keep_remote_files", "_ansible_module_name",
-        "_ansible_no_log", "_ansible_remote_tmp", "_ansible_shell_executable",
-        "_ansible_socket", "_ansible_syslog_facility", "_ansible_tmpdir",
-        "_ansible_verbosity", "_ansible_version",
-    })
-    for pname, pspec in options.items():
-        for alias in (pspec.get("aliases") or []):
-            valid_params.add(alias)
-
-    unknown = user_keys - valid_params
-    if unknown:
-        violations.append({
-            "module": module,
-            "message": f"Unsupported parameters for {module}: {', '.join(sorted(unknown))}",
-            "task_key": task.get("key", ""),
-        })
-
-    for pname, pspec in options.items():
-        if pspec.get("required") and pname not in user_keys:
-            aliases = pspec.get("aliases") or []
-            if not any(a in user_keys for a in aliases):
-                violations.append({
-                    "module": module,
-                    "message": f"Missing required parameter '{pname}' for {module}",
-                    "task_key": task.get("key", ""),
-                })
-
-    for pname, pspec in options.items():
-        if pname in user_keys and pspec.get("choices"):
-            val = module_options[pname]
-            choices = pspec["choices"]
-            if val not in choices:
-                violations.append({
-                    "module": module,
-                    "message": (
-                        f"Value '{val}' for parameter '{pname}' of {module} "
-                        f"is not one of: {', '.join(str(c) for c in choices)}"
-                    ),
-                    "task_key": task.get("key", ""),
-                })
-
-json.dump(violations, sys.stdout)
+json.dump(specs, sys.stdout)
 """)
+
+_ANSIBLE_INTERNAL_PARAMS = frozenset(
+    {
+        "_raw_params",
+        "_ansible_check_mode",
+        "_ansible_debug",
+        "_ansible_diff",
+        "_ansible_keep_remote_files",
+        "_ansible_module_name",
+        "_ansible_no_log",
+        "_ansible_remote_tmp",
+        "_ansible_shell_executable",
+        "_ansible_socket",
+        "_ansible_syslog_facility",
+        "_ansible_tmpdir",
+        "_ansible_verbosity",
+        "_ansible_version",
+    }
+)
+
+
+def _check_tasks_against_specs(
+    specs: dict[str, object],
+    tasks: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Validate task arguments against docstring-derived specs.
+
+    Args:
+        specs: Per-module spec dicts (options, required_together, etc.).
+        tasks: Task dicts with module, module_options, key, file, line.
+
+    Returns:
+        List of raw violation dicts (module, message, task_key).
+    """
+    violations: list[dict[str, object]] = []
+    for task in tasks:
+        module = task.get("module", "")
+        module_options = task.get("module_options", {})
+        if not module or not isinstance(module_options, dict):
+            continue
+
+        spec_raw = specs.get(str(module))
+        if not isinstance(spec_raw, dict):
+            continue
+        spec = cast(dict[str, object], spec_raw)
+
+        options_raw = spec.get("options", {})
+        if not isinstance(options_raw, dict):
+            continue
+        options = cast(dict[str, object], options_raw)
+
+        user_keys = set(module_options.keys())
+        if "free_form" in options:
+            continue
+        if any("{{" in str(v) for v in module_options.values()):
+            continue
+
+        valid_params: set[str] = set(options.keys())
+        valid_params.update(_ANSIBLE_INTERNAL_PARAMS)
+        for _pname, pspec_raw in options.items():
+            if isinstance(pspec_raw, dict):
+                for alias in pspec_raw.get("aliases") or []:
+                    valid_params.add(str(alias))
+
+        unknown = user_keys - valid_params
+        if unknown:
+            violations.append(
+                {
+                    "module": module,
+                    "message": f"Unsupported parameters for {module}: {', '.join(sorted(unknown))}",
+                    "task_key": task.get("key", ""),
+                }
+            )
+
+        for pname, pspec_raw in options.items():
+            if not isinstance(pspec_raw, dict):
+                continue
+            if pspec_raw.get("required") and pname not in user_keys:
+                aliases = pspec_raw.get("aliases") or []
+                if not any(str(a) in user_keys for a in aliases):
+                    violations.append(
+                        {
+                            "module": module,
+                            "message": f"Missing required parameter '{pname}' for {module}",
+                            "task_key": task.get("key", ""),
+                        }
+                    )
+
+        for pname, pspec_raw in options.items():
+            if not isinstance(pspec_raw, dict):
+                continue
+            if pname in user_keys and pspec_raw.get("choices"):
+                val = module_options[pname]
+                choices = pspec_raw["choices"]
+                if val not in choices:
+                    violations.append(
+                        {
+                            "module": module,
+                            "message": (
+                                f"Value '{val}' for parameter '{pname}' of {module} "
+                                f"is not one of: {', '.join(str(c) for c in choices)}"
+                            ),
+                            "task_key": task.get("key", ""),
+                        }
+                    )
+    return violations
 
 
 def run(
@@ -123,31 +170,14 @@ def run(
 ) -> list[dict[str, object]]:
     """Run docstring-based argspec validation in the venv's Python.
 
+    Uses the plugin cache to avoid re-fetching specs for modules whose
+    collection version is already cached from a prior scan.
+
     Args:
         task_nodes: List of task node dicts.
         venv_root: Path to ansible venv root.
         env_extra: Optional extra environment variables.
         **_kwargs: Ignored keyword arguments.
-
-    Returns:
-        List of violation dicts.
-    """
-    return _run_argspec_script(_SCRIPT, task_nodes, venv_root, env_extra)
-
-
-def _run_argspec_script(
-    script: str,
-    task_nodes: list[dict[str, object]],
-    venv_root: Path,
-    env_extra: dict[str, str] | None = None,
-) -> list[dict[str, object]]:
-    """Run argspec validation script in venv Python.
-
-    Args:
-        script: Python script to execute.
-        task_nodes: List of task node dicts.
-        venv_root: Path to ansible venv root.
-        env_extra: Optional extra environment variables.
 
     Returns:
         List of violation dicts.
@@ -174,44 +204,30 @@ def _run_argspec_script(
     if not tasks_for_check:
         return []
 
-    python = venv_root / "bin" / "python"
-    if not python.is_file():
-        sys.stderr.write(f"{RULE_ID}: venv python not found at {python}, skipping\n")
-        return []
+    venv_str = str(venv_root)
+    all_modules = list(task_modules.keys())
+    cached_specs, uncached = plugin_cache.partition("docspec", venv_str, all_modules)
+    all_specs: dict[str, object] = dict(cached_specs)
 
-    env = dict(os.environ)
-    env.pop("PYTHONPATH", None)
-    if env_extra:
-        env.update(env_extra)
+    if uncached:
+        fresh_specs = _fetch_specs(uncached, venv_root, env_extra)
+        for name, spec in fresh_specs.items():
+            resolved_fqcn = ""
+            if isinstance(spec, dict):
+                for other_name, other_spec in fresh_specs.items():
+                    if other_spec is spec and other_name != name and "." in other_name:
+                        resolved_fqcn = other_name
+                        break
+            plugin_cache.put("docspec", venv_str, name, spec, resolved_fqcn=resolved_fqcn)
+        all_specs.update(fresh_specs)
 
-    try:
-        result = subprocess.run(
-            [str(python), "-c", script],
-            input=json.dumps({"modules": list(task_modules.keys()), "tasks": tasks_for_check}),
-            capture_output=True,
-            text=True,
-            timeout=60,
-            env=env,
-        )
-    except subprocess.TimeoutExpired:
-        sys.stderr.write(f"{RULE_ID} check timed out\n")
-        return []
-
-    if result.returncode != 0:
-        sys.stderr.write(f"{RULE_ID} check failed: {result.stderr[:500]}\n")
-        return []
-
-    try:
-        raw_violations = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        sys.stderr.write(f"{RULE_ID} returned invalid JSON: {result.stdout[:200]}\n")
-        return []
+    raw_violations = _check_tasks_against_specs(all_specs, tasks_for_check)
 
     task_by_key = {t["key"]: t for t in tasks_for_check}
-    violations = []
+    violations: list[dict[str, object]] = []
     for rv in raw_violations:
         task_key = rv.get("task_key", "")
-        task = task_by_key.get(task_key, {})
+        task = task_by_key.get(str(task_key), {})
         line = task.get("line")
         line_num = line[0] if isinstance(line, list | tuple) and line else 1
         violations.append(
@@ -221,9 +237,61 @@ def _run_argspec_script(
                 "message": rv.get("message", "argument validation failed"),
                 "file": task.get("file", ""),
                 "line": line_num,
-                "path": task_key,
+                "path": str(task_key),
                 "scope": "task",
             }
         )
 
     return violations
+
+
+def _fetch_specs(
+    module_names: list[str],
+    venv_root: Path,
+    env_extra: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Fetch docstring-derived specs via subprocess for uncached modules.
+
+    Args:
+        module_names: Module names to fetch specs for.
+        venv_root: Path to ansible venv root.
+        env_extra: Optional extra environment variables.
+
+    Returns:
+        Dict mapping module name to spec dict.
+    """
+    if not module_names:
+        return {}
+
+    python = venv_root / "bin" / "python"
+    if not python.is_file():
+        sys.stderr.write(f"{RULE_ID}: venv python not found at {python}, skipping\n")
+        return {}
+
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    if env_extra:
+        env.update(env_extra)
+
+    try:
+        result = subprocess.run(
+            [str(python), "-c", _SPEC_SCRIPT],
+            input=json.dumps({"modules": module_names}),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(f"{RULE_ID} spec fetch timed out\n")
+        return {}
+
+    if result.returncode != 0:
+        sys.stderr.write(f"{RULE_ID} spec fetch failed: {result.stderr[:500]}\n")
+        return {}
+
+    try:
+        return cast(dict[str, object], json.loads(result.stdout))
+    except json.JSONDecodeError:
+        sys.stderr.write(f"{RULE_ID} returned invalid JSON: {result.stdout[:200]}\n")
+        return {}

--- a/src/apme_engine/validators/ansible/rules/L058_argspec_doc.py
+++ b/src/apme_engine/validators/ansible/rules/L058_argspec_doc.py
@@ -212,13 +212,7 @@ def run(
     if uncached:
         fresh_specs = _fetch_specs(uncached, venv_root, env_extra)
         for name, spec in fresh_specs.items():
-            resolved_fqcn = ""
-            if isinstance(spec, dict):
-                for other_name, other_spec in fresh_specs.items():
-                    if other_spec is spec and other_name != name and "." in other_name:
-                        resolved_fqcn = other_name
-                        break
-            plugin_cache.put("docspec", venv_str, name, spec, resolved_fqcn=resolved_fqcn)
+            plugin_cache.put("docspec", venv_str, name, spec)
         all_specs.update(fresh_specs)
 
     raw_violations = _check_tasks_against_specs(all_specs, tasks_for_check)

--- a/src/apme_engine/validators/ansible/rules/L059_argspec_mock.py
+++ b/src/apme_engine/validators/ansible/rules/L059_argspec_mock.py
@@ -12,15 +12,17 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
+from typing import cast
+
+from apme_engine.validators.ansible.cache import plugin_cache
 
 RULE_ID = "L059"
 
-_SCRIPT = textwrap.dedent("""\
+_SPEC_SCRIPT = textwrap.dedent("""\
 import json, sys, importlib, importlib.util, os
 
 data = json.loads(sys.stdin.read())
 module_names = data.get("modules", [])
-tasks = data.get("tasks", [])
 
 class _CapturedSpec(Exception):
     pass
@@ -69,110 +71,160 @@ try:
                         pass
 
             if captured.get("argument_spec"):
-                arg_spec = captured["argument_spec"]
-                specs[name] = {
-                    "argument_spec": arg_spec,
+                entry = {
+                    "argument_spec": captured["argument_spec"],
                     "required_together": captured.get("required_together", []),
                     "mutually_exclusive": captured.get("mutually_exclusive", []),
                     "required_one_of": captured.get("required_one_of", []),
                     "required_if": captured.get("required_if", []),
                 }
+                specs[name] = entry
                 fqcn = getattr(ctx, "resolved_fqcn", "") or ""
                 if fqcn and fqcn != name:
-                    specs[fqcn] = specs[name]
+                    specs[fqcn] = entry
         except Exception:
             continue
 except Exception as e:
     sys.stderr.write(f"L059: failed to load specs: {e}\\n")
 
-violations = []
-for task in tasks:
-    module = task.get("module", "")
-    module_options = task.get("module_options", {})
-    if not module or not isinstance(module_options, dict):
-        continue
-
-    spec = specs.get(module)
-    if not spec:
-        continue
-
-    arg_spec = spec.get("argument_spec", {})
-    user_keys = set(module_options.keys())
-
-    if any("{{" in str(v) for v in module_options.values()):
-        continue
-
-    valid_params = set(arg_spec.keys())
-    valid_params.update({
-        "_raw_params", "_ansible_check_mode", "_ansible_debug",
-        "_ansible_diff", "_ansible_keep_remote_files", "_ansible_module_name",
-        "_ansible_no_log", "_ansible_remote_tmp", "_ansible_shell_executable",
-        "_ansible_socket", "_ansible_syslog_facility", "_ansible_tmpdir",
-        "_ansible_verbosity", "_ansible_version",
-    })
-    for pname, pdef in arg_spec.items():
-        if isinstance(pdef, dict):
-            for alias in (pdef.get("aliases") or []):
-                valid_params.add(alias)
-
-    unknown = user_keys - valid_params
-    if unknown:
-        violations.append({
-            "module": module,
-            "message": f"Unsupported parameters for {module}: {', '.join(sorted(unknown))}",
-            "task_key": task.get("key", ""),
-        })
-
-    for pname, pdef in arg_spec.items():
-        if isinstance(pdef, dict) and pdef.get("required") and pname not in user_keys:
-            aliases = pdef.get("aliases") or []
-            if not any(a in user_keys for a in aliases):
-                violations.append({
-                    "module": module,
-                    "message": f"Missing required parameter '{pname}' for {module}",
-                    "task_key": task.get("key", ""),
-                })
-
-    for pname, pdef in arg_spec.items():
-        if isinstance(pdef, dict) and pname in user_keys and pdef.get("choices"):
-            val = module_options[pname]
-            choices = pdef["choices"]
-            if val not in choices:
-                violations.append({
-                    "module": module,
-                    "message": (
-                        f"Value '{val}' for parameter '{pname}' of {module} "
-                        f"is not one of: {', '.join(str(c) for c in choices)}"
-                    ),
-                    "task_key": task.get("key", ""),
-                })
-
-    me = spec.get("mutually_exclusive", [])
-    for group in (me or []):
-        present = [p for p in group if p in user_keys]
-        if len(present) > 1:
-            violations.append({
-                "module": module,
-                "message": f"Parameters are mutually exclusive for {module}: {', '.join(present)}",
-                "task_key": task.get("key", ""),
-            })
-
-    rt = spec.get("required_together", [])
-    for group in (rt or []):
-        present = [p for p in group if p in user_keys]
-        if present and len(present) != len(group):
-            missing = [p for p in group if p not in user_keys]
-            violations.append({
-                "module": module,
-                "message": (
-                    f"Parameters must be used together for {module}: "
-                    f"{', '.join(group)} (missing: {', '.join(missing)})"
-                ),
-                "task_key": task.get("key", ""),
-            })
-
-json.dump(violations, sys.stdout)
+json.dump(specs, sys.stdout)
 """)
+
+_ANSIBLE_INTERNAL_PARAMS = frozenset(
+    {
+        "_raw_params",
+        "_ansible_check_mode",
+        "_ansible_debug",
+        "_ansible_diff",
+        "_ansible_keep_remote_files",
+        "_ansible_module_name",
+        "_ansible_no_log",
+        "_ansible_remote_tmp",
+        "_ansible_shell_executable",
+        "_ansible_socket",
+        "_ansible_syslog_facility",
+        "_ansible_tmpdir",
+        "_ansible_verbosity",
+        "_ansible_version",
+    }
+)
+
+
+def _check_tasks_against_specs(
+    specs: dict[str, object],
+    tasks: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Validate task arguments against mock-captured argspecs.
+
+    Args:
+        specs: Per-module spec dicts (argument_spec, mutually_exclusive, etc.).
+        tasks: Task dicts with module, module_options, key, file, line.
+
+    Returns:
+        List of raw violation dicts (module, message, task_key).
+    """
+    violations: list[dict[str, object]] = []
+    for task in tasks:
+        module = task.get("module", "")
+        module_options = task.get("module_options", {})
+        if not module or not isinstance(module_options, dict):
+            continue
+
+        spec_raw = specs.get(str(module))
+        if not isinstance(spec_raw, dict):
+            continue
+        spec = cast(dict[str, object], spec_raw)
+
+        arg_spec_raw = spec.get("argument_spec", {})
+        if not isinstance(arg_spec_raw, dict):
+            continue
+        arg_spec = cast(dict[str, object], arg_spec_raw)
+
+        user_keys = set(module_options.keys())
+
+        if any("{{" in str(v) for v in module_options.values()):
+            continue
+
+        valid_params: set[str] = set(arg_spec.keys())
+        valid_params.update(_ANSIBLE_INTERNAL_PARAMS)
+        for _pname, pdef in arg_spec.items():
+            if isinstance(pdef, dict):
+                for alias in pdef.get("aliases") or []:
+                    valid_params.add(str(alias))
+
+        unknown = user_keys - valid_params
+        if unknown:
+            violations.append(
+                {
+                    "module": module,
+                    "message": f"Unsupported parameters for {module}: {', '.join(sorted(unknown))}",
+                    "task_key": task.get("key", ""),
+                }
+            )
+
+        for pname, pdef in arg_spec.items():
+            if isinstance(pdef, dict) and pdef.get("required") and pname not in user_keys:
+                aliases = pdef.get("aliases") or []
+                if not any(str(a) in user_keys for a in aliases):
+                    violations.append(
+                        {
+                            "module": module,
+                            "message": f"Missing required parameter '{pname}' for {module}",
+                            "task_key": task.get("key", ""),
+                        }
+                    )
+
+        for pname, pdef in arg_spec.items():
+            if isinstance(pdef, dict) and pname in user_keys and pdef.get("choices"):
+                val = module_options[pname]
+                choices = pdef["choices"]
+                if val not in choices:
+                    violations.append(
+                        {
+                            "module": module,
+                            "message": (
+                                f"Value '{val}' for parameter '{pname}' of {module} "
+                                f"is not one of: {', '.join(str(c) for c in choices)}"
+                            ),
+                            "task_key": task.get("key", ""),
+                        }
+                    )
+
+        me = spec.get("mutually_exclusive", [])
+        if isinstance(me, list):
+            for group in me:
+                if not isinstance(group, list):
+                    continue
+                present = [p for p in group if p in user_keys]
+                if len(present) > 1:
+                    violations.append(
+                        {
+                            "module": module,
+                            "message": f"Parameters are mutually exclusive for {module}: {', '.join(present)}",
+                            "task_key": task.get("key", ""),
+                        }
+                    )
+
+        rt = spec.get("required_together", [])
+        if isinstance(rt, list):
+            for group in rt:
+                if not isinstance(group, list):
+                    continue
+                present = [p for p in group if p in user_keys]
+                if present and len(present) != len(group):
+                    missing = [p for p in group if p not in user_keys]
+                    violations.append(
+                        {
+                            "module": module,
+                            "message": (
+                                f"Parameters must be used together for {module}: "
+                                f"{', '.join(str(g) for g in group)} (missing: {', '.join(missing)})"
+                            ),
+                            "task_key": task.get("key", ""),
+                        }
+                    )
+
+    return violations
 
 
 def run(
@@ -182,6 +234,9 @@ def run(
     **_kwargs: object,
 ) -> list[dict[str, object]]:
     """Run mock/patch-based argspec validation in the venv's Python.
+
+    Uses the plugin cache to avoid re-capturing argspecs for modules whose
+    collection version is already cached from a prior scan.
 
     Args:
         task_nodes: List of task node dicts.
@@ -214,44 +269,30 @@ def run(
     if not tasks_for_check:
         return []
 
-    python = venv_root / "bin" / "python"
-    if not python.is_file():
-        sys.stderr.write(f"{RULE_ID}: venv python not found at {python}, skipping\n")
-        return []
+    venv_str = str(venv_root)
+    all_modules = list(task_modules.keys())
+    cached_specs, uncached = plugin_cache.partition("mockspec", venv_str, all_modules)
+    all_specs: dict[str, object] = dict(cached_specs)
 
-    env = dict(os.environ)
-    env.pop("PYTHONPATH", None)
-    if env_extra:
-        env.update(env_extra)
+    if uncached:
+        fresh_specs = _fetch_specs(uncached, venv_root, env_extra)
+        for name, spec in fresh_specs.items():
+            resolved_fqcn = ""
+            if isinstance(spec, dict):
+                for other_name, other_spec in fresh_specs.items():
+                    if other_spec is spec and other_name != name and "." in other_name:
+                        resolved_fqcn = other_name
+                        break
+            plugin_cache.put("mockspec", venv_str, name, spec, resolved_fqcn=resolved_fqcn)
+        all_specs.update(fresh_specs)
 
-    try:
-        result = subprocess.run(
-            [str(python), "-c", _SCRIPT],
-            input=json.dumps({"modules": list(task_modules.keys()), "tasks": tasks_for_check}),
-            capture_output=True,
-            text=True,
-            timeout=60,
-            env=env,
-        )
-    except subprocess.TimeoutExpired:
-        sys.stderr.write(f"{RULE_ID} check timed out\n")
-        return []
-
-    if result.returncode != 0:
-        sys.stderr.write(f"{RULE_ID} check failed: {result.stderr[:500]}\n")
-        return []
-
-    try:
-        raw_violations = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        sys.stderr.write(f"{RULE_ID} returned invalid JSON: {result.stdout[:200]}\n")
-        return []
+    raw_violations = _check_tasks_against_specs(all_specs, tasks_for_check)
 
     task_by_key = {t["key"]: t for t in tasks_for_check}
-    violations = []
+    violations: list[dict[str, object]] = []
     for rv in raw_violations:
         task_key = rv.get("task_key", "")
-        task = task_by_key.get(task_key, {})
+        task = task_by_key.get(str(task_key), {})
         line = task.get("line")
         line_num = line[0] if isinstance(line, list | tuple) and line else 1
         violations.append(
@@ -261,9 +302,61 @@ def run(
                 "message": rv.get("message", "argument validation failed"),
                 "file": task.get("file", ""),
                 "line": line_num,
-                "path": task_key,
+                "path": str(task_key),
                 "scope": "task",
             }
         )
 
     return violations
+
+
+def _fetch_specs(
+    module_names: list[str],
+    venv_root: Path,
+    env_extra: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Fetch mock-captured argspecs via subprocess for uncached modules.
+
+    Args:
+        module_names: Module names to fetch specs for.
+        venv_root: Path to ansible venv root.
+        env_extra: Optional extra environment variables.
+
+    Returns:
+        Dict mapping module name to spec dict.
+    """
+    if not module_names:
+        return {}
+
+    python = venv_root / "bin" / "python"
+    if not python.is_file():
+        sys.stderr.write(f"{RULE_ID}: venv python not found at {python}, skipping\n")
+        return {}
+
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    if env_extra:
+        env.update(env_extra)
+
+    try:
+        result = subprocess.run(
+            [str(python), "-c", _SPEC_SCRIPT],
+            input=json.dumps({"modules": module_names}),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(f"{RULE_ID} spec fetch timed out\n")
+        return {}
+
+    if result.returncode != 0:
+        sys.stderr.write(f"{RULE_ID} spec fetch failed: {result.stderr[:500]}\n")
+        return {}
+
+    try:
+        return cast(dict[str, object], json.loads(result.stdout))
+    except json.JSONDecodeError:
+        sys.stderr.write(f"{RULE_ID} returned invalid JSON: {result.stdout[:200]}\n")
+        return {}

--- a/src/apme_engine/validators/ansible/rules/L059_argspec_mock.py
+++ b/src/apme_engine/validators/ansible/rules/L059_argspec_mock.py
@@ -277,13 +277,7 @@ def run(
     if uncached:
         fresh_specs = _fetch_specs(uncached, venv_root, env_extra)
         for name, spec in fresh_specs.items():
-            resolved_fqcn = ""
-            if isinstance(spec, dict):
-                for other_name, other_spec in fresh_specs.items():
-                    if other_spec is spec and other_name != name and "." in other_name:
-                        resolved_fqcn = other_name
-                        break
-            plugin_cache.put("mockspec", venv_str, name, spec, resolved_fqcn=resolved_fqcn)
+            plugin_cache.put("mockspec", venv_str, name, spec)
         all_specs.update(fresh_specs)
 
     raw_violations = _check_tasks_against_specs(all_specs, tasks_for_check)

--- a/src/apme_engine/validators/ansible/rules/M001_M004_introspect.py
+++ b/src/apme_engine/validators/ansible/rules/M001_M004_introspect.py
@@ -13,7 +13,8 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
-from typing import cast
+
+from apme_engine.validators.ansible.cache import plugin_cache
 
 _SCRIPT = textwrap.dedent("""\
 import json, sys
@@ -61,6 +62,9 @@ def _run_introspection(
 ) -> dict[str, object]:
     """Run plugin introspection in the venv's Python. Returns {name: info_dict}.
 
+    Uses the plugin cache to skip subprocess calls for modules whose
+    collection version is already cached from a prior scan.
+
     Args:
         module_names: List of module names to introspect.
         venv_root: Path to ansible venv root.
@@ -72,17 +76,23 @@ def _run_introspection(
     if not module_names:
         return {}
 
+    venv_str = str(venv_root)
+    cached_results, uncached = plugin_cache.partition("introspect", venv_str, module_names)
+
+    if not uncached:
+        return cached_results
+
     python = venv_root / "bin" / "python"
     if not python.is_file():
         sys.stderr.write(f"M001-M004: venv python not found at {python}, skipping introspection\n")
-        return {}
+        return cached_results
 
     env = dict(os.environ)
     env.pop("PYTHONPATH", None)
     if env_extra:
         env.update(env_extra)
 
-    payload: dict[str, object] = {"modules": module_names}
+    payload: dict[str, object] = {"modules": uncached}
 
     try:
         result = subprocess.run(
@@ -95,17 +105,28 @@ def _run_introspection(
         )
     except subprocess.TimeoutExpired:
         sys.stderr.write("Plugin introspection timed out\n")
-        return {}
+        return cached_results
 
     if result.returncode != 0:
         sys.stderr.write(f"Plugin introspection failed: {result.stderr[:500]}\n")
-        return {}
+        return cached_results
 
     try:
-        return cast(dict[str, object], json.loads(result.stdout))
+        fresh: dict[str, object] = json.loads(result.stdout)
     except json.JSONDecodeError:
         sys.stderr.write(f"Plugin introspection returned invalid JSON: {result.stdout[:200]}\n")
-        return {}
+        return cached_results
+
+    for name, info in fresh.items():
+        resolved_fqcn = ""
+        if isinstance(info, dict):
+            resolved_fqcn = str(info.get("fqcn", ""))
+        plugin_cache.put("introspect", venv_str, name, info, resolved_fqcn=resolved_fqcn)
+
+    merged: dict[str, object] = {}
+    merged.update(cached_results)
+    merged.update(fresh)
+    return merged
 
 
 def run(

--- a/tests/integration/test_daemon_pipeline.py
+++ b/tests/integration/test_daemon_pipeline.py
@@ -16,6 +16,7 @@ Run with::
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 import subprocess
 import sys
@@ -536,3 +537,50 @@ def test_scan_persisted_to_gateway(scan_data: YAMLDict, infrastructure: object) 
     )
     for entry in top_resp:
         assert entry.get("count", 0) > 0, f"Rule {entry.get('rule_id')} in /violations/top should have count>0"
+
+
+# ---------------------------------------------------------------------------
+# Ansible introspection cache: second scan should get cache hits
+# ---------------------------------------------------------------------------
+
+_CACHE_HIT_SESSION = "cache-hit-test"
+
+
+@pytest.mark.integration  # type: ignore[untyped-decorator]
+def test_ansible_cache_hits_on_second_scan(
+    scan_data: YAMLDict,
+    infrastructure: object,
+) -> None:
+    """Second scan of the same project gets plugin introspection cache hits.
+
+    The first scan (via ``scan_result`` fixture) warms the daemon's
+    in-memory PluginCache. A second scan of the same fixture with the
+    same session reuses the same venv and collection versions, so
+    M001-M004/L058/L059 should get cache hits. We verify by reading
+    the daemon log file.
+
+    Args:
+        scan_data: Parsed scan data from the first scan (ensures it ran first).
+        infrastructure: Daemon infrastructure (provides data_dir for daemon.log).
+    """
+    data_dir = getattr(infrastructure, "data_dir", "")
+    assert data_dir, "data_dir not set on Infrastructure"
+    daemon_log = Path(data_dir) / "daemon.log"
+
+    _scan_json(FIXTURE_DIR)
+
+    assert daemon_log.is_file(), f"daemon.log not found at {daemon_log}"
+    log_text = daemon_log.read_text()
+
+    cache_lines = [
+        line for line in log_text.splitlines() if "Ansible validator: total" in line and "cache introspect=" in line
+    ]
+    assert len(cache_lines) >= 2, (
+        f"Expected at least 2 Ansible validator cache log lines (first scan + second scan), "
+        f"found {len(cache_lines)}.\nAll cache lines:\n" + "\n".join(cache_lines)
+    )
+
+    last_line = cache_lines[-1]
+    hit_counts = re.findall(r"(\d+)h/", last_line)
+    total_hits = sum(int(h) for h in hit_counts)
+    assert total_hits > 0, f"Second scan should have cache hits but found 0.\nLast cache line: {last_line}"

--- a/tests/integration/test_daemon_pipeline.py
+++ b/tests/integration/test_daemon_pipeline.py
@@ -547,7 +547,6 @@ def test_scan_persisted_to_gateway(scan_data: YAMLDict, infrastructure: object) 
 @pytest.mark.integration  # type: ignore[untyped-decorator]
 def test_ansible_cache_hits_on_second_scan(
     scan_data: YAMLDict,
-    infrastructure: object,
 ) -> None:
     """Second scan of the same project gets plugin introspection cache hits.
 
@@ -557,20 +556,21 @@ def test_ansible_cache_hits_on_second_scan(
     M001-M004/L058/L059 should get cache hits. We verify by reading
     the daemon log file.
 
+    Uses the launcher module's resolved ``_DATA_DIR`` to find
+    ``daemon.log`` — the module-level path is fixed at import time and
+    may differ from the conftest's ``data_dir`` when the env var was
+    set after import.
+
     Args:
         scan_data: Parsed scan data from the first scan (ensures it ran first).
-        infrastructure: Daemon infrastructure (provides data_dir for daemon.log).
     """
-    data_dir = getattr(infrastructure, "data_dir", "")
-    assert data_dir, "data_dir not set on Infrastructure"
-    daemon_log = Path(data_dir) / "daemon.log"
+    from apme_engine.daemon.launcher import _DATA_DIR
+
+    daemon_log = _DATA_DIR / "daemon.log"
 
     _scan_json(FIXTURE_DIR)
 
-    if not daemon_log.is_file():
-        pytest.skip(
-            f"daemon.log not found at {daemon_log} (APME_DATA_DIR may have been resolved before conftest set it)"
-        )
+    assert daemon_log.is_file(), f"daemon.log not found at {daemon_log}"
     log_text = daemon_log.read_text()
 
     cache_lines = [

--- a/tests/integration/test_daemon_pipeline.py
+++ b/tests/integration/test_daemon_pipeline.py
@@ -543,8 +543,6 @@ def test_scan_persisted_to_gateway(scan_data: YAMLDict, infrastructure: object) 
 # Ansible introspection cache: second scan should get cache hits
 # ---------------------------------------------------------------------------
 
-_CACHE_HIT_SESSION = "cache-hit-test"
-
 
 @pytest.mark.integration  # type: ignore[untyped-decorator]
 def test_ansible_cache_hits_on_second_scan(
@@ -569,7 +567,10 @@ def test_ansible_cache_hits_on_second_scan(
 
     _scan_json(FIXTURE_DIR)
 
-    assert daemon_log.is_file(), f"daemon.log not found at {daemon_log}"
+    if not daemon_log.is_file():
+        pytest.skip(
+            f"daemon.log not found at {daemon_log} (APME_DATA_DIR may have been resolved before conftest set it)"
+        )
     log_text = daemon_log.read_text()
 
     cache_lines = [

--- a/tests/integration/test_daemon_pipeline.py
+++ b/tests/integration/test_daemon_pipeline.py
@@ -550,7 +550,7 @@ def test_ansible_cache_hits_on_second_scan(
 ) -> None:
     """Second scan of the same project gets plugin introspection cache hits.
 
-    The first scan (via ``scan_result`` fixture) warms the daemon's
+    The first scan (via ``scan_data`` fixture) warms the daemon's
     in-memory PluginCache. A second scan of the same fixture with the
     same session reuses the same venv and collection versions, so
     M001-M004/L058/L059 should get cache hits. We verify by reading

--- a/tests/test_ansible_cache.py
+++ b/tests/test_ansible_cache.py
@@ -1,0 +1,719 @@
+"""Tests for Ansible plugin introspection LRU cache.
+
+Covers PluginCache, version discovery helpers, and the cached code paths
+in M001_M004_introspect, L058_argspec_doc, and L059_argspec_mock.
+"""
+
+import json
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from apme_engine.validators.ansible.cache import (
+    PluginCache,
+    _ansible_core_version,
+    _collection_version,
+    _parse_fqcn,
+)
+
+
+class TestParseFqcn:
+    """Tests for _parse_fqcn helper."""
+
+    def test_full_fqcn(self) -> None:
+        """Three-part FQCN returns (namespace, name, short_name)."""
+        assert _parse_fqcn("ansible.builtin.copy") == ("ansible", "builtin", "copy")
+
+    def test_deep_fqcn(self) -> None:
+        """FQCN with dots in short name preserves them."""
+        assert _parse_fqcn("community.general.a.b") == ("community", "general", "a.b")
+
+    def test_short_form_returns_none(self) -> None:
+        """Short-form names (< 3 parts) return None."""
+        assert _parse_fqcn("ping") is None
+        assert _parse_fqcn("my.module") is None
+
+    def test_empty_string(self) -> None:
+        """Empty string returns None."""
+        assert _parse_fqcn("") is None
+
+
+class TestCollectionVersion:
+    """Tests for _collection_version reading MANIFEST.json."""
+
+    def test_reads_manifest(self, tmp_path: Path) -> None:
+        """Reads version from MANIFEST.json in the expected path.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        col_dir = tmp_path / "lib" / "python3.11" / "site-packages" / "ansible_collections" / "community" / "general"
+        col_dir.mkdir(parents=True)
+        manifest = {"collection_info": {"version": "5.8.0"}}
+        (col_dir / "MANIFEST.json").write_text(json.dumps(manifest))
+
+        assert _collection_version(str(tmp_path), "community", "general") == "5.8.0"
+
+    def test_missing_manifest_returns_empty(self, tmp_path: Path) -> None:
+        """Returns empty string when MANIFEST.json doesn't exist.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        assert _collection_version(str(tmp_path), "community", "general") == ""
+
+    def test_malformed_manifest(self, tmp_path: Path) -> None:
+        """Returns empty string when MANIFEST.json is malformed.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        col_dir = tmp_path / "lib" / "python3.11" / "site-packages" / "ansible_collections" / "ns" / "col"
+        col_dir.mkdir(parents=True)
+        (col_dir / "MANIFEST.json").write_text("not json")
+
+        assert _collection_version(str(tmp_path), "ns", "col") == ""
+
+    def test_manifest_missing_version_key(self, tmp_path: Path) -> None:
+        """Returns empty string when version key is absent.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        col_dir = tmp_path / "lib" / "python3.11" / "site-packages" / "ansible_collections" / "ns" / "col"
+        col_dir.mkdir(parents=True)
+        (col_dir / "MANIFEST.json").write_text(json.dumps({"collection_info": {}}))
+
+        assert _collection_version(str(tmp_path), "ns", "col") == ""
+
+
+class TestAnsibleCoreVersion:
+    """Tests for _ansible_core_version reading release.py."""
+
+    def test_reads_release_py(self, tmp_path: Path) -> None:
+        """Reads __version__ from ansible/release.py.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        release_dir = tmp_path / "lib" / "python3.11" / "site-packages" / "ansible"
+        release_dir.mkdir(parents=True)
+        (release_dir / "release.py").write_text("__version__ = '2.16.3'\n")
+
+        assert _ansible_core_version(str(tmp_path)) == "2.16.3"
+
+    def test_double_quoted(self, tmp_path: Path) -> None:
+        """Handles double-quoted version strings.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        release_dir = tmp_path / "lib" / "python3.11" / "site-packages" / "ansible"
+        release_dir.mkdir(parents=True)
+        (release_dir / "release.py").write_text('__version__ = "2.17.0"\n')
+
+        assert _ansible_core_version(str(tmp_path)) == "2.17.0"
+
+    def test_missing_release_py(self, tmp_path: Path) -> None:
+        """Returns empty string when release.py doesn't exist.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        assert _ansible_core_version(str(tmp_path)) == ""
+
+
+class TestPluginCacheCore:
+    """Tests for the PluginCache get/put/partition/stats lifecycle."""
+
+    def _make_venv(self, tmp_path: Path, namespace: str, name: str, version: str) -> str:
+        """Create a fake venv with a MANIFEST.json for version discovery.
+
+        Args:
+            tmp_path: Temporary directory.
+            namespace: Collection namespace.
+            name: Collection name.
+            version: Collection version.
+
+        Returns:
+            Venv root path string.
+        """
+        col_dir = tmp_path / "lib" / "python3.11" / "site-packages" / "ansible_collections" / namespace / name
+        col_dir.mkdir(parents=True)
+        manifest = {"collection_info": {"version": version}}
+        (col_dir / "MANIFEST.json").write_text(json.dumps(manifest))
+        return str(tmp_path)
+
+    def _make_builtin_venv(self, tmp_path: Path, core_version: str) -> str:
+        """Create a fake venv with ansible/release.py.
+
+        Args:
+            tmp_path: Temporary directory.
+            core_version: ansible-core version string.
+
+        Returns:
+            Venv root path string.
+        """
+        release_dir = tmp_path / "lib" / "python3.11" / "site-packages" / "ansible"
+        release_dir.mkdir(parents=True)
+        (release_dir / "release.py").write_text(f"__version__ = '{core_version}'\n")
+        return str(tmp_path)
+
+    def test_put_and_get_fqcn(self, tmp_path: Path) -> None:
+        """FQCN put/get round-trips correctly.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+        venv = self._make_venv(tmp_path, "community", "general", "5.8.0")
+
+        cache.put("introspect", venv, "community.general.ping", {"fqcn": "community.general.ping"})
+        result = cache.get("introspect", venv, "community.general.ping")
+
+        assert result == {"fqcn": "community.general.ping"}
+
+    def test_get_miss_returns_none(self, tmp_path: Path) -> None:
+        """Cache miss returns None.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+        venv = self._make_venv(tmp_path, "community", "general", "5.8.0")
+
+        assert cache.get("introspect", venv, "community.general.ping") is None
+
+    def test_short_form_always_misses(self, tmp_path: Path) -> None:
+        """Short-form names can't be resolved without subprocess, so always miss.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+        venv = self._make_venv(tmp_path, "community", "general", "5.8.0")
+
+        cache.put("introspect", venv, "ping", {"fqcn": "ansible.builtin.ping"})
+        assert cache.get("introspect", venv, "ping") is None
+
+    def test_put_with_resolved_fqcn_backfills(self, tmp_path: Path) -> None:
+        """Put with resolved_fqcn stores under both short-form key and FQCN.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+        venv = self._make_builtin_venv(tmp_path, "2.16.3")
+        info = {"fqcn": "ansible.builtin.ping"}
+
+        cache.put("introspect", venv, "ping", info, resolved_fqcn="ansible.builtin.ping")
+        result = cache.get("introspect", venv, "ansible.builtin.ping")
+
+        assert result == info
+
+    def test_ansible_builtin_uses_core_version(self, tmp_path: Path) -> None:
+        """ansible.builtin.* modules key by ansible-core version.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+        venv = self._make_builtin_venv(tmp_path, "2.16.3")
+
+        cache.put("introspect", venv, "ansible.builtin.copy", {"fqcn": "ansible.builtin.copy"})
+        assert cache.get("introspect", venv, "ansible.builtin.copy") == {"fqcn": "ansible.builtin.copy"}
+
+    def test_different_collection_versions_miss(self, tmp_path: Path) -> None:
+        """Different collection versions are separate cache entries.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+
+        venv1_dir = tmp_path / "venv1"
+        venv1 = self._make_venv(venv1_dir, "community", "general", "5.8.0")
+        cache.put("introspect", venv1, "community.general.ping", {"v": "5.8.0"})
+
+        venv2_dir = tmp_path / "venv2"
+        venv2 = self._make_venv(venv2_dir, "community", "general", "6.0.0")
+        assert cache.get("introspect", venv2, "community.general.ping") is None
+
+    def test_same_version_cross_venv_hits(self, tmp_path: Path) -> None:
+        """Same collection version in different venvs gets cache hits.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+
+        venv1_dir = tmp_path / "venv1"
+        venv1 = self._make_venv(venv1_dir, "community", "general", "5.8.0")
+        cache.put("introspect", venv1, "community.general.ping", {"v": "5.8.0"})
+
+        venv2_dir = tmp_path / "venv2"
+        venv2 = self._make_venv(venv2_dir, "community", "general", "5.8.0")
+        assert cache.get("introspect", venv2, "community.general.ping") == {"v": "5.8.0"}
+
+    def test_partition_splits_cached_and_uncached(self, tmp_path: Path) -> None:
+        """Partition returns cached results and uncached module names.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+        venv = self._make_venv(tmp_path, "community", "general", "5.8.0")
+
+        cache.put("docspec", venv, "community.general.ping", {"options": {}})
+
+        cached, uncached = cache.partition(
+            "docspec",
+            venv,
+            ["community.general.ping", "community.general.uri", "shortform"],
+        )
+
+        assert "community.general.ping" in cached
+        assert "community.general.uri" in uncached
+        assert "shortform" in uncached
+
+    def test_stats_tracks_hits_and_misses(self, tmp_path: Path) -> None:
+        """Stats correctly count hits and misses.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+        venv = self._make_venv(tmp_path, "community", "general", "5.8.0")
+
+        cache.put("introspect", venv, "community.general.ping", {"data": True})
+        cache.get("introspect", venv, "community.general.ping")  # hit
+        cache.get("introspect", venv, "community.general.uri")  # miss
+        cache.get("introspect", venv, "shortform")  # miss (short-form)
+
+        s = cache.stats()
+        assert s["cache_introspect_hits"] == 1
+        assert s["cache_introspect_misses"] == 2
+        assert s["cache_docspec_hits"] == 0
+
+    def test_lru_eviction(self, tmp_path: Path) -> None:
+        """Oldest entries are evicted when max_entries is exceeded.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache(max_entries=3)
+        venv = self._make_venv(tmp_path, "community", "general", "5.8.0")
+
+        for i in range(5):
+            cache.put("introspect", venv, f"community.general.mod{i}", {"i": i})
+
+        assert cache.get("introspect", venv, "community.general.mod0") is None
+        assert cache.get("introspect", venv, "community.general.mod1") is None
+        assert cache.get("introspect", venv, "community.general.mod4") == {"i": 4}
+
+    def test_stores_are_independent(self, tmp_path: Path) -> None:
+        """Each store (introspect, docspec, mockspec) is independent.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+        venv = self._make_venv(tmp_path, "community", "general", "5.8.0")
+
+        cache.put("introspect", venv, "community.general.ping", {"store": "introspect"})
+        cache.put("docspec", venv, "community.general.ping", {"store": "docspec"})
+
+        assert cache.get("introspect", venv, "community.general.ping") == {"store": "introspect"}
+        assert cache.get("docspec", venv, "community.general.ping") == {"store": "docspec"}
+        assert cache.get("mockspec", venv, "community.general.ping") is None
+
+    def test_no_version_means_no_cache(self, tmp_path: Path) -> None:
+        """FQCN with no discoverable version returns None (no cache).
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        cache = PluginCache()
+        venv = str(tmp_path)
+
+        cache.put("introspect", venv, "community.general.ping", {"data": True})
+        assert cache.get("introspect", venv, "community.general.ping") is None
+
+
+class TestM001M004CachedPath:
+    """Tests for the cache-integrated M001-M004 introspection."""
+
+    def _make_venv_with_python(self, tmp_path: Path) -> Path:
+        """Create a fake venv directory with a python binary stub.
+
+        Args:
+            tmp_path: Temporary directory.
+
+        Returns:
+            Path to venv root.
+        """
+        venv = tmp_path / "venv"
+        bin_dir = venv / "bin"
+        bin_dir.mkdir(parents=True)
+        python = bin_dir / "python"
+        python.write_text("#!/bin/sh\necho 'fake'")
+        python.chmod(0o755)
+
+        col_dir = venv / "lib" / "python3.11" / "site-packages" / "ansible_collections" / "community" / "general"
+        col_dir.mkdir(parents=True)
+        manifest = {"collection_info": {"version": "5.8.0"}}
+        (col_dir / "MANIFEST.json").write_text(json.dumps(manifest))
+        return venv
+
+    def test_second_call_uses_cache(self, tmp_path: Path) -> None:
+        """Second introspection call for same FQCN hits cache, no subprocess.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from apme_engine.validators.ansible.cache import PluginCache
+        from apme_engine.validators.ansible.rules import M001_M004_introspect
+
+        venv = self._make_venv_with_python(tmp_path)
+        fresh_cache = PluginCache()
+
+        subprocess_result = json.dumps({
+            "community.general.ping": {
+                "fqcn": "community.general.ping",
+                "deprecated": False,
+                "warnings": [],
+                "redirects": [],
+                "removed": False,
+                "removal_msg": "",
+                "plugin_path": "/some/path",
+            }
+        })
+
+        with patch.object(M001_M004_introspect, "plugin_cache", fresh_cache):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = type("Result", (), {"returncode": 0, "stdout": subprocess_result, "stderr": ""})()
+
+                result1 = M001_M004_introspect._run_introspection(
+                    ["community.general.ping"], venv,
+                )
+                assert "community.general.ping" in result1
+                assert mock_run.call_count == 1
+
+                result2 = M001_M004_introspect._run_introspection(
+                    ["community.general.ping"], venv,
+                )
+                assert "community.general.ping" in result2
+                assert mock_run.call_count == 1  # no additional call
+
+    def test_short_form_backfills_fqcn(self, tmp_path: Path) -> None:
+        """Short-form names always go to subprocess but FQCN gets backfilled.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from apme_engine.validators.ansible.cache import PluginCache
+        from apme_engine.validators.ansible.rules import M001_M004_introspect
+
+        venv = self._make_venv_with_python(tmp_path)
+
+        release_dir = venv / "lib" / "python3.11" / "site-packages" / "ansible"
+        release_dir.mkdir(parents=True)
+        (release_dir / "release.py").write_text("__version__ = '2.16.3'\n")
+
+        fresh_cache = PluginCache()
+        subprocess_result = json.dumps({
+            "ping": {
+                "fqcn": "ansible.builtin.ping",
+                "deprecated": False,
+                "warnings": [],
+                "redirects": [],
+                "removed": False,
+                "removal_msg": "",
+                "plugin_path": "/some/path",
+            }
+        })
+
+        with patch.object(M001_M004_introspect, "plugin_cache", fresh_cache):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = type("Result", (), {"returncode": 0, "stdout": subprocess_result, "stderr": ""})()
+
+                M001_M004_introspect._run_introspection(["ping"], venv)
+
+                hit = fresh_cache.get("introspect", str(venv), "ansible.builtin.ping")
+                assert hit is not None
+                assert isinstance(hit, dict)
+                assert hit["fqcn"] == "ansible.builtin.ping"
+
+    def test_mixed_cached_and_uncached(self, tmp_path: Path) -> None:
+        """Partition splits modules; only uncached ones go to subprocess.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from apme_engine.validators.ansible.cache import PluginCache
+        from apme_engine.validators.ansible.rules import M001_M004_introspect
+
+        venv = self._make_venv_with_python(tmp_path)
+        fresh_cache = PluginCache()
+
+        pre_cached = {"fqcn": "community.general.ping", "deprecated": False, "warnings": [], "redirects": [], "removed": False, "removal_msg": "", "plugin_path": ""}
+        fresh_cache.put("introspect", str(venv), "community.general.ping", pre_cached)
+
+        subprocess_result = json.dumps({
+            "community.general.uri": {"fqcn": "community.general.uri", "deprecated": False, "warnings": [], "redirects": [], "removed": False, "removal_msg": "", "plugin_path": ""}
+        })
+
+        with patch.object(M001_M004_introspect, "plugin_cache", fresh_cache):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = type("Result", (), {"returncode": 0, "stdout": subprocess_result, "stderr": ""})()
+
+                result = M001_M004_introspect._run_introspection(
+                    ["community.general.ping", "community.general.uri"], venv,
+                )
+
+                assert "community.general.ping" in result
+                assert "community.general.uri" in result
+                assert mock_run.call_count == 1
+
+                call_input = mock_run.call_args[1].get("input") or mock_run.call_args[0][0] if mock_run.call_args[0] else ""
+                if isinstance(call_input, str):
+                    sent = json.loads(call_input)
+                    assert "community.general.ping" not in sent["modules"]
+                    assert "community.general.uri" in sent["modules"]
+
+
+class TestL058HostSideChecking:
+    """Tests for L058 _check_tasks_against_specs (host-side validation)."""
+
+    def test_unknown_param(self) -> None:
+        """Detects unsupported parameters."""
+        from apme_engine.validators.ansible.rules.L058_argspec_doc import _check_tasks_against_specs
+
+        specs: dict[str, object] = {
+            "community.general.ping": {"options": {"data": {"type": "str"}}},
+        }
+        tasks: list[dict[str, object]] = [
+            {"module": "community.general.ping", "module_options": {"bogus": "val"}, "key": "t1"},
+        ]
+
+        violations = _check_tasks_against_specs(specs, tasks)
+        assert len(violations) == 1
+        assert "Unsupported parameters" in str(violations[0]["message"])
+
+    def test_missing_required(self) -> None:
+        """Detects missing required parameters."""
+        from apme_engine.validators.ansible.rules.L058_argspec_doc import _check_tasks_against_specs
+
+        specs: dict[str, object] = {
+            "my.mod.x": {"options": {"name": {"type": "str", "required": True}}},
+        }
+        tasks: list[dict[str, object]] = [
+            {"module": "my.mod.x", "module_options": {"other": "val"}, "key": "t1"},
+        ]
+
+        violations = _check_tasks_against_specs(specs, tasks)
+        assert any("Missing required" in str(v["message"]) for v in violations)
+
+    def test_invalid_choice(self) -> None:
+        """Detects invalid choice values."""
+        from apme_engine.validators.ansible.rules.L058_argspec_doc import _check_tasks_against_specs
+
+        specs: dict[str, object] = {
+            "my.mod.x": {"options": {"state": {"type": "str", "choices": ["present", "absent"]}}},
+        }
+        tasks: list[dict[str, object]] = [
+            {"module": "my.mod.x", "module_options": {"state": "running"}, "key": "t1"},
+        ]
+
+        violations = _check_tasks_against_specs(specs, tasks)
+        assert any("not one of" in str(v["message"]) for v in violations)
+
+    def test_free_form_skipped(self) -> None:
+        """Modules with free_form option skip validation."""
+        from apme_engine.validators.ansible.rules.L058_argspec_doc import _check_tasks_against_specs
+
+        specs: dict[str, object] = {
+            "my.mod.x": {"options": {"free_form": {"type": "str"}, "name": {"required": True}}},
+        }
+        tasks: list[dict[str, object]] = [
+            {"module": "my.mod.x", "module_options": {"anything": "goes"}, "key": "t1"},
+        ]
+
+        violations = _check_tasks_against_specs(specs, tasks)
+        assert len(violations) == 0
+
+    def test_jinja_skipped(self) -> None:
+        """Tasks with Jinja templates in values skip validation."""
+        from apme_engine.validators.ansible.rules.L058_argspec_doc import _check_tasks_against_specs
+
+        specs: dict[str, object] = {
+            "my.mod.x": {"options": {"name": {"type": "str", "required": True}}},
+        }
+        tasks: list[dict[str, object]] = [
+            {"module": "my.mod.x", "module_options": {"name": "{{ var }}"}, "key": "t1"},
+        ]
+
+        violations = _check_tasks_against_specs(specs, tasks)
+        assert len(violations) == 0
+
+
+class TestL059HostSideChecking:
+    """Tests for L059 _check_tasks_against_specs (host-side validation)."""
+
+    def test_unknown_param(self) -> None:
+        """Detects unsupported parameters."""
+        from apme_engine.validators.ansible.rules.L059_argspec_mock import _check_tasks_against_specs
+
+        specs: dict[str, object] = {
+            "my.mod.x": {"argument_spec": {"name": {"type": "str"}}},
+        }
+        tasks: list[dict[str, object]] = [
+            {"module": "my.mod.x", "module_options": {"bogus": "val"}, "key": "t1"},
+        ]
+
+        violations = _check_tasks_against_specs(specs, tasks)
+        assert len(violations) == 1
+        assert "Unsupported parameters" in str(violations[0]["message"])
+
+    def test_mutually_exclusive(self) -> None:
+        """Detects mutually exclusive parameter violations."""
+        from apme_engine.validators.ansible.rules.L059_argspec_mock import _check_tasks_against_specs
+
+        specs: dict[str, object] = {
+            "my.mod.x": {
+                "argument_spec": {"src": {"type": "str"}, "content": {"type": "str"}},
+                "mutually_exclusive": [["src", "content"]],
+            },
+        }
+        tasks: list[dict[str, object]] = [
+            {"module": "my.mod.x", "module_options": {"src": "a", "content": "b"}, "key": "t1"},
+        ]
+
+        violations = _check_tasks_against_specs(specs, tasks)
+        assert any("mutually exclusive" in str(v["message"]) for v in violations)
+
+    def test_required_together(self) -> None:
+        """Detects required_together violations."""
+        from apme_engine.validators.ansible.rules.L059_argspec_mock import _check_tasks_against_specs
+
+        specs: dict[str, object] = {
+            "my.mod.x": {
+                "argument_spec": {"host": {"type": "str"}, "port": {"type": "int"}},
+                "required_together": [["host", "port"]],
+            },
+        }
+        tasks: list[dict[str, object]] = [
+            {"module": "my.mod.x", "module_options": {"host": "localhost"}, "key": "t1"},
+        ]
+
+        violations = _check_tasks_against_specs(specs, tasks)
+        assert any("must be used together" in str(v["message"]) for v in violations)
+
+    def test_aliases_accepted(self) -> None:
+        """Parameter aliases are recognized as valid."""
+        from apme_engine.validators.ansible.rules.L059_argspec_mock import _check_tasks_against_specs
+
+        specs: dict[str, object] = {
+            "my.mod.x": {
+                "argument_spec": {"name": {"type": "str", "aliases": ["hostname"]}},
+            },
+        }
+        tasks: list[dict[str, object]] = [
+            {"module": "my.mod.x", "module_options": {"hostname": "box1"}, "key": "t1"},
+        ]
+
+        violations = _check_tasks_against_specs(specs, tasks)
+        assert len(violations) == 0
+
+
+class TestL058CachedRun:
+    """Tests for L058 run() with the cache path."""
+
+    def test_cached_specs_skip_subprocess(self, tmp_path: Path) -> None:
+        """When specs are already cached, no subprocess is spawned.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from apme_engine.validators.ansible.cache import PluginCache
+        from apme_engine.validators.ansible.rules import L058_argspec_doc
+
+        venv = tmp_path / "venv"
+        (venv / "bin").mkdir(parents=True)
+
+        col_dir = venv / "lib" / "python3.11" / "site-packages" / "ansible_collections" / "community" / "general"
+        col_dir.mkdir(parents=True)
+        (col_dir / "MANIFEST.json").write_text(json.dumps({"collection_info": {"version": "5.8.0"}}))
+
+        fresh_cache = PluginCache()
+        spec = {"options": {"data": {"type": "str"}}}
+        fresh_cache.put("docspec", str(venv), "community.general.ping", spec)
+
+        task_nodes: list[dict[str, object]] = [
+            {
+                "module": "community.general.ping",
+                "module_options": {"bogus_param": "val"},
+                "key": "task-1",
+                "file": "playbook.yml",
+                "line": [10],
+            },
+        ]
+
+        with patch.object(L058_argspec_doc, "plugin_cache", fresh_cache):
+            with patch("subprocess.run") as mock_run:
+                violations = L058_argspec_doc.run(task_nodes, venv)
+
+                assert mock_run.call_count == 0
+                assert len(violations) == 1
+                assert violations[0]["rule_id"] == "L058"
+                assert "Unsupported parameters" in str(violations[0]["message"])
+
+
+class TestL059CachedRun:
+    """Tests for L059 run() with the cache path."""
+
+    def test_cached_specs_skip_subprocess(self, tmp_path: Path) -> None:
+        """When argspecs are already cached, no subprocess is spawned.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from apme_engine.validators.ansible.cache import PluginCache
+        from apme_engine.validators.ansible.rules import L059_argspec_mock
+
+        venv = tmp_path / "venv"
+        (venv / "bin").mkdir(parents=True)
+
+        col_dir = venv / "lib" / "python3.11" / "site-packages" / "ansible_collections" / "community" / "general"
+        col_dir.mkdir(parents=True)
+        (col_dir / "MANIFEST.json").write_text(json.dumps({"collection_info": {"version": "5.8.0"}}))
+
+        fresh_cache = PluginCache()
+        spec = {
+            "argument_spec": {"name": {"type": "str"}},
+            "mutually_exclusive": [],
+            "required_together": [],
+        }
+        fresh_cache.put("mockspec", str(venv), "community.general.ping", spec)
+
+        task_nodes: list[dict[str, object]] = [
+            {
+                "module": "community.general.ping",
+                "module_options": {"bad_param": "val"},
+                "key": "task-1",
+                "file": "playbook.yml",
+                "line": [10],
+            },
+        ]
+
+        with patch.object(L059_argspec_mock, "plugin_cache", fresh_cache):
+            with patch("subprocess.run") as mock_run:
+                violations = L059_argspec_mock.run(task_nodes, venv)
+
+                assert mock_run.call_count == 0
+                assert len(violations) == 1
+                assert violations[0]["rule_id"] == "L059"
+                assert "Unsupported parameters" in str(violations[0]["message"])

--- a/tests/test_ansible_cache.py
+++ b/tests/test_ansible_cache.py
@@ -5,12 +5,8 @@ in M001_M004_introspect, L058_argspec_doc, and L059_argspec_mock.
 """
 
 import json
-import os
-import textwrap
 from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 from apme_engine.validators.ansible.cache import (
     PluginCache,
@@ -380,33 +376,39 @@ class TestM001M004CachedPath:
         venv = self._make_venv_with_python(tmp_path)
         fresh_cache = PluginCache()
 
-        subprocess_result = json.dumps({
-            "community.general.ping": {
-                "fqcn": "community.general.ping",
-                "deprecated": False,
-                "warnings": [],
-                "redirects": [],
-                "removed": False,
-                "removal_msg": "",
-                "plugin_path": "/some/path",
+        subprocess_result = json.dumps(
+            {
+                "community.general.ping": {
+                    "fqcn": "community.general.ping",
+                    "deprecated": False,
+                    "warnings": [],
+                    "redirects": [],
+                    "removed": False,
+                    "removal_msg": "",
+                    "plugin_path": "/some/path",
+                }
             }
-        })
+        )
 
-        with patch.object(M001_M004_introspect, "plugin_cache", fresh_cache):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = type("Result", (), {"returncode": 0, "stdout": subprocess_result, "stderr": ""})()
+        with (
+            patch.object(M001_M004_introspect, "plugin_cache", fresh_cache),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = type("Result", (), {"returncode": 0, "stdout": subprocess_result, "stderr": ""})()
 
-                result1 = M001_M004_introspect._run_introspection(
-                    ["community.general.ping"], venv,
-                )
-                assert "community.general.ping" in result1
-                assert mock_run.call_count == 1
+            result1 = M001_M004_introspect._run_introspection(
+                ["community.general.ping"],
+                venv,
+            )
+            assert "community.general.ping" in result1
+            assert mock_run.call_count == 1
 
-                result2 = M001_M004_introspect._run_introspection(
-                    ["community.general.ping"], venv,
-                )
-                assert "community.general.ping" in result2
-                assert mock_run.call_count == 1  # no additional call
+            result2 = M001_M004_introspect._run_introspection(
+                ["community.general.ping"],
+                venv,
+            )
+            assert "community.general.ping" in result2
+            assert mock_run.call_count == 1  # no additional call
 
     def test_short_form_backfills_fqcn(self, tmp_path: Path) -> None:
         """Short-form names always go to subprocess but FQCN gets backfilled.
@@ -424,28 +426,32 @@ class TestM001M004CachedPath:
         (release_dir / "release.py").write_text("__version__ = '2.16.3'\n")
 
         fresh_cache = PluginCache()
-        subprocess_result = json.dumps({
-            "ping": {
-                "fqcn": "ansible.builtin.ping",
-                "deprecated": False,
-                "warnings": [],
-                "redirects": [],
-                "removed": False,
-                "removal_msg": "",
-                "plugin_path": "/some/path",
+        subprocess_result = json.dumps(
+            {
+                "ping": {
+                    "fqcn": "ansible.builtin.ping",
+                    "deprecated": False,
+                    "warnings": [],
+                    "redirects": [],
+                    "removed": False,
+                    "removal_msg": "",
+                    "plugin_path": "/some/path",
+                }
             }
-        })
+        )
 
-        with patch.object(M001_M004_introspect, "plugin_cache", fresh_cache):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = type("Result", (), {"returncode": 0, "stdout": subprocess_result, "stderr": ""})()
+        with (
+            patch.object(M001_M004_introspect, "plugin_cache", fresh_cache),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = type("Result", (), {"returncode": 0, "stdout": subprocess_result, "stderr": ""})()
 
-                M001_M004_introspect._run_introspection(["ping"], venv)
+            M001_M004_introspect._run_introspection(["ping"], venv)
 
-                hit = fresh_cache.get("introspect", str(venv), "ansible.builtin.ping")
-                assert hit is not None
-                assert isinstance(hit, dict)
-                assert hit["fqcn"] == "ansible.builtin.ping"
+            hit = fresh_cache.get("introspect", str(venv), "ansible.builtin.ping")
+            assert hit is not None
+            assert isinstance(hit, dict)
+            assert hit["fqcn"] == "ansible.builtin.ping"
 
     def test_mixed_cached_and_uncached(self, tmp_path: Path) -> None:
         """Partition splits modules; only uncached ones go to subprocess.
@@ -459,30 +465,51 @@ class TestM001M004CachedPath:
         venv = self._make_venv_with_python(tmp_path)
         fresh_cache = PluginCache()
 
-        pre_cached = {"fqcn": "community.general.ping", "deprecated": False, "warnings": [], "redirects": [], "removed": False, "removal_msg": "", "plugin_path": ""}
+        pre_cached = {
+            "fqcn": "community.general.ping",
+            "deprecated": False,
+            "warnings": [],
+            "redirects": [],
+            "removed": False,
+            "removal_msg": "",
+            "plugin_path": "",
+        }
         fresh_cache.put("introspect", str(venv), "community.general.ping", pre_cached)
 
-        subprocess_result = json.dumps({
-            "community.general.uri": {"fqcn": "community.general.uri", "deprecated": False, "warnings": [], "redirects": [], "removed": False, "removal_msg": "", "plugin_path": ""}
-        })
+        subprocess_result = json.dumps(
+            {
+                "community.general.uri": {
+                    "fqcn": "community.general.uri",
+                    "deprecated": False,
+                    "warnings": [],
+                    "redirects": [],
+                    "removed": False,
+                    "removal_msg": "",
+                    "plugin_path": "",
+                }
+            }
+        )
 
-        with patch.object(M001_M004_introspect, "plugin_cache", fresh_cache):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = type("Result", (), {"returncode": 0, "stdout": subprocess_result, "stderr": ""})()
+        with (
+            patch.object(M001_M004_introspect, "plugin_cache", fresh_cache),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = type("Result", (), {"returncode": 0, "stdout": subprocess_result, "stderr": ""})()
 
-                result = M001_M004_introspect._run_introspection(
-                    ["community.general.ping", "community.general.uri"], venv,
-                )
+            result = M001_M004_introspect._run_introspection(
+                ["community.general.ping", "community.general.uri"],
+                venv,
+            )
 
-                assert "community.general.ping" in result
-                assert "community.general.uri" in result
-                assert mock_run.call_count == 1
+            assert "community.general.ping" in result
+            assert "community.general.uri" in result
+            assert mock_run.call_count == 1
 
-                call_input = mock_run.call_args[1].get("input") or mock_run.call_args[0][0] if mock_run.call_args[0] else ""
-                if isinstance(call_input, str):
-                    sent = json.loads(call_input)
-                    assert "community.general.ping" not in sent["modules"]
-                    assert "community.general.uri" in sent["modules"]
+            call_input = mock_run.call_args[1].get("input") or mock_run.call_args[0][0] if mock_run.call_args[0] else ""
+            if isinstance(call_input, str):
+                sent = json.loads(call_input)
+                assert "community.general.ping" not in sent["modules"]
+                assert "community.general.uri" in sent["modules"]
 
 
 class TestL058HostSideChecking:
@@ -662,14 +689,16 @@ class TestL058CachedRun:
             },
         ]
 
-        with patch.object(L058_argspec_doc, "plugin_cache", fresh_cache):
-            with patch("subprocess.run") as mock_run:
-                violations = L058_argspec_doc.run(task_nodes, venv)
+        with (
+            patch.object(L058_argspec_doc, "plugin_cache", fresh_cache),
+            patch("subprocess.run") as mock_run,
+        ):
+            violations = L058_argspec_doc.run(task_nodes, venv)
 
-                assert mock_run.call_count == 0
-                assert len(violations) == 1
-                assert violations[0]["rule_id"] == "L058"
-                assert "Unsupported parameters" in str(violations[0]["message"])
+            assert mock_run.call_count == 0
+            assert len(violations) == 1
+            assert violations[0]["rule_id"] == "L058"
+            assert "Unsupported parameters" in str(violations[0]["message"])
 
 
 class TestL059CachedRun:
@@ -709,11 +738,13 @@ class TestL059CachedRun:
             },
         ]
 
-        with patch.object(L059_argspec_mock, "plugin_cache", fresh_cache):
-            with patch("subprocess.run") as mock_run:
-                violations = L059_argspec_mock.run(task_nodes, venv)
+        with (
+            patch.object(L059_argspec_mock, "plugin_cache", fresh_cache),
+            patch("subprocess.run") as mock_run,
+        ):
+            violations = L059_argspec_mock.run(task_nodes, venv)
 
-                assert mock_run.call_count == 0
-                assert len(violations) == 1
-                assert violations[0]["rule_id"] == "L059"
-                assert "Unsupported parameters" in str(violations[0]["message"])
+            assert mock_run.call_count == 0
+            assert len(violations) == 1
+            assert violations[0]["rule_id"] == "L059"
+            assert "Unsupported parameters" in str(violations[0]["message"])


### PR DESCRIPTION
## Summary
- Add an in-memory LRU cache to the Ansible validator so repeat scans and cross-venv calls with identical collection versions skip redundant subprocess invocations for plugin resolution and argspec introspection
- Closes #169

## Changes
- **New `PluginCache` class** (`validators/ansible/cache.py`): three `OrderedDict`-based LRU stores (`introspect`, `docspec`, `mockspec`) bounded at 1024 entries, keyed by `(collection_fqcn, collection_version, plugin_name)`. Version discovery reads `MANIFEST.json` for collections and `ansible/release.py` for `ansible.builtin.*`. Short-form names always miss but get backfilled under the resolved FQCN after subprocess resolution. Thread-safe via single lock. Internal version memo caches bounded at 256 entries with LRU eviction.
- **M001-M004**: `_run_introspection()` partitions modules into cached/uncached before calling subprocess; only uncached modules go to the subprocess. Results are stored back with resolved FQCNs for downstream L058/L059 cache hits.
- **L058**: Separated subprocess script into spec-only resolution (`_SPEC_SCRIPT`) and host-side task validation (`_check_tasks_against_specs()`). Specs are cached per-module in the `docspec` store.
- **L059**: Same separation pattern — mock argspec capture in subprocess, task validation on host. Specs cached per-module in the `mockspec` store.
- **Diagnostics**: `AnsibleRunResult.metadata` carries cache hit/miss stats; wired into `ValidatorDiagnostics.metadata` in the daemon servicer. Summary logged to stderr on every Ansible validator invocation.
- **37 unit tests** covering cache mechanics (LRU eviction, cross-venv hits, short-form backfill, partition, stats), host-side validation (L058/L059 `_check_tasks_against_specs`), and cached `run()` paths (subprocess skipped when specs pre-cached).
- **Integration test** (`test_ansible_cache_hits_on_second_scan`): runs two scans of terrible-playbook against the daemon, reads `daemon.log` (located via the launcher's resolved `_DATA_DIR`), and asserts the second scan reports cache hits > 0.

### Copilot review feedback addressed
- Fixed `stats()` docstring to match actual key prefix (`cache_introspect_hits`)
- Removed dead `resolved_fqcn` inference in L058/L059 that used `is` identity on `json.loads()` results — always false since JSON decoding creates fresh objects
- Bounded `_version_cache` and `_core_version_cache` with LRU eviction (256 entries) to prevent unbounded growth in long-lived daemons
- Removed unused `_CACHE_HIT_SESSION` constant and unused imports
- Fixed integration test to import `_DATA_DIR` from the launcher module instead of assuming it matches the conftest's `data_dir`

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2279 passed, 60.07% coverage)
- [x] `tox -e integration` passes (all 5 CI checks green)