### PR TITLE
docs: add installation section with pip+git tagged releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ Six app containers, one pod. All inter-service communication is gRPC. The Galaxy
 
 ## Quick start
 
+### Installation
+
+```bash
+# Install a specific release (recommended)
+pip install apme-engine@git+https://github.com/ansible/apme.git@v2026.4.1
+
+# Install with AI escalation support
+pip install "apme-engine[ai] @ git+https://github.com/ansible/apme.git@v2026.4.1"
+
+# Install the latest development version (main branch)
+pip install apme-engine@git+https://github.com/ansible/apme.git@main
+```
+
+Replace the tag with any [release version](https://github.com/ansible/apme/releases).
+
 ### Local development (no containers)
 
 ```bash


### PR DESCRIPTION
## Summary

The README Quick Start section jumped straight into CLI usage without showing how to install the package. Now that we have tagged releases, users need to know how to install from a specific version.

## Changes

- Added an **Installation** subsection under Quick Start showing:
  - `pip install` from a tagged release via Git URL (e.g. `@v2026.4.1`)
  - Install with the `[ai]` extra for AI escalation support
  - Install from `main` for the latest dev version
- Links to the GitHub releases page for version discovery

## Test plan

- [x] `tox -e lint` passes
- [x] Markdown renders correctly