### PR TITLE
feat(skills): add docs-qa-audit skill and initial audit report

### DIFF
--- a/.agents/skills/docs-qa-audit/SKILL.md
+++ b/.agents/skills/docs-qa-audit/SKILL.md
@@ -145,6 +145,6 @@ See [procedure.md](procedure.md) for the detailed step-by-step implementation gu
 ## Notes
 
 - Run periodically before releases or customer engagements
-- Output is designed as input for `/red-hat-quick-deck` skill
+- Output is designed to feed presentation decks or release-readiness reviews
 - Gaps with DRs can be tracked via `/sdlc-status`
 - **Link format**: When the report lives in `docs/reports/`, use `../../` prefix for repo-root links

--- a/.agents/skills/docs-qa-audit/SKILL.md
+++ b/.agents/skills/docs-qa-audit/SKILL.md
@@ -82,6 +82,10 @@ Markdown report (`docs/reports/docs-qa-audit-YYYY-MM-DD.md`) containing:
 
 ## Procedure
 
+See [procedure.md](procedure.md) for the detailed step-by-step implementation guide.
+
+### Overview
+
 1. **Load Question Set** — Use the categories above
 2. **Search Documentation** — Glob `docs/**/*.md`, `README.md`, `.sdlc/**/*.md`
 3. **Search Code** — Grep for CLI help, config loaders, API endpoints

--- a/.agents/skills/docs-qa-audit/SKILL.md
+++ b/.agents/skills/docs-qa-audit/SKILL.md
@@ -26,7 +26,9 @@ Use when:
 
 ## Output
 
-Markdown report (`docs/reports/docs-qa-audit-YYYY-MM-DD.md`) containing:
+Markdown report written by default to `docs/reports/docs-qa-audit-YYYY-MM-DD.md`.
+If invoked with `--output path/to/report.md`, write the report to that path
+instead. The report contains:
 1. **Coverage Matrix** — Questions with status (✓ covered / ⚠ partial / ✗ gap)
 2. **Source References** — Links to docs/code that answer each question
 3. **Gap Analysis** — Missing answers with suggested doc locations
@@ -107,7 +109,7 @@ See [procedure.md](procedure.md) for the detailed step-by-step implementation gu
 | User guides | `docs/guides/*.md` |
 | README | `README.md` |
 | Rule docs | `docs/rules/*.md`, `src/**/rules/*.md` |
-| API docs | `docs/api/*.md`, `src/apme_gateway/api/` |
+| API docs | `docs/architecture/*.md`, `docs/design/*.md`, `src/apme_gateway/api/` |
 | ADRs | `.sdlc/adrs/*.md` |
 | CLI help | `src/apme_engine/cli/*.py` |
 | Config | `src/apme_engine/cli/_rules_yml.py`, `.apme/` patterns |

--- a/.agents/skills/docs-qa-audit/SKILL.md
+++ b/.agents/skills/docs-qa-audit/SKILL.md
@@ -1,3 +1,17 @@
+---
+name: docs-qa-audit
+description: >
+  Audit documentation coverage against common user questions. Generates a Q&A
+  matrix, searches docs/code for answers, flags gaps, and creates DRs for
+  missing content. Use when asked to "audit docs", "check documentation
+  coverage", "what questions can users answer", or before releases/demos.
+argument-hint: "[--output path/to/report.md]"
+user-invocable: true
+metadata:
+  author: APME Team
+  version: 1.0.0
+---
+
 # docs-qa-audit
 
 Audit documentation coverage against common user questions. Generates a Q&A matrix, searches docs/code for answers, flags gaps, and creates DRs for missing content.
@@ -108,8 +122,8 @@ Markdown report (`docs/reports/docs-qa-audit-YYYY-MM-DD.md`) containing:
 
 | # | Question | Status | Source |
 |---|----------|--------|--------|
