### PR TITLE
feat(remediation): add per-rule AI prompt hints via rule doc frontmatter

### DIFF
--- a/.sdlc/templates/rule-doc.md
+++ b/.sdlc/templates/rule-doc.md
@@ -6,6 +6,11 @@ category: lint
 validator: native
 tags: []
 since: 1.0.0
+# ai_prompt: |
+#   Optional per-rule guidance injected into the AI remediation prompt.
+#   Use this to tell the AI how to handle this specific rule — e.g.,
+#   when to add "# noqa" instead of fixing the code, or domain-specific
+#   context about when the flagged pattern is legitimate.
 ---
 
 # LXXX: Short Descriptive Title

--- a/docs/design/DESIGN_REMEDIATION.md
+++ b/docs/design/DESIGN_REMEDIATION.md
@@ -258,7 +258,7 @@ Violations on non-task nodes (e.g., play-level scope) are marked `MANUAL` for hu
 
 ### Prompt Contract
 
-The LLM receives the node's YAML and violations via `AINodeContext`. The prompt includes a **Rule-Specific Guidance** section built from optional `ai_prompt` frontmatter in rule doc `.md` files. This allows per-rule customization of how the AI handles specific violations (e.g., instructing it to add `# noqa` for false-positive-prone rules rather than modifying code). Hints are loaded once at startup via `_load_ai_prompts()` with `lru_cache`. Rules without `ai_prompt` frontmatter use the default best-practices guidance.
+The LLM receives the node's YAML and violations via `AINodeContext`. The prompt includes a **Rule-Specific Guidance** section built from optional `ai_prompt` frontmatter in rule doc `.md` files. This allows per-rule customization of how the AI handles specific violations (e.g., instructing it to add `# noqa` for false-positive-prone rules rather than modifying code). Hints are loaded lazily on first prompt build via `_load_ai_prompts()` and cached with `lru_cache` for subsequent calls. Rules without `ai_prompt` frontmatter use the default best-practices guidance.
 
 The LLM returns an `AINodeFix`:
 

--- a/docs/design/DESIGN_REMEDIATION.md
+++ b/docs/design/DESIGN_REMEDIATION.md
@@ -258,7 +258,9 @@ Violations on non-task nodes (e.g., play-level scope) are marked `MANUAL` for hu
 
 ### Prompt Contract
 
-The LLM receives the node's YAML and violations via `AINodeContext`. It returns an `AINodeFix`:
+The LLM receives the node's YAML and violations via `AINodeContext`. The prompt includes a **Rule-Specific Guidance** section built from optional `ai_prompt` frontmatter in rule doc `.md` files. This allows per-rule customization of how the AI handles specific violations (e.g., instructing it to add `# noqa` for false-positive-prone rules rather than modifying code). Hints are loaded once at startup via `_load_ai_prompts()` with `lru_cache`. Rules without `ai_prompt` frontmatter use the default best-practices guidance.
+
+The LLM returns an `AINodeFix`:
 
 ```json
 {

--- a/docs/rules/RULE_DOC_FORMAT.md
+++ b/docs/rules/RULE_DOC_FORMAT.md
@@ -12,7 +12,7 @@ Rule `.md` files describe a single rule and provide examples that can be used bo
 
 1. **YAML frontmatter** (optional but recommended for test harness)
    - `rule_id` — Rule identifier (e.g. `L026`, `R102`, `L024`).
-   - `validator` — `native` or `opa`.
+   - `validator` — `native`, `opa`, or `ansible`.
    - `description` — One-line description.
    - `ai_prompt` — *(optional)* Per-rule guidance injected into the AI remediation prompt. Use YAML literal block (`|`) for multiline text. Tells the AI how to handle this rule — e.g., when to add `# noqa` instead of modifying code, or domain context about when the flagged pattern is legitimate. See `src/apme_engine/remediation/abbenay_provider.py` for how hints are loaded and injected.
 

--- a/docs/rules/RULE_DOC_FORMAT.md
+++ b/docs/rules/RULE_DOC_FORMAT.md
@@ -14,6 +14,7 @@ Rule `.md` files describe a single rule and provide examples that can be used bo
    - `rule_id` — Rule identifier (e.g. `L026`, `R102`, `L024`).
    - `validator` — `native` or `opa`.
    - `description` — One-line description.
