### PR TITLE
feat(helm): OpenShift compatibility and operational improvements

### DIFF
--- a/deploy/helm/apme/Chart.yaml
+++ b/deploy/helm/apme/Chart.yaml
@@ -3,6 +3,9 @@ name: apme
 description: Ansible Policy & Modernization Engine — policy enforcement and modernization for Ansible content
 type: application
 version: 0.1.0
+# appVersion is informational only.  CI publishes images tagged by git SHA
+# (e.g. "sha-7cb2464"), NOT by this semver string.  Always set image.tag in
+# your values override to a real published tag.
 appVersion: "0.2.10"
 home: https://github.com/ansible/apme
 sources:

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -38,7 +38,7 @@ Ingress:
 
 Access the UI via port-forward:
   kubectl port-forward svc/{{ include "apme.fullname" . }}-ui 8081:8081
-  open http://localhost:8081
+  Then browse to: http://localhost:8081
 
 Access the Gateway API:
   kubectl port-forward svc/{{ include "apme.fullname" . }}-gateway 8080:8080

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -1,0 +1,47 @@
+APME has been installed.
+
+Components deployed:
+  - Engine (Primary + Native + OPA + Ansible + Galaxy Proxy)
+{{- if .Values.gitleaks.enabled }}
+  - Gitleaks validator
+{{- end }}
+{{- if .Values.collectionHealth.enabled }}
+  - Collection Health validator
+{{- end }}
+{{- if .Values.depAudit.enabled }}
+  - Dependency Audit validator
+{{- end }}
+  - Gateway (REST API + gRPC reporting)
+  - UI (React SPA)
+{{- if .Values.abbenay.enabled }}
+  - Abbenay AI provider
+{{- end }}
+
+{{- if .Values.route.enabled }}
+
+OpenShift Routes:
+  UI:      https://{{ .Values.route.host | default "<auto-assigned>" }}/
+  API:     https://{{ .Values.route.host | default "<auto-assigned>" }}/api
+{{- else if .Values.ingress.enabled }}
+
+Ingress:
+{{- range .Values.ingress.hosts }}
+  Host: {{ .host }}
+{{- end }}
+{{- else }}
+
+Access the UI via port-forward:
+  kubectl port-forward svc/{{ include "apme.fullname" . }}-ui 8081:8081
+  open http://localhost:8081
+
+Access the Gateway API:
+  kubectl port-forward svc/{{ include "apme.fullname" . }}-gateway 8080:8080
+  curl http://localhost:8080/api/v1/dashboard/summary
+{{- end }}
+
+{{- if not .Values.image.tag }}
+
+WARNING: image.tag is not set. The chart falls back to appVersion
+({{ .Chart.AppVersion }}) which may not match a published image tag.
+Set image.tag to a valid tag (e.g. a git SHA like "sha-7cb2464").
+{{- end }}

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -20,8 +20,14 @@ Components deployed:
 {{- if .Values.route.enabled }}
 
 OpenShift Routes:
-  UI:      https://{{ .Values.route.host | default "<auto-assigned>" }}/
-  API:     https://{{ .Values.route.host | default "<auto-assigned>" }}/api
+{{- if .Values.route.host }}
+  UI:      https://{{ .Values.route.host }}/
+  API:     https://{{ .Values.route.host }}/api
+{{- else }}
+  Route hosts are auto-assigned by OpenShift and may differ per Route.
+  To view the actual hosts, run:
+    oc get route
+{{- end }}
 {{- else if .Values.ingress.enabled }}
 
 Ingress:

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -36,11 +36,18 @@ Ingress:
 {{- end }}
 {{- else }}
 
-Access the UI via port-forward:
+No Ingress or Route is enabled.
+
+UI port-forward (static assets only):
   kubectl port-forward svc/{{ include "apme.fullname" . }}-ui 8081:8081
   Then browse to: http://localhost:8081
 
