### PR TITLE
fix(galaxy-proxy): use configured Galaxy servers for version discovery

### DIFF
--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -247,7 +247,12 @@ def create_app(
             versions = meta.versions
 
         if versions is None:
-            galaxy_versions = await _fetch_galaxy_versions(namespace, name)
+            _, servers_cfg, _ = _get_galaxy_config()
+            galaxy_versions = await _fetch_galaxy_versions(
+                namespace,
+                name,
+                servers=servers_cfg,
+            )
             if galaxy_versions:
                 cache.put_metadata(namespace, name, galaxy_versions)
                 versions = galaxy_versions
@@ -475,21 +480,75 @@ def _galaxy_version_sort_key(version: str) -> tuple[int, Version | str]:
         return (1, version)
 
 
-async def _fetch_galaxy_versions(namespace: str, name: str) -> list[str]:
+async def _fetch_galaxy_versions(
+    namespace: str,
+    name: str,
+    *,
+    servers: list[GalaxyServerConfig] | None = None,
+) -> list[str]:
     """Fetch all published version strings for a collection from Galaxy.
+
+    When *servers* is provided, each configured server is tried in order
+    (matching ``ansible.cfg`` ``server_list`` semantics).  The first
+    server to return a successful response wins.  If no configured server
+    succeeds — or if no servers are configured — falls back to public
+    Galaxy (``galaxy.ansible.com``).
+
+    This enables version discovery from console.redhat.com / Automation
+    Hub / private Galaxy instances configured via the Gateway UI.
 
     Args:
         namespace: Collection namespace.
         name: Collection name.
+        servers: Ordered list of Galaxy server configs (optional).
 
     Returns:
-        List of version strings, empty on error.
+        Sorted list of version strings, empty on error.
+    """
+    base_urls: list[tuple[str, str | None]] = []
+    for srv in servers or []:
+        base_urls.append((srv.url.rstrip("/"), srv.token))
+    base_urls.append((_GALAXY_API_URL, None))
+
+    for base_url, token in base_urls:
+        versions = await _fetch_versions_from(namespace, name, base_url, token=token)
+        if versions is not None:
+            return sorted(set(versions), key=_galaxy_version_sort_key)
+
+    return []
+
+
+async def _fetch_versions_from(
+    namespace: str,
+    name: str,
+    base_url: str,
+    *,
+    token: str | None = None,
+) -> list[str] | None:
+    """Fetch version strings from a single Galaxy-compatible server.
+
+    Args:
+        namespace: Collection namespace.
+        name: Collection name.
+        base_url: Base URL of the Galaxy API (no trailing slash).
+        token: Optional auth token for the server.
+
+    Returns:
+        List of version strings on success, or ``None`` on failure so
+        the caller can fall through to the next server.
     """
     versions: list[str] = []
-    url = f"{_GALAXY_API_URL}{_GALAXY_VERSIONS_PATH}/{namespace}/{name}/versions/"
+    url = f"{base_url}{_GALAXY_VERSIONS_PATH}/{namespace}/{name}/versions/"
     params: dict[str, str | int] = {"limit": 100, "offset": 0}
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Token {token}"
     try:
-        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(
+            timeout=15.0,
+            follow_redirects=True,
+            headers=headers,
+        ) as client:
             while True:
                 resp = await client.get(url, params=params)
                 resp.raise_for_status()
@@ -500,8 +559,15 @@ async def _fetch_galaxy_versions(namespace: str, name: str) -> list[str]:
                     break
                 params["offset"] = int(params["offset"]) + int(params["limit"])
     except (httpx.HTTPError, KeyError, ValueError) as exc:
-        logger.warning("Failed to fetch Galaxy versions for %s.%s: %s", namespace, name, exc)
-    return sorted(set(versions), key=_galaxy_version_sort_key)
+        logger.warning(
+            "Failed to fetch Galaxy versions for %s.%s from %s: %s",
+            namespace,
+            name,
+            base_url,
+            exc,
+        )
+        return None
+    return versions
 
 
 def _list_cached_wheels(cache: ProxyCache, namespace: str, name: str) -> list[str]:

--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -526,23 +526,30 @@ async def _fetch_galaxy_versions(
 
 
 def _normalize_galaxy_url(raw_url: str) -> str:
-    """Strip ansible.cfg-style ``/api/...`` suffixes so we can append our own path.
+    """Strip ansible.cfg-style ``/api/...`` suffixes from the URL path.
 
     Configured Galaxy servers often include ``/api/``, ``/api/galaxy/``,
     or ``/api/galaxy/content/...`` in their URL.  ``_GALAXY_VERSIONS_PATH``
     already starts with ``/api/v3/...``, so we must strip any leading
-    ``/api`` segment to avoid ``/api/api/v3/...``.
+    ``/api`` path segment to avoid ``/api/api/v3/...``.
+
+    Only the *path* component is inspected — hostnames like
+    ``https://api.example.com`` are preserved correctly.
 
     Args:
         raw_url: Server URL as provided by the user / Gateway config.
 
     Returns:
-        Base URL with trailing ``/api...`` segments removed.
+        Base URL with ``/api...`` path segments removed.
     """
-    url = raw_url.rstrip("/")
-    if "/api" in url:
-        url = url[: url.index("/api")]
-    return url
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(raw_url)
+    path = parts.path.rstrip("/")
+    idx = path.find("/api")
+    if idx != -1:
+        path = path[:idx]
+    return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
 
 
 async def _fetch_versions_from(

--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -518,6 +518,26 @@ async def _fetch_galaxy_versions(
     return []
 
 
+def _normalize_galaxy_url(raw_url: str) -> str:
+    """Strip ansible.cfg-style ``/api/...`` suffixes so we can append our own path.
+
+    Configured Galaxy servers often include ``/api/``, ``/api/galaxy/``,
+    or ``/api/galaxy/content/...`` in their URL.  ``_GALAXY_VERSIONS_PATH``
+    already starts with ``/api/v3/...``, so we must strip any leading
+    ``/api`` segment to avoid ``/api/api/v3/...``.
+
+    Args:
+        raw_url: Server URL as provided by the user / Gateway config.
+
+    Returns:
+        Base URL with trailing ``/api...`` segments removed.
+    """
+    url = raw_url.rstrip("/")
+    if "/api" in url:
+        url = url[: url.index("/api")]
+    return url
+
+
 async def _fetch_versions_from(
     namespace: str,
     name: str,
@@ -538,7 +558,8 @@ async def _fetch_versions_from(
         the caller can fall through to the next server.
     """
     versions: list[str] = []
-    url = f"{base_url}{_GALAXY_VERSIONS_PATH}/{namespace}/{name}/versions/"
+    normalized = _normalize_galaxy_url(base_url)
+    url = f"{normalized}{_GALAXY_VERSIONS_PATH}/{namespace}/{name}/versions/"
     params: dict[str, str | int] = {"limit": 100, "offset": 0}
     headers: dict[str, str] = {}
     if token:

--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -515,6 +515,13 @@ async def _fetch_galaxy_versions(
         if versions is not None:
             return sorted(set(versions), key=_galaxy_version_sort_key)
 
+    tried = [u for u, _ in base_urls]
+    logger.warning(
+        "All Galaxy servers failed for %s.%s (tried: %s)",
+        namespace,
+        name,
+        ", ".join(tried),
+    )
     return []
 
 
@@ -580,11 +587,11 @@ async def _fetch_versions_from(
                     break
                 params["offset"] = int(params["offset"]) + int(params["limit"])
     except (httpx.HTTPError, KeyError, ValueError) as exc:
-        logger.warning(
-            "Failed to fetch Galaxy versions for %s.%s from %s: %s",
+        logger.debug(
+            "Version fetch from %s failed for %s.%s: %s",
+            base_url,
             namespace,
             name,
-            base_url,
             exc,
         )
         return None

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import unittest.mock
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -355,6 +356,195 @@ class TestAdminGalaxyConfig:
             json={"servers": [{"name": "hub", "url": "https://a.com"}, {"name": "HUB", "url": "https://b.com"}]},
         )
         assert resp.status_code == 422
+
+
+class TestVersionDiscoveryWithServers:
+    """Tests for _fetch_galaxy_versions using configured Galaxy servers."""
+
+    def test_version_discovery_uses_configured_server(self, tmp_path: Path) -> None:
+        """Version discovery queries configured servers before public Galaxy.
+
+        Args:
+            tmp_path: Pytest-provided temporary directory.
+        """
+        from galaxy_proxy.collection_downloader import GalaxyServerConfig
+
+        cache_dir = tmp_path / "cache"
+        application = create_app(cache_dir=cache_dir, enable_passthrough=False)
+
+        with TestClient(application) as client:
+            client.post(
+                "/admin/galaxy-config",
+                json={"servers": [{"name": "hub", "url": "https://hub.example.com", "token": "tok"}]},
+            )
+
+            mock_fetch = AsyncMock(return_value=["2.0.0", "1.0.0"])
+            with patch("galaxy_proxy.proxy.server._fetch_galaxy_versions", mock_fetch):
+                resp = client.get("/simple/ansible-collection-ansible-posix/")
+
+            assert resp.status_code == 200
+            mock_fetch.assert_called_once()
+            call_kwargs = mock_fetch.call_args
+            servers = call_kwargs.kwargs.get("servers") or call_kwargs[1].get("servers")
+            assert servers is not None
+            assert len(servers) == 1
+            assert isinstance(servers[0], GalaxyServerConfig)
+            assert servers[0].url == "https://hub.example.com"
+            assert servers[0].token == "tok"
+
+    def test_version_discovery_falls_back_to_public_galaxy(self, tmp_path: Path) -> None:
+        """Without configured servers, version discovery falls back to public Galaxy.
+
+        Args:
+            tmp_path: Pytest-provided temporary directory.
+        """
+        cache_dir = tmp_path / "cache"
+        application = create_app(cache_dir=cache_dir, enable_passthrough=False)
+
+        mock_fetch = AsyncMock(return_value=["1.5.4"])
+        with (
+            TestClient(application) as client,
+            patch("galaxy_proxy.proxy.server._fetch_galaxy_versions", mock_fetch),
+        ):
+            resp = client.get("/simple/ansible-collection-ansible-posix/")
+
+        assert resp.status_code == 200
+        call_kwargs = mock_fetch.call_args
+        servers = call_kwargs.kwargs.get("servers") or call_kwargs[1].get("servers")
+        assert servers is None
+
+    def test_fetch_versions_tries_servers_in_order(self) -> None:
+        """_fetch_galaxy_versions tries configured servers before public Galaxy.
+
+        Verifies that the first successful server short-circuits further attempts.
+        """
+        import asyncio
+
+        from galaxy_proxy.collection_downloader import GalaxyServerConfig
+        from galaxy_proxy.proxy.server import _fetch_galaxy_versions
+
+        servers = [
+            GalaxyServerConfig(name="hub", url="https://hub.example.com", token="tok"),
+        ]
+
+        with patch(
+            "galaxy_proxy.proxy.server._fetch_versions_from",
+            new_callable=AsyncMock,
+            return_value=["3.0.0", "2.0.0"],
+        ) as mock_inner:
+            result = asyncio.run(
+                _fetch_galaxy_versions("ansible", "posix", servers=servers),
+            )
+
+        assert result == ["2.0.0", "3.0.0"]
+        mock_inner.assert_called_once_with(
+            "ansible",
+            "posix",
+            "https://hub.example.com",
+            token="tok",
+        )
+
+    def test_fetch_versions_falls_through_on_failure(self) -> None:
+        """When a configured server fails, _fetch_galaxy_versions tries the next.
+
+        Private server returns None (failure), public Galaxy returns versions.
+        """
+        import asyncio
+
+        from galaxy_proxy.collection_downloader import GalaxyServerConfig
+        from galaxy_proxy.proxy.server import _fetch_galaxy_versions
+
+        servers = [
+            GalaxyServerConfig(name="hub", url="https://hub.example.com", token="tok"),
+        ]
+
+        async def _side_effect(
+            ns: str,
+            name: str,
+            base_url: str,
+            *,
+            token: str | None = None,
+        ) -> list[str] | None:
+            if base_url == "https://hub.example.com":
+                return None
+            return ["1.5.4"]
+
+        with patch(
+            "galaxy_proxy.proxy.server._fetch_versions_from",
+            new_callable=AsyncMock,
+            side_effect=_side_effect,
+        ) as mock_inner:
+            result = asyncio.run(
+                _fetch_galaxy_versions("ansible", "posix", servers=servers),
+            )
+
+        assert result == ["1.5.4"]
+        assert mock_inner.call_count == 2
+
+    def test_fetch_versions_sends_auth_token(self) -> None:
+        """_fetch_versions_from passes the auth token in the Authorization header.
+
+        Verifies the httpx client is configured with the token.
+        """
+        import asyncio
+
+        from galaxy_proxy.proxy.server import _fetch_versions_from
+
+        captured_headers: dict[str, str] = {}
+
+        def _capture_client(**kwargs: object) -> unittest.mock.MagicMock:
+            hdrs = kwargs.get("headers")
+            if isinstance(hdrs, dict):
+                captured_headers.update(hdrs)
+            mock_resp = unittest.mock.MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"data": [{"version": "1.0.0"}], "links": {}}
+            mock_resp.raise_for_status.return_value = None
+
+            client = unittest.mock.MagicMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            return client
+
+        with patch("galaxy_proxy.proxy.server.httpx.AsyncClient", side_effect=_capture_client):
+            result = asyncio.run(
+                _fetch_versions_from("ansible", "posix", "https://hub.example.com", token="secret"),
+            )
+
+        assert result == ["1.0.0"]
+        assert captured_headers["Authorization"] == "Token secret"
+
+    def test_fetch_versions_no_token_no_auth_header(self) -> None:
+        """_fetch_versions_from omits Authorization header when no token is provided."""
+        import asyncio
+
+        from galaxy_proxy.proxy.server import _fetch_versions_from
+
+        captured_headers: dict[str, str] = {}
+
+        def _capture_client(**kwargs: object) -> unittest.mock.MagicMock:
+            hdrs = kwargs.get("headers")
+            if isinstance(hdrs, dict):
+                captured_headers.update(hdrs)
+            mock_resp = unittest.mock.MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"data": [{"version": "2.0.0"}], "links": {}}
+            mock_resp.raise_for_status.return_value = None
+
+            client = unittest.mock.MagicMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            return client
+
+        with patch("galaxy_proxy.proxy.server.httpx.AsyncClient", side_effect=_capture_client):
+            result = asyncio.run(
+                _fetch_versions_from("ansible", "posix", "https://galaxy.ansible.com"),
+            )
+
+        assert result == ["2.0.0"]
+        assert "Authorization" not in captured_headers
 
 
 class TestConvertTarballs:

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -546,6 +546,101 @@ class TestVersionDiscoveryWithServers:
         assert result == ["2.0.0"]
         assert "Authorization" not in captured_headers
 
+    @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+        ("raw_url", "expected"),
+        [
+            ("https://galaxy.ansible.com", "https://galaxy.ansible.com"),
+            ("https://galaxy.ansible.com/", "https://galaxy.ansible.com"),
+            ("https://galaxy.ansible.com/api/", "https://galaxy.ansible.com"),
+            ("https://hub.example.com/api/galaxy/", "https://hub.example.com"),
+            (
+                "https://hub.example.com/api/galaxy/content/published/",
+                "https://hub.example.com",
+            ),
+            ("https://console.redhat.com/api/automation-hub", "https://console.redhat.com"),
+        ],
+    )
+    def test_normalize_galaxy_url(self, raw_url: str, expected: str) -> None:
+        """_normalize_galaxy_url strips /api... suffixes from server URLs.
+
+        Args:
+            raw_url: Input URL to normalize.
+            expected: Expected normalized URL.
+        """
+        from galaxy_proxy.proxy.server import _normalize_galaxy_url
+
+        assert _normalize_galaxy_url(raw_url) == expected
+
+    def test_fetch_versions_from_normalizes_api_url(self) -> None:
+        """_fetch_versions_from normalizes URLs that include /api/ to avoid /api/api/v3/...."""
+        import asyncio
+
+        from galaxy_proxy.proxy.server import _fetch_versions_from
+
+        captured_urls: list[str] = []
+
+        def _capture_client(**kwargs: object) -> unittest.mock.MagicMock:
+            mock_resp = unittest.mock.MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"data": [{"version": "1.0.0"}], "links": {}}
+            mock_resp.raise_for_status.return_value = None
+
+            async def _get(url: str, **kw: object) -> unittest.mock.MagicMock:
+                captured_urls.append(url)
+                return mock_resp
+
+            client = unittest.mock.MagicMock()
+            client.get = _get
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            return client
+
+        with patch("galaxy_proxy.proxy.server.httpx.AsyncClient", side_effect=_capture_client):
+            result = asyncio.run(
+                _fetch_versions_from(
+                    "ansible",
+                    "posix",
+                    "https://hub.example.com/api/",
+                    token="tok",
+                ),
+            )
+
+        assert result == ["1.0.0"]
+        assert len(captured_urls) == 1
+        assert "/api/api/" not in captured_urls[0]
+        assert "/api/v3/plugin/ansible/" in captured_urls[0]
+
+    def test_version_discovery_with_api_url_through_project_page(self, tmp_path: Path) -> None:
+        """Version discovery handles configured server URLs that include /api/.
+
+        Args:
+            tmp_path: Pytest-provided temporary directory.
+        """
+        from galaxy_proxy.collection_downloader import GalaxyServerConfig
+
+        cache_dir = tmp_path / "cache"
+        application = create_app(cache_dir=cache_dir, enable_passthrough=False)
+
+        with TestClient(application) as client:
+            client.post(
+                "/admin/galaxy-config",
+                json={"servers": [{"name": "hub", "url": "https://hub.example.com/api/", "token": "tok"}]},
+            )
+
+            mock_fetch = AsyncMock(return_value=["2.0.0", "1.0.0"])
+            with patch("galaxy_proxy.proxy.server._fetch_galaxy_versions", mock_fetch):
+                resp = client.get("/simple/ansible-collection-ansible-posix/")
+
+            assert resp.status_code == 200
+            mock_fetch.assert_called_once()
+            call_kwargs = mock_fetch.call_args
+            servers = call_kwargs.kwargs.get("servers") or call_kwargs[1].get("servers")
+            assert servers is not None
+            assert len(servers) == 1
+            assert isinstance(servers[0], GalaxyServerConfig)
+            assert servers[0].url == "https://hub.example.com/api/"
+            assert servers[0].token == "tok"
+
 
 class TestConvertTarballs:
     """Tests for POST /convert-tarballs endpoint."""

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -558,6 +558,9 @@ class TestVersionDiscoveryWithServers:
                 "https://hub.example.com",
             ),
             ("https://console.redhat.com/api/automation-hub", "https://console.redhat.com"),