+   - `ai_prompt` — *(optional)* Per-rule guidance injected into the AI remediation prompt. Use YAML literal block (`|`) for multiline text. Tells the AI how to handle this rule — e.g., when to add `# noqa` instead of modifying code, or domain context about when the flagged pattern is legitimate. See `src/apme_engine/remediation/abbenay_provider.py` for how hints are loaded and injected.
 
 2. **Title and prose** — Human-readable explanation of what the rule checks.
 

--- a/src/apme_engine/remediation/abbenay_provider.py
+++ b/src/apme_engine/remediation/abbenay_provider.py
@@ -458,6 +458,7 @@ def _load_ai_prompts() -> dict[str, str]:
             try:
                 fm = yaml.safe_load(m.group(1))
             except yaml.YAMLError:
+                logger.warning("Failed to parse YAML frontmatter in %s", md_path)
                 continue
             if not isinstance(fm, dict):
                 continue
@@ -466,7 +467,7 @@ def _load_ai_prompts() -> dict[str, str]:
             if rule_id and ai_prompt:
                 prompts[str(rule_id)] = str(ai_prompt).strip()
 
-    logger.info("Loaded ai_prompt hints for %d rules", len(prompts))
+    logger.debug("Loaded ai_prompt hints for %d rules", len(prompts))
     return prompts
 
 

--- a/src/apme_engine/remediation/abbenay_provider.py
+++ b/src/apme_engine/remediation/abbenay_provider.py
@@ -7,9 +7,11 @@ Install with: pip install apme-engine[ai]
 from __future__ import annotations
 
 import contextlib
+import functools
 import json
 import logging
 import os
+import re
 from importlib.resources import files as pkg_files
 from pathlib import Path
 
@@ -52,6 +54,8 @@ YAML task/block while following Ansible best practices.
 ## Violations
 
 {violation_list}
+
+{rule_guidance_section}
 
 ## YAML to fix
 ```yaml
@@ -96,6 +100,12 @@ Rules:
   improvements, or best-practice adjustments beyond what is required to resolve the
   listed violations. If a line is not related to a listed violation, preserve it
   exactly as-is — same quoting, same structure, same values.
+- Do NOT add new YAML keys, variables, blocks, or structural elements that were not
+  in the original snippet. Do NOT add default() filters, vars blocks, or register
+  variables unless a listed violation specifically requires it.
+- Adding "# noqa: <RULE_ID>" is a valid way to address a violation when the flagged
+  behavior is intentional and justified. When using noqa, your explanation MUST state
+  why the suppression is safe. Do not combine noqa with code changes for the same rule.
 - If none of the listed violations can be fixed, return the original snippet unchanged
   in fixed_snippet and put all violations in "skipped".
 - fixed_snippet must contain the COMPLETE corrected YAML, not a partial diff
@@ -118,6 +128,8 @@ expected and legitimate in this context).
 
 Rule: [{rule_id}] {message}
 File: {file_path}
+
+{rule_guidance_section}
 
 ## YAML Under Review
 ```yaml
@@ -163,6 +175,13 @@ def _build_validation_prompt(context: AINodeContext) -> str:
     rule_id = str(v.get("rule_id", ""))
     message = str(v.get("message", ""))
 
+    ai_prompts = _load_ai_prompts()
+    bare_id = rule_id.split(":")[-1] if ":" in rule_id else rule_id
+    hint = ai_prompts.get(bare_id)
+    rule_guidance = ""
+    if hint:
+        rule_guidance = f"## Rule-Specific Guidance\n\n**[{bare_id}]**: {hint}"
+
     parent_section = ""
     if context.parent_context:
         parent_section = f"## Inherited Context (from parent play/block)\n{context.parent_context}"
@@ -179,6 +198,7 @@ def _build_validation_prompt(context: AINodeContext) -> str:
         yaml_lines=context.yaml_lines,
         parent_context_section=parent_section,
         sibling_context_section=sibling_section,
+        rule_guidance_section=rule_guidance,
     )
 
 
@@ -249,6 +269,22 @@ def _build_node_prompt(context: AINodeContext) -> str:
     rule_ids = [str(v.get("rule_id", "")) for v in context.violations]
     best_practices = _get_best_practices_for_rules(rule_ids)
 