-Access the Gateway API:
+NOTE: The UI makes same-origin requests to /api/v1/... which will not
+reach the Gateway when only the UI Service is port-forwarded.
+For a fully functional browser UI, enable Ingress or an OpenShift Route
+so that /api is routed to the Gateway Service.
+
+Access the Gateway API directly via port-forward:
   kubectl port-forward svc/{{ include "apme.fullname" . }}-gateway 8080:8080
   curl http://localhost:8080/api/v1/dashboard/summary
 {{- end }}

--- a/deploy/helm/apme/templates/abbenay-deployment.yaml
+++ b/deploy/helm/apme/templates/abbenay-deployment.yaml
@@ -23,14 +23,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "apme.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: abbenay
           image: {{ .Values.abbenay.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args: ["daemon", "--grpc-host", "0.0.0.0", "--grpc-port", "50057"]
           env:
             - name: APME_ABBENAY_TOKEN

--- a/deploy/helm/apme/templates/engine-deployment.yaml
+++ b/deploy/helm/apme/templates/engine-deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     app.kubernetes.io/component: engine
 spec:
   replicas: {{ .Values.engine.replicas }}
+  {{- with .Values.engine.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "apme.selectorLabels" . | nindent 6 }}
@@ -26,15 +30,19 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "apme.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         # -- Primary orchestrator
         - name: primary
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "primary" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: APME_PRIMARY_LISTEN
               value: "0.0.0.0:50051"
@@ -77,6 +85,16 @@ spec:
             - name: grpc
               containerPort: 50051
               protocol: TCP
+          readinessProbe:
+            grpc:
+              port: 50051
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: 50051
+            initialDelaySeconds: 15
+            periodSeconds: 30
           volumeMounts:
             - name: sessions
               mountPath: /sessions
@@ -87,11 +105,23 @@ spec:
         - name: native
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "native" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: APME_NATIVE_VALIDATOR_LISTEN
               value: "0.0.0.0:50055"
+          readinessProbe:
+            grpc:
+              port: 50055
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: 50055
+            initialDelaySeconds: 15
+            periodSeconds: 30
           resources:
             {{- toYaml .Values.engine.resources.native | nindent 12 }}
 
@@ -99,11 +129,23 @@ spec:
         - name: opa
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "opa" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: APME_OPA_VALIDATOR_LISTEN
               value: "0.0.0.0:50054"
+          readinessProbe:
+            grpc:
+              port: 50054
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: 50054
+            initialDelaySeconds: 15
+            periodSeconds: 30
           resources:
             {{- toYaml .Values.engine.resources.opa | nindent 12 }}
 
@@ -111,13 +153,25 @@ spec:
         - name: ansible
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "ansible" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: APME_ANSIBLE_VALIDATOR_LISTEN
               value: "0.0.0.0:50053"
             - name: APME_GALAXY_PROXY_URL
               value: "http://127.0.0.1:8765"
+          readinessProbe:
+            grpc:
+              port: 50053
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: 50053
+            initialDelaySeconds: 15
+            periodSeconds: 30
           volumeMounts:
             - name: sessions
               mountPath: /sessions
@@ -130,11 +184,23 @@ spec:
         - name: gitleaks
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "gitleaks" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: APME_GITLEAKS_VALIDATOR_LISTEN
               value: "0.0.0.0:50056"
+          readinessProbe:
+            grpc:
+              port: 50056
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: 50056
+            initialDelaySeconds: 15
+            periodSeconds: 30
           resources:
             {{- toYaml .Values.engine.resources.gitleaks | nindent 12 }}
         {{- end }}
@@ -144,11 +210,23 @@ spec:
         - name: collection-health
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "collection-health" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: APME_COLLECTION_HEALTH_VALIDATOR_LISTEN
               value: "0.0.0.0:50058"
+          readinessProbe:
+            grpc:
+              port: 50058
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: 50058
+            initialDelaySeconds: 15
+            periodSeconds: 30
           volumeMounts:
             - name: sessions
               mountPath: /sessions
@@ -162,11 +240,23 @@ spec:
         - name: dep-audit
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "dep-audit" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: APME_DEP_AUDIT_VALIDATOR_LISTEN
               value: "0.0.0.0:50059"
+          readinessProbe:
+            grpc:
+              port: 50059
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: 50059
+            initialDelaySeconds: 15
+            periodSeconds: 30
           volumeMounts:
             - name: sessions
               mountPath: /sessions
@@ -179,8 +269,20 @@ spec:
         - name: galaxy-proxy
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "galaxy-proxy" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          readinessProbe:
+            tcpSocket:
+              port: 8765
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8765
+            initialDelaySeconds: 10
+            periodSeconds: 30
           volumeMounts:
             - name: proxy-cache
               mountPath: /cache
@@ -212,5 +314,9 @@ spec:
       {{- end }}
       {{- with .Values.engine.affinity }}
       affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.engine.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/apme/templates/engine-deployment.yaml
+++ b/deploy/helm/apme/templates/engine-deployment.yaml
@@ -86,12 +86,12 @@ spec:
               containerPort: 50051
               protocol: TCP
           readinessProbe:
-            grpc:
+            tcpSocket:
               port: 50051
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            grpc:
+            tcpSocket:
               port: 50051
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -113,12 +113,12 @@ spec:
             - name: APME_NATIVE_VALIDATOR_LISTEN
               value: "0.0.0.0:50055"
           readinessProbe:
-            grpc:
+            tcpSocket:
               port: 50055
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            grpc:
+            tcpSocket:
               port: 50055
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -137,12 +137,12 @@ spec:
             - name: APME_OPA_VALIDATOR_LISTEN
               value: "0.0.0.0:50054"
           readinessProbe:
-            grpc:
+            tcpSocket:
               port: 50054
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            grpc:
+            tcpSocket:
               port: 50054
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -163,12 +163,12 @@ spec:
             - name: APME_GALAXY_PROXY_URL
               value: "http://127.0.0.1:8765"
           readinessProbe:
-            grpc:
+            tcpSocket:
               port: 50053
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            grpc:
+            tcpSocket:
               port: 50053
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -192,12 +192,12 @@ spec:
             - name: APME_GITLEAKS_VALIDATOR_LISTEN
               value: "0.0.0.0:50056"
           readinessProbe:
-            grpc:
+            tcpSocket:
               port: 50056
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            grpc:
+            tcpSocket:
               port: 50056
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -218,12 +218,12 @@ spec:
             - name: APME_COLLECTION_HEALTH_VALIDATOR_LISTEN
               value: "0.0.0.0:50058"
           readinessProbe:
-            grpc:
+            tcpSocket:
               port: 50058
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            grpc:
+            tcpSocket:
               port: 50058
             initialDelaySeconds: 15
             periodSeconds: 30
@@ -248,12 +248,12 @@ spec:
             - name: APME_DEP_AUDIT_VALIDATOR_LISTEN
               value: "0.0.0.0:50059"
           readinessProbe:
-            grpc:
+            tcpSocket:
               port: 50059
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            grpc:
+            tcpSocket:
               port: 50059
             initialDelaySeconds: 15
             periodSeconds: 30

--- a/deploy/helm/apme/templates/gateway-deployment.yaml
+++ b/deploy/helm/apme/templates/gateway-deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     app.kubernetes.io/component: gateway
 spec:
   replicas: {{ .Values.gateway.replicas }}
+  {{- with .Values.gateway.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "apme.selectorLabels" . | nindent 6 }}
@@ -29,14 +33,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "apme.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: gateway
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "gateway" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: APME_PRIMARY_ADDRESS
               value: "{{ include "apme.fullname" . }}-engine:50051"

--- a/deploy/helm/apme/templates/networkpolicy.yaml
+++ b/deploy/helm/apme/templates/networkpolicy.yaml
@@ -58,8 +58,7 @@ spec:
       ports:
         - port: 8080
           protocol: TCP
-    - from: []
-      ports:
+    - ports:
         - port: 8080
           protocol: TCP
 ---
@@ -78,8 +77,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - from: []
-      ports:
+    - ports:
         - port: 8081
           protocol: TCP
 {{- end }}

--- a/deploy/helm/apme/templates/networkpolicy.yaml
+++ b/deploy/helm/apme/templates/networkpolicy.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "apme.fullname" . }}-engine
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: engine
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "apme.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: engine
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "apme.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: gateway
+      ports:
+        - port: 50051
+          protocol: TCP
+        - port: 50058
+          protocol: TCP
+        - port: 50059
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "apme.fullname" . }}-gateway
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "apme.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "apme.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: ui
+      ports:
+        - port: 8080
+          protocol: TCP
+    - from: []
+      ports:
+        - port: 8080
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "apme.fullname" . }}-ui
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "apme.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ui
+  policyTypes:
+    - Ingress
+  ingress:
+    - from: []
+      ports:
+        - port: 8081
+          protocol: TCP
+{{- end }}

