### PR TITLE
ci(ui): fix Playwright browser mismatch on cache hit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,17 +66,6 @@ jobs:
           curl -fsSL -o /usr/local/bin/opa \
             https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
           chmod +x /usr/local/bin/opa
-      - name: Get Playwright version
-        id: pw
-        run: echo "version=$(grep -A1 'name = "playwright"' uv.lock | grep version | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        id: pw-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
-      - name: Install Playwright (browser + system deps)
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: uv run --extra dev playwright install --with-deps chromium
       - name: Build and serve UI
         run: |
           cd frontend && npm ci && npm run build && cd ..

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,9 @@ commands =
 description = Playwright UI tests (requires running gateway + UI)
 extras = dev, gateway
 commands =
+    playwright install --with-deps chromium
     pytest -m ui tests/test_ui_playwright.py -v --tb=long {posargs}
+allowlist_externals = playwright
 pass_env =
     APME_UI_URL
     APME_DB_PATH


### PR DESCRIPTION
## Summary

- Fix the `ui` CI job failing due to Playwright browser version mismatch
- Move browser installation into the tox environment so it always matches the Playwright version running the tests
- Remove fragile cache/version-extraction machinery from the workflow

## Root cause

The workflow installed browsers via `uv run --extra dev` (which uses `uv.lock` and resolved Playwright **1.58.0**, browser revision 1208). But `tox -e ui` creates its own virtualenv via `uv pip install` (which does **not** use `uv.lock`) and resolved Playwright **1.59.0** (browser revision 1217). The tests failed because revision 1217 browsers were never downloaded — only 1208 existed on disk.

The cache was a red herring. The real bug was two different Playwright versions in play.

## Changes

- **`tox.ini`**: Add `playwright install --with-deps chromium` as the first command in `[testenv:ui]`, ensuring browsers always match the exact Playwright version tox resolves
- **`.github/workflows/test.yml`**: Remove the Playwright version extraction, `actions/cache`, and conditional install steps — the ~3s browser download is not worth the caching complexity

## Test plan

- [x] `tox -e lint` passes
- [x] YAML validated
- [x] Browser install runs inside the same env as the tests, eliminating version mismatch by construction

Closes #300