+    ai_prompts = _load_ai_prompts()
+    guidance_entries: list[str] = []
+    seen_rules: set[str] = set()
+    for v in context.violations:
+        rid = str(v.get("rule_id", ""))
+        bare = rid.split(":")[-1] if ":" in rid else rid
+        if bare and bare not in seen_rules:
+            hint = ai_prompts.get(bare)
+            if hint:
+                guidance_entries.append(f"**[{bare}]**: {hint}")
+                seen_rules.add(bare)
+
+    rule_guidance = ""
+    if guidance_entries:
+        rule_guidance = "## Rule-Specific Guidance\n\n" + "\n\n".join(guidance_entries)
+
     parent_section = ""
     if context.parent_context:
         parent_section = f"## Inherited Context (from parent play/block)\n{context.parent_context}"
@@ -271,6 +307,7 @@ def _build_node_prompt(context: AINodeContext) -> str:
         sibling_context_section=sibling_section,
         best_practices=best_practices,
         feedback_section=feedback_section,
+        rule_guidance_section=rule_guidance,
     )
 
 
@@ -385,6 +422,52 @@ def _load_best_practices() -> dict[str, list[str]]:
     loaded.pop("_meta", None)
     _BEST_PRACTICES = loaded
     return _BEST_PRACTICES
+
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+
+_VALIDATORS_ROOT = Path(__file__).resolve().parent.parent / "validators"
+_RULE_DOC_DIRS = [
+    _VALIDATORS_ROOT / "native" / "rules",
+    _VALIDATORS_ROOT / "opa" / "bundle",
+    _VALIDATORS_ROOT / "ansible" / "rules",
+]
+
+
+@functools.lru_cache(maxsize=1)
+def _load_ai_prompts() -> dict[str, str]:
+    """Load ``ai_prompt`` hints from rule doc frontmatter across all validators.
+
+    Walks native/rules, opa/bundle, and ansible/rules directories, parsing
+    YAML frontmatter with ``yaml.safe_load`` to support multiline values.
+    The result is cached for the process lifetime (consistent with
+    ``_load_best_practices``).
+
+    Returns:
+        Mapping of rule_id to ai_prompt text.
+    """
+    prompts: dict[str, str] = {}
+    for rule_dir in _RULE_DOC_DIRS:
+        if not rule_dir.is_dir():
+            continue
+        for md_path in rule_dir.glob("*.md"):
+            text = md_path.read_text(encoding="utf-8")
+            m = _FRONTMATTER_RE.match(text)
+            if not m:
+                continue
+            try:
+                fm = yaml.safe_load(m.group(1))
+            except yaml.YAMLError:
+                continue
+            if not isinstance(fm, dict):
+                continue
+            rule_id = fm.get("rule_id", "")
+            ai_prompt = fm.get("ai_prompt", "")
+            if rule_id and ai_prompt:
+                prompts[str(rule_id)] = str(ai_prompt).strip()
+
+    logger.info("Loaded ai_prompt hints for %d rules", len(prompts))
+    return prompts
 
 
 def _get_best_practices_for_rules(rule_ids: list[str]) -> str:

--- a/src/apme_engine/remediation/abbenay_provider.py
+++ b/src/apme_engine/remediation/abbenay_provider.py
@@ -96,10 +96,10 @@ Respond with ONLY this JSON (no markdown fences, no explanation outside JSON):
 }}
 
 Rules:
-- CRITICAL: Fix ONLY the violations listed above. Do NOT make any other changes,
-  improvements, or best-practice adjustments beyond what is required to resolve the
-  listed violations. If a line is not related to a listed violation, preserve it
-  exactly as-is — same quoting, same structure, same values.
+- CRITICAL: Fix ONLY the violations listed above. Every change you make MUST be
+  directly traceable to a specific listed violation. Do not make cosmetic, stylistic,
+  defensive, or "just in case" changes. If a line is not related to a listed
+  violation, preserve it exactly as-is — same quoting, same structure, same values.
 - Do NOT add new YAML keys, variables, blocks, or structural elements that were not
   in the original snippet. Do NOT add default() filters, vars blocks, or register
   variables unless a listed violation specifically requires it.

--- a/src/apme_engine/validators/native/rules/R101_command_exec.md
+++ b/src/apme_engine/validators/native/rules/R101_command_exec.md
@@ -3,6 +3,16 @@ rule_id: R101
 validator: native
 description: Task executes parameterized command (annotation-based)
 scope: task