--- a/deploy/helm/apme/templates/networkpolicy.yaml
+++ b/deploy/helm/apme/templates/networkpolicy.yaml
@@ -46,6 +46,14 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "apme.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: engine
+      ports:
+        - port: 50060
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "apme.selectorLabels" . | nindent 14 }}
               app.kubernetes.io/component: ui
       ports:
         - port: 8080

--- a/deploy/helm/apme/templates/pdb.yaml
+++ b/deploy/helm/apme/templates/pdb.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "apme.fullname" . }}-engine
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: engine
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "apme.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: engine
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "apme.fullname" . }}-gateway
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "apme.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "apme.fullname" . }}-ui
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "apme.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ui
+{{- end }}

--- a/deploy/helm/apme/templates/route.yaml
+++ b/deploy/helm/apme/templates/route.yaml
@@ -22,7 +22,9 @@ spec:
     targetPort: http
   tls:
     termination: {{ .Values.route.tls.termination | default "edge" }}
+    {{- if ne (.Values.route.tls.termination | default "edge") "passthrough" }}
     insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy | default "Redirect" }}
+    {{- end }}
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -48,5 +50,7 @@ spec:
     targetPort: http
   tls:
     termination: {{ .Values.route.tls.termination | default "edge" }}
+    {{- if ne (.Values.route.tls.termination | default "edge") "passthrough" }}
     insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy | default "Redirect" }}