+            ("https://api.example.com", "https://api.example.com"),
+            ("https://api.example.com/", "https://api.example.com"),
+            ("https://api.galaxy.example.com/api/", "https://api.galaxy.example.com"),
         ],
     )
     def test_normalize_galaxy_url(self, raw_url: str, expected: str) -> None:


### PR DESCRIPTION
## Summary
- Version discovery (`_fetch_galaxy_versions`) was hardcoded to `galaxy.ansible.com`, even when private Galaxy servers (console.redhat.com, Automation Hub) were configured via the Gateway UI
- Collection downloads already used configured servers, but the PEP 503 index page's version listing did not — this closes that gap

## Changes
- **`_fetch_galaxy_versions`** now accepts an optional `servers: list[GalaxyServerConfig]` parameter; tries each configured server in order (with auth tokens) before falling back to public Galaxy
- Extracted **`_fetch_versions_from`** as a single-server helper that returns `None` on failure for clean fallthrough
- **`project_page`** handler now passes the configured Galaxy servers from app state to version discovery (via `_get_galaxy_config()`)
- Added 6 tests in `TestVersionDiscoveryWithServers`: server passthrough, fallback behavior, server ordering, failure fallthrough, auth token injection, and no-token case

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (all 27 proxy tests pass; pre-existing failures in rule_doc_integration_test and test_session_venv_e2e are unrelated)

Closes #261

Made with [Cursor](https://cursor.com)