+ai_prompt: |
+  This rule flags tasks that execute commands built from variables. Evaluate
+  whether the variable comes from a trusted source (role defaults, inventory,
+  well-known facts) or from untrusted user input. If the command construction
+  is safe and intentional, add "# noqa: R101" to the task line — but DO NOT
+  modify the command itself (no adding default filters, no re-quoting, no
+  refactoring). Your explanation MUST justify why the suppression is safe,
+  e.g. "variable comes from role defaults, not user input" or "command is
+  constructed from well-known facts." Only refactor the command if the
+  variable usage is clearly unsafe.
 ---
 
 ## Command exec (R101)

--- a/src/apme_engine/validators/native/rules/R103_download_exec.md
+++ b/src/apme_engine/validators/native/rules/R103_download_exec.md
@@ -3,6 +3,15 @@ rule_id: R103
 validator: native
 description: Task downloads and executes (annotation-based).
 scope: task
+ai_prompt: |
+  This rule flags download-then-execute patterns — a supply chain risk.
+  Check whether the download URL uses HTTPS from a trusted, pinned source
+  and whether the downloaded artifact is verified (checksum, GPG). If the
+  pattern is justified and verified, add "# noqa: R103" — but DO NOT
+  modify the task itself. Your explanation MUST justify why the pattern is
+  safe, e.g. "downloads from vendor HTTPS endpoint with checksum
+  verification." If verification is missing, suggest adding checksum
+  validation or using a package manager instead.
 ---
 
 ## Download exec (R103)

--- a/src/apme_engine/validators/native/rules/R104_unauthorized_download_src.md
+++ b/src/apme_engine/validators/native/rules/R104_unauthorized_download_src.md
@@ -3,6 +3,13 @@ rule_id: R104
 validator: native
 description: Download from unauthorized source (annotation-based).
 scope: task
+ai_prompt: |
+  This rule flags downloads from non-HTTPS URLs. If the URL targets
+  localhost, a private network, or an internal mirror that does not support
+  TLS, add "# noqa: R104" — but DO NOT modify the URL itself. Your
+  explanation MUST justify why plain HTTP is acceptable, e.g. "URL targets
+  localhost" or "internal mirror without TLS support." Otherwise, change
+  the URL scheme from http:// to https://.
 ---
 
 ## Unauthorized download (R104)

--- a/src/apme_engine/validators/native/rules/R105_outbound_transfer.md
+++ b/src/apme_engine/validators/native/rules/R105_outbound_transfer.md
@@ -3,6 +3,15 @@ rule_id: R105
 validator: native
 description: Outbound transfer (annotation-based).
 scope: task
+ai_prompt: |
+  This rule flags outbound data transfers to parameterized URLs. Evaluate
+  whether the destination is a well-known, trusted endpoint (e.g., an
+  internal API, a monitoring webhook). If the transfer is intentional and
+  the destination is trusted, add "# noqa: R105" — but DO NOT modify the
+  task itself. Your explanation MUST justify why the destination is safe,
+  e.g. "sends to internal monitoring API" or "webhook URL is defined in
+  group_vars." If the destination variable could be attacker-controlled,
+  flag it for the user.
 ---
 
 ## Outbound transfer (R105)

--- a/src/apme_engine/validators/native/rules/R108_privilege_escalation.md
+++ b/src/apme_engine/validators/native/rules/R108_privilege_escalation.md
@@ -3,6 +3,15 @@ rule_id: R108
 validator: native
 description: Privilege escalation (annotation-based).
 scope: play
+ai_prompt: |
+  This rule flags privilege escalation (become: true). Many tasks
+  legitimately require become — package installation, service management,
+  file ownership changes, and system configuration all need root. If the
+  task genuinely needs elevated privileges, add "# noqa: R108" to the task
+  line — but DO NOT modify the task itself. Your explanation MUST justify
+  why become is required, e.g. "task installs packages via dnf which
+  requires root" or "task manages systemd services." Only attempt to
+  remove become if the task clearly does not need elevated privileges.
 ---
 
 ## Privilege escalation (R108)

--- a/src/apme_engine/validators/opa/bundle/M006.md
+++ b/src/apme_engine/validators/opa/bundle/M006.md
@@ -3,6 +3,11 @@ rule_id: M006
 validator: opa
 description: become with ignore_errors will not catch timeout in 2.19+.
 scope: task