+    {{- end }}
 {{- end }}

--- a/deploy/helm/apme/templates/route.yaml
+++ b/deploy/helm/apme/templates/route.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "apme.fullname" . }}-ui
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "apme.fullname" . }}-ui
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: {{ .Values.route.tls.termination | default "edge" }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy | default "Redirect" }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "apme.fullname" . }}-api
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  path: /api
+  to:
+    kind: Service
+    name: {{ include "apme.fullname" . }}-gateway
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: {{ .Values.route.tls.termination | default "edge" }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy | default "Redirect" }}
+{{- end }}

--- a/deploy/helm/apme/templates/route.yaml
+++ b/deploy/helm/apme/templates/route.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.route.enabled }}
+{{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
+{{- fail "route.enabled is true but the cluster does not provide the route.openshift.io/v1 API (not an OpenShift cluster?)" }}
+{{- end }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/deploy/helm/apme/templates/ui-deployment.yaml
+++ b/deploy/helm/apme/templates/ui-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: init-nginx-conf
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "ui" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["sh", "-c", "cp /etc/nginx/conf.d/* /mnt/conf.d/ 2>/dev/null || true"]
+          command: ["sh", "-c", "cp -a /etc/nginx/conf.d/. /mnt/conf.d/"]
           volumeMounts:
             - name: nginx-conf
               mountPath: /mnt/conf.d

--- a/deploy/helm/apme/templates/ui-deployment.yaml
+++ b/deploy/helm/apme/templates/ui-deployment.yaml
@@ -26,8 +26,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "apme.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: init-nginx-conf
+          image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "ui" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-c", "cp /etc/nginx/conf.d/* /mnt/conf.d/ 2>/dev/null || true"]
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /mnt/conf.d
       containers:
         - name: ui
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "ui" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
@@ -52,8 +62,22 @@ spec:
               port: http
             initialDelaySeconds: 3
             periodSeconds: 10
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: nginx-conf
+          emptyDir: {}
       {{- with .Values.ui.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -5,6 +5,10 @@
 
 image:
   registry: ghcr.io/ansible
+  # -- Image tag for all APME containers.
+  # CI publishes images with git SHA tags (e.g. "sha-7cb2464").
+  # Set this explicitly; the fallback is Chart.yaml appVersion which is
+  # informational and may not correspond to a published image tag.
   tag: ""
   pullPolicy: IfNotPresent
 
@@ -15,6 +19,9 @@ fullnameOverride: ""
 # -- Engine stack (Primary + all validators + Galaxy Proxy)
 engine:
   replicas: 1
+  # Recreate avoids RWO PVC conflicts during rolling updates
+  strategy:
+    type: Recreate
   resources:
     primary:
       requests:
@@ -75,6 +82,16 @@ engine:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # -- Spread engine pods across nodes when replicas > 1 (or HPA is active).
+  # Example:
+  #   topologySpreadConstraints:
+  #     - maxSkew: 1
+  #       topologyKey: kubernetes.io/hostname
+  #       whenUnsatisfiable: ScheduleAnyway
+  #       labelSelector:
+  #         matchLabels:
+  #           app.kubernetes.io/component: engine
+  topologySpreadConstraints: []
 
 # -- Gitleaks is optional (requires external binary in the image)
 gitleaks:
@@ -91,6 +108,9 @@ depAudit:
 # -- Gateway (REST + gRPC reporting + SQLite persistence)
 gateway:
   replicas: 1
+  # Recreate avoids RWO PVC conflicts during rolling updates
+  strategy:
+    type: Recreate
   resources:
     requests:
       cpu: 250m
@@ -107,9 +127,10 @@ gateway:
     githubToken: ""
 
 # -- UI (nginx-served React SPA)
-# The default nginx image requires writable /var/run and /var/cache, so
-# the container securityContext omits runAsNonRoot to avoid startup failures.
-# Override with a non-root context once the image supports unprivileged mode.
+# The stock nginx image requires writable /var/run, /var/cache/nginx, and
+# /etc/nginx/conf.d.  The chart mounts emptyDir volumes for these paths so
+# the container works under OCP restricted-v2 SCC (arbitrary non-root UID).
+# For a proper long-term fix, rebuild the image on nginxinc/nginx-unprivileged.
 ui:
   replicas: 1
   securityContext: {}
@@ -172,6 +193,15 @@ ingress:
           service: ui
   tls: []
 
+# -- OpenShift Route (alternative to Ingress for OCP clusters)
+route:
+  enabled: false
+  host: ""
+  annotations: {}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+
 # -- Horizontal Pod Autoscaler for the engine Deployment
 autoscaling:
   enabled: false
@@ -180,14 +210,28 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 80
 
+# -- Network policies for inter-service traffic (OCP clusters with default-deny)
+networkPolicy:
+  enabled: false
+
+# -- PodDisruptionBudgets (protect availability during node drains)
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
 serviceAccount:
   create: true
   annotations: {}
   name: ""
 
 podAnnotations: {}
-podSecurityContext:
-  fsGroup: 1000
-securityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
+
+# -- Pod-level security context.
+# Defaults to empty so OCP restricted-v2 SCC can inject its own UID/GID range.
+# For vanilla Kubernetes set: podSecurityContext: { fsGroup: 1000 }
+podSecurityContext: {}
+
+# -- Container-level security context.
+# Defaults to empty so OCP restricted-v2 SCC can inject its own UID/GID range.
+# For vanilla Kubernetes set: securityContext: { runAsNonRoot: true, runAsUser: 1000 }
+securityContext: {}

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -194,6 +194,10 @@ ingress:
   tls: []
 
 # -- OpenShift Route (alternative to Ingress for OCP clusters)
+# Set route.host to serve the UI and API on the same domain (e.g.
+# "apme.apps.ocp.example.com").  When host is empty, OpenShift
+# auto-assigns a different host per Route and the UI/API will be on
+# separate domains.
 route:
   enabled: false
   host: ""

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -203,6 +203,10 @@ route:
   host: ""
   annotations: {}
   tls:
+    # Only "edge" termination is supported out of the box — backend services
+    # (UI nginx, Gateway FastAPI) serve plain HTTP.  "reencrypt" and
+    # "passthrough" require TLS-enabled backends and are not supported
+    # without custom container builds.
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
 

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -19,7 +19,9 @@ fullnameOverride: ""
 # -- Engine stack (Primary + all validators + Galaxy Proxy)
 engine:
   replicas: 1
-  # Recreate avoids RWO PVC conflicts during rolling updates
+  # Recreate avoids RWO PVC conflicts during single-replica rolling updates.
+  # Multi-replica deployments use emptyDir (no PVC conflict) and can safely
+  # override this to RollingUpdate for zero-downtime upgrades.
   strategy:
     type: Recreate
   resources:


### PR DESCRIPTION
## Summary

- Make the Helm chart deploy cleanly on OpenShift 4.x with the `restricted-v2` SCC by removing hardcoded UID/GID defaults and making securityContext blocks conditional
- Add missing operational primitives (health probes, NetworkPolicies, PDBs, Routes, NOTES.txt, deployment strategy, topology spread) for production readiness on both OCP and vanilla Kubernetes

## Changes

### Critical fixes
- **Conditional securityContext** — All pod-level and container-level `securityContext` blocks now use `{{- with }}` guards, and `values.yaml` defaults to empty maps. Setting `podSecurityContext: {}` / `securityContext: {}` cleanly omits the blocks, letting OCP SCC inject namespace-allocated UIDs. Vanilla K8s users can still set explicit values in overrides.
- **UI nginx writable paths** — Mounts `emptyDir` volumes for `/var/cache/nginx`, `/var/run`, and `/etc/nginx/conf.d` plus an `initContainer` (using `cp -a conf.d/.`) to seed the nginx config. Resolves `CrashLoopBackOff` on OCP where containers run as arbitrary non-root UIDs.
- **appVersion documentation** — `Chart.yaml` and `NOTES.txt` now document that `appVersion` is informational only and warn when `image.tag` is unset (CI publishes SHA tags, not semver).

### Medium improvements
- **OpenShift Route template** — `route.yaml` with separate routes for UI and Gateway API, gated on `route.enabled` (default `false`). Supports TLS termination and custom annotations. Documents that `route.host` must be set for shared UI/API domain; prints `oc get route` guidance when hosts are auto-assigned.
- **Engine health probes** — `tcpSocket` readiness + liveness probes on all 8 engine containers. Uses TCP (not native gRPC probes) because the services expose a custom Health RPC rather than the standard `grpc.health.v1.Health/Check`. Follow-up to add standard health servicer: #293.

### Low/operational improvements
- **NetworkPolicy templates** — Gated on `networkPolicy.enabled`. Allows engine→gateway reporting (port 50060), UI→gateway, and ingress from any source to gateway (8080) and UI (8081).
- **Deployment strategy** — Engine and gateway default to `Recreate` to avoid RWO PVC conflicts during rolling updates.
- **NOTES.txt** — Post-install output listing deployed components, access instructions (port-forward / ingress / route with `oc get route` guidance for auto-assigned hosts), and image tag warnings.
- **PodDisruptionBudget templates** — Gated on `podDisruptionBudget.enabled` with configurable `minAvailable`.
- **Topology spread constraints** — Configurable `topologySpreadConstraints` on the engine deployment for multi-replica scenarios.

## Test plan
- [x] `helm template` renders cleanly with default values (empty securityContext)
- [x] `helm template` renders correct securityContext when overrides are provided
- [x] `helm template --set route.enabled=true,networkPolicy.enabled=true,podDisruptionBudget.enabled=true` renders all OCP resources (2 Routes, 3 NetworkPolicies, 3 PDBs)
- [x] `helm install --dry-run` produces correct NOTES.txt output (with and without image.tag, with and without route.host)
- [x] 16 tcpSocket probes rendered (readiness + liveness × 8 containers), 0 grpc probes
- [x] Zero `securityContext` entries rendered when defaults are empty (OCP path)
- [x] Gateway NetworkPolicy includes port 50060 for engine→gateway reporting
- [x] No `from: []` in NetworkPolicies (verified gateway/UI allow from any source)
- [ ] `tox -e lint` passes (Helm-only changes — no Python files touched)
- [ ] `tox -e unit` passes (Helm-only changes — no Python files touched)