-| 1 | What is APME? | ✓ | [README.md#overview](README.md) |
-| 2 | How do I install? | ✓ | [README.md#quick-start](README.md) |
+| 1 | What is APME? | ✓ | [README.md#overview](../../README.md#overview) |
+| 2 | How do I install? | ✓ | [README.md#quick-start](../../README.md#quick-start) |
 | 3 | How do I write custom OPA rules? | ⚠ | ADR-042 (not user-facing) |
 | 4 | How do I use with Backstage? | ✗ | — |
 
@@ -127,3 +141,4 @@ Markdown report (`docs/reports/docs-qa-audit-YYYY-MM-DD.md`) containing:
 - Run periodically before releases or customer engagements
 - Output is designed as input for `/red-hat-quick-deck` skill
 - Gaps with DRs can be tracked via `/sdlc-status`
+- **Link format**: When the report lives in `docs/reports/`, use `../../` prefix for repo-root links

--- a/.agents/skills/docs-qa-audit/SKILL.md
+++ b/.agents/skills/docs-qa-audit/SKILL.md
@@ -30,7 +30,7 @@ Markdown report (`docs/reports/docs-qa-audit-YYYY-MM-DD.md`) containing:
 1. **Coverage Matrix** — Questions with status (✓ covered / ⚠ partial / ✗ gap)
 2. **Source References** — Links to docs/code that answer each question
 3. **Gap Analysis** — Missing answers with suggested doc locations
-4. **Action Items** — DRs created for gaps, draft PRs for answers
+4. **Action Items** — DRs created for gaps, draft answer stubs for documentation
 
 ## Question Categories
 

--- a/.agents/skills/docs-qa-audit/docs-qa-audit.md
+++ b/.agents/skills/docs-qa-audit/docs-qa-audit.md
@@ -1,0 +1,129 @@
+# docs-qa-audit
+
+Audit documentation coverage against common user questions. Generates a Q&A matrix, searches docs/code for answers, flags gaps, and creates DRs for missing content.
+
+## Trigger
+
+Use when:
+- "audit docs", "check documentation coverage", "docs qa"
+- "what questions can users answer", "documentation gaps"
+- "validate user guides", "check we have answers"
+- Preparing for customer demos or releases
+
+## Output
+
+Markdown report (`docs/reports/docs-qa-audit-YYYY-MM-DD.md`) containing:
+1. **Coverage Matrix** — Questions with status (✓ covered / ⚠ partial / ✗ gap)
+2. **Source References** — Links to docs/code that answer each question
+3. **Gap Analysis** — Missing answers with suggested doc locations
+4. **Action Items** — DRs created for gaps, draft PRs for answers
+
+## Question Categories
+
+### 1. What Is It / What Does It Do
+- What is APME and what problem does it solve?
+- What types of Ansible content can APME scan?
+- What rules does APME enforce and why?
+- How does APME differ from ansible-lint?
+- What are the severity levels and what do they mean?
+
+### 2. How Can I Use It
+- How do I install APME?
+- How do I run a basic scan?
+- How do I get JSON output for automation?
+- How do I run APME in a container?
+- How do I use the daemon vs pod mode?
+
+### 3. Rule Configuration
+- How do I enable/disable specific rules?
+- How do I change rule severity?
+- How do I suppress a rule for a specific line (noqa)?
+- How do I configure rules per-project?
+- How do I enforce rules and ignore noqa comments?
+
+### 4. Bring Your Own Rules
+- Can I add custom rules?
+- How do I write a custom OPA/Rego rule?
+- How do I add custom rules via plugins?
+- What rule ID conventions should custom rules follow?
+
+### 5. Demonstrating Value
+- How do I show before/after remediation?
+- How do I track improvement over time (health score)?
+- How do I generate reports for stakeholders?
+- How do I measure AI fix acceptance rates?
+- What metrics does the Gateway API provide?
+
+### 6. Integration with Existing Tools
+- How do I integrate with GitHub Actions?
+- How do I integrate with GitLab CI?
+- How do I integrate with Jenkins?
+- How do I integrate with Azure DevOps?
+- How do I use APME with AAP/AWX?
+- How do I use APME with Backstage?
+- How do I use APME with pre-commit hooks?
+- How do I migrate from ansible-lint?
+- How do I use APME in an air-gapped environment?
+- How do I integrate with VS Code?
+
+## Procedure
+
+1. **Load Question Set** — Use the categories above
+2. **Search Documentation** — Glob `docs/**/*.md`, `README.md`, `.sdlc/**/*.md`
+3. **Search Code** — Grep for CLI help, config loaders, API endpoints
+4. **Score Coverage**:
+   - ✓ **Covered**: Clear answer in user-facing docs
+   - ⚠ **Partial**: Answer exists but incomplete or only in code/ADRs
+   - ✗ **Gap**: No answer found
+5. **Generate Matrix** — Markdown table with question, status, source
+6. **Handle Gaps**:
+   - Create DR for each gap (if not already exists)
+   - Draft answer stub based on code/ADR research
+   - Suggest target doc file for the answer
+7. **Output Report** — Write to `docs/reports/docs-qa-audit-YYYY-MM-DD.md`
+
+## Search Locations
+
+| Content Type | Locations |
+|--------------|-----------|
+| User guides | `docs/guides/*.md` |
+| README | `README.md` |
+| Rule docs | `docs/rules/*.md`, `src/**/rules/*.md` |
+| API docs | `docs/api/*.md`, `src/apme_gateway/api/` |
+| ADRs | `.sdlc/adrs/*.md` |
+| CLI help | `src/apme_engine/cli/*.py` |
+| Config | `src/apme_engine/cli/_rules_yml.py`, `.apme/` patterns |
+
+## Example Output
+
+```markdown
+# Documentation Q&A Audit — 2026-05-21
+
+## Coverage Summary
+- **Covered**: 18/25 (72%)
+- **Partial**: 4/25 (16%)
+- **Gaps**: 3/25 (12%)
+
+## Coverage Matrix
+
+| # | Question | Status | Source |
+|---|----------|--------|--------|
+| 1 | What is APME? | ✓ | [README.md#overview](README.md) |
+| 2 | How do I install? | ✓ | [README.md#quick-start](README.md) |
+| 3 | How do I write custom OPA rules? | ⚠ | ADR-042 (not user-facing) |
+| 4 | How do I use with Backstage? | ✗ | — |
+
+## Gaps & Actions
+
+### Gap: Backstage Integration
+- **Question**: How do I use APME with Backstage?
+- **DR Created**: DR-018-backstage-integration-guide
+- **Suggested Location**: `docs/guides/BACKSTAGE_INTEGRATION.md`
+- **Draft Answer**: [See PR #XXX]
+```
+
+## Notes
+
+- Run periodically before releases or customer engagements
+- Output is designed as input for `/red-hat-quick-deck` skill
+- Gaps with DRs can be tracked via `/sdlc-status`

--- a/.agents/skills/docs-qa-audit/procedure.md
+++ b/.agents/skills/docs-qa-audit/procedure.md
@@ -227,9 +227,9 @@ to that explicit path instead:
 ## Executive Summary
 
 - **Total Questions**: X
-- **Covered**: Y (Z%)
-- **Partial**: A (B%)
-- **Gaps**: C (D%)
+- **Covered** (✓): Y (Z%)
+- **Partial** (⚠): A (B%)
+- **Gaps** (✗): C (D%)
 
 ## Coverage by Category
 

--- a/.agents/skills/docs-qa-audit/procedure.md
+++ b/.agents/skills/docs-qa-audit/procedure.md
@@ -1,0 +1,278 @@
+# docs-qa-audit Procedure
+
+When this skill is invoked, follow these steps exactly.
+
+## Step 1: Initialize Question Set
+
+Use these questions organized by category:
+
+```yaml
+categories:
+  what_is_it:
+    name: "What Is It / What Does It Do"
+    questions:
+      - id: Q01
+        question: "What is APME and what problem does it solve?"
+        keywords: ["policy", "modernization", "ansible", "aap", "validation"]
+      - id: Q02
+        question: "What types of Ansible content can APME scan?"
+        keywords: ["playbook", "role", "collection", "inventory", "content types"]
+      - id: Q03
+        question: "What rules does APME enforce and why?"
+        keywords: ["rule catalog", "L0", "M0", "R1", "severity"]
+      - id: Q04
+        question: "How does APME differ from ansible-lint?"
+        keywords: ["ansible-lint", "comparison", "difference", "migrate"]
+      - id: Q05
+        question: "What are the severity levels and what do they mean?"
+        keywords: ["severity", "critical", "error", "high", "medium", "low", "info"]
+
+  how_to_use:
+    name: "How Can I Use It"
+    questions:
+      - id: Q06
+        question: "How do I install APME?"
+        keywords: ["install", "uv", "pip", "setup", "quick start"]
+      - id: Q07
+        question: "How do I run a basic scan?"
+        keywords: ["check", "scan", "apme check", "command"]
+      - id: Q08
+        question: "How do I get JSON output for automation?"
+        keywords: ["--json", "json output", "machine readable", "parse"]
+      - id: Q09
+        question: "How do I run APME in a container?"
+        keywords: ["container", "podman", "docker", "image"]
+      - id: Q10
+        question: "How do I use daemon vs pod mode?"
+        keywords: ["daemon", "pod", "start", "local", "deployment"]
+
+  rule_config:
+    name: "Rule Configuration"
+    questions:
+      - id: Q11
+        question: "How do I enable/disable specific rules?"
+        keywords: ["enable", "disable", "rules.yml", "enabled: false"]
+      - id: Q12
+        question: "How do I change rule severity?"
+        keywords: ["severity", "override", "severity_override"]
+      - id: Q13
+        question: "How do I suppress a rule for a specific line?"
+        keywords: ["noqa", "suppress", "inline", "comment"]
+      - id: Q14
+        question: "How do I configure rules per-project?"
+        keywords: [".apme", "rules.yml", "project config"]
+      - id: Q15
+        question: "How do I enforce rules and ignore noqa comments?"
+        keywords: ["enforced", "ignore noqa", "strict"]
+
+  custom_rules:
+    name: "Bring Your Own Rules"
+    questions:
+      - id: Q16
+        question: "Can I add custom rules?"
+        keywords: ["custom", "byo", "bring your own", "extend"]
+      - id: Q17
+        question: "How do I write a custom OPA/Rego rule?"
+        keywords: ["opa", "rego", "custom bundle", "policy"]
+      - id: Q18
+        question: "How do I add custom rules via plugins?"
+        keywords: ["plugin", "EXT-", "grpc", "third-party"]
+      - id: Q19
+        question: "What rule ID conventions should custom rules follow?"
+        keywords: ["rule id", "convention", "L0", "M0", "prefix"]
+
+  demonstrating_value:
+    name: "Demonstrating Value"
+    questions:
+      - id: Q20
+        question: "How do I show before/after remediation?"
+        keywords: ["diff", "before", "after", "remediate", "fix"]
+      - id: Q21
+        question: "How do I track improvement over time?"
+        keywords: ["health score", "trend", "progress", "improvement"]
+      - id: Q22
+        question: "How do I generate reports for stakeholders?"
+        keywords: ["report", "stakeholder", "summary", "gateway"]
+      - id: Q23
+        question: "How do I measure AI fix acceptance rates?"
+        keywords: ["ai", "acceptance", "confidence", "approval"]
+      - id: Q24
+        question: "What metrics does the Gateway API provide?"
+        keywords: ["metrics", "api", "gateway", "statistics"]
+
+  integrations:
+    name: "Integration with Existing Tools"
+    questions:
+      - id: Q25
+        question: "How do I integrate with GitHub Actions?"
+        keywords: ["github", "actions", "workflow", "ci"]
+      - id: Q26
+        question: "How do I integrate with GitLab CI?"
+        keywords: ["gitlab", "ci", "pipeline"]
+      - id: Q27
+        question: "How do I integrate with Jenkins?"
+        keywords: ["jenkins", "pipeline", "groovy"]
+      - id: Q28
+        question: "How do I integrate with Azure DevOps?"
+        keywords: ["azure", "devops", "pipeline"]
+      - id: Q29
+        question: "How do I use APME with AAP/AWX?"
+        keywords: ["aap", "awx", "controller", "tower"]
+      - id: Q30
+        question: "How do I use APME with Backstage?"
+        keywords: ["backstage", "portal", "plugin"]
+      - id: Q31
+        question: "How do I use APME with pre-commit hooks?"
+        keywords: ["pre-commit", "hook", "git"]
+      - id: Q32
+        question: "How do I migrate from ansible-lint?"
+        keywords: ["migrate", "ansible-lint", "transition"]
+      - id: Q33
+        question: "How do I use APME in an air-gapped environment?"
+        keywords: ["air-gap", "offline", "disconnected"]
+      - id: Q34
+        question: "How do I integrate with VS Code?"
+        keywords: ["vscode", "vs code", "editor", "extension"]
+```
+
+## Step 2: Search Documentation
+
+For each question, search these locations in order:
+
+1. **Primary user docs** (highest weight):
+   ```
+   docs/guides/*.md
+   README.md
+   docs/rules/RULE_CATALOG.md
+   ```
+
+2. **Secondary docs** (partial coverage):
+   ```
+   .sdlc/adrs/*.md
+   .sdlc/specs/*.md
+   docs/reports/*.md
+   ```
+
+3. **Code as documentation** (lowest weight):
+   ```
+   src/apme_engine/cli/*.py (--help text)
+   src/apme_engine/cli/_rules_yml.py
+   src/apme_gateway/api/router.py
+   ```
+
+Use `grep -l` with keywords to find matching files, then read relevant sections.
+
+## Step 3: Score Each Question
+
+For each question, determine status:
+
+| Status | Criteria |
+|--------|----------|
+| ✓ Covered | Clear, user-facing answer in `docs/guides/` or `README.md` |
+| ⚠ Partial | Answer exists but: only in ADRs, incomplete, or buried in code |
+| ✗ Gap | No answer found, or only implementation exists |
+
+Record:
+- `status`: ✓, ⚠, or ✗
+- `source`: File path and section/line
+- `excerpt`: Brief quote showing the answer (if found)
+- `notes`: Why partial, or what's missing
+
+## Step 4: Generate Coverage Matrix
+
+Create markdown table:
+
+```markdown
+## Coverage Matrix
+
+| ID | Category | Question | Status | Source |
+|----|----------|----------|--------|--------|
+| Q01 | What Is It | What is APME and what problem does it solve? | ✓ | [README.md#overview](README.md) |
+```
+
+## Step 5: Handle Gaps
+
+For each gap (✗) or significant partial (⚠):
+
+### 5a. Check for Existing DR
+```bash
+grep -l "<question keywords>" .sdlc/decisions/open/*.md
+```
+
+### 5b. If No DR Exists, Create One
+Use `/dr-new` skill with:
+- Title: Documentation gap — <question summary>
+- Context: User question that cannot be answered
+- Options: Which doc to add it to
+
+### 5c. Draft Answer Stub
+Research the answer from:
+- ADRs (architectural context)
+- Code (actual behavior)
+- Existing partial docs
+
+Create draft in `docs/drafts/` or suggest PR content.
+
+## Step 6: Generate Report
+
+Write report to `docs/reports/docs-qa-audit-YYYY-MM-DD.md`:
+
+```markdown
+# Documentation Q&A Audit — YYYY-MM-DD
+
+## Executive Summary
+
+- **Total Questions**: X
+- **Covered**: Y (Z%)
+- **Partial**: A (B%)
+- **Gaps**: C (D%)
+
+## Coverage by Category
+
+| Category | Covered | Partial | Gap |
+|----------|---------|---------|-----|
+| What Is It | 4/5 | 1/5 | 0/5 |
+| ... | ... | ... | ... |
+
+## Coverage Matrix
+
+[Full table from Step 4]
+
+## Gap Analysis
+
+### Gap 1: <Question>
+- **ID**: Q##
+- **Question**: Full question text
+- **Impact**: Why this matters to users
+- **Suggested Location**: `docs/guides/FOO.md`
+- **Research Notes**: What we found in code/ADRs
+- **DR**: [DR-0XX](../.sdlc/decisions/open/DR-0XX.md) (if created)
+
+## Partial Coverage Improvements
+
+### Partial 1: <Question>
+- **Current Source**: ADR-0XX
+- **Gap**: Not user-facing / incomplete
+- **Recommendation**: Add section to `docs/guides/FOO.md`
+
+## Action Items
+
+- [ ] DR-0XX: <gap summary>
+- [ ] Update `docs/guides/FOO.md` with <topic>
+- [ ] Create `docs/guides/BAR.md` for <new guide>
+
+## Next Steps
+
+1. Review gaps with stakeholders
+2. Prioritize based on customer frequency
+3. Create PRs for draft answers
+4. Re-run audit after updates
+```
+
+## Step 7: Summarize to User
+
+After generating the report, output:
+1. Coverage percentage summary
+2. List of gaps found
+3. DRs created (if any)
+4. Path to full report

--- a/.agents/skills/docs-qa-audit/procedure.md
+++ b/.agents/skills/docs-qa-audit/procedure.md
@@ -180,14 +180,14 @@ Record:
 
 ## Step 4: Generate Coverage Matrix
 
-Create markdown table:
+Create markdown table. **Important:** Since reports live in `docs/reports/`, use `../../` prefix for repo-root links.
 
 ```markdown
 ## Coverage Matrix
 
 | ID | Category | Question | Status | Source |
 |----|----------|----------|--------|--------|
-| Q01 | What Is It | What is APME and what problem does it solve? | ✓ | [README.md#overview](README.md) |
+| Q01 | What Is It | What is APME and what problem does it solve? | ✓ | [README.md#overview](../../README.md#overview) |
 ```
 
 ## Step 5: Handle Gaps
@@ -246,7 +246,7 @@ Write report to `docs/reports/docs-qa-audit-YYYY-MM-DD.md`:
 - **Impact**: Why this matters to users
 - **Suggested Location**: `docs/guides/FOO.md`
 - **Research Notes**: What we found in code/ADRs
-- **DR**: [DR-0XX](../.sdlc/decisions/open/DR-0XX.md) (if created)
+- **DR**: [DR-0XX](../../.sdlc/decisions/open/DR-0XX.md) (if created)
 
 ## Partial Coverage Improvements
 

--- a/.agents/skills/docs-qa-audit/procedure.md
+++ b/.agents/skills/docs-qa-audit/procedure.md
@@ -148,6 +148,8 @@ For each question, search these locations in order:
 
 2. **Secondary docs** (partial coverage):
    ```
+   docs/architecture/*.md
+   docs/design/*.md
    .sdlc/adrs/*.md
    .sdlc/specs/*.md
    docs/reports/*.md (exclude docs-qa-audit-*.md to avoid self-matching)
@@ -168,8 +170,8 @@ For each question, determine status:
 
 | Status | Criteria |
 |--------|----------|
-| ✓ Covered | Clear, user-facing answer in `docs/guides/` or `README.md` |
-| ⚠ Partial | Answer exists but: only in ADRs, incomplete, or buried in code |
+| ✓ Covered | Clear, user-facing answer in `docs/guides/`, `README.md`, or equivalent end-user docs |
+| ⚠ Partial | Answer exists but is incomplete, only in architecture/design/ADRs, or buried in code |
 | ✗ Gap | No answer found, or only implementation exists |
 
 Record:
@@ -187,7 +189,7 @@ Create markdown table. **Important:** Since reports live in `docs/reports/`, use
 
 | ID | Category | Question | Status | Source |
 |----|----------|----------|--------|--------|
-| Q01 | What Is It | What is APME and what problem does it solve? | ✓ | [README.md#overview](../../README.md#overview) |
+| Q01 | What Is It / What Does It Do | What is APME and what problem does it solve? | ✓ | [README.md#overview](../../README.md#overview) |
 ```
 
 ## Step 5: Handle Gaps
@@ -231,10 +233,16 @@ to that explicit path instead:
 
 ## Coverage by Category
 
-| Category | Covered | Partial | Gap |
-|----------|---------|---------|-----|
-| What Is It | 4/5 | 1/5 | 0/5 |
-| ... | ... | ... | ... |
+| Category | Covered | Partial | Gap | Score |
+|----------|---------|---------|-----|-------|
+| What Is It / What Does It Do | 4/5 | 1/5 | 0/5 | 90% |
+| ... | ... | ... | ... | ... |
+
+`Score` is a weighted coverage percentage:
+- covered = 1.0
+- partial = 0.5
+- gap = 0.0
+- formula = `((covered + 0.5 * partial) / total_questions) * 100`, rounded to the nearest whole percent
 
 ## Coverage Matrix
 

--- a/.agents/skills/docs-qa-audit/procedure.md
+++ b/.agents/skills/docs-qa-audit/procedure.md
@@ -150,7 +150,7 @@ For each question, search these locations in order:
    ```
    .sdlc/adrs/*.md
    .sdlc/specs/*.md
-   docs/reports/*.md
+   docs/reports/*.md (exclude docs-qa-audit-*.md to avoid self-matching)
    ```
 
 3. **Code as documentation** (lowest weight):

--- a/.agents/skills/docs-qa-audit/procedure.md
+++ b/.agents/skills/docs-qa-audit/procedure.md
@@ -215,7 +215,9 @@ Create draft in `docs/drafts/` or suggest PR content.
 
 ## Step 6: Generate Report
 
-Write report to `docs/reports/docs-qa-audit-YYYY-MM-DD.md`:
+Write the report to `docs/reports/docs-qa-audit-YYYY-MM-DD.md` by default. If
+the user invoked the skill with `--output path/to/report.md`, write the report
+to that explicit path instead:
 
 ```markdown
 # Documentation Q&A Audit — YYYY-MM-DD

--- a/docs/guides/RULE_CONFIGURATION.md
+++ b/docs/guides/RULE_CONFIGURATION.md
@@ -27,7 +27,7 @@ rules:
 |--------|------|---------|-------------|
 | `enabled` | bool | `true` | Set to `false` to skip this rule |
 | `severity` | string | (rule default) | Override: `info`, `low`, `medium`, `high`, `critical` |
-| `enforced` | bool | `false` | If `true`, bypasses rule-level fingerprint suppressions during CLI suppression processing |
+| `enforced` | bool | `false` | If `true`, bypasses rule-level fingerprint suppressions from `.apme/suppressions.yml` during CLI suppression processing |
 
 ### Inline Suppression
 
@@ -38,10 +38,10 @@ Suppress rules on specific tasks using `# noqa`:
   ansible.builtin.shell: rm -rf /tmp/*
 ```
 
-**Note:** `enforced: true` prevents rule-level suppressions from bypassing a
-rule during CLI suppression processing. Native graph-rule `# noqa` comments are
-parsed earlier in the scan path, so this setting does not currently override
-those inline suppressions.
+**Note:** `enforced: true` affects `.apme/suppressions.yml` fingerprint
+suppressions during CLI suppression processing. Native graph-rule `# noqa`
+comments are parsed earlier during scan-time evaluation, so this setting does
+not currently override those inline suppressions.
 
 ### CLI Flags
 

--- a/docs/guides/RULE_CONFIGURATION.md
+++ b/docs/guides/RULE_CONFIGURATION.md
@@ -27,7 +27,7 @@ rules:
 |--------|------|---------|-------------|
 | `enabled` | bool | `true` | Set to `false` to skip this rule |
 | `severity` | string | (rule default) | Override: `info`, `low`, `medium`, `high`, `critical` |
-| `enforced` | bool | `false` | If `true`, bypasses rule-level fingerprint suppressions from `.apme/suppressions.yml` during CLI suppression processing |
+| `enforced` | bool | `false` | If `true`, bypasses all fingerprint suppression modes from `.apme/suppressions.yml` during CLI suppression processing |
 
 ### Inline Suppression
 

--- a/docs/guides/RULE_CONFIGURATION.md
+++ b/docs/guides/RULE_CONFIGURATION.md
@@ -43,6 +43,12 @@ suppressions during CLI suppression processing. Native graph-rule `# noqa`
 comments are parsed earlier during scan-time evaluation, so this setting does
 not currently override those inline suppressions.
 
+Fingerprint suppressions live in `.apme/suppressions.yml`. The CLI can manage
+that file with `apme suppress add`, `apme suppress list`, and
+`apme suppress remove`. The file stores entries under a top-level
+`suppressions:` list with fields such as `fingerprint`, `rule_id`, `mode`,
+`reason`, and `created`.
+
 ### CLI Flags
 
 Skip entire validation categories at scan time:

--- a/docs/guides/RULE_CONFIGURATION.md
+++ b/docs/guides/RULE_CONFIGURATION.md
@@ -38,7 +38,10 @@ Suppress rules on specific tasks using `# noqa`:
   ansible.builtin.shell: rm -rf /tmp/*
 ```
 
-**Note:** If a rule has `enforced: true` in `.apme/rules.yml`, inline suppressions are ignored.
+**Note:** `enforced: true` prevents rule-level suppressions from bypassing a
+rule during CLI suppression processing. Native graph-rule `# noqa` comments are
+parsed earlier in the scan path, so this setting does not currently override
+those inline suppressions.
 
 ### CLI Flags
 

--- a/docs/guides/RULE_CONFIGURATION.md
+++ b/docs/guides/RULE_CONFIGURATION.md
@@ -27,7 +27,7 @@ rules:
 |--------|------|---------|-------------|
 | `enabled` | bool | `true` | Set to `false` to skip this rule |
 | `severity` | string | (rule default) | Override: `info`, `low`, `medium`, `high`, `critical` |
-| `enforced` | bool | `false` | If `true`, ignores inline `# noqa` comments |
+| `enforced` | bool | `false` | If `true`, bypasses rule-level fingerprint suppressions during CLI suppression processing |
 
 ### Inline Suppression
 

--- a/docs/reports/docs-qa-audit-2026-05-21.md
+++ b/docs/reports/docs-qa-audit-2026-05-21.md
@@ -67,7 +67,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Question**: How do I track improvement over time?
 - **Impact**: Stakeholders want to see progress. Without guidance, users cannot demonstrate ROI.
 - **Suggested Location**: `docs/guides/REPORTING.md` (new file)
-- **Research Notes**: Gateway API has `/projects/{id}/trend` endpoint and health scores per 13-gateway architecture doc, but no user guide exists.
+- **Research Notes**: Gateway API has `GET /api/v1/projects/{id}/trend` endpoint and health scores per 13-gateway architecture doc, but no user guide exists.
 - **Draft Answer**: The Gateway REST API provides trend data via `GET /api/v1/projects/{id}/trend`. The UI dashboard shows violation trends over time. Health scores are computed per project.
 
 ### Gap 2: Gateway API Metrics Guide (Q24)

--- a/docs/reports/docs-qa-audit-2026-05-21.md
+++ b/docs/reports/docs-qa-audit-2026-05-21.md
@@ -3,9 +3,9 @@
 ## Executive Summary
 
 - **Total Questions**: 34
-- **Covered**: 13 (38%)
-- **Partial**: 9 (26%)
-- **Gaps**: 12 (35%)
+- **Covered** (✓): 12 (35%)
+- **Partial** (⚠): 9 (26%)
+- **Gaps** (✗): 13 (38%)
 
 The documentation has solid coverage of core functionality (installation, basic scanning, container deployment, rule catalog) but significant gaps exist in CI/CD integration guides, tooling ecosystem integration, and some rule configuration topics.
 
@@ -24,40 +24,40 @@ The documentation has solid coverage of core functionality (installation, basic 
 
 | ID | Category | Question | Status | Source |
 |----|----------|----------|--------|--------|
-| Q01 | What Is It | What is APME and what problem does it solve? | Covered | [README.md#what-apme-is](README.md) |
-| Q02 | What Is It | What types of Ansible content can APME scan? | Covered | [README.md#what-apme-is](README.md) |
-| Q03 | What Is It | What rules does APME enforce and why? | Covered | [docs/rules/RULE_CATALOG.md](docs/rules/RULE_CATALOG.md) |
-| Q04 | What Is It | How does APME differ from ansible-lint? | Partial | [docs/rules/ANSIBLELINT_COVERAGE.md](docs/rules/ANSIBLELINT_COVERAGE.md) |
-| Q05 | What Is It | What are the severity levels and what do they mean? | Covered | [docs/rules/RULE_CATALOG.md](docs/rules/RULE_CATALOG.md) |
-| Q06 | How Can I Use It | How do I install APME? | Covered | [README.md#install](README.md) |
-| Q07 | How Can I Use It | How do I run a basic scan? | Covered | [README.md#basic-usage](README.md) |
-| Q08 | How Can I Use It | How do I get JSON output for automation? | Covered | [README.md#basic-usage](README.md) |
-| Q09 | How Can I Use It | How do I run APME in a container? | Covered | [README.md#container-deployment-podman](README.md), [docs/guides/DEPLOYMENT.md](docs/guides/DEPLOYMENT.md) |
-| Q10 | How Can I Use It | How do I use daemon vs pod mode? | Partial | [docs/guides/DEPLOYMENT.md#local-development-daemon-mode](docs/guides/DEPLOYMENT.md) |
-| Q11 | Rule Config | How do I enable/disable specific rules? | Partial | [src/apme_engine/cli/_rules_yml.py](src/apme_engine/cli/_rules_yml.py) (code only) |
-| Q12 | Rule Config | How do I change rule severity? | Partial | [.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md](.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
-| Q13 | Rule Config | How do I suppress a rule for a specific line? | Gap | No documentation found |
-| Q14 | Rule Config | How do I configure rules per-project? | Partial | [src/apme_engine/cli/_rules_yml.py](src/apme_engine/cli/_rules_yml.py) (code only) |
-| Q15 | Rule Config | How do I enforce rules and ignore noqa comments? | Covered | [.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md](.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
-| Q16 | Custom Rules | Can I add custom rules? | Partial | [.sdlc/adrs/ADR-042-third-party-plugin-services.md](.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
-| Q17 | Custom Rules | How do I write a custom OPA/Rego rule? | Partial | [docs/guides/DEVELOPMENT.md#opa-rego-rule](docs/guides/DEVELOPMENT.md) |
-| Q18 | Custom Rules | How do I add custom rules via plugins? | Partial | [.sdlc/adrs/ADR-042-third-party-plugin-services.md](.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
-| Q19 | Custom Rules | What rule ID conventions should custom rules follow? | Gap | ADR-008 exists but not user-facing |
-| Q20 | Value | How do I show before/after remediation? | Covered | [README.md#basic-usage](README.md) |
-| Q21 | Value | How do I track improvement over time? | Gap | No documentation found |
-| Q22 | Value | How do I generate reports for stakeholders? | Partial | [docs/architecture/13-gateway-and-persistence.md](docs/architecture/13-gateway-and-persistence.md) |
-| Q23 | Value | How do I measure AI fix acceptance rates? | Gap | API exists per 13-gateway, no user guide |
-| Q24 | Value | What metrics does the Gateway API provide? | Gap | [docs/architecture/13-gateway-and-persistence.md](docs/architecture/13-gateway-and-persistence.md) (architecture, not guide) |
-| Q25 | Integration | How do I integrate with GitHub Actions? | Gap | No documentation found |
-| Q26 | Integration | How do I integrate with GitLab CI? | Gap | No documentation found |
-| Q27 | Integration | How do I integrate with Jenkins? | Gap | No documentation found |
-| Q28 | Integration | How do I integrate with Azure DevOps? | Gap | No documentation found |
-| Q29 | Integration | How do I use APME with AAP/AWX? | Gap | No documentation found |
-| Q30 | Integration | How do I use APME with Backstage? | Gap | No documentation found |
-| Q31 | Integration | How do I use APME with pre-commit hooks? | Gap | No documentation found |
-| Q32 | Integration | How do I migrate from ansible-lint? | Covered | [docs/rules/ANSIBLELINT_COVERAGE.md](docs/rules/ANSIBLELINT_COVERAGE.md) |
-| Q33 | Integration | How do I use APME in an air-gapped environment? | Covered | [docs/guides/DEPLOYMENT.md#custom-ca-certificates](docs/guides/DEPLOYMENT.md) |
-| Q34 | Integration | How do I integrate with VS Code? | Covered | No VS Code extension exists yet; N/A |
+| Q01 | What Is It | What is APME and what problem does it solve? | ✓ | [README.md#what-apme-is](../../README.md#what-apme-is) |
+| Q02 | What Is It | What types of Ansible content can APME scan? | ✓ | [README.md#what-apme-is](../../README.md#what-apme-is) |
+| Q03 | What Is It | What rules does APME enforce and why? | ✓ | [RULE_CATALOG.md](../rules/RULE_CATALOG.md) |
+| Q04 | What Is It | How does APME differ from ansible-lint? | ⚠ | [ANSIBLELINT_COVERAGE.md](../rules/ANSIBLELINT_COVERAGE.md) |
+| Q05 | What Is It | What are the severity levels and what do they mean? | ✓ | [RULE_CATALOG.md](../rules/RULE_CATALOG.md) |
+| Q06 | How Can I Use It | How do I install APME? | ✓ | [README.md#install](../../README.md#install) |
+| Q07 | How Can I Use It | How do I run a basic scan? | ✓ | [README.md#basic-usage](../../README.md#basic-usage) |
+| Q08 | How Can I Use It | How do I get JSON output for automation? | ✓ | [README.md#basic-usage](../../README.md#basic-usage) |
+| Q09 | How Can I Use It | How do I run APME in a container? | ✓ | [README.md](../../README.md), [DEPLOYMENT.md](../guides/DEPLOYMENT.md) |
+| Q10 | How Can I Use It | How do I use daemon vs pod mode? | ⚠ | [DEPLOYMENT.md#local-development-daemon-mode](../guides/DEPLOYMENT.md#local-development-daemon-mode) |
+| Q11 | Rule Config | How do I enable/disable specific rules? | ⚠ | [_rules_yml.py](../../src/apme_engine/cli/_rules_yml.py) (code only) |
+| Q12 | Rule Config | How do I change rule severity? | ⚠ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
+| Q13 | Rule Config | How do I suppress a rule for a specific line? | ✗ | No documentation found |
+| Q14 | Rule Config | How do I configure rules per-project? | ⚠ | [_rules_yml.py](../../src/apme_engine/cli/_rules_yml.py) (code only) |
+| Q15 | Rule Config | How do I enforce rules and ignore noqa comments? | ✓ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
+| Q16 | Custom Rules | Can I add custom rules? | ⚠ | [ADR-042](../../.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
+| Q17 | Custom Rules | How do I write a custom OPA/Rego rule? | ⚠ | [DEVELOPMENT.md](../guides/DEVELOPMENT.md) |
+| Q18 | Custom Rules | How do I add custom rules via plugins? | ⚠ | [ADR-042](../../.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
+| Q19 | Custom Rules | What rule ID conventions should custom rules follow? | ✗ | ADR-008 exists but not user-facing |
+| Q20 | Value | How do I show before/after remediation? | ✓ | [README.md#basic-usage](../../README.md#basic-usage) |
+| Q21 | Value | How do I track improvement over time? | ✗ | No documentation found |
+| Q22 | Value | How do I generate reports for stakeholders? | ⚠ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) |
+| Q23 | Value | How do I measure AI fix acceptance rates? | ✗ | API exists per 13-gateway, no user guide |
+| Q24 | Value | What metrics does the Gateway API provide? | ✗ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) (architecture, not guide) |
+| Q25 | Integration | How do I integrate with GitHub Actions? | ✗ | No documentation found |
+| Q26 | Integration | How do I integrate with GitLab CI? | ✗ | No documentation found |
+| Q27 | Integration | How do I integrate with Jenkins? | ✗ | No documentation found |
+| Q28 | Integration | How do I integrate with Azure DevOps? | ✗ | No documentation found |
+| Q29 | Integration | How do I use APME with AAP/AWX? | ✗ | No documentation found |
+| Q30 | Integration | How do I use APME with Backstage? | ✗ | No documentation found |
+| Q31 | Integration | How do I integrate with pre-commit hooks? | ✗ | No documentation found |
+| Q32 | Integration | How do I migrate from ansible-lint? | ✓ | [ANSIBLELINT_COVERAGE.md](../rules/ANSIBLELINT_COVERAGE.md) |
+| Q33 | Integration | How do I use APME in an air-gapped environment? | ✓ | [DEPLOYMENT.md#custom-ca-certificates](../guides/DEPLOYMENT.md#custom-ca-certificates) |
+| Q34 | Integration | How do I integrate with VS Code? | ✗ | No VS Code extension exists yet |
 
 ## Gap Analysis
 

--- a/docs/reports/docs-qa-audit-2026-05-21.md
+++ b/docs/reports/docs-qa-audit-2026-05-21.md
@@ -3,11 +3,11 @@
 ## Executive Summary
 
 - **Total Questions**: 34
-- **Covered** (✓): 11 (32%)
-- **Partial** (⚠): 10 (29%)
-- **Gaps** (✗): 13 (38%)
+- **Covered** (✓): 16 (47%)
+- **Partial** (⚠): 8 (24%)
+- **Gaps** (✗): 10 (29%)
 
-The documentation has solid coverage of core functionality (installation, basic scanning, container deployment, rule catalog) but significant gaps exist in CI/CD integration guides, tooling ecosystem integration, and some rule configuration topics.
+The documentation has solid coverage of core functionality (installation, basic scanning, container deployment, rule catalog, and rule configuration) but significant gaps remain in CI/CD integration guides, tooling ecosystem integration, and higher-level reporting workflows.
 
 ## Coverage by Category
 
@@ -15,9 +15,9 @@ The documentation has solid coverage of core functionality (installation, basic 
 |----------|---------|---------|-----|-------|
 | What Is It / What Does It Do | 4/5 | 1/5 | 0/5 | 90% |
 | How Can I Use It | 4/5 | 1/5 | 0/5 | 90% |
-| Rule Configuration | 0/5 | 4/5 | 1/5 | 40% |
-| Bring Your Own Rules | 0/4 | 3/4 | 1/4 | 38% |
-| Demonstrating Value | 1/5 | 1/5 | 3/5 | 30% |
+| Rule Configuration | 4/5 | 1/5 | 0/5 | 90% |
+| Bring Your Own Rules | 0/4 | 4/4 | 0/4 | 50% |
+| Demonstrating Value | 2/5 | 1/5 | 2/5 | 50% |
 | Integration with Existing Tools | 2/10 | 0/10 | 8/10 | 20% |
 
 ## Coverage Matrix
@@ -34,19 +34,19 @@ The documentation has solid coverage of core functionality (installation, basic 
 | Q08 | How Can I Use It | How do I get JSON output for automation? | ✓ | [README.md#basic-usage](../../README.md#basic-usage) |
 | Q09 | How Can I Use It | How do I run APME in a container? | ✓ | [README.md](../../README.md), [DEPLOYMENT.md](../guides/DEPLOYMENT.md) |
 | Q10 | How Can I Use It | How do I use daemon vs pod mode? | ⚠ | [DEPLOYMENT.md#local-development-daemon-mode](../guides/DEPLOYMENT.md#local-development-daemon-mode) |
-| Q11 | Rule Configuration | How do I enable/disable specific rules? | ⚠ | [_rules_yml.py](../../src/apme_engine/cli/_rules_yml.py) (code only) |
-| Q12 | Rule Configuration | How do I change rule severity? | ⚠ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
-| Q13 | Rule Configuration | How do I suppress a rule for a specific line? | ✗ | No documentation found |
-| Q14 | Rule Configuration | How do I configure rules per-project? | ⚠ | [_rules_yml.py](../../src/apme_engine/cli/_rules_yml.py) (code only) |
-| Q15 | Rule Configuration | How do I enforce rules and ignore noqa comments? | ⚠ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
+| Q11 | Rule Configuration | How do I enable/disable specific rules? | ✓ | [RULE_CONFIGURATION.md](../guides/RULE_CONFIGURATION.md) |
+| Q12 | Rule Configuration | How do I change rule severity? | ✓ | [RULE_CONFIGURATION.md](../guides/RULE_CONFIGURATION.md) |
+| Q13 | Rule Configuration | How do I suppress a rule for a specific line? | ✓ | [RULE_CONFIGURATION.md](../guides/RULE_CONFIGURATION.md) |
+| Q14 | Rule Configuration | How do I configure rules per-project? | ✓ | [RULE_CONFIGURATION.md](../guides/RULE_CONFIGURATION.md) |
+| Q15 | Rule Configuration | How do I enforce rules and ignore noqa comments? | ⚠ | [RULE_CONFIGURATION.md](../guides/RULE_CONFIGURATION.md), [graph_scanner.py](../../src/apme_engine/engine/graph_scanner.py) |
 | Q16 | Bring Your Own Rules | Can I add custom rules? | ⚠ | [ADR-042](../../.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
 | Q17 | Bring Your Own Rules | How do I write a custom OPA/Rego rule? | ⚠ | [DEVELOPMENT.md](../guides/DEVELOPMENT.md) |
 | Q18 | Bring Your Own Rules | How do I add custom rules via plugins? | ⚠ | [ADR-042](../../.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
-| Q19 | Bring Your Own Rules | What rule ID conventions should custom rules follow? | ✗ | ADR-008 exists but not user-facing |
+| Q19 | Bring Your Own Rules | What rule ID conventions should custom rules follow? | ⚠ | [RULE_CONFIGURATION.md](../guides/RULE_CONFIGURATION.md) |
 | Q20 | Demonstrating Value | How do I show before/after remediation? | ✓ | [README.md#basic-usage](../../README.md#basic-usage) |
 | Q21 | Demonstrating Value | How do I track improvement over time? | ✗ | No documentation found |
 | Q22 | Demonstrating Value | How do I generate reports for stakeholders? | ⚠ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) |
-| Q23 | Demonstrating Value | How do I measure AI fix acceptance rates? | ✗ | API exists per 13-gateway, no user guide |
+| Q23 | Demonstrating Value | How do I measure AI fix acceptance rates? | ✓ | [RULE_CONFIGURATION.md](../guides/RULE_CONFIGURATION.md) |
 | Q24 | Demonstrating Value | What metrics does the Gateway API provide? | ✗ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) (architecture, not guide) |
 | Q25 | Integration with Existing Tools | How do I integrate with GitHub Actions? | ✗ | No documentation found |
 | Q26 | Integration with Existing Tools | How do I integrate with GitLab CI? | ✗ | No documentation found |
@@ -61,25 +61,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 
 ## Gap Analysis
 
-### Gap 1: Inline Suppression (Q13)
-
-- **ID**: Q13
-- **Question**: How do I suppress a rule for a specific line?
-- **Impact**: Users need to suppress false positives in specific locations without disabling the rule globally. This is a fundamental workflow.
-- **Suggested Location**: `docs/guides/RULE_CONFIGURATION.md` or README.md
-- **Research Notes**: The engine currently parses inline suppression via `# noqa: <RULE_ID>` comments in `graph_scanner.py`, and ADR-041 documents the `enforced` flag to ignore those suppressions. There is still no user-facing documentation explaining the syntax or usage.
-- **Draft Answer**: Add an inline `# noqa: <RULE_ID>` comment to suppress that rule for the node. Use `enforced: true` in `.apme/rules.yml` to make suppression impossible for compliance-critical rules.
-
-### Gap 2: Rule ID Conventions for Custom Rules (Q19)
-
-- **ID**: Q19
-- **Question**: What rule ID conventions should custom rules follow?
-- **Impact**: Users writing custom rules need to understand the ID naming scheme to avoid conflicts and maintain consistency.
-- **Suggested Location**: `docs/guides/CUSTOM_RULES.md` (new file)
-- **Research Notes**: ADR-008 defines L/M/R/P/SEC prefixes. ADR-042 defines EXT- prefix for plugins. This information exists but is not in user-facing docs.
-- **Draft Answer**: Built-in rules use prefixes: L (lint), M (modernize), R (risk), P (policy), SEC (secrets). Custom plugin rules must use `EXT-<plugin_name>-<NNN>` format (e.g., `EXT-secteam-001`).
-
-### Gap 3: Tracking Improvement Over Time (Q21)
+### Gap 1: Tracking Improvement Over Time (Q21)
 
 - **ID**: Q21
 - **Question**: How do I track improvement over time?
@@ -88,16 +70,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Research Notes**: Gateway API has `/projects/{id}/trend` endpoint and health scores per 13-gateway architecture doc, but no user guide exists.
 - **Draft Answer**: The Gateway REST API provides trend data via `GET /api/v1/projects/{id}/trend`. The UI dashboard shows violation trends over time. Health scores are computed per project.
 
-### Gap 4: AI Acceptance Rates (Q23)
-
-- **ID**: Q23
-- **Question**: How do I measure AI fix acceptance rates?
-- **Impact**: Teams evaluating AI remediation need metrics to justify the investment.
-- **Suggested Location**: `docs/guides/REPORTING.md` (new file)
-- **Research Notes**: Gateway API has `GET /api/v1/stats/ai-acceptance` endpoint per 13-gateway.
-- **Draft Answer**: Query `GET /api/v1/stats/ai-acceptance` from the Gateway API for proposal approval/rejection statistics.
-
-### Gap 5: Gateway API Metrics Guide (Q24)
+### Gap 2: Gateway API Metrics Guide (Q24)
 
 - **ID**: Q24
 - **Question**: What metrics does the Gateway API provide?
@@ -106,7 +79,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Research Notes**: Full endpoint list exists in 13-gateway architecture doc. Needs user-facing guide with examples.
 - **Draft Answer**: Document the dashboard endpoints: `/api/v1/dashboard/summary`, `/api/v1/violations/top`, `/api/v1/stats/remediation-rates`, `/api/v1/stats/ai-acceptance`.
 
-### Gap 6: GitHub Actions Integration (Q25)
+### Gap 3: GitHub Actions Integration (Q25)
 
 - **ID**: Q25
 - **Question**: How do I integrate with GitHub Actions?
@@ -115,7 +88,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Research Notes**: The CLI supports `--json` output and exit codes suitable for CI. No example workflow exists.
 - **Draft Answer**: Create example workflow using `pip install apme-engine@git+https://github.com/ansible/apme.git@main` and `apme check --json .`.
 
-### Gap 7: GitLab CI Integration (Q26)
+### Gap 4: GitLab CI Integration (Q26)
 
 - **ID**: Q26
 - **Question**: How do I integrate with GitLab CI?
@@ -123,7 +96,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
 - **Research Notes**: Same CLI capabilities apply. No `.gitlab-ci.yml` example exists.
 
-### Gap 8: Jenkins Integration (Q27)
+### Gap 5: Jenkins Integration (Q27)
 
 - **ID**: Q27
 - **Question**: How do I integrate with Jenkins?
@@ -131,7 +104,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
 - **Research Notes**: CLI can be run in Jenkins pipelines. No example Jenkinsfile exists.
 
-### Gap 9: Azure DevOps Integration (Q28)
+### Gap 6: Azure DevOps Integration (Q28)
 
 - **ID**: Q28
 - **Question**: How do I integrate with Azure DevOps?
@@ -139,7 +112,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
 - **Research Notes**: No Azure Pipelines example exists.
 
-### Gap 10: AAP/AWX Integration (Q29)
+### Gap 7: AAP/AWX Integration (Q29)
 
 - **ID**: Q29
 - **Question**: How do I use APME with AAP/AWX?
@@ -148,7 +121,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Research Notes**: README mentions AAP 2.5+ as the target. Roadmap mentions EE compatibility rules. No integration guide exists.
 - **Draft Answer**: APME scans content for AAP 2.5+ compatibility. For EE integration, use `--ansible-core-version` flag. Future: EE compatibility rules (R505-R507) planned.
 
-### Gap 11: Backstage Integration (Q30)
+### Gap 8: Backstage Integration (Q30)
 
 - **ID**: Q30
 - **Question**: How do I use APME with Backstage?
@@ -156,7 +129,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Suggested Location**: `docs/guides/BACKSTAGE_INTEGRATION.md` (new file)
 - **Research Notes**: No Backstage plugin or integration guide exists. The Gateway API could be consumed by a Backstage plugin.
 
-### Gap 12: Pre-commit Hooks (Q31)
+### Gap 9: Pre-commit Hooks (Q31)
 
 - **ID**: Q31
 - **Question**: How do I use APME with pre-commit hooks?
@@ -164,6 +137,15 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Suggested Location**: `docs/guides/CI_INTEGRATION.md` or README.md
 - **Research Notes**: No `.pre-commit-config.yaml` example exists. The CLI could be wrapped as a pre-commit hook.
 - **Draft Answer**: Create `.pre-commit-config.yaml` entry using `apme check` as a local hook.
+
+### Gap 10: VS Code Integration (Q34)
+
+- **ID**: Q34
+- **Question**: How do I integrate with VS Code?
+- **Impact**: Editor integration is a common adoption path for local developer workflows.
+- **Suggested Location**: `docs/guides/EDITOR_INTEGRATION.md` or README.md
+- **Research Notes**: No VS Code extension or editor integration guide exists in the repo today.
+- **Draft Answer**: Document the current status explicitly: there is no VS Code extension yet, and users should run `apme check` from the terminal or CI until an editor integration exists.
 
 ## Partial Coverage Improvements
 
@@ -179,59 +161,46 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Gap**: Explains both modes but lacks a decision tree for when to use each.
 - **Recommendation**: Add a "Which mode should I use?" section with clear guidance.
 
-### Partial 3: Enable/Disable Rules (Q11)
+### Partial 3: Enforced Rules vs `noqa` (Q15)
 
-- **Current Source**: Code in `_rules_yml.py`
-- **Gap**: The `.apme/rules.yml` format is only documented in code comments.
-- **Recommendation**: Create `docs/guides/RULE_CONFIGURATION.md` with examples.
+- **Current Source**: `docs/guides/RULE_CONFIGURATION.md`, `graph_scanner.py`
+- **Gap**: The guide documents `enforced`, but the native graph-rule scan path parses `# noqa` before violations are created. The user-facing docs should be explicit about that current limitation.
+- **Recommendation**: Keep the guide aligned with implementation details until the engine supports bypassing native graph-rule `# noqa` suppressions.
 
-### Partial 4: Severity Override (Q12)
-
-- **Current Source**: ADR-041
-- **Gap**: ADR explains architecture, not user workflow.
-- **Recommendation**: Add user-facing examples to `docs/guides/RULE_CONFIGURATION.md`.
-
-### Partial 5: Per-project Config (Q14)
-
-- **Current Source**: Code in `_rules_yml.py`
-- **Gap**: No user documentation for `.apme/rules.yml`.
-- **Recommendation**: Document in `docs/guides/RULE_CONFIGURATION.md`.
-
-### Partial 6: Custom Rules Overview (Q16)
+### Partial 4: Custom Rules Overview (Q16)
 
 - **Current Source**: ADR-042
 - **Gap**: ADR is developer-focused, not user-facing.
 - **Recommendation**: Create `docs/guides/CUSTOM_RULES.md` with high-level overview.
 
-### Partial 7: Custom OPA/Rego Rules (Q17)
+### Partial 5: Rule ID Conventions (Q19)
+
+- **Current Source**: `docs/guides/RULE_CONFIGURATION.md`
+- **Gap**: The guide mentions custom prefixes, but the custom-rule story is still spread across configuration docs, ADRs, and future plugin design. A dedicated custom-rules guide would be clearer for users.
+- **Recommendation**: Fold rule ID conventions into `docs/guides/CUSTOM_RULES.md` alongside plugin and extension guidance.
+
+### Partial 6: Custom OPA/Rego Rules (Q17)
 
 - **Current Source**: docs/guides/DEVELOPMENT.md
 - **Gap**: Development guide shows internal rule addition, not external/user-facing custom rules.
 - **Recommendation**: Clarify distinction between internal development and plugin extensibility.
 
-### Partial 8: Plugin Rules (Q18)
+### Partial 7: Plugin Rules (Q18)
 
 - **Current Source**: ADR-042
 - **Gap**: SDK documentation planned but not yet published.
 - **Recommendation**: Complete Phase 5 of ADR-042 implementation (documentation and SDK guide).
 
-### Partial 9: Stakeholder Reports (Q22)
+### Partial 8: Stakeholder Reports (Q22)
 
 - **Current Source**: 13-gateway architecture doc
-- **Gap**: API endpoints documented but no guide on generating stakeholder reports.
-- **Recommendation**: Create `docs/guides/REPORTING.md` with report examples.
-
-### Partial 10: Enforced Rules vs `noqa` (Q15)
-
-- **Current Source**: ADR-041
-- **Gap**: The behavior is documented architecturally, but there is no user-facing configuration guide explaining `enforced: true` or how it interacts with `# noqa: <RULE_ID>`.
-- **Recommendation**: Add an "Enforced Rules" section to `docs/guides/RULE_CONFIGURATION.md` with examples showing both inline suppression and rule-level enforcement.
+- **Gap**: API endpoints are documented, but there is still no guide on generating stakeholder-facing reports or choosing between dashboard summaries, trends, and proposal statistics.
+- **Recommendation**: Create `docs/guides/REPORTING.md` with report examples and workflow guidance.
 
 ## Action Items
 
 ### High Priority (Core User Workflows)
 
-- [ ] Create `docs/guides/RULE_CONFIGURATION.md` documenting `.apme/rules.yml` format, inline suppression (`# noqa: <RULE_ID>`), severity overrides, and `enforced` flag
 - [ ] Create `docs/guides/CI_INTEGRATION.md` with examples for GitHub Actions, GitLab CI, Jenkins, Azure DevOps, and pre-commit hooks
 
 ### Medium Priority (Value Demonstration)
@@ -243,11 +212,12 @@ The documentation has solid coverage of core functionality (installation, basic 
 
 - [ ] Create `docs/guides/CUSTOM_RULES.md` with rule ID conventions and plugin SDK overview
 - [ ] Create `docs/guides/AAP_INTEGRATION.md` for AAP/EE integration guidance
+- [ ] Document the current "no VS Code extension yet" status and any recommended editor workflow
 - [ ] Document Backstage integration pattern when plugin is available
 
 ## Next Steps
 
 1. Review gaps with stakeholders to prioritize based on customer frequency
-2. Create `RULE_CONFIGURATION.md` and `CI_INTEGRATION.md` as highest-impact additions
-3. Add `# noqa: <RULE_ID>` suppression syntax to user-facing docs immediately
+2. Create `CI_INTEGRATION.md` as the highest-impact missing guide
+3. Create `REPORTING.md` for trends, dashboard metrics, and stakeholder workflows
 4. Re-run audit after documentation updates

--- a/docs/reports/docs-qa-audit-2026-05-21.md
+++ b/docs/reports/docs-qa-audit-2026-05-21.md
@@ -24,40 +24,40 @@ The documentation has solid coverage of core functionality (installation, basic 
 
 | ID | Category | Question | Status | Source |
 |----|----------|----------|--------|--------|
-| Q01 | What Is It | What is APME and what problem does it solve? | ✓ | [README.md#what-apme-is](../../README.md#what-apme-is) |
-| Q02 | What Is It | What types of Ansible content can APME scan? | ✓ | [README.md#what-apme-is](../../README.md#what-apme-is) |
-| Q03 | What Is It | What rules does APME enforce and why? | ✓ | [RULE_CATALOG.md](../rules/RULE_CATALOG.md) |
-| Q04 | What Is It | How does APME differ from ansible-lint? | ⚠ | [ANSIBLELINT_COVERAGE.md](../rules/ANSIBLELINT_COVERAGE.md) |
-| Q05 | What Is It | What are the severity levels and what do they mean? | ✓ | [RULE_CATALOG.md](../rules/RULE_CATALOG.md) |
+| Q01 | What Is It / What Does It Do | What is APME and what problem does it solve? | ✓ | [README.md#what-apme-is](../../README.md#what-apme-is) |
+| Q02 | What Is It / What Does It Do | What types of Ansible content can APME scan? | ✓ | [README.md#what-apme-is](../../README.md#what-apme-is) |
+| Q03 | What Is It / What Does It Do | What rules does APME enforce and why? | ✓ | [RULE_CATALOG.md](../rules/RULE_CATALOG.md) |
+| Q04 | What Is It / What Does It Do | How does APME differ from ansible-lint? | ⚠ | [ANSIBLELINT_COVERAGE.md](../rules/ANSIBLELINT_COVERAGE.md) |
+| Q05 | What Is It / What Does It Do | What are the severity levels and what do they mean? | ✓ | [RULE_CATALOG.md](../rules/RULE_CATALOG.md) |
 | Q06 | How Can I Use It | How do I install APME? | ✓ | [README.md#install](../../README.md#install) |
 | Q07 | How Can I Use It | How do I run a basic scan? | ✓ | [README.md#basic-usage](../../README.md#basic-usage) |
 | Q08 | How Can I Use It | How do I get JSON output for automation? | ✓ | [README.md#basic-usage](../../README.md#basic-usage) |
 | Q09 | How Can I Use It | How do I run APME in a container? | ✓ | [README.md](../../README.md), [DEPLOYMENT.md](../guides/DEPLOYMENT.md) |
 | Q10 | How Can I Use It | How do I use daemon vs pod mode? | ⚠ | [DEPLOYMENT.md#local-development-daemon-mode](../guides/DEPLOYMENT.md#local-development-daemon-mode) |
-| Q11 | Rule Config | How do I enable/disable specific rules? | ⚠ | [_rules_yml.py](../../src/apme_engine/cli/_rules_yml.py) (code only) |
-| Q12 | Rule Config | How do I change rule severity? | ⚠ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
-| Q13 | Rule Config | How do I suppress a rule for a specific line? | ✗ | No documentation found |
-| Q14 | Rule Config | How do I configure rules per-project? | ⚠ | [_rules_yml.py](../../src/apme_engine/cli/_rules_yml.py) (code only) |
-| Q15 | Rule Config | How do I enforce rules and ignore noqa comments? | ✓ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
-| Q16 | Custom Rules | Can I add custom rules? | ⚠ | [ADR-042](../../.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
-| Q17 | Custom Rules | How do I write a custom OPA/Rego rule? | ⚠ | [DEVELOPMENT.md](../guides/DEVELOPMENT.md) |
-| Q18 | Custom Rules | How do I add custom rules via plugins? | ⚠ | [ADR-042](../../.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
-| Q19 | Custom Rules | What rule ID conventions should custom rules follow? | ✗ | ADR-008 exists but not user-facing |
-| Q20 | Value | How do I show before/after remediation? | ✓ | [README.md#basic-usage](../../README.md#basic-usage) |
-| Q21 | Value | How do I track improvement over time? | ✗ | No documentation found |
-| Q22 | Value | How do I generate reports for stakeholders? | ⚠ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) |
-| Q23 | Value | How do I measure AI fix acceptance rates? | ✗ | API exists per 13-gateway, no user guide |
-| Q24 | Value | What metrics does the Gateway API provide? | ✗ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) (architecture, not guide) |
-| Q25 | Integration | How do I integrate with GitHub Actions? | ✗ | No documentation found |
-| Q26 | Integration | How do I integrate with GitLab CI? | ✗ | No documentation found |
-| Q27 | Integration | How do I integrate with Jenkins? | ✗ | No documentation found |
-| Q28 | Integration | How do I integrate with Azure DevOps? | ✗ | No documentation found |
-| Q29 | Integration | How do I use APME with AAP/AWX? | ✗ | No documentation found |
-| Q30 | Integration | How do I use APME with Backstage? | ✗ | No documentation found |
-| Q31 | Integration | How do I integrate with pre-commit hooks? | ✗ | No documentation found |
-| Q32 | Integration | How do I migrate from ansible-lint? | ✓ | [ANSIBLELINT_COVERAGE.md](../rules/ANSIBLELINT_COVERAGE.md) |
-| Q33 | Integration | How do I use APME in an air-gapped environment? | ✓ | [DEPLOYMENT.md#custom-ca-certificates](../guides/DEPLOYMENT.md#custom-ca-certificates) |
-| Q34 | Integration | How do I integrate with VS Code? | ✗ | No VS Code extension exists yet |
+| Q11 | Rule Configuration | How do I enable/disable specific rules? | ⚠ | [_rules_yml.py](../../src/apme_engine/cli/_rules_yml.py) (code only) |
+| Q12 | Rule Configuration | How do I change rule severity? | ⚠ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
+| Q13 | Rule Configuration | How do I suppress a rule for a specific line? | ✗ | No documentation found |
+| Q14 | Rule Configuration | How do I configure rules per-project? | ⚠ | [_rules_yml.py](../../src/apme_engine/cli/_rules_yml.py) (code only) |
+| Q15 | Rule Configuration | How do I enforce rules and ignore noqa comments? | ✓ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
+| Q16 | Bring Your Own Rules | Can I add custom rules? | ⚠ | [ADR-042](../../.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
+| Q17 | Bring Your Own Rules | How do I write a custom OPA/Rego rule? | ⚠ | [DEVELOPMENT.md](../guides/DEVELOPMENT.md) |
+| Q18 | Bring Your Own Rules | How do I add custom rules via plugins? | ⚠ | [ADR-042](../../.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
+| Q19 | Bring Your Own Rules | What rule ID conventions should custom rules follow? | ✗ | ADR-008 exists but not user-facing |
+| Q20 | Demonstrating Value | How do I show before/after remediation? | ✓ | [README.md#basic-usage](../../README.md#basic-usage) |
+| Q21 | Demonstrating Value | How do I track improvement over time? | ✗ | No documentation found |
+| Q22 | Demonstrating Value | How do I generate reports for stakeholders? | ⚠ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) |
+| Q23 | Demonstrating Value | How do I measure AI fix acceptance rates? | ✗ | API exists per 13-gateway, no user guide |
+| Q24 | Demonstrating Value | What metrics does the Gateway API provide? | ✗ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) (architecture, not guide) |
+| Q25 | Integration with Existing Tools | How do I integrate with GitHub Actions? | ✗ | No documentation found |
+| Q26 | Integration with Existing Tools | How do I integrate with GitLab CI? | ✗ | No documentation found |
+| Q27 | Integration with Existing Tools | How do I integrate with Jenkins? | ✗ | No documentation found |
+| Q28 | Integration with Existing Tools | How do I integrate with Azure DevOps? | ✗ | No documentation found |
+| Q29 | Integration with Existing Tools | How do I use APME with AAP/AWX? | ✗ | No documentation found |
+| Q30 | Integration with Existing Tools | How do I use APME with Backstage? | ✗ | No documentation found |
+| Q31 | Integration with Existing Tools | How do I integrate with pre-commit hooks? | ✗ | No documentation found |
+| Q32 | Integration with Existing Tools | How do I migrate from ansible-lint? | ✓ | [ANSIBLELINT_COVERAGE.md](../rules/ANSIBLELINT_COVERAGE.md) |
+| Q33 | Integration with Existing Tools | How do I use APME in an air-gapped environment? | ✓ | [DEPLOYMENT.md#custom-ca-certificates](../guides/DEPLOYMENT.md#custom-ca-certificates) |
+| Q34 | Integration with Existing Tools | How do I integrate with VS Code? | ✗ | No VS Code extension exists yet |
 
 ## Gap Analysis
 
@@ -68,7 +68,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Impact**: Users need to suppress false positives in specific locations without disabling the rule globally. This is a fundamental workflow.
 - **Suggested Location**: `docs/guides/CONFIGURATION.md` (new file) or README.md
 - **Research Notes**: ADR-041 mentions `# apme:ignore` annotations and `enforced` flag to ignore them, but there is no user-facing documentation explaining the syntax or usage.
-- **Draft Answer**: Add inline `# apme:ignore` or `# apme:ignore[L026]` comment to suppress violations on that line. Use `enforced: true` in `.apme/rules.yml` to make suppression impossible for compliance-critical rules.
+- **Draft Answer**: Add inline `# apme:ignore` comment to suppress violations on that line. Use `enforced: true` in `.apme/rules.yml` to make suppression impossible for compliance-critical rules.
 
 ### Gap 2: Rule ID Conventions for Custom Rules (Q19)
 
@@ -104,7 +104,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Impact**: API consumers need a reference to build dashboards and integrations.
 - **Suggested Location**: `docs/guides/REPORTING.md` (new file)
 - **Research Notes**: Full endpoint list exists in 13-gateway architecture doc. Needs user-facing guide with examples.
-- **Draft Answer**: Document the dashboard endpoints: `/dashboard/summary`, `/violations/top`, `/stats/remediation-rates`, `/stats/ai-acceptance`.
+- **Draft Answer**: Document the dashboard endpoints: `/api/v1/dashboard/summary`, `/api/v1/violations/top`, `/api/v1/stats/remediation-rates`, `/api/v1/stats/ai-acceptance`.
 
 ### Gap 6: GitHub Actions Integration (Q25)
 

--- a/docs/reports/docs-qa-audit-2026-05-21.md
+++ b/docs/reports/docs-qa-audit-2026-05-21.md
@@ -1,0 +1,247 @@
+# Documentation Q&A Audit - 2026-05-21
+
+## Executive Summary
+
+- **Total Questions**: 34
+- **Covered**: 13 (38%)
+- **Partial**: 9 (26%)
+- **Gaps**: 12 (35%)
+
+The documentation has solid coverage of core functionality (installation, basic scanning, container deployment, rule catalog) but significant gaps exist in CI/CD integration guides, tooling ecosystem integration, and some rule configuration topics.
+
+## Coverage by Category
+
+| Category | Covered | Partial | Gap | Score |
+|----------|---------|---------|-----|-------|
+| What Is It / What Does It Do | 4/5 | 1/5 | 0/5 | 90% |
+| How Can I Use It | 4/5 | 1/5 | 0/5 | 90% |
+| Rule Configuration | 1/5 | 3/5 | 1/5 | 50% |
+| Bring Your Own Rules | 0/4 | 3/4 | 1/4 | 38% |
+| Demonstrating Value | 1/5 | 1/5 | 3/5 | 30% |
+| Integration with Existing Tools | 3/10 | 0/10 | 7/10 | 30% |
+
+## Coverage Matrix
+
+| ID | Category | Question | Status | Source |
+|----|----------|----------|--------|--------|
+| Q01 | What Is It | What is APME and what problem does it solve? | Covered | [README.md#what-apme-is](README.md) |
+| Q02 | What Is It | What types of Ansible content can APME scan? | Covered | [README.md#what-apme-is](README.md) |
+| Q03 | What Is It | What rules does APME enforce and why? | Covered | [docs/rules/RULE_CATALOG.md](docs/rules/RULE_CATALOG.md) |
+| Q04 | What Is It | How does APME differ from ansible-lint? | Partial | [docs/rules/ANSIBLELINT_COVERAGE.md](docs/rules/ANSIBLELINT_COVERAGE.md) |
+| Q05 | What Is It | What are the severity levels and what do they mean? | Covered | [docs/rules/RULE_CATALOG.md](docs/rules/RULE_CATALOG.md) |
+| Q06 | How Can I Use It | How do I install APME? | Covered | [README.md#install](README.md) |
+| Q07 | How Can I Use It | How do I run a basic scan? | Covered | [README.md#basic-usage](README.md) |
+| Q08 | How Can I Use It | How do I get JSON output for automation? | Covered | [README.md#basic-usage](README.md) |
+| Q09 | How Can I Use It | How do I run APME in a container? | Covered | [README.md#container-deployment-podman](README.md), [docs/guides/DEPLOYMENT.md](docs/guides/DEPLOYMENT.md) |
+| Q10 | How Can I Use It | How do I use daemon vs pod mode? | Partial | [docs/guides/DEPLOYMENT.md#local-development-daemon-mode](docs/guides/DEPLOYMENT.md) |
+| Q11 | Rule Config | How do I enable/disable specific rules? | Partial | [src/apme_engine/cli/_rules_yml.py](src/apme_engine/cli/_rules_yml.py) (code only) |
+| Q12 | Rule Config | How do I change rule severity? | Partial | [.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md](.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
+| Q13 | Rule Config | How do I suppress a rule for a specific line? | Gap | No documentation found |
+| Q14 | Rule Config | How do I configure rules per-project? | Partial | [src/apme_engine/cli/_rules_yml.py](src/apme_engine/cli/_rules_yml.py) (code only) |
+| Q15 | Rule Config | How do I enforce rules and ignore noqa comments? | Covered | [.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md](.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
+| Q16 | Custom Rules | Can I add custom rules? | Partial | [.sdlc/adrs/ADR-042-third-party-plugin-services.md](.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
+| Q17 | Custom Rules | How do I write a custom OPA/Rego rule? | Partial | [docs/guides/DEVELOPMENT.md#opa-rego-rule](docs/guides/DEVELOPMENT.md) |
+| Q18 | Custom Rules | How do I add custom rules via plugins? | Partial | [.sdlc/adrs/ADR-042-third-party-plugin-services.md](.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
+| Q19 | Custom Rules | What rule ID conventions should custom rules follow? | Gap | ADR-008 exists but not user-facing |
+| Q20 | Value | How do I show before/after remediation? | Covered | [README.md#basic-usage](README.md) |
+| Q21 | Value | How do I track improvement over time? | Gap | No documentation found |
+| Q22 | Value | How do I generate reports for stakeholders? | Partial | [docs/architecture/13-gateway-and-persistence.md](docs/architecture/13-gateway-and-persistence.md) |
+| Q23 | Value | How do I measure AI fix acceptance rates? | Gap | API exists per 13-gateway, no user guide |
+| Q24 | Value | What metrics does the Gateway API provide? | Gap | [docs/architecture/13-gateway-and-persistence.md](docs/architecture/13-gateway-and-persistence.md) (architecture, not guide) |
+| Q25 | Integration | How do I integrate with GitHub Actions? | Gap | No documentation found |
+| Q26 | Integration | How do I integrate with GitLab CI? | Gap | No documentation found |
+| Q27 | Integration | How do I integrate with Jenkins? | Gap | No documentation found |
+| Q28 | Integration | How do I integrate with Azure DevOps? | Gap | No documentation found |
+| Q29 | Integration | How do I use APME with AAP/AWX? | Gap | No documentation found |
+| Q30 | Integration | How do I use APME with Backstage? | Gap | No documentation found |
+| Q31 | Integration | How do I use APME with pre-commit hooks? | Gap | No documentation found |
+| Q32 | Integration | How do I migrate from ansible-lint? | Covered | [docs/rules/ANSIBLELINT_COVERAGE.md](docs/rules/ANSIBLELINT_COVERAGE.md) |
+| Q33 | Integration | How do I use APME in an air-gapped environment? | Covered | [docs/guides/DEPLOYMENT.md#custom-ca-certificates](docs/guides/DEPLOYMENT.md) |
+| Q34 | Integration | How do I integrate with VS Code? | Covered | No VS Code extension exists yet; N/A |
+
+## Gap Analysis
+
+### Gap 1: Inline Suppression (Q13)
+
+- **ID**: Q13
+- **Question**: How do I suppress a rule for a specific line?
+- **Impact**: Users need to suppress false positives in specific locations without disabling the rule globally. This is a fundamental workflow.
+- **Suggested Location**: `docs/guides/CONFIGURATION.md` (new file) or README.md
+- **Research Notes**: ADR-041 mentions `# apme:ignore` annotations and `enforced` flag to ignore them, but there is no user-facing documentation explaining the syntax or usage.
+- **Draft Answer**: Add inline `# apme:ignore` or `# apme:ignore[L026]` comment to suppress violations on that line. Use `enforced: true` in `.apme/rules.yml` to make suppression impossible for compliance-critical rules.
+
+### Gap 2: Rule ID Conventions for Custom Rules (Q19)
+
+- **ID**: Q19
+- **Question**: What rule ID conventions should custom rules follow?
+- **Impact**: Users writing custom rules need to understand the ID naming scheme to avoid conflicts and maintain consistency.
+- **Suggested Location**: `docs/guides/CUSTOM_RULES.md` (new file)
+- **Research Notes**: ADR-008 defines L/M/R/P/SEC prefixes. ADR-042 defines EXT- prefix for plugins. This information exists but is not in user-facing docs.
+- **Draft Answer**: Built-in rules use prefixes: L (lint), M (modernize), R (risk), P (policy), SEC (secrets). Custom plugin rules must use `EXT-<plugin_name>-<NNN>` format (e.g., `EXT-secteam-001`).
+
+### Gap 3: Tracking Improvement Over Time (Q21)
+
+- **ID**: Q21
+- **Question**: How do I track improvement over time?
+- **Impact**: Stakeholders want to see progress. Without guidance, users cannot demonstrate ROI.
+- **Suggested Location**: `docs/guides/REPORTING.md` (new file)
+- **Research Notes**: Gateway API has `/projects/{id}/trend` endpoint and health scores per 13-gateway architecture doc, but no user guide exists.
+- **Draft Answer**: The Gateway REST API provides trend data via `GET /api/v1/projects/{id}/trend`. The UI dashboard shows violation trends over time. Health scores are computed per project.
+
+### Gap 4: AI Acceptance Rates (Q23)
+
+- **ID**: Q23
+- **Question**: How do I measure AI fix acceptance rates?
+- **Impact**: Teams evaluating AI remediation need metrics to justify the investment.
+- **Suggested Location**: `docs/guides/REPORTING.md` (new file)
+- **Research Notes**: Gateway API has `GET /api/v1/stats/ai-acceptance` endpoint per 13-gateway.
+- **Draft Answer**: Query `GET /api/v1/stats/ai-acceptance` from the Gateway API for proposal approval/rejection statistics.
+
+### Gap 5: Gateway API Metrics Guide (Q24)
+
+- **ID**: Q24
+- **Question**: What metrics does the Gateway API provide?
+- **Impact**: API consumers need a reference to build dashboards and integrations.
+- **Suggested Location**: `docs/guides/REPORTING.md` (new file)
+- **Research Notes**: Full endpoint list exists in 13-gateway architecture doc. Needs user-facing guide with examples.
+- **Draft Answer**: Document the dashboard endpoints: `/dashboard/summary`, `/violations/top`, `/stats/remediation-rates`, `/stats/ai-acceptance`.
+
+### Gap 6: GitHub Actions Integration (Q25)
+
+- **ID**: Q25
+- **Question**: How do I integrate with GitHub Actions?
+- **Impact**: GitHub Actions is the most common CI system. Without a guide, users must figure out integration themselves.
+- **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
+- **Research Notes**: The CLI supports `--json` output and exit codes suitable for CI. No example workflow exists.
+- **Draft Answer**: Create example workflow using `pip install apme-engine@git+...` and `apme check --json .`.
+
+### Gap 7: GitLab CI Integration (Q26)
+
+- **ID**: Q26
+- **Question**: How do I integrate with GitLab CI?
+- **Impact**: GitLab CI is widely used. Missing documentation forces users to experiment.
+- **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
+- **Research Notes**: Same CLI capabilities apply. No `.gitlab-ci.yml` example exists.
+
+### Gap 8: Jenkins Integration (Q27)
+
+- **ID**: Q27
+- **Question**: How do I integrate with Jenkins?
+- **Impact**: Many enterprises use Jenkins. Integration guide needed.
+- **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
+- **Research Notes**: CLI can be run in Jenkins pipelines. No example Jenkinsfile exists.
+
+### Gap 9: Azure DevOps Integration (Q28)
+
+- **ID**: Q28
+- **Question**: How do I integrate with Azure DevOps?
+- **Impact**: Azure DevOps users need guidance.
+- **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
+- **Research Notes**: No Azure Pipelines example exists.
+
+### Gap 10: AAP/AWX Integration (Q29)
+
+- **ID**: Q29
+- **Question**: How do I use APME with AAP/AWX?
+- **Impact**: AAP is the target platform for APME. Integration with execution environments and workflows is critical.
+- **Suggested Location**: `docs/guides/AAP_INTEGRATION.md` (new file)
+- **Research Notes**: README mentions AAP 2.5+ as the target. Roadmap mentions EE compatibility rules. No integration guide exists.
+- **Draft Answer**: APME scans content for AAP 2.5+ compatibility. For EE integration, use `--ansible-core-version` flag. Future: EE compatibility rules (R505-R507) planned.
+
+### Gap 11: Backstage Integration (Q30)
+
+- **ID**: Q30
+- **Question**: How do I use APME with Backstage?
+- **Impact**: Portal/Backstage integration is relevant for platform engineering teams.
+- **Suggested Location**: `docs/guides/BACKSTAGE_INTEGRATION.md` (new file)
+- **Research Notes**: No Backstage plugin or integration guide exists. The Gateway API could be consumed by a Backstage plugin.
+
+### Gap 12: Pre-commit Hooks (Q31)
+
+- **ID**: Q31
+- **Question**: How do I use APME with pre-commit hooks?
+- **Impact**: Pre-commit is a popular developer workflow. Missing documentation is a usability gap.
+- **Suggested Location**: `docs/guides/CI_INTEGRATION.md` or README.md
+- **Research Notes**: No `.pre-commit-config.yaml` example exists. The CLI could be wrapped as a pre-commit hook.
+- **Draft Answer**: Create `.pre-commit-config.yaml` entry using `apme check` as a local hook.
+
+## Partial Coverage Improvements
+
+### Partial 1: ansible-lint Comparison (Q04)
+
+- **Current Source**: docs/rules/ANSIBLELINT_COVERAGE.md
+- **Gap**: Coverage matrix exists but lacks a prose explanation of key differences and migration path.
+- **Recommendation**: Add a "Why APME vs ansible-lint" section to README.md or a dedicated comparison guide.
+
+### Partial 2: Daemon vs Pod Mode (Q10)
+
+- **Current Source**: docs/guides/DEPLOYMENT.md
+- **Gap**: Explains both modes but lacks a decision tree for when to use each.
+- **Recommendation**: Add a "Which mode should I use?" section with clear guidance.
+
+### Partial 3: Enable/Disable Rules (Q11)
+
+- **Current Source**: Code in `_rules_yml.py`
+- **Gap**: The `.apme/rules.yml` format is only documented in code comments.
+- **Recommendation**: Create `docs/guides/CONFIGURATION.md` with examples.
+
+### Partial 4: Severity Override (Q12)
+
+- **Current Source**: ADR-041
+- **Gap**: ADR explains architecture, not user workflow.
+- **Recommendation**: Add user-facing examples to CONFIGURATION.md.
+
+### Partial 5: Per-project Config (Q14)
+
+- **Current Source**: Code in `_rules_yml.py`
+- **Gap**: No user documentation for `.apme/rules.yml`.
+- **Recommendation**: Document in CONFIGURATION.md.
+
+### Partial 6: Custom Rules Overview (Q16)
+
+- **Current Source**: ADR-042
+- **Gap**: ADR is developer-focused, not user-facing.
+- **Recommendation**: Create `docs/guides/CUSTOM_RULES.md` with high-level overview.
+
+### Partial 7: Custom OPA/Rego Rules (Q17)
+
+- **Current Source**: docs/guides/DEVELOPMENT.md
+- **Gap**: Development guide shows internal rule addition, not external/user-facing custom rules.
+- **Recommendation**: Clarify distinction between internal development and plugin extensibility.
+
+### Partial 8: Plugin Rules (Q18)
+
+- **Current Source**: ADR-042
+- **Gap**: SDK documentation planned but not yet published.
+- **Recommendation**: Complete Phase 5 of ADR-042 implementation (documentation and SDK guide).
+
+### Partial 9: Stakeholder Reports (Q22)
+
+- **Current Source**: 13-gateway architecture doc
+- **Gap**: API endpoints documented but no guide on generating stakeholder reports.
+- **Recommendation**: Create `docs/guides/REPORTING.md` with report examples.
+
+## Action Items
+
+### High Priority (Core User Workflows)
+
+- [ ] Create `docs/guides/CONFIGURATION.md` documenting `.apme/rules.yml` format, inline suppression (`# apme:ignore`), severity overrides, and `enforced` flag
+- [ ] Create `docs/guides/CI_INTEGRATION.md` with examples for GitHub Actions, GitLab CI, Jenkins, Azure DevOps, and pre-commit hooks
+
+### Medium Priority (Value Demonstration)
+
+- [ ] Create `docs/guides/REPORTING.md` documenting Gateway API metrics, trend endpoints, AI acceptance stats, and stakeholder reporting workflows
+- [ ] Add "Why APME vs ansible-lint" comparison section to README.md or a dedicated guide
+
+### Lower Priority (Advanced/Future)
+
+- [ ] Create `docs/guides/CUSTOM_RULES.md` with rule ID conventions and plugin SDK overview
+- [ ] Create `docs/guides/AAP_INTEGRATION.md` for AAP/EE integration guidance
+- [ ] Document Backstage integration pattern when plugin is available
+
+## Next Steps
+
+1. Review gaps with stakeholders to prioritize based on customer frequency
+2. Create CONFIGURATION.md and CI_INTEGRATION.md as highest-impact additions
+3. Add inline suppression syntax to user-facing docs immediately
+4. Re-run audit after documentation updates

--- a/docs/reports/docs-qa-audit-2026-05-21.md
+++ b/docs/reports/docs-qa-audit-2026-05-21.md
@@ -18,7 +18,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 | Rule Configuration | 1/5 | 3/5 | 1/5 | 50% |
 | Bring Your Own Rules | 0/4 | 3/4 | 1/4 | 38% |
 | Demonstrating Value | 1/5 | 1/5 | 3/5 | 30% |
-| Integration with Existing Tools | 3/10 | 0/10 | 7/10 | 30% |
+| Integration with Existing Tools | 2/10 | 0/10 | 8/10 | 20% |
 
 ## Coverage Matrix
 

--- a/docs/reports/docs-qa-audit-2026-05-21.md
+++ b/docs/reports/docs-qa-audit-2026-05-21.md
@@ -4,8 +4,8 @@
 
 - **Total Questions**: 34
 - **Covered** (✓): 16 (47%)
-- **Partial** (⚠): 8 (24%)
-- **Gaps** (✗): 10 (29%)
+- **Partial** (⚠): 9 (26%)
+- **Gaps** (✗): 9 (26%)
 
 The documentation has solid coverage of core functionality (installation, basic scanning, container deployment, rule catalog, and rule configuration) but significant gaps remain in CI/CD integration guides, tooling ecosystem integration, and higher-level reporting workflows.
 
@@ -17,7 +17,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 | How Can I Use It | 4/5 | 1/5 | 0/5 | 90% |
 | Rule Configuration | 4/5 | 1/5 | 0/5 | 90% |
 | Bring Your Own Rules | 0/4 | 4/4 | 0/4 | 50% |
-| Demonstrating Value | 2/5 | 1/5 | 2/5 | 50% |
+| Demonstrating Value | 2/5 | 2/5 | 1/5 | 60% |
 | Integration with Existing Tools | 2/10 | 0/10 | 8/10 | 20% |
 
 ## Coverage Matrix
@@ -47,7 +47,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 | Q21 | Demonstrating Value | How do I track improvement over time? | ✗ | No documentation found |
 | Q22 | Demonstrating Value | How do I generate reports for stakeholders? | ⚠ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) |
 | Q23 | Demonstrating Value | How do I measure AI fix acceptance rates? | ✓ | [RULE_CONFIGURATION.md](../guides/RULE_CONFIGURATION.md) |
-| Q24 | Demonstrating Value | What metrics does the Gateway API provide? | ✗ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) (architecture, not guide) |
+| Q24 | Demonstrating Value | What metrics does the Gateway API provide? | ⚠ | [13-gateway-and-persistence.md](../architecture/13-gateway-and-persistence.md) |
 | Q25 | Integration with Existing Tools | How do I integrate with GitHub Actions? | ✗ | No documentation found |
 | Q26 | Integration with Existing Tools | How do I integrate with GitLab CI? | ✗ | No documentation found |
 | Q27 | Integration with Existing Tools | How do I integrate with Jenkins? | ✗ | No documentation found |
@@ -70,16 +70,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Research Notes**: Gateway API has `GET /api/v1/projects/{id}/trend` endpoint and health scores per 13-gateway architecture doc, but no user guide exists.
 - **Draft Answer**: The Gateway REST API provides trend data via `GET /api/v1/projects/{id}/trend`. The UI dashboard shows violation trends over time. Health scores are computed per project.
 
-### Gap 2: Gateway API Metrics Guide (Q24)
-
-- **ID**: Q24
-- **Question**: What metrics does the Gateway API provide?
-- **Impact**: API consumers need a reference to build dashboards and integrations.
-- **Suggested Location**: `docs/guides/REPORTING.md` (new file)
-- **Research Notes**: Full endpoint list exists in 13-gateway architecture doc. Needs user-facing guide with examples.
-- **Draft Answer**: Document the dashboard endpoints: `/api/v1/dashboard/summary`, `/api/v1/violations/top`, `/api/v1/stats/remediation-rates`, `/api/v1/stats/ai-acceptance`.
-
-### Gap 3: GitHub Actions Integration (Q25)
+### Gap 2: GitHub Actions Integration (Q25)
 
 - **ID**: Q25
 - **Question**: How do I integrate with GitHub Actions?
@@ -88,7 +79,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Research Notes**: The CLI supports `--json` output and exit codes suitable for CI. No example workflow exists.
 - **Draft Answer**: Create example workflow using `pip install apme-engine@git+https://github.com/ansible/apme.git@main` and `apme check --json .`.
 
-### Gap 4: GitLab CI Integration (Q26)
+### Gap 3: GitLab CI Integration (Q26)
 
 - **ID**: Q26
 - **Question**: How do I integrate with GitLab CI?
@@ -96,7 +87,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
 - **Research Notes**: Same CLI capabilities apply. No `.gitlab-ci.yml` example exists.
 
-### Gap 5: Jenkins Integration (Q27)
+### Gap 4: Jenkins Integration (Q27)
 
 - **ID**: Q27
 - **Question**: How do I integrate with Jenkins?
@@ -104,7 +95,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
 - **Research Notes**: CLI can be run in Jenkins pipelines. No example Jenkinsfile exists.
 
-### Gap 6: Azure DevOps Integration (Q28)
+### Gap 5: Azure DevOps Integration (Q28)
 
 - **ID**: Q28
 - **Question**: How do I integrate with Azure DevOps?
@@ -112,7 +103,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
 - **Research Notes**: No Azure Pipelines example exists.
 
-### Gap 7: AAP/AWX Integration (Q29)
+### Gap 6: AAP/AWX Integration (Q29)
 
 - **ID**: Q29
 - **Question**: How do I use APME with AAP/AWX?
@@ -121,7 +112,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Research Notes**: README mentions AAP 2.5+ as the target. Roadmap mentions EE compatibility rules. No integration guide exists.
 - **Draft Answer**: APME scans content for AAP 2.5+ compatibility. For EE integration, use `--ansible-core-version` flag. Future: EE compatibility rules (R505-R507) planned.
 
-### Gap 8: Backstage Integration (Q30)
+### Gap 7: Backstage Integration (Q30)
 
 - **ID**: Q30
 - **Question**: How do I use APME with Backstage?
@@ -129,7 +120,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Suggested Location**: `docs/guides/BACKSTAGE_INTEGRATION.md` (new file)
 - **Research Notes**: No Backstage plugin or integration guide exists. The Gateway API could be consumed by a Backstage plugin.
 
-### Gap 9: Pre-commit Hooks (Q31)
+### Gap 8: Pre-commit Hooks (Q31)
 
 - **ID**: Q31
 - **Question**: How do I use APME with pre-commit hooks?
@@ -138,7 +129,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Research Notes**: No `.pre-commit-config.yaml` example exists. The CLI could be wrapped as a pre-commit hook.
 - **Draft Answer**: Create `.pre-commit-config.yaml` entry using `apme check` as a local hook.
 
-### Gap 10: VS Code Integration (Q34)
+### Gap 9: VS Code Integration (Q34)
 
 - **ID**: Q34
 - **Question**: How do I integrate with VS Code?
@@ -196,6 +187,12 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Current Source**: 13-gateway architecture doc
 - **Gap**: API endpoints are documented, but there is still no guide on generating stakeholder-facing reports or choosing between dashboard summaries, trends, and proposal statistics.
 - **Recommendation**: Create `docs/guides/REPORTING.md` with report examples and workflow guidance.
+
+### Partial 9: Gateway API Metrics (Q24)
+
+- **Current Source**: `docs/architecture/13-gateway-and-persistence.md`
+- **Gap**: The architecture doc lists the available dashboard and stats endpoints, but there is no user-facing reporting guide explaining which metrics to use for dashboards, trends, or stakeholder summaries.
+- **Recommendation**: Cover these endpoints in `docs/guides/REPORTING.md` with examples and usage guidance.
 
 ## Action Items
 

--- a/docs/reports/docs-qa-audit-2026-05-21.md
+++ b/docs/reports/docs-qa-audit-2026-05-21.md
@@ -3,8 +3,8 @@
 ## Executive Summary
 
 - **Total Questions**: 34
-- **Covered** (✓): 12 (35%)
-- **Partial** (⚠): 9 (26%)
+- **Covered** (✓): 11 (32%)
+- **Partial** (⚠): 10 (29%)
 - **Gaps** (✗): 13 (38%)
 
 The documentation has solid coverage of core functionality (installation, basic scanning, container deployment, rule catalog) but significant gaps exist in CI/CD integration guides, tooling ecosystem integration, and some rule configuration topics.
@@ -15,7 +15,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 |----------|---------|---------|-----|-------|
 | What Is It / What Does It Do | 4/5 | 1/5 | 0/5 | 90% |
 | How Can I Use It | 4/5 | 1/5 | 0/5 | 90% |
-| Rule Configuration | 1/5 | 3/5 | 1/5 | 50% |
+| Rule Configuration | 0/5 | 4/5 | 1/5 | 40% |
 | Bring Your Own Rules | 0/4 | 3/4 | 1/4 | 38% |
 | Demonstrating Value | 1/5 | 1/5 | 3/5 | 30% |
 | Integration with Existing Tools | 2/10 | 0/10 | 8/10 | 20% |
@@ -38,7 +38,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 | Q12 | Rule Configuration | How do I change rule severity? | ⚠ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
 | Q13 | Rule Configuration | How do I suppress a rule for a specific line? | ✗ | No documentation found |
 | Q14 | Rule Configuration | How do I configure rules per-project? | ⚠ | [_rules_yml.py](../../src/apme_engine/cli/_rules_yml.py) (code only) |
-| Q15 | Rule Configuration | How do I enforce rules and ignore noqa comments? | ✓ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
+| Q15 | Rule Configuration | How do I enforce rules and ignore noqa comments? | ⚠ | [ADR-041](../../.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md) |
 | Q16 | Bring Your Own Rules | Can I add custom rules? | ⚠ | [ADR-042](../../.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
 | Q17 | Bring Your Own Rules | How do I write a custom OPA/Rego rule? | ⚠ | [DEVELOPMENT.md](../guides/DEVELOPMENT.md) |
 | Q18 | Bring Your Own Rules | How do I add custom rules via plugins? | ⚠ | [ADR-042](../../.sdlc/adrs/ADR-042-third-party-plugin-services.md) |
@@ -66,9 +66,9 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **ID**: Q13
 - **Question**: How do I suppress a rule for a specific line?
 - **Impact**: Users need to suppress false positives in specific locations without disabling the rule globally. This is a fundamental workflow.
-- **Suggested Location**: `docs/guides/CONFIGURATION.md` (new file) or README.md
-- **Research Notes**: ADR-041 mentions `# apme:ignore` annotations and `enforced` flag to ignore them, but there is no user-facing documentation explaining the syntax or usage.
-- **Draft Answer**: Add inline `# apme:ignore` comment to suppress violations on that line. Use `enforced: true` in `.apme/rules.yml` to make suppression impossible for compliance-critical rules.
+- **Suggested Location**: `docs/guides/RULE_CONFIGURATION.md` or README.md
+- **Research Notes**: The engine currently parses inline suppression via `# noqa: <RULE_ID>` comments in `graph_scanner.py`, and ADR-041 documents the `enforced` flag to ignore those suppressions. There is still no user-facing documentation explaining the syntax or usage.
+- **Draft Answer**: Add an inline `# noqa: <RULE_ID>` comment to suppress that rule for the node. Use `enforced: true` in `.apme/rules.yml` to make suppression impossible for compliance-critical rules.
 
 ### Gap 2: Rule ID Conventions for Custom Rules (Q19)
 
@@ -113,7 +113,7 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Impact**: GitHub Actions is the most common CI system. Without a guide, users must figure out integration themselves.
 - **Suggested Location**: `docs/guides/CI_INTEGRATION.md` (new file)
 - **Research Notes**: The CLI supports `--json` output and exit codes suitable for CI. No example workflow exists.
-- **Draft Answer**: Create example workflow using `pip install apme-engine@git+...` and `apme check --json .`.
+- **Draft Answer**: Create example workflow using `pip install apme-engine@git+https://github.com/ansible/apme.git@main` and `apme check --json .`.
 
 ### Gap 7: GitLab CI Integration (Q26)
 
@@ -183,19 +183,19 @@ The documentation has solid coverage of core functionality (installation, basic 
 
 - **Current Source**: Code in `_rules_yml.py`
 - **Gap**: The `.apme/rules.yml` format is only documented in code comments.
-- **Recommendation**: Create `docs/guides/CONFIGURATION.md` with examples.
+- **Recommendation**: Create `docs/guides/RULE_CONFIGURATION.md` with examples.
 
 ### Partial 4: Severity Override (Q12)
 
 - **Current Source**: ADR-041
 - **Gap**: ADR explains architecture, not user workflow.
-- **Recommendation**: Add user-facing examples to CONFIGURATION.md.
+- **Recommendation**: Add user-facing examples to `docs/guides/RULE_CONFIGURATION.md`.
 
 ### Partial 5: Per-project Config (Q14)
 
 - **Current Source**: Code in `_rules_yml.py`
 - **Gap**: No user documentation for `.apme/rules.yml`.
-- **Recommendation**: Document in CONFIGURATION.md.
+- **Recommendation**: Document in `docs/guides/RULE_CONFIGURATION.md`.
 
 ### Partial 6: Custom Rules Overview (Q16)
 
@@ -221,11 +221,17 @@ The documentation has solid coverage of core functionality (installation, basic 
 - **Gap**: API endpoints documented but no guide on generating stakeholder reports.
 - **Recommendation**: Create `docs/guides/REPORTING.md` with report examples.
 
+### Partial 10: Enforced Rules vs `noqa` (Q15)
+
+- **Current Source**: ADR-041
+- **Gap**: The behavior is documented architecturally, but there is no user-facing configuration guide explaining `enforced: true` or how it interacts with `# noqa: <RULE_ID>`.
+- **Recommendation**: Add an "Enforced Rules" section to `docs/guides/RULE_CONFIGURATION.md` with examples showing both inline suppression and rule-level enforcement.
+
 ## Action Items
 
 ### High Priority (Core User Workflows)
 
-- [ ] Create `docs/guides/CONFIGURATION.md` documenting `.apme/rules.yml` format, inline suppression (`# apme:ignore`), severity overrides, and `enforced` flag
+- [ ] Create `docs/guides/RULE_CONFIGURATION.md` documenting `.apme/rules.yml` format, inline suppression (`# noqa: <RULE_ID>`), severity overrides, and `enforced` flag
 - [ ] Create `docs/guides/CI_INTEGRATION.md` with examples for GitHub Actions, GitLab CI, Jenkins, Azure DevOps, and pre-commit hooks
 
 ### Medium Priority (Value Demonstration)
@@ -242,6 +248,6 @@ The documentation has solid coverage of core functionality (installation, basic 
 ## Next Steps
 
 1. Review gaps with stakeholders to prioritize based on customer frequency
-2. Create CONFIGURATION.md and CI_INTEGRATION.md as highest-impact additions
-3. Add inline suppression syntax to user-facing docs immediately
+2. Create `RULE_CONFIGURATION.md` and `CI_INTEGRATION.md` as highest-impact additions
+3. Add `# noqa: <RULE_ID>` suppression syntax to user-facing docs immediately
 4. Re-run audit after documentation updates


### PR DESCRIPTION
## Summary

Adds a new skill for auditing documentation coverage against common user questions, plus the first audit report.

### docs-qa-audit Skill
- 34 questions across 6 categories (what/how/rules/custom/value/integrations)
- Searches docs, ADRs, architecture/design docs, and code for answers
- Scores coverage: ✓ covered / ⚠ partial / ✗ gap
- Generates markdown report designed as input for quick-deck presentations
- Creates DRs and drafts answers for gaps
- Procedure, examples, and status formatting now align with the current report shape and category naming

### Initial Audit Results
- **47% covered** (16/34)
- **26% partial** (9/34)
- **26% gaps** (9/34)

**Strong coverage:**
- What APME is and does (90%)
- Installation and basic usage (90%)
- Rule configuration basics (90%)

**Major gaps identified:**
- CI/CD integration (no guides for GitHub Actions, GitLab CI, Jenkins, Azure DevOps)
- Higher-level reporting workflows (trends and stakeholder reports still need a guide)
- AAP/Backstage/editor integration guidance
- Custom rule guidance is still fragmented across docs and ADRs

### Follow-up Clarifications
- Rule configuration docs now distinguish `.apme/suppressions.yml` fingerprint suppression from native graph-rule `# noqa` behavior and point to the `apme suppress` workflow
- The Step 6 template includes the same ✓/⚠/✗ summary markers used elsewhere in the skill
- The trend-endpoint references now consistently use `/api/v1/...` paths
- Q24 is now scored as partial, matching the rubric for architecture-doc-only coverage

## Test Plan

- [x] Skill files created and committed
- [x] Audit procedure executed successfully
- [x] Report generated at `docs/reports/docs-qa-audit-2026-05-21.md`
- [x] Report includes actionable gaps and recommendations
- [x] `tox -e lint`
- [x] `tox -e unit`

## Follow-up Actions

Per the audit, these docs should be created or expanded:
1. `docs/guides/CI_INTEGRATION.md` - CI/CD examples
2. `docs/guides/REPORTING.md` - trends, dashboard metrics, stakeholder workflows
3. `docs/guides/CUSTOM_RULES.md` - rule ID conventions and plugin guidance