+ai_prompt: |
+  In ansible-core 2.19+, a become timeout raises UNREACHABLE instead of a
+  task error. If the task has both become: true and ignore_errors: true, add
+  "ignore_unreachable: true" alongside ignore_errors. Do not remove
+  ignore_errors — both are needed.
 ---
 
 ## Become timeout unreachable (M006)

--- a/tests/test_ai_escalation.py
+++ b/tests/test_ai_escalation.py
@@ -8,11 +8,15 @@ from pathlib import Path
 from unittest.mock import patch
 
 from apme_engine.remediation.abbenay_provider import (
+    _build_node_prompt,
+    _build_validation_prompt,
     _extract_json_object,
     _get_best_practices_for_rules,
+    _load_ai_prompts,
     _load_best_practices,
     discover_abbenay,
 )
+from apme_engine.remediation.ai_context import AINodeContext
 from apme_engine.remediation.ai_provider import (
     AISkipped,
 )
@@ -233,3 +237,157 @@ class TestBestPractices:
         """Returns combined practices for multiple rule categories."""
         result = _get_best_practices_for_rules(["M001", "L011"])
         assert "FQCN" in result
+
+
+# ---------------------------------------------------------------------------
+# Per-rule AI prompt hint tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAiPrompts:
+    """Tests for _load_ai_prompts() frontmatter parsing and prompt injection."""
+
+    def test_loads_from_real_rule_docs(self) -> None:
+        """Loads ai_prompt hints from seeded rule docs."""
+        _load_ai_prompts.cache_clear()
+        prompts = _load_ai_prompts()
+        assert "R108" in prompts
+        assert "privilege" in prompts["R108"].lower()
+        assert "R101" in prompts
+        assert "M006" in prompts
+        _load_ai_prompts.cache_clear()
+
+    def test_loads_from_temp_dir(self, tmp_path: Path) -> None:
+        """Parses ai_prompt from a synthetic rule doc in a temp directory.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        rule_md = tmp_path / "T999_test.md"
+        rule_md.write_text(
+            "---\nrule_id: T999\nai_prompt: |\n  Test hint for T999.\n---\n# T999\n",
+            encoding="utf-8",
+        )
+        _load_ai_prompts.cache_clear()
+        with patch(
+            "apme_engine.remediation.abbenay_provider._RULE_DOC_DIRS",
+            [tmp_path],
+        ):
+            prompts = _load_ai_prompts()
+        assert prompts == {"T999": "Test hint for T999."}
+        _load_ai_prompts.cache_clear()
+
+    def test_skips_missing_ai_prompt(self, tmp_path: Path) -> None:
+        """Rules without ai_prompt are not included in the map.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        rule_md = tmp_path / "L999.md"
+        rule_md.write_text(
+            "---\nrule_id: L999\ndescription: no hint\n---\n",
+            encoding="utf-8",
+        )
+        _load_ai_prompts.cache_clear()
+        with patch(
+            "apme_engine.remediation.abbenay_provider._RULE_DOC_DIRS",
+            [tmp_path],
+        ):
+            prompts = _load_ai_prompts()
+        assert "L999" not in prompts
+        _load_ai_prompts.cache_clear()
+
+    def test_bad_yaml_logged_and_skipped(self, tmp_path: Path) -> None:
+        """Malformed frontmatter is warned and skipped.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        rule_md = tmp_path / "BAD.md"
+        rule_md.write_text("---\n: : :\n---\n", encoding="utf-8")
+        _load_ai_prompts.cache_clear()
+        with patch(
+            "apme_engine.remediation.abbenay_provider._RULE_DOC_DIRS",
+            [tmp_path],
+        ):
+            prompts = _load_ai_prompts()
+        assert prompts == {}
+        _load_ai_prompts.cache_clear()
+
+    def test_node_prompt_includes_guidance(self, tmp_path: Path) -> None:
+        """Rule guidance section appears in the node prompt when ai_prompt exists.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        rule_md = tmp_path / "R999.md"
+        rule_md.write_text(
+            "---\nrule_id: R999\nai_prompt: |\n  Custom guidance.\n---\n",
+            encoding="utf-8",
+        )
+        _load_ai_prompts.cache_clear()
+        with patch(
+            "apme_engine.remediation.abbenay_provider._RULE_DOC_DIRS",
+            [tmp_path],
+        ):
+            ctx = AINodeContext(
+                node_id="task-1",
+                node_type="task",
+                file_path="test.yml",
+                yaml_lines="- name: test\n  ansible.builtin.debug:\n    msg: hi",
+                violations=[{"rule_id": "R999", "message": "test violation"}],
+            )
+            prompt = _build_node_prompt(ctx)
+        assert "Rule-Specific Guidance" in prompt
+        assert "Custom guidance." in prompt
+        _load_ai_prompts.cache_clear()
+
+    def test_validation_prompt_includes_guidance(self, tmp_path: Path) -> None:
+        """Rule guidance section appears in the validation prompt.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        rule_md = tmp_path / "R888.md"
+        rule_md.write_text(
+            "---\nrule_id: R888\nai_prompt: |\n  Validate carefully.\n---\n",
+            encoding="utf-8",
+        )
+        _load_ai_prompts.cache_clear()
+        with patch(
+            "apme_engine.remediation.abbenay_provider._RULE_DOC_DIRS",
+            [tmp_path],
+        ):
+            ctx = AINodeContext(
+                node_id="task-2",
+                node_type="task",
+                file_path="test.yml",
+                yaml_lines="- name: test\n  ansible.builtin.command: whoami",
+                violations=[{"rule_id": "R888", "message": "test finding"}],
+            )
+            prompt = _build_validation_prompt(ctx)
+        assert "Rule-Specific Guidance" in prompt
+        assert "Validate carefully." in prompt
+        _load_ai_prompts.cache_clear()
+
+    def test_no_guidance_when_no_hints(self, tmp_path: Path) -> None:
+        """No guidance section when no rules have ai_prompt.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        _load_ai_prompts.cache_clear()
+        with patch(
+            "apme_engine.remediation.abbenay_provider._RULE_DOC_DIRS",
+            [tmp_path],
+        ):
+            ctx = AINodeContext(
+                node_id="task-3",
+                node_type="task",
+                file_path="test.yml",
+                yaml_lines="- name: test\n  ansible.builtin.debug:\n    msg: hi",
+                violations=[{"rule_id": "ZZZZ", "message": "unknown rule"}],
+            )
+            prompt = _build_node_prompt(ctx)
+        assert "Rule-Specific Guidance" not in prompt
+        _load_ai_prompts.cache_clear()


