### PR TITLE
feat(gateway): SCM token support for private repository operations

### DIFF
--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -126,6 +126,7 @@ async def initiate_operation(project_id: str, body: OperateRequest) -> OperateRe
             options=body.options,
             scan_id=scan_id,
             galaxy_servers=galaxy_servers,
+            scm_token=proj.scm_token or cfg.scm_token,
         )
     )
     state.grpc_task = task
@@ -417,6 +418,7 @@ async def _drive_operation(
     options: dict[str, Any],
     scan_id: str,
     galaxy_servers: Any = None,
+    scm_token: str | None = None,
 ) -> None:
     """Background task that clones the repo and drives Primary's FixSession.
 
@@ -433,13 +435,14 @@ async def _drive_operation(
         options: Client-supplied options.
         scan_id: Engine scan identifier.
         galaxy_servers: Galaxy server defs.
+        scm_token: Optional SCM token for private repository access.
     """
     from apme_gateway.scan.driver import fetch_remote_head, run_project_operation
 
     registry = get_operation_registry()
 
     try:
-        await fetch_remote_head(repo_url, branch)
+        await fetch_remote_head(repo_url, branch, scm_token=scm_token)
 
         registry.transition(operation_id, OperationStatus.CLONING)
 
@@ -588,6 +591,7 @@ async def _drive_operation(
             approval_queue=approval_queue,
             scan_id=scan_id,
             galaxy_servers=galaxy_servers or None,
+            scm_token=scm_token,
         )
 
         if bridge_task is not None:

--- a/src/apme_gateway/api/router.py
+++ b/src/apme_gateway/api/router.py
@@ -571,7 +571,11 @@ async def get_project_detail(project_id: str) -> ProjectDetail:
 
     has_new = False
     if proj.last_scanned_commit:
-        remote_sha = await fetch_remote_head(proj.repo_url, proj.branch)
+        from apme_gateway.config import load_config
+
+        cfg = load_config()
+        token = proj.scm_token or cfg.scm_token
+        remote_sha = await fetch_remote_head(proj.repo_url, proj.branch, scm_token=token)
         if remote_sha and remote_sha != proj.last_scanned_commit:
             has_new = True
 
@@ -1489,7 +1493,9 @@ async def create_pull_request(
             )
 
     # Token priority: inline request > project config > global env
