### PR TITLE
docs(readme): clarify quick start install and daemon mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,19 @@ Six app containers, one pod. All inter-service communication is gRPC. The Galaxy
 
 ## Quick start
 
-### Local development (no containers)
+### Install
 
 ```bash
-# Install tox (one-time)
-uv tool install tox --with tox-uv
+pip install apme-engine
+```
 
-# Run a check (user-facing); engine runs the internal scan pipeline
+The CLI automatically starts a local daemon with all validators when you run a
+command. No containers required for basic usage.
+
+### Basic usage
+
+```bash
+# Scan a playbook or project
 apme check /path/to/playbook-or-project
 
 # JSON output
@@ -148,11 +154,12 @@ apme remediate --ai --auto-approve /path/to/playbook-or-project
 
 ### Container deployment (Podman)
 
-The full pod runs 9 containers: engine services (Primary, Native, OPA, Ansible,
+For the web UI, persistent scan history, or AI-assisted remediation, run the
+full pod. This is also required for APME development.
+
+The pod runs 9 containers: engine services (Primary, Native, OPA, Ansible,
 Gitleaks, Galaxy Proxy), Gateway (REST API + persistence), UI (React dashboard),
-and Abbenay (AI provider). Pod management scripts (`build.sh`, `up.sh`,
-`down.sh`, `wait-for-pod.sh`) run from the **repo root**. The CLI helper
-`run-cli.sh` runs from the directory you want to scan.
+and Abbenay (AI provider).
 
 ```
 Container        Port   Role

--- a/README.md
+++ b/README.md
@@ -103,9 +103,17 @@ Six app containers, one pod. All inter-service communication is gRPC. The Galaxy
 ### Install
 
 ```bash
-pip install apme-engine
+# Install a specific release (recommended)
+pip install apme-engine@git+https://github.com/ansible/apme.git@v2026.4.1
+
+# Install with AI escalation support
+pip install "apme-engine[ai] @ git+https://github.com/ansible/apme.git@v2026.4.1"
+
+# Install the latest development version (main branch)
+pip install apme-engine@git+https://github.com/ansible/apme.git@main
 ```
 
+Replace the tag with any [release version](https://github.com/ansible/apme/releases).
 The CLI automatically starts a local daemon with all validators when you run a
 command. No containers required for basic usage.
 


### PR DESCRIPTION
## Summary

- Add explicit "Install" section showing `pip install apme-engine`
- Explain that CLI auto-starts local daemon (no containers needed for basic usage)
- Clarify when container deployment is needed (UI, persistence, AI, development)

## Problem

The quick start section was confusing:
- Listed `tox` install but didn't explain how to install APME itself
- Running `apme check` failed with "command not found" because install step was missing
- Unclear whether containers were required for basic CLI usage

## Test plan

- [ ] Verify `pip install apme-engine && apme check .` works on clean system
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)