### PR DESCRIPTION
## Summary
- Add per-rule AI prompt customization sourced from rule doc frontmatter, allowing rules to control how the AI handles their specific violations (e.g., when to noqa vs fix)
- Tighten shared prompt template to prevent gratuitous code changes, require every change be traceable to a listed violation, and legitimize noqa as a first-class fix strategy

## Changes
- **`abbenay_provider.py`**: Add `_load_ai_prompts()` with `@lru_cache(maxsize=1)` — walks native/opa/ansible rule doc dirs, parses YAML frontmatter with `yaml.safe_load`, returns `rule_id -> ai_prompt` map. Logs warning on malformed frontmatter, DEBUG on load count.
- **`NODE_PROMPT_TEMPLATE`** / **`VALIDATION_PROMPT_TEMPLATE`**: Add `{rule_guidance_section}` placeholder between Violations and YAML sections
- **`_build_node_prompt()`** / **`_build_validation_prompt()`**: Look up `ai_prompt` hints per violation, format into "Rule-Specific Guidance" section
- **Shared prompt rules**: Three new instructions:
  1. Every change must be directly traceable to a listed violation — no cosmetic/defensive/"just in case" changes
  2. Prohibit adding new YAML keys/vars/blocks not in the original snippet
  3. Legitimize `# noqa` as a valid fix with required justification; don't combine noqa with code changes for the same rule
- **Rule docs seeded**: R101 (command exec), R103 (download+exec), R104 (unauthorized download), R105 (outbound transfer), R108 (privilege escalation), M006 (become timeout)
- All `ai_prompt` values instruct the AI to justify noqa suppressions and not modify unrelated code
- **7 new unit tests** in `TestLoadAiPrompts`: real docs, temp dir, missing hints, malformed YAML, node prompt injection, validation prompt injection, no-hints case

## Quality of life
- Updated `.sdlc/templates/rule-doc.md` with commented-out `ai_prompt` field for future rule authors
- Updated `docs/rules/RULE_DOC_FORMAT.md` with `ai_prompt` frontmatter documentation and fixed validator values (added `ansible`)
- Updated `docs/design/DESIGN_REMEDIATION.md` Prompt Contract section (fixed lazy-load wording)

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2286 passed, 0 failures, 60.30% coverage)
- [x] Docs updated