### PR TITLE
feat(gateway): support inline scm_token for PR creation

### DIFF
--- a/src/apme_gateway/api/router.py
+++ b/src/apme_gateway/api/router.py
@@ -1488,7 +1488,8 @@ async def create_pull_request(
                 detail="No patched files found for this activity",
             )
 
-    token = project.scm_token or cfg.scm_token
+    # Token priority: inline request > project config > global env
+    token = body.scm_token or project.scm_token or cfg.scm_token
     if not token:
         raise HTTPException(
             status_code=422,

--- a/src/apme_gateway/api/schemas.py
+++ b/src/apme_gateway/api/schemas.py
@@ -617,11 +617,13 @@ class CreatePullRequestRequest(BaseModel):  # type: ignore[misc]
         branch_name: Name for the new branch (default auto-generated).
         title: PR title (default auto-generated from remediation stats).
         body: PR body in Markdown (default auto-generated).
+        scm_token: One-time SCM token for this PR (overrides project/global token).
     """
 
     branch_name: str | None = None
     title: str | None = None
     body: str | None = None
+    scm_token: str | None = None
 
 
 class CreatePullRequestResponse(BaseModel):  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Allow clients to pass a one-time SCM token in the PR creation request body, enabling UI prompts for tokens when not pre-configured (e.g., Backstage plugin).

## Changes

- `schemas.py`: Added `scm_token` field to `CreatePullRequestRequest`
- `router.py`: Updated token resolution to check `body.scm_token` first
- Token priority: inline request > project config > global env

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` — 1 pre-existing failure on upstream/main (`test_no_marker_returns_target`), unrelated
- [x] Existing project/global token behavior unchanged (inline token is `None` by default)
- [x] PR creation works with inline token (tested via Backstage plugin)