### PR TITLE
feat(gateway): add Backstage plugin integration support (ADR-055)

### DIFF
--- a/.sdlc/adrs/ADR-055-backstage-plugin-ui.md
+++ b/.sdlc/adrs/ADR-055-backstage-plugin-ui.md
@@ -1,0 +1,86 @@
+# ADR-055: Replace Standalone UI with Backstage Plugin
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04
+
+## Context
+
+APME currently ships a standalone React/PatternFly SPA served by nginx on port 8081.
+This UI talks exclusively to the APME Gateway REST API.  Meanwhile, the Ansible
+self-service automation portal (built on Red Hat Developer Hub / Backstage) is
+becoming the standard operational interface for Ansible Automation Platform.
+Running a separate UI alongside the portal creates deployment overhead, duplicated
+auth flows, and a fragmented user experience.
+
+The portal already hosts plugins for AAP operations (`backstage-rhaap`), self-service
+templates, catalog sync, and scaffolder actions via
+[ansible-backstage-plugins](https://github.com/ansible/ansible-backstage-plugins),
+deployed by the
+[ansible-portal-chart](https://github.com/ansible-automation-platform/ansible-portal-chart)
+Helm chart.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Keep standalone UI | No cross-repo work, full control | Duplicate auth, separate deployment, fragmented UX |
+| Embed APME UI in iframe | Quick integration | No shared auth, CORS issues, poor UX |
+| Backstage plugin (chosen) | Unified auth (AAP OAuth), single deployment, standard plugin patterns, sidebar integration | Cross-repo work, must support SSE/WS proxying, port 16 pages |
+
+## Decision
+
+**Replace the standalone APME UI with a Backstage frontend plugin (`plugin-apme`) and
+a backend proxy module (`plugin-apme-backend`).** These live in the
+`ansible-backstage-plugins` monorepo alongside existing Ansible plugins.
+
+The APME engine stack (Primary, validators, Galaxy Proxy, Gateway) deploys as an
+**optional Kubernetes Deployment** in the portal Helm chart, gated by `apme.enabled`.
+
+### Key design choices
+
+1. **Backend proxy pattern**: The Backstage backend module proxies all Gateway
+   REST, SSE, and WebSocket traffic.  The frontend plugin never calls the Gateway
+   directly — all requests go through Backstage's backend, which forwards the
+   authenticated user identity via `X-Backstage-User`.
+
+2. **Separate Deployment, not sidecar**: The APME engine runs as its own
+   Deployment with a ClusterIP Service (`apme-gateway:8080`).  This preserves
+   the existing pod-as-a-unit scaling model (ADR-012) and keeps the RHDH pod
+   simple.
+
+3. **All 16 pages ported**: Dashboard, Projects (list/detail), Analytics,
+   Playground, Activity (list/detail), Sessions (list/detail), Health, Rules,
+   Collections (list/detail), Python Packages (list/detail), Settings.
+
+4. **Overlap resolution**: Portal's PAH collection catalog sync and APME's
+   per-project dependency/health analysis are complementary.  Auth uses the
+   portal's AAP OAuth; the Gateway gets identity headers for future enforcement.
+   All scanning, remediation, rules, playground, analytics, and session features
+   are APME-specific with no portal overlap.
+
+5. **Dynamic plugin support**: Both plugins export dynamic plugin metadata
+   (`export-dynamic`) so they can be loaded via RHDH's OCI or tarball plugin
+   delivery without rebuilding the portal image.
+
+## Consequences
+
+- The standalone `apme-ui` container and `containers/ui/` directory remain for
+  local Podman pod development but are no longer the primary UI for production.
+- The Gateway must accept an `X-Backstage-User` header and configurable CORS
+  origins (`APME_CORS_ORIGINS`).
+- Container images for the engine stack must be published to a registry
+  accessible by the Kubernetes cluster.
+- Future UI features target the Backstage plugin, not the standalone SPA.
+
+## Related
+
+- ADR-012: Scale Pods Not Services
+- ADR-029: Gateway REST API
+- ADR-030: UI Architecture
+- ADR-037: UI-Gateway Communication
+- ADR-054: Production Deployment

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -59,6 +59,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-051](ADR-051-dependency-health-scanning.md) | Dependency Health Scanning | 2026-04-07 |
 | [ADR-053](ADR-053-github-integration-strategy.md) | GitHub Integration Strategy | 2026-04-10 |
 | [ADR-054](ADR-054-production-deployment.md) | Production Deployment — Helm Chart and bootc VM Image | 2026-04-10 |
+| [ADR-055](ADR-055-backstage-plugin-ui.md) | Replace Standalone UI with Backstage Plugin | 2026-04 |
 
 ## Proposed
 
@@ -89,7 +90,7 @@ Decisions replaced by newer ADRs.
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-055)
+2. Use the next available number (currently ADR-056)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/.sdlc/context/architecture.md
+++ b/.sdlc/context/architecture.md
@@ -354,6 +354,54 @@ Primary, Native, OPA, Ansible, and Gitleaks all implement the `Health` RPC. A se
 
 ---
 