-    token = body.scm_token or project.scm_token or cfg.scm_token
+    # Strip whitespace to prevent whitespace-only tokens overriding valid fallbacks
+    inline_token = body.scm_token.strip() if body.scm_token else None
+    token = inline_token or project.scm_token or cfg.scm_token
     if not token:
         raise HTTPException(
             status_code=422,
@@ -2240,7 +2246,9 @@ async def project_operate_ws(
             await websocket.send_json({"type": "error", "message": "Project not found"})
             return
 
-        remote_sha = await fetch_remote_head(proj.repo_url, proj.branch)
+        cfg = load_config()
+        scm_token = proj.scm_token or cfg.scm_token
+        remote_sha = await fetch_remote_head(proj.repo_url, proj.branch, scm_token=scm_token)
         if remote_sha and proj.last_scanned_commit and remote_sha != proj.last_scanned_commit:
             await websocket.send_json(
                 {
@@ -2251,7 +2259,6 @@ async def project_operate_ws(
                 }
             )
 
-        cfg = load_config()
         galaxy_servers = await load_galaxy_server_defs()
 
         op_scan_id = uuid.uuid4().hex
@@ -2398,6 +2405,7 @@ async def project_operate_ws(
                     approval_queue=approval_queue,
                     scan_id=op_scan_id,
                     galaxy_servers=galaxy_servers or None,
+                    scm_token=scm_token,
                 )
 
             op_task = asyncio.create_task(_run_op())
@@ -2440,6 +2448,7 @@ async def project_operate_ws(
                 progress_callback=_progress_cb,
                 scan_id=op_scan_id,
                 galaxy_servers=galaxy_servers or None,
+                scm_token=scm_token,
             )
             completed_scan_id = scan_id
 

--- a/src/apme_gateway/scan/driver.py
+++ b/src/apme_gateway/scan/driver.py
@@ -20,6 +20,7 @@ import time
 import uuid
 from collections.abc import AsyncIterator, Callable, Coroutine
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import grpc
 import grpc.aio
@@ -76,7 +77,28 @@ def _git_subprocess_env() -> dict[str, str]:
     return env
 
 
-async def fetch_remote_head(repo_url: str, branch: str) -> str | None:
+def _inject_token_in_url(repo_url: str, token: str) -> str:
+    """Inject an authentication token into an HTTPS git URL.
+
+    Converts ``https://github.com/owner/repo`` to
+    ``https://x-access-token:TOKEN@github.com/owner/repo``.
+
+    Args:
+        repo_url: Original HTTPS clone URL.
+        token: SCM token (e.g., GitHub PAT).
+
+    Returns:
+        URL with embedded credentials.
+    """
+    parsed = urlparse(repo_url)
+    # Use x-access-token as username (GitHub convention), token as password
+    netloc_with_auth = f"x-access-token:{token}@{parsed.hostname}"
+    if parsed.port:
+        netloc_with_auth += f":{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc_with_auth))
+
+
+async def fetch_remote_head(repo_url: str, branch: str, scm_token: str | None = None) -> str | None:
     """Query the remote for the HEAD commit SHA of *branch* without cloning.
 
     Uses ``git ls-remote`` which only contacts the server for ref advertisement.
@@ -86,6 +108,7 @@ async def fetch_remote_head(repo_url: str, branch: str) -> str | None:
     Args:
         repo_url: HTTPS clone URL.
         branch: Branch name to resolve.
+        scm_token: Optional SCM token for private repository access.
 
     Returns:
         40-char hex SHA, or ``None`` if the lookup fails.
@@ -99,7 +122,9 @@ async def fetch_remote_head(repo_url: str, branch: str) -> str | None:
     if cached and (now - cached[0]) < _REMOTE_HEAD_TTL:
         return cached[1]
 
-    cmd = ["git", "ls-remote", "--exit-code", repo_url, f"refs/heads/{branch}"]
+    # Inject token for private repo access
+    effective_url = _inject_token_in_url(repo_url, scm_token) if scm_token else repo_url
+    cmd = ["git", "ls-remote", "--exit-code", effective_url, f"refs/heads/{branch}"]
     loop = asyncio.get_running_loop()
     sha: str | None = None
     try:
@@ -153,7 +178,7 @@ def get_clone_head(clone_dir: str) -> str | None:
     return None
 
 
-async def clone_repo(repo_url: str, branch: str, dest: str) -> None:
+async def clone_repo(repo_url: str, branch: str, dest: str, scm_token: str | None = None) -> None:
     """Shallow-clone an SCM repo into *dest*.
 
     Only ``https://`` URLs are permitted to prevent SSRF via ``file://``,
@@ -163,6 +188,7 @@ async def clone_repo(repo_url: str, branch: str, dest: str) -> None:
         repo_url: HTTPS clone URL.
         branch: Branch to check out.
         dest: Target directory (must not already exist).
+        scm_token: Optional SCM token for private repository access.
 
     Raises:
         ValueError: If *repo_url* uses a disallowed scheme.
@@ -176,6 +202,9 @@ async def clone_repo(repo_url: str, branch: str, dest: str) -> None:
         msg = f"Invalid branch name: {branch[:60]}"
         raise ValueError(msg)
 
+    # Inject token for private repo access
+    effective_url = _inject_token_in_url(repo_url, scm_token) if scm_token else repo_url
+
     cmd = [
         "git",
         "clone",
@@ -184,7 +213,7 @@ async def clone_repo(repo_url: str, branch: str, dest: str) -> None:
         "--single-branch",
         "--depth",
         "1",
-        repo_url,
+        effective_url,
         dest,
     ]
     loop = asyncio.get_running_loop()
@@ -220,6 +249,7 @@ async def run_project_operation(
     approval_queue: asyncio.Queue[list[str]] | None = None,
     scan_id: str | None = None,
     galaxy_servers: list[GalaxyServerDef] | None = None,
+    scm_token: str | None = None,
 ) -> tuple[str, primary_pb2.SessionResult | None, str]:
     """Clone a project repo and run check or remediate via Primary ``FixSession``.
 
@@ -240,6 +270,7 @@ async def run_project_operation(
         approval_queue: Queue of approved proposal IDs (remediate mode, when AI proposes).
         scan_id: Optional pre-generated scan ID; one is created if omitted.
         galaxy_servers: Global Galaxy server defs to inject into scan metadata (ADR-045).
+        scm_token: Optional SCM token for private repository access.
 
     Returns:
         Tuple of (scan_id, SessionResult or None, clone_commit_sha).
@@ -252,7 +283,7 @@ async def run_project_operation(
     temp_dir = tempfile.mkdtemp(prefix=prefix)
 
     try:
-        await clone_repo(repo_url, branch, temp_dir)
+        await clone_repo(repo_url, branch, temp_dir, scm_token=scm_token)
         clone_sha = get_clone_head(temp_dir) or ""
 
         chunks = list(
@@ -341,6 +372,7 @@ async def run_project_scan(
     progress_callback: ProgressCallback | None = None,
     scan_id: str | None = None,
     galaxy_servers: list[GalaxyServerDef] | None = None,
+    scm_token: str | None = None,
 ) -> tuple[str, primary_pb2.SessionResult | None, str]:
     """Backward-compatible alias for check mode.
 
@@ -357,6 +389,7 @@ async def run_project_scan(
         progress_callback: Optional async callable for each ``SessionEvent``.
         scan_id: Optional pre-generated scan ID.
         galaxy_servers: Global Galaxy server defs to inject (ADR-045).
+        scm_token: Optional SCM token for private repository access.
 
     Returns:
         Tuple of (scan_id, SessionResult or None, clone_commit_sha).
@@ -372,6 +405,7 @@ async def run_project_scan(
         progress_callback=progress_callback,
         scan_id=scan_id,
         galaxy_servers=galaxy_servers,
+        scm_token=scm_token,
     )
 
 
@@ -389,6 +423,7 @@ async def run_project_fix(
     approval_queue: asyncio.Queue[list[str]] | None = None,
     scan_id: str | None = None,
     galaxy_servers: list[GalaxyServerDef] | None = None,
+    scm_token: str | None = None,
 ) -> tuple[str, primary_pb2.SessionResult | None, str]:
     """Backward-compatible alias for remediate mode.
 
@@ -408,6 +443,7 @@ async def run_project_fix(
         approval_queue: Queue of approved proposal IDs.
         scan_id: Optional pre-generated scan ID.
         galaxy_servers: Global Galaxy server defs to inject (ADR-045).
+        scm_token: Optional SCM token for private repository access.
 
     Returns:
         Tuple of (scan_id, SessionResult or None, clone_commit_sha).
@@ -426,4 +462,5 @@ async def run_project_fix(
         approval_queue=approval_queue,
         scan_id=scan_id,
         galaxy_servers=galaxy_servers,
+        scm_token=scm_token,
     )

--- a/src/apme_gateway/scan/driver.py
+++ b/src/apme_gateway/scan/driver.py
@@ -21,7 +21,7 @@ import time
 import uuid
 from collections.abc import AsyncIterator, Callable, Coroutine
 from typing import Any
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 import grpc
 import grpc.aio
@@ -123,7 +123,9 @@ def _inject_token_in_url(repo_url: str, token: str) -> str:
     else:
         username = "git"
 
-    netloc_with_auth = f"{username}:{token}@{hostname}"
+    # Percent-encode token to handle special characters (@, :, /, etc.)
+    encoded_token = quote(token, safe="")
+    netloc_with_auth = f"{username}:{encoded_token}@{hostname}"
     if parsed.port:
         netloc_with_auth += f":{parsed.port}"
     return urlunparse(parsed._replace(netloc=netloc_with_auth))
@@ -147,7 +149,9 @@ async def fetch_remote_head(repo_url: str, branch: str, scm_token: str | None = 
     if not any(repo_url.startswith(scheme) for scheme in _ALLOWED_SCHEMES):
         return None
 
-    cache_key = f"{repo_url}:{branch}"
+    # Include token presence in cache key to avoid mixing authenticated/unauthenticated results
+    token_marker = ":auth" if scm_token else ""
+    cache_key = f"{repo_url}:{branch}{token_marker}"
     now = time.monotonic()
     cached = _REMOTE_HEAD_CACHE.get(cache_key)
     if cached and (now - cached[0]) < _REMOTE_HEAD_TTL:

--- a/src/apme_gateway/scan/driver.py
+++ b/src/apme_gateway/scan/driver.py
@@ -13,6 +13,7 @@ import asyncio
 import hashlib
 import logging
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -52,6 +53,23 @@ _REMOTE_HEAD_CACHE: dict[str, tuple[float, str | None]] = {}
 _REMOTE_HEAD_TTL = 60.0  # seconds
 _REMOTE_HEAD_CACHE_MAX = 256
 
+_CRED_REDACT_RE = re.compile(r"(https?://)[^@]+@")
+
+
+def _redact_credentials(text: str) -> str:
+    """Redact embedded credentials from URLs in text.
+
+    Replaces ``https://user:token@host`` with ``https://[REDACTED]@host``
+    to prevent token exposure in logs or error messages.
+
+    Args:
+        text: Text potentially containing URLs with credentials.
+
+    Returns:
+        Text with credentials redacted.
+    """
+    return _CRED_REDACT_RE.sub(r"\1[REDACTED]@", text)
+
 
 def _git_subprocess_env() -> dict[str, str]:
     """Return environment variables for git subprocesses.
@@ -80,19 +98,32 @@ def _git_subprocess_env() -> dict[str, str]:
 def _inject_token_in_url(repo_url: str, token: str) -> str:
     """Inject an authentication token into an HTTPS git URL.
 
-    Converts ``https://github.com/owner/repo`` to
-    ``https://x-access-token:TOKEN@github.com/owner/repo``.
+    Supports multiple SCM providers with their respective auth schemes:
+    - GitHub: ``x-access-token:TOKEN``
+    - GitLab: ``oauth2:TOKEN``
+    - Bitbucket: ``x-token-auth:TOKEN``
+    - Others: ``git:TOKEN`` (generic fallback)
 
     Args:
         repo_url: Original HTTPS clone URL.
-        token: SCM token (e.g., GitHub PAT).
+        token: SCM token (e.g., PAT, OAuth token).
 
     Returns:
         URL with embedded credentials.
     """
     parsed = urlparse(repo_url)
-    # Use x-access-token as username (GitHub convention), token as password
-    netloc_with_auth = f"x-access-token:{token}@{parsed.hostname}"
+    hostname = parsed.hostname or ""
+
+    if "github" in hostname:
+        username = "x-access-token"
+    elif "gitlab" in hostname:
+        username = "oauth2"
+    elif "bitbucket" in hostname:
+        username = "x-token-auth"
+    else:
+        username = "git"
+
+    netloc_with_auth = f"{username}:{token}@{hostname}"
     if parsed.port:
         netloc_with_auth += f":{parsed.port}"
     return urlunparse(parsed._replace(netloc=netloc_with_auth))
@@ -228,7 +259,8 @@ async def clone_repo(repo_url: str, branch: str, dest: str, scm_token: str | Non
         ),
     )
     if result.returncode != 0:
-        raise RuntimeError(f"git clone failed (exit {result.returncode}): {result.stderr[:500]}")
+        safe_stderr = _redact_credentials(result.stderr[:500])
+        raise RuntimeError(f"git clone failed (exit {result.returncode}): {safe_stderr}")
 
 
 ProgressCallback = Callable[[primary_pb2.SessionEvent], Coroutine[Any, Any, None]]

--- a/tests/test_scan_driver.py
+++ b/tests/test_scan_driver.py
@@ -266,6 +266,19 @@ class TestInjectTokenInUrl:
         url = _inject_token_in_url("https://github.com/org/sub/repo.git", "token")
         assert url == "https://x-access-token:token@github.com/org/sub/repo.git"
 
+    def test_encodes_special_characters(self) -> None:
+        """Special characters in tokens are percent-encoded."""
+        url = _inject_token_in_url("https://github.com/owner/repo.git", "token@with:special/chars")
+        # @ becomes %40, : becomes %3A, / becomes %2F
+        assert "token%40with%3Aspecial%2Fchars" in url
+        assert "@github.com" in url  # The auth separator @ is preserved
+
+    def test_encodes_hash_and_question(self) -> None:
+        """Hash and question mark in tokens are encoded to prevent URL parsing issues."""
+        url = _inject_token_in_url("https://github.com/owner/repo.git", "token#with?chars")
+        assert "%23" in url  # # encoded
+        assert "%3F" in url  # ? encoded
+
 
 class TestRedactCredentials:
     """Tests for _redact_credentials helper."""
@@ -362,3 +375,40 @@ async def test_fetch_remote_head_with_scm_token() -> None:
     assert sha == fake_sha
     call_args = mock_run.call_args[0][0]
     assert "oauth2:glpat-test@gitlab.com" in call_args[3]
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_fetch_remote_head_cache_separates_auth_and_unauth() -> None:
+    """Verify cache keys differentiate authenticated vs unauthenticated requests."""
+    fake_sha_unauth = "a" * 40
+    fake_sha_auth = "b" * 40
+    _REMOTE_HEAD_CACHE.clear()
+
+    with (
+        patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
+        patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
+    ):
+        # First call: unauthenticated
+        result_unauth = MagicMock()
+        result_unauth.returncode = 0
+        result_unauth.stdout = f"{fake_sha_unauth}\trefs/heads/main\n"
+        mock_run.return_value = result_unauth
+        mock_loop.return_value.run_in_executor = AsyncMock(side_effect=lambda _exec, func: func())
+
+        sha1 = await fetch_remote_head("https://github.com/owner/repo.git", "main")
+        assert sha1 == fake_sha_unauth
+
+        # Second call: authenticated (different token, should NOT use cached unauth result)
+        result_auth = MagicMock()
+        result_auth.returncode = 0
+        result_auth.stdout = f"{fake_sha_auth}\trefs/heads/main\n"
+        mock_run.return_value = result_auth
+
+        sha2 = await fetch_remote_head(
+            "https://github.com/owner/repo.git",
+            "main",
+            scm_token="ghp_secret",
+        )
+        # Should make a new request, not return cached unauthenticated result
+        assert sha2 == fake_sha_auth
+        assert mock_run.call_count == 2

--- a/tests/test_scan_driver.py
+++ b/tests/test_scan_driver.py
@@ -13,6 +13,8 @@ from apme.v1 import primary_pb2
 from apme_gateway.scan.driver import (
     _REMOTE_HEAD_CACHE,
     _git_subprocess_env,
+    _inject_token_in_url,
+    _redact_credentials,
     clone_repo,
     derive_session_id,
     fetch_remote_head,
@@ -229,3 +231,134 @@ def test_get_clone_head_invalid_dir_returns_none() -> None:
     with tempfile.TemporaryDirectory() as td:
         sha = get_clone_head(td)
         assert sha is None
+
+
+class TestInjectTokenInUrl:
+    """Tests for _inject_token_in_url with multiple SCM providers."""
+
+    def test_github_uses_x_access_token(self) -> None:
+        """GitHub URLs use x-access-token username."""
+        url = _inject_token_in_url("https://github.com/owner/repo.git", "ghp_test123")
+        assert url == "https://x-access-token:ghp_test123@github.com/owner/repo.git"
+
+    def test_gitlab_uses_oauth2(self) -> None:
+        """GitLab URLs use oauth2 username."""
+        url = _inject_token_in_url("https://gitlab.com/owner/repo.git", "glpat-test123")
+        assert url == "https://oauth2:glpat-test123@gitlab.com/owner/repo.git"
+
+    def test_bitbucket_uses_x_token_auth(self) -> None:
+        """Bitbucket URLs use x-token-auth username."""
+        url = _inject_token_in_url("https://bitbucket.org/owner/repo.git", "bb_test123")
+        assert url == "https://x-token-auth:bb_test123@bitbucket.org/owner/repo.git"
+
+    def test_unknown_provider_uses_git(self) -> None:
+        """Unknown providers use git as fallback username."""
+        url = _inject_token_in_url("https://custom-git.example.com/repo.git", "token123")
+        assert url == "https://git:token123@custom-git.example.com/repo.git"
+
+    def test_preserves_port(self) -> None:
+        """Port numbers are preserved in the URL."""
+        url = _inject_token_in_url("https://gitlab.com:8443/owner/repo.git", "token")
+        assert url == "https://oauth2:token@gitlab.com:8443/owner/repo.git"
+
+    def test_preserves_path(self) -> None:
+        """Path components are preserved."""
+        url = _inject_token_in_url("https://github.com/org/sub/repo.git", "token")
+        assert url == "https://x-access-token:token@github.com/org/sub/repo.git"
+
+
+class TestRedactCredentials:
+    """Tests for _redact_credentials helper."""
+
+    def test_redacts_token_in_url(self) -> None:
+        """Credentials in URLs are redacted."""
+        text = "fatal: https://x-access-token:ghp_secret123@github.com/repo.git not found"
+        result = _redact_credentials(text)
+        assert "ghp_secret123" not in result
+        assert "[REDACTED]" in result
+        assert "github.com/repo.git" in result
+
+    def test_redacts_multiple_urls(self) -> None:
+        """Multiple URLs in text are all redacted."""
+        text = "tried https://user:pass1@a.com and https://user:pass2@b.com"
+        result = _redact_credentials(text)
+        assert "pass1" not in result
+        assert "pass2" not in result
+
+    def test_preserves_urls_without_auth(self) -> None:
+        """URLs without credentials are unchanged."""
+        text = "clone https://github.com/public/repo.git"
+        result = _redact_credentials(text)
+        assert result == text
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_clone_repo_with_scm_token() -> None:
+    """Verify clone_repo injects token into URL when provided."""
+    with patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop:
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        mock_loop.return_value.run_in_executor = AsyncMock(return_value=result)
+
+        with (
+            tempfile.TemporaryDirectory() as td,
+            patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = result
+            mock_loop.return_value.run_in_executor = AsyncMock(side_effect=lambda _exec, func: func())
+
+            dest = os.path.join(td, "repo")
+            await clone_repo("https://github.com/owner/repo.git", "main", dest, scm_token="ghp_test")
+
+        call_args = mock_run.call_args[0][0]
+        assert "x-access-token:ghp_test@github.com" in call_args[-2]
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_clone_repo_redacts_error_messages() -> None:
+    """Verify clone_repo redacts tokens from error messages."""
+    with patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop:
+        result = MagicMock()
+        result.returncode = 128
+        result.stderr = "fatal: https://x-access-token:ghp_secret@github.com/repo not found"
+        mock_loop.return_value.run_in_executor = AsyncMock(return_value=result)
+
+        with tempfile.TemporaryDirectory() as td:
+            dest = os.path.join(td, "repo")
+            with pytest.raises(RuntimeError) as exc_info:
+                await clone_repo(
+                    "https://github.com/bad/repo.git",
+                    "main",
+                    dest,
+                    scm_token="ghp_secret",
+                )
+
+        assert "ghp_secret" not in str(exc_info.value)
+        assert "[REDACTED]" in str(exc_info.value)
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_fetch_remote_head_with_scm_token() -> None:
+    """Verify fetch_remote_head injects token when provided."""
+    fake_sha = "c" * 40
+    _REMOTE_HEAD_CACHE.clear()
+    with (
+        patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
+        patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = f"{fake_sha}\trefs/heads/main\n"
+        mock_run.return_value = result
+        mock_loop.return_value.run_in_executor = AsyncMock(side_effect=lambda _exec, func: func())
+
+        sha = await fetch_remote_head(
+            "https://gitlab.com/owner/repo.git",
+            "main",
+            scm_token="glpat-test",
+        )
+
+    assert sha == fake_sha
+    call_args = mock_run.call_args[0][0]
+    assert "oauth2:glpat-test@gitlab.com" in call_args[3]


### PR DESCRIPTION
## Summary

- Add SCM token support for cloning private repositories during project operations (scan/remediate)
- Add inline `scm_token` parameter for PR creation endpoint to override project/global token

## Changes

**`src/apme_gateway/scan/driver.py`:**
- Add `_inject_token_in_url()` helper to embed credentials in HTTPS git URLs using `x-access-token` pattern
- Update `fetch_remote_head()`, `clone_repo()`, `run_project_operation()` and wrappers to accept `scm_token`

**`src/apme_gateway/api/operation_router.py`:**
- Pass `proj.scm_token or cfg.scm_token` through project operations

**`src/apme_gateway/api/router.py` & `schemas.py`:**
- Add optional `scm_token` field to PR creation request for one-time token override

## Token Sources (priority order)

1. Request body `scm_token` (PR creation only)
2. Project-level `scm_token` (set via API)
3. Global `APME_SCM_TOKEN` environment variable

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` passes
- [x] Tested locally: created project with private repo URL + token, scan completed successfully

🤖 Generated with [Claude Code](https://claude.ai/code)