### PR TITLE
feat(ui): persist playground session across navigation

### DIFF
--- a/frontend/src/hooks/useSessionStream.ts
+++ b/frontend/src/hooks/useSessionStream.ts
@@ -114,16 +114,38 @@ const RECONNECTABLE_PHASES: ReadonlySet<SessionStatus> = new Set([
 // ── Session persistence ────────────────────────────────────────────
 
 const SESSION_STORAGE_KEY = "apme_active_session";
+const DEFAULT_TTL_SECONDS = 1800;
 
-interface PersistedSession {
+export interface PersistedSession {
   sessionId: string;
   scanId: string;
   timestamp: number;
+  ttlSeconds: number;
 }
 
-function persistSession(sessionId: string, scanId: string): void {
+function isPersistedSession(v: unknown): v is PersistedSession {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.sessionId === "string" &&
+    typeof o.scanId === "string" &&
+    typeof o.timestamp === "number" &&
+    typeof o.ttlSeconds === "number"
+  );
+}
+
+function persistSession(
+  sessionId: string,
+  scanId: string,
+  ttlSeconds?: number,
+): void {
   try {
-    const data: PersistedSession = { sessionId, scanId, timestamp: Date.now() };
+    const data: PersistedSession = {
+      sessionId,
+      scanId,
+      timestamp: Date.now(),
+      ttlSeconds: ttlSeconds ?? DEFAULT_TTL_SECONDS,
+    };
     sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(data));
   } catch {
     // sessionStorage may be unavailable (private browsing, quota)
@@ -140,20 +162,24 @@ function clearPersistedSession(): void {
 
 /**
  * Check for an active session persisted across navigation.
- * Returns null if none exists or if it's older than the server TTL.
+ * Returns null if none exists, is malformed, or has exceeded its TTL.
  */
 export function getPersistedSession(): PersistedSession | null {
   try {
     const raw = sessionStorage.getItem(SESSION_STORAGE_KEY);
     if (!raw) return null;
-    const data = JSON.parse(raw) as PersistedSession;
-    const SESSION_TTL_MS = 1800 * 1000; // matches APME_SESSION_TTL default
-    if (Date.now() - data.timestamp > SESSION_TTL_MS) {
+    const data: unknown = JSON.parse(raw);
+    if (!isPersistedSession(data)) {
+      clearPersistedSession();
+      return null;
+    }
+    if (Date.now() - data.timestamp > data.ttlSeconds * 1000) {
       clearPersistedSession();
       return null;
     }
     return data;
   } catch {
+    clearPersistedSession();
     return null;
   }
 }
@@ -213,7 +239,13 @@ export function useSessionStream() {
             setSessionId(msg.session_id as string);
             sessionIdRef.current = msg.session_id as string;
             setScanId(msg.scan_id as string);
-            persistSession(msg.session_id as string, msg.scan_id as string);
+            persistSession(
+              msg.session_id as string,
+              msg.scan_id as string,
+              typeof msg.ttl_seconds === "number"
+                ? msg.ttl_seconds
+                : undefined,
+            );
             updateStatus("checking");
             break;
 
@@ -277,6 +309,7 @@ export function useSessionStream() {
             break;
 
           case "closed":
+            clearPersistedSession();
             if (
               statusRef.current !== "complete" &&
               statusRef.current !== "error"

--- a/frontend/src/hooks/useSessionStream.ts
+++ b/frontend/src/hooks/useSessionStream.ts
@@ -11,7 +11,7 @@
  * ``?resume=<session_id>`` gateway endpoint.
  */
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -111,6 +111,53 @@ const RECONNECTABLE_PHASES: ReadonlySet<SessionStatus> = new Set([
   "awaiting_approval",
 ]);
 
+// ── Session persistence ────────────────────────────────────────────
+
+const SESSION_STORAGE_KEY = "apme_active_session";
+
+interface PersistedSession {
+  sessionId: string;
+  scanId: string;
+  timestamp: number;
+}
+
+function persistSession(sessionId: string, scanId: string): void {
+  try {
+    const data: PersistedSession = { sessionId, scanId, timestamp: Date.now() };
+    sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    // sessionStorage may be unavailable (private browsing, quota)
+  }
+}
+
+function clearPersistedSession(): void {
+  try {
+    sessionStorage.removeItem(SESSION_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Check for an active session persisted across navigation.
+ * Returns null if none exists or if it's older than the server TTL.
+ */
+export function getPersistedSession(): PersistedSession | null {
+  try {
+    const raw = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (!raw) return null;
+    const data = JSON.parse(raw) as PersistedSession;
+    const SESSION_TTL_MS = 1800 * 1000; // matches APME_SESSION_TTL default
+    if (Date.now() - data.timestamp > SESSION_TTL_MS) {
+      clearPersistedSession();
+      return null;
+    }
+    return data;
+  } catch {
+    return null;
+  }
+}
+
 // ── Hook ───────────────────────────────────────────────────────────
 
 export function useSessionStream() {
@@ -147,6 +194,7 @@ export function useSessionStream() {
     setError(null);
     setCanReconnect(false);
     sessionIdRef.current = null;
+    clearPersistedSession();
   }, [updateStatus]);
 
   /** Wire shared WS event handlers (used by both start and resume). */
@@ -165,6 +213,7 @@ export function useSessionStream() {
             setSessionId(msg.session_id as string);
             sessionIdRef.current = msg.session_id as string;
             setScanId(msg.scan_id as string);
+            persistSession(msg.session_id as string, msg.scan_id as string);
             updateStatus("checking");
             break;
 
@@ -199,6 +248,7 @@ export function useSessionStream() {
           case "result":
             setResult(msg as unknown as SessionResult);
             setCanReconnect(false);
+            clearPersistedSession();
             updateStatus("complete");
             if (ws.readyState === WebSocket.OPEN) {
               ws.send(JSON.stringify({ type: "close" }));
@@ -370,8 +420,20 @@ export function useSessionStream() {
 
   const cancel = useCallback(() => {
     wsRef.current?.close();
+    clearPersistedSession();
     updateStatus("idle");
   }, [updateStatus]);
+
+  // Close WebSocket on unmount (navigation away) but keep the persisted
+  // session reference so the user can resume when they navigate back.
+  useEffect(() => {
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, []);
 
   return {
     status,

--- a/frontend/src/pages/PlaygroundPage.tsx
+++ b/frontend/src/pages/PlaygroundPage.tsx
@@ -131,6 +131,7 @@ export function PlaygroundPage() {
   }, [reset]);
 
   const isRunning = opStatus === 'connecting' || opStatus === 'preparing' || opStatus === 'checking' || opStatus === 'applying';
+  const [dismissedDisconnect, setDismissedDisconnect] = useState(false);
 
   const handleReconnect = useCallback(() => {
     if (sessionId && scanId) {
@@ -146,12 +147,12 @@ export function PlaygroundPage() {
       />
 
       <div style={{ padding: '0 24px 24px' }}>
-        {rawStatus === 'disconnected' && canReconnect && (
+        {rawStatus === 'disconnected' && canReconnect && !dismissedDisconnect && (
           <Alert
             variant="warning"
             isInline
             title="Session disconnected"
-            actionClose={<AlertActionCloseButton onClose={handleReset} />}
+            actionClose={<AlertActionCloseButton onClose={() => setDismissedDisconnect(true)} />}
             style={{ marginBottom: 16 }}
           >
             <p style={{ marginBottom: 8 }}>{error}</p>

--- a/frontend/src/pages/PlaygroundPage.tsx
+++ b/frontend/src/pages/PlaygroundPage.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PageLayout, PageHeader } from '@ansible/ansible-ui-framework';
 import {
+  Alert,
+  AlertActionCloseButton,
   Button,
   Card,
   CardBody,
@@ -9,6 +11,7 @@ import {
 import JSZip from 'jszip';
 import { AI_MODEL_STORAGE_KEY } from './SettingsPage';
 import {
+  getPersistedSession,
   useSessionStream,
   type Patch,
   type SessionResult,
@@ -40,16 +43,30 @@ export function PlaygroundPage() {
   const {
     status: rawStatus,
     progress: rawProgress,
+    sessionId,
     scanId,
     tier1,
     proposals: rawProposals,
     result,
     error,
+    canReconnect,
     startSession,
+    resumeSession,
     approve,
     cancel,
     reset,
   } = useSessionStream();
+
+  // Auto-resume a persisted session when the page mounts.
+  const resumeAttempted = useRef(false);
+  useEffect(() => {
+    if (resumeAttempted.current || rawStatus !== 'idle') return;
+    resumeAttempted.current = true;
+    const persisted = getPersistedSession();
+    if (persisted) {
+      resumeSession(persisted.sessionId, persisted.scanId);
+    }
+  }, [rawStatus, resumeSession]);
 
   const opStatus = mapSessionStatus(rawStatus);
   const opProgress: OperationProgress[] = rawProgress.map((p) => ({
@@ -115,6 +132,12 @@ export function PlaygroundPage() {
 
   const isRunning = opStatus === 'connecting' || opStatus === 'preparing' || opStatus === 'checking' || opStatus === 'applying';
 
+  const handleReconnect = useCallback(() => {
+    if (sessionId && scanId) {
+      resumeSession(sessionId, scanId);
+    }
+  }, [sessionId, scanId, resumeSession]);
+
   return (
     <PageLayout>
       <PageHeader
@@ -123,6 +146,25 @@ export function PlaygroundPage() {
       />
 
       <div style={{ padding: '0 24px 24px' }}>
+        {rawStatus === 'disconnected' && canReconnect && (
+          <Alert
+            variant="warning"
+            isInline
+            title="Session disconnected"
+            actionClose={<AlertActionCloseButton onClose={handleReset} />}
+            style={{ marginBottom: 16 }}
+          >
+            <p style={{ marginBottom: 8 }}>{error}</p>
+            <Button variant="primary" onClick={handleReconnect} size="sm">
+              Reconnect
+            </Button>
+            {' '}
+            <Button variant="link" onClick={handleReset} size="sm">
+              Start Over
+            </Button>
+          </Alert>
+        )}
+
         {opStatus === 'idle' && (
           <Card>
             <CardBody>

--- a/frontend/src/test/sessionPersistence.test.ts
+++ b/frontend/src/test/sessionPersistence.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import {
+  getPersistedSession,
+  type PersistedSession,
+} from "../hooks/useSessionStream";
+
+const STORAGE_KEY = "apme_active_session";
+
+describe("getPersistedSession", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(getPersistedSession()).toBeNull();
+  });
+
+  it("returns a valid persisted session", () => {
+    const data: PersistedSession = {
+      sessionId: "sess-1",
+      scanId: "scan-1",
+      timestamp: Date.now(),
+      ttlSeconds: 1800,
+    };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+
+    const result = getPersistedSession();
+    expect(result).toEqual(data);
+  });
+
+  it("returns null and clears storage when TTL is exceeded", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-13T12:00:00Z"));
+
+    const data: PersistedSession = {
+      sessionId: "sess-1",
+      scanId: "scan-1",
+      timestamp: Date.now(),
+      ttlSeconds: 600,
+    };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+
+    vi.setSystemTime(new Date("2026-04-13T12:11:00Z"));
+
+    expect(getPersistedSession()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns session when within TTL", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-13T12:00:00Z"));
+
+    const data: PersistedSession = {
+      sessionId: "sess-1",
+      scanId: "scan-1",
+      timestamp: Date.now(),
+      ttlSeconds: 1800,
+    };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+
+    vi.setSystemTime(new Date("2026-04-13T12:29:00Z"));
+
+    expect(getPersistedSession()).toEqual(data);
+  });
+
+  it("respects server-provided TTL instead of hardcoded default", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-13T12:00:00Z"));
+
+    const data: PersistedSession = {
+      sessionId: "sess-1",
+      scanId: "scan-1",
+      timestamp: Date.now(),
+      ttlSeconds: 300,
+    };
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+
+    vi.setSystemTime(new Date("2026-04-13T12:06:00Z"));
+
+    expect(getPersistedSession()).toBeNull();
+  });
+
+  it("returns null and clears storage for corrupt JSON", () => {
+    sessionStorage.setItem(STORAGE_KEY, "not-json{{{");
+
+    expect(getPersistedSession()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns null and clears storage when fields are missing", () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ sessionId: "sess-1" }),
+    );
+
+    expect(getPersistedSession()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns null and clears storage when fields have wrong types", () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        sessionId: 123,
+        scanId: "scan-1",
+        timestamp: "not-a-number",
+        ttlSeconds: 1800,
+      }),
+    );
+
+    expect(getPersistedSession()).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Persist the active FixSession reference to `sessionStorage` so navigating away from the Playground page and returning auto-resumes the session instead of losing it
- Wire up the previously unused `canReconnect`/`resumeSession` surface from `useSessionStream` into the Playground UI

## Changes
- **`useSessionStream.ts`**: Add `sessionStorage` persistence — write `{sessionId, scanId, timestamp, ttlSeconds}` on `session_created` (using server-provided `ttl_seconds`), clear on `result`/`reset`/`cancel`/`closed`. Export `getPersistedSession()` with type-safe validation and server-derived TTL expiry. Add `useEffect` cleanup to close WebSocket on unmount while preserving the persisted reference for resume
- **`PlaygroundPage.tsx`**: Auto-resume persisted session on mount via `useEffect` + `getPersistedSession()`. Show a PatternFly `Alert` banner in `disconnected` state with "Reconnect" and "Start Over" actions (close button dismisses the alert without resetting session state). Wire `sessionId`, `canReconnect`, `resumeSession` from the hook (previously unused)
- **`sessionPersistence.test.ts`**: 8 Vitest cases covering valid session, TTL expiry, within-TTL, server-provided TTL, corrupt JSON, missing fields, and wrong field types

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2279 passed)
- [x] Vitest frontend tests pass (8 new, 50 total)
- [ ] Manual: start a check in Playground, navigate to Projects, return to Playground — session resumes
- [ ] Manual: disconnect WS during `awaiting_approval` — banner appears with Reconnect button
- [ ] Manual: complete a check or click "Start Over" — `sessionStorage` cleared, fresh state on next visit

Closes #94 (parts 2 & 4)