+## Backstage Integration (ADR-055)
+
+APME can be deployed as a plugin within the **Ansible self-service automation portal**
+(Red Hat Developer Hub / Backstage). This replaces the standalone nginx-served UI with
+Backstage plugins while keeping the engine stack identical.
+
+```
+┌──────────────── Kubernetes Cluster ──────────────────┐
+│                                                       │
+│  ┌─────────────────────────────────────────────────┐  │
+│  │  RHDH Pod (Backstage)                           │  │
+│  │  ┌───────────────┐  ┌────────────────────────┐  │  │
+│  │  │ plugin-apme   │  │ plugin-apme-backend    │  │  │
+│  │  │ (frontend)    │  │ (proxy → Gateway)      │  │  │
+│  │  └───────────────┘  └──────────┬─────────────┘  │  │
+│  └────────────────────────────────┼────────────────┘  │
+│                                   │                    │
+│  ┌────────────────────────────────▼────────────────┐  │
+│  │  APME Engine Deployment (apme.enabled)          │  │
+│  │  Gateway :8080 | Primary :50051 | Validators    │  │
+│  │  Native :50055 | OPA :50054 | Ansible :50053    │  │
+│  │  Galaxy Proxy :8765 | Gitleaks :50056 (opt)     │  │
+│  └─────────────────────────────────────────────────┘  │
+└───────────────────────────────────────────────────────┘
+```
+
+### Deployment
+
+The portal Helm chart (`ansible-portal-chart`) deploys APME when `apme.enabled=true`:
+
+- **Deployment** with all engine containers sharing localhost (same pod-as-unit model)
+- **ClusterIP Service** `<release>-apme-gateway` exposing port 8080
+- **PVCs** for sessions, gateway data, and proxy cache
+- **Dynamic plugins** loaded into RHDH for the frontend and backend
+
+The Backstage backend plugin proxies all REST, SSE, and WebSocket traffic to the
+Gateway and forwards the authenticated user identity via `X-Backstage-User`.
+
+### Overlap with Portal
+
+| Feature | Portal | APME | Resolution |
+|---------|--------|------|------------|
+| Collections | PAH catalog sync | Dependency health analysis | Complementary — keep both |
+| Auth | AAP OAuth | Gateway (currently open) | Backend plugin forwards identity |
+| Scanning, remediation, rules, playground | Not provided | APME-specific | No overlap |
+
+---
+
 ## Decision Records
 
 See [ADR Index](/.sdlc/adrs/README.md) for the full Architecture Decision Records covering all major design choices:
@@ -364,3 +412,4 @@ See [ADR Index](/.sdlc/adrs/README.md) for the full Architecture Decision Record
 - [ADR-012: Scale Pods Not Services](/.sdlc/adrs/ADR-012-scale-pods-not-services.md)
 - [ADR-013: Structured Diagnostics](/.sdlc/adrs/ADR-013-structured-diagnostics.md)
 - [ADR-039: Unified Operation Stream](/.sdlc/adrs/ADR-039-unified-operation-stream.md) — `FixSession` for check and remediate; `ScanStream` removed
+- [ADR-055: Backstage Plugin UI](/.sdlc/adrs/ADR-055-backstage-plugin-ui.md) — Replace standalone UI with Backstage plugin

