### PR TITLE
ci(containers): add semver image tags on release and remove path filters

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -40,8 +40,8 @@ jobs:
           tags: |
             type=sha
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}
-            type=semver,pattern={{major}},enable=${{ github.ref_type == 'tag' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+            type=semver,pattern={{major}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
 
       - id: base-ref
@@ -103,8 +103,8 @@ jobs:
           tags: |
             type=sha
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}
-            type=semver,pattern={{major}},enable=${{ github.ref_type == 'tag' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+            type=semver,pattern={{major}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
 
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -3,14 +3,8 @@ name: Container Images
 on:
   push:
     branches: [main]
-    paths:
-      - "containers/**"
-      - "src/**"
-      - "pyproject.toml"
-      - "uv.lock"
-      - "frontend/**"
-      - "proto/**"
-      - ".github/workflows/container-images.yml"
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
 
 permissions:
@@ -45,7 +39,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-base
           tags: |
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}
+            type=semver,pattern={{major}},enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
 
       - id: base-ref
         run: echo "image=${{ env.REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-base:${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
@@ -105,7 +102,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-${{ matrix.image.name }}
           tags: |
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}
+            type=semver,pattern={{major}},enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
 
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:


### PR DESCRIPTION
## Summary

Extends the existing container-images workflow to produce semver-tagged images on release, so `latest` always points to the last stable tagged release rather than the latest main commit.

## Changes

- **Tag trigger**: workflow now also runs on `v*.*.*` tag pushes
- **Semver tags on release**: stable releases get `{{version}}`, `{{major}}.{{minor}}`, `{{major}}`, and `latest` tags; pre-release tags (e.g. `v1.0.0-rc.1`) only get the full `{{version}}` tag
- **No `latest` on main**: removed `latest` from branch pushes — main builds produce SHA-only tags
- **Path filters removed**: every merge to main rebuilds all images (simpler, no missed rebuilds)

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` — 1 pre-existing failure on upstream/main (`test_no_marker_returns_target`), unrelated to this change
- [x] Workflow YAML is syntactically valid
- [ ] Verify tag push produces expected semver image tags (post-merge)