--- a/.sdlc/context/deployment.md
+++ b/.sdlc/context/deployment.md
@@ -222,6 +222,62 @@ tox -e wipe                             # stop + wipe DB/sessions
 
 ---
 
+## Kubernetes / Backstage Deployment (ADR-055)
+
+APME can be deployed alongside the **Ansible self-service automation portal**
+using the Helm chart at
+[ansible-portal-chart](https://github.com/ansible-automation-platform/ansible-portal-chart).
+
+### Enable APME
+
+```bash
+helm upgrade --install portal ./ansible-portal-chart \
+  --set apme.enabled=true \
+  --set apme.gateway.image=ghcr.io/your-org/apme-gateway:latest \
+  --set apme.primary.image=ghcr.io/your-org/apme-primary:latest \
+  --set apme.native.image=ghcr.io/your-org/apme-native:latest \
+  --set apme.opa.image=ghcr.io/your-org/apme-opa:latest \
+  --set apme.ansible.image=ghcr.io/your-org/apme-ansible:latest \
+  --set apme.galaxyProxy.image=ghcr.io/your-org/apme-galaxy-proxy:latest
+```
+
+This deploys:
+
+| Resource | Purpose |
+|----------|---------|
+| **Deployment** `<release>-apme` | All engine containers (Gateway, Primary, validators, Galaxy Proxy) sharing localhost |
+| **Service** `<release>-apme-gateway` | ClusterIP on port 8080 for the Backstage backend plugin |
+| **PVCs** | `sessions` (5Gi), `gateway-data` (1Gi), `proxy-cache` (5Gi) |
+| **Dynamic plugins** | Frontend (`plugin-apme`) and backend (`plugin-apme-backend`) loaded into RHDH |
+
+### Configuration
+
+In the Helm values:
+
+```yaml
+apme:
+  enabled: true
+  gitleaks:
+    enabled: true    # Set false to skip secrets scanning
+  persistence:
+    storageClass: "" # Use cluster default
+    sessions:
+      size: 5Gi
+    gatewayData:
+      size: 1Gi
+    proxyCache:
+      size: 5Gi
+  feedback:
+    enabled: false
+```
+
+### Environment Variables
+
+The APME Gateway accepts `APME_CORS_ORIGINS` (comma-separated) for cross-origin
+requests and logs `X-Backstage-User` headers forwarded by the Backstage proxy.
+
+---
+
 ## Related Documents
 
 - [Architecture series](/docs/architecture/) — Container topology and service contracts
@@ -231,3 +287,4 @@ tox -e wipe                             # stop + wipe DB/sessions
 - [ADR-024](/.sdlc/adrs/ADR-024-thin-cli-daemon-mode.md) — Thin CLI with local daemon mode
 - [ADR-028](/.sdlc/adrs/ADR-028-session-based-fix-workflow.md) — Session-based fix workflow (FixSession bidi stream)
 - [ADR-039](/.sdlc/adrs/ADR-039-unified-operation-stream.md) — Unified check/remediate via `FixSession`; `ScanStream` removed
+- [ADR-055](/.sdlc/adrs/ADR-055-backstage-plugin-ui.md) — Replace standalone UI with Backstage plugin

--- a/src/apme_gateway/app.py
+++ b/src/apme_gateway/app.py
@@ -2,16 +2,23 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
 
 from apme_gateway._galaxy_proxy_sync import schedule_push
 from apme_gateway.api.feedback import router as feedback_router
 from apme_gateway.api.operation_router import operation_router
 from apme_gateway.api.router import router
+from apme_gateway.config import load_config
 from apme_gateway.operation_registry import get_operation_registry
+
+_log = logging.getLogger(__name__)
+
+_BACKSTAGE_USER_HEADER = "X-Backstage-User"
 
 
 @asynccontextmanager
@@ -40,12 +47,33 @@ def create_app() -> FastAPI:
     Returns:
         Configured FastAPI instance.
     """
+    cfg = load_config()
     app = FastAPI(
         title="APME Gateway",
         description="Reporting persistence and read-only REST API (ADR-020 / ADR-029)",
         version="0.1.0",
         lifespan=_lifespan,
     )
+
+    if cfg.cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cfg.cors_origins,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+    @app.middleware("http")  # type: ignore[untyped-decorator]
+    async def _log_backstage_user(  # noqa: DOC101,DOC103,DOC107,DOC201
+        request: Request,
+        call_next: object,
+    ) -> object:
+        backstage_user = request.headers.get(_BACKSTAGE_USER_HEADER)
+        if backstage_user:
+            _log.info("backstage_user=%s method=%s path=%s", backstage_user, request.method, request.url.path)
+        return await call_next(request)  # type: ignore[operator]
+
     app.include_router(router)
     app.include_router(feedback_router)
     app.include_router(operation_router)

--- a/src/apme_gateway/config.py
+++ b/src/apme_gateway/config.py
@@ -21,6 +21,7 @@ class GatewayConfig:
         feedback_github_token: GitHub token with ``issues:write`` for feedback.
         scm_token: Global SCM token fallback for PR creation (ADR-050).
         github_api_url: GitHub API base URL (ADR-050). Default ``https://api.github.com``.
+        cors_origins: Allowed CORS origins for Backstage proxy integration (ADR-055).
     """
 
     db_path: str = field(default_factory=lambda: os.environ.get("APME_DB_PATH", "/data/apme.db"))
@@ -42,6 +43,9 @@ class GatewayConfig:
     )
     github_api_url: str = field(
         default_factory=lambda: os.environ.get("APME_GITHUB_API_URL", "https://api.github.com"),
+    )
+    cors_origins: list[str] = field(
+        default_factory=lambda: [o.strip() for o in os.environ.get("APME_CORS_ORIGINS", "").split(",") if o.strip()],
     )
 
 


### PR DESCRIPTION
## Summary

Add gateway-side support for deploying APME as a Backstage plugin within the Ansible self-service automation portal (Red Hat Developer Hub). This replaces the standalone nginx-served UI with Backstage plugins while keeping the engine stack identical.

### Changes

**Gateway code (`src/apme_gateway/`):**
- `app.py` — Add CORS middleware (configurable via `APME_CORS_ORIGINS` env var) to support cross-origin requests from the Backstage frontend. Add HTTP middleware that logs the `X-Backstage-User` header forwarded by the Backstage backend proxy, enabling audit trail of which portal user triggered each API call.
- `config.py` — Add `cors_origins` field to `GatewayConfig`, parsed from `APME_CORS_ORIGINS` environment variable (comma-separated list of allowed origins).

**Documentation:**
- `ADR-055-backstage-plugin-ui.md` — New Architecture Decision Record documenting the decision to replace the standalone APME UI with a Backstage plugin pair (`plugin-apme` frontend + `plugin-apme-backend` proxy). Covers options considered, key design choices (backend proxy pattern, separate deployment, all 16 pages ported, overlap resolution with portal features, dynamic plugin support), and consequences.
- `architecture.md` — Add Backstage integration section with ASCII deployment diagram, description of how the portal Helm chart deploys APME, and overlap resolution table (collections catalog sync vs dependency health analysis, auth forwarding, APME-specific features).
- `deployment.md` — Add Kubernetes/Backstage deployment section with Helm install commands, resource table (Deployment, Service, PVCs, dynamic plugins), configuration reference, and environment variable documentation.
- `ADR README` — Register ADR-055 in the index, bump next available number to ADR-056.

### Context

The companion Backstage plugins (`plugin-apme` and `plugin-apme-backend`) live in the [ansible-backstage-plugins](https://github.com/ansible/ansible-backstage-plugins) repo. The Helm chart integration lives in the portal chart repo. This PR covers only the gateway-side changes needed to support the integration.

## Test plan

- [ ] Gateway starts successfully with `APME_CORS_ORIGINS=*` set
- [ ] CORS preflight (`OPTIONS`) requests return correct headers
- [ ] Requests with `X-Backstage-User` header are logged at INFO level
- [ ] Requests without the header proceed normally (no error)
- [ ] Existing API behavior is unchanged when `APME_CORS_ORIGINS` is unset (no CORS middleware added)
- [ ] `tox` / `pytest` pass with no regressions

Made with [Cursor](https://cursor.com)