### PR TITLE
docs(deck): add consumer surfaces, remediation tiers, and AAP upgrade slides

### DIFF
--- a/docs/presentations/apme-quick-deck.html
+++ b/docs/presentations/apme-quick-deck.html
@@ -472,7 +472,7 @@
         <div class="arch-row">
           <div class="arch-box">Automation Portal<span class="port">Fleet dashboards</span></div>
           <div class="arch-box">CI/CD Pipelines<span class="port">Block on policy</span></div>
-          <div class="arch-box">AI Agents (MCP)<span class="port">Scan & explain</span></div>
+          <div class="arch-box">AI Agents (MCP)<span class="port">Scan &amp; explain</span></div>
           <div class="arch-box">IDE (LSP)<span class="port">Inline warnings</span></div>
           <div class="arch-box">CLI<span class="port">Local scans</span></div>
         </div>
@@ -484,7 +484,7 @@
     <div class="slide" data-notes="<strong>Human oversight at every level:</strong> APME never modifies content autonomously. Tier 1 generates patches for human review. Tier 2 AI proposals require explicit accept/reject. Tier 3 flags issues for manual resolution.<br><br><strong>Trust model:</strong> Engine produces diffs; humans apply them. This is critical for enterprise adoption.">
       <div class="slide-label animate-in">—— HOW IT WORKS</div>
       <h2 class="animate-in">Parse, Validate, Remediate — <span class="accent">Human in the Loop</span></h2>
-      <div class="two-col animate-in" style="margin-top: 32px; grid-template-columns: 1fr 1fr 1fr; max-width: 1100px;">
+      <div class="three-col animate-in" style="margin-top: 32px; grid-template-columns: 1fr 1fr 1fr; max-width: 1100px;">
         <div class="col">
           <h3 style="color: var(--accent);">Tier 1: Automatic</h3>
           <p>Known patterns with deterministic fixes. Provably correct.</p>
@@ -539,7 +539,7 @@
       <p class="source animate-in">OPA/Rego · Native Python · Ansible Runtime · Gitleaks</p>
     </div>
 
-    <!-- SLIDE 7: DEPENDENCY HEALTH -->
+    <!-- SLIDE 10: DEPENDENCY HEALTH -->
     <div class="slide" data-notes="<strong>Dependency health scanning:</strong> Two optional validators assess supply-chain risk inline during apme check.<br><br><strong>Collection Health Validator:</strong> Scans installed Ansible collections for deprecated modules, missing argument specs, and FQCN violations. Cached by FQCN+version for fast subsequent runs.<br><br><strong>Python Dependency Auditor:</strong> Checks packages against CVE databases via pip-audit.<br><br><strong>CLI flags:</strong><br>• --skip-dep-scan — skip all dependency scanning<br>• --skip-collection-scan — skip only collection health<br>• --skip-python-audit — skip only CVE audit">
       <div class="slide-label animate-in">—— SUPPLY CHAIN SECURITY</div>
       <h2 class="animate-in">Know Your <span class="accent">Dependencies</span></h2>
@@ -566,7 +566,7 @@
       <p class="source animate-in">Optional — skip with --skip-dep-scan</p>
     </div>
 
-    <!-- SLIDE 8: DASHBOARD -->
+    <!-- SLIDE 11: DASHBOARD -->
     <div class="slide" data-notes="<strong>Dashboard features:</strong><br>• Project-level health scores<br>• Current vs fixable violations tracking<br>• AI Candidates — issues that can be auto-remediated<br>• Top 10 cleanest and most-violated projects<br>• Stale project detection<br><br>The UI is a React dashboard served via nginx at :8081.">
       <div class="slide-label animate-in">—— THE DASHBOARD</div>
       <h2 class="animate-in">Visibility Into <span class="accent">Every Violation</span></h2>
@@ -576,7 +576,7 @@
       <p class="source animate-in">APME Dashboard · Real-time violation tracking and remediation status</p>
     </div>
 
-    <!-- SLIDE 9: AI REMEDIATION -->
+    <!-- SLIDE 12: AI REMEDIATION -->
     <div class="slide" data-notes="<strong>Remediation pipeline:</strong><br>1. apme format — YAML normalization (indentation, key ordering, Jinja spacing)<br>2. Idempotency check — ensure formatting is stable<br>3. Re-scan — validate changes<br>4. apme remediate --ai — AI-assisted fixes via Abbenay daemon<br><br><strong>Human-in-the-loop:</strong> By default, AI suggestions require interactive review. Use --auto-approve for CI pipelines.">
       <div class="slide-label animate-in">—— AI-ASSISTED</div>
       <h2 class="animate-in">From Detection to <span class="accent">Remediation</span></h2>
@@ -593,14 +593,14 @@
       </div>
     </div>
 
-    <!-- SLIDE 10: QUOTE -->
+    <!-- SLIDE 13: QUOTE -->
     <div class="slide" data-notes="<strong>Positioning:</strong> APME provides the compatibility floor. It's complementary to Molecule, integration tests, and staging dry-runs — not a replacement.<br><br>Static analysis runs in seconds without infrastructure. Execution-time tools validate behavior against real systems. Both are needed.">
       <div class="slide-label animate-in">—— THE PROMISE</div>
       <blockquote class="quote animate-in">For organizations managing hundreds of roles across ansible-core version upgrades, this shift-left is the difference between a planned migration and an emergency one.</blockquote>
       <p class="quote-attr animate-in">— APME Documentation</p>
     </div>
 
-    <!-- SLIDE 11: CTA -->
+    <!-- SLIDE 14: CTA -->
     <div class="slide" data-notes="<strong>Quick start commands:</strong><br>• apme check /path — run all validators<br>• apme check --json . — JSON output for CI<br>• apme check -v . — timing diagnostics<br>• apme format --apply . — auto-format YAML<br>• apme remediate --ai . — AI-assisted fixes<br><br><strong>Container deployment:</strong> tox -e up builds 9 images and starts the pod.">
       <div class="slide-label animate-in">—— GET STARTED</div>
       <h2 class="animate-in">Try APME <span class="accent">Today</span></h2>
@@ -614,7 +614,7 @@
       <p class="source animate-in">Apache 2.0 Licensed · github.com/ansible/apme</p>
     </div>
 
-    <!-- SLIDE 12: THANK YOU -->
+    <!-- SLIDE 15: THANK YOU -->
     <div class="slide center-content" data-notes="<strong>Resources:</strong><br>• <a href='https://github.com/ansible/apme'>github.com/ansible/apme</a><br>• docs/architecture/ for design details<br>• Apache 2.0 license<br><br>Thank you for watching!">
       <div class="slide-label animate-in">—— THANK YOU</div>
       <h1 class="animate-in">Thank <span class="accent">You</span></h1>

--- a/docs/presentations/apme-quick-deck.html
+++ b/docs/presentations/apme-quick-deck.html
@@ -167,15 +167,21 @@
       gap: var(--rh-space-2xl, 48px);
       max-width: 1000px;
     }
-    .two-col .col h3 {
+    .three-col {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: var(--rh-space-2xl, 48px);
+      max-width: 1100px;
+    }
+    .two-col .col h3, .three-col .col h3 {
       font-family: var(--font-display);
       font-size: var(--rh-font-size-heading-sm, 1.25rem);
       font-weight: 700;
       margin-bottom: var(--rh-space-md, 16px);
       color: var(--text-primary);
     }
-    .two-col .col.highlight h3 { color: var(--accent); }
-    .two-col .col p, .two-col .col li {
+    .two-col .col.highlight h3, .three-col .col.highlight h3 { color: var(--accent); }
+    .two-col .col p, .two-col .col li, .three-col .col p, .three-col .col li {
       font-size: var(--rh-font-size-body-text-md, 1rem);
       color: var(--text-secondary);
       line-height: 1.6;
@@ -484,7 +490,7 @@
     <div class="slide" data-notes="<strong>Human oversight at every level:</strong> APME never modifies content autonomously. Tier 1 generates patches for human review. Tier 2 AI proposals require explicit accept/reject. Tier 3 flags issues for manual resolution.<br><br><strong>Trust model:</strong> Engine produces diffs; humans apply them. This is critical for enterprise adoption.">
       <div class="slide-label animate-in">—— HOW IT WORKS</div>
       <h2 class="animate-in">Parse, Validate, Remediate — <span class="accent">Human in the Loop</span></h2>
-      <div class="three-col animate-in" style="margin-top: 32px; grid-template-columns: 1fr 1fr 1fr; max-width: 1100px;">
+      <div class="three-col animate-in" style="margin-top: 32px;">
         <div class="col">
           <h3 style="color: var(--accent);">Tier 1: Automatic</h3>
           <p>Known patterns with deterministic fixes. Provably correct.</p>

--- a/docs/presentations/apme-quick-deck.html
+++ b/docs/presentations/apme-quick-deck.html
@@ -460,10 +460,81 @@
       <p class="source animate-in">Unified gRPC contract — adding a new validator means implementing one RPC</p>
     </div>
 
-    <!-- SLIDE 6: BIG NUMBER -->
-    <div class="slide center-content" data-notes="<strong>Rule coverage:</strong> 100+ rules across four backends, including:<br>• L003–L105: Lint rules (structural, semantic)<br>• M001–M011: Module compatibility rules<br>• R101–R501: Remediation rules<br>• SEC:*: 800+ Gitleaks secret patterns<br><br>Every rule has colocated tests (*_test.py, *_test.rego) for validation.">
+    <!-- SLIDE 6: WHAT THE ENGINE ENABLES -->
+    <div class="slide" data-notes="<strong>One API, every surface:</strong> The Content Health API provides a single contract that any consumer can call. Portal teams, CI pipelines, AI agents, IDE extensions, and CLI users all get identical checks, policies, and remediation logic.<br><br><strong>No fragmentation:</strong> Unlike separate tools for lint, security, and compatibility, APME consolidates everything behind one endpoint.">
+      <div class="slide-label animate-in">—— WHAT IT ENABLES</div>
+      <h2 class="animate-in">One API, <span class="accent">Every Surface</span></h2>
+      <div class="arch-diagram animate-in" style="margin-top: 24px;">
+        <div class="arch-row">
+          <div class="arch-box primary" style="min-width: 280px;">Content Health API<span class="port">Scan · Remediate · Scores</span></div>
+        </div>
+        <div class="arch-arrow" style="transform: rotate(90deg);">↓</div>
+        <div class="arch-row">
+          <div class="arch-box">Automation Portal<span class="port">Fleet dashboards</span></div>
+          <div class="arch-box">CI/CD Pipelines<span class="port">Block on policy</span></div>
+          <div class="arch-box">AI Agents (MCP)<span class="port">Scan & explain</span></div>
+          <div class="arch-box">IDE (LSP)<span class="port">Inline warnings</span></div>
+          <div class="arch-box">CLI<span class="port">Local scans</span></div>
+        </div>
+      </div>
+      <p class="source animate-in">Every surface calls the same API — checks, policies, and remediation are identical regardless of consumer</p>
+    </div>
+
+    <!-- SLIDE 7: HOW IT WORKS - 3 TIER MODEL -->
+    <div class="slide" data-notes="<strong>Human oversight at every level:</strong> APME never modifies content autonomously. Tier 1 generates patches for human review. Tier 2 AI proposals require explicit accept/reject. Tier 3 flags issues for manual resolution.<br><br><strong>Trust model:</strong> Engine produces diffs; humans apply them. This is critical for enterprise adoption.">
+      <div class="slide-label animate-in">—— HOW IT WORKS</div>
+      <h2 class="animate-in">Parse, Validate, Remediate — <span class="accent">Human in the Loop</span></h2>
+      <div class="two-col animate-in" style="margin-top: 32px; grid-template-columns: 1fr 1fr 1fr; max-width: 1100px;">
+        <div class="col">
+          <h3 style="color: var(--accent);">Tier 1: Automatic</h3>
+          <p>Known patterns with deterministic fixes. Provably correct.</p>
+          <p style="margin-top: 12px; font-size: 0.9rem; color: var(--text-muted);"><strong>Human:</strong> Reviews and applies generated patches</p>
+        </div>
+        <div class="col">
+          <h3 style="color: var(--accent);">Tier 2: AI-Assisted</h3>
+          <p>Complex issues where AI proposes a fix via Abbenay daemon.</p>
+          <p style="margin-top: 12px; font-size: 0.9rem; color: var(--text-muted);"><strong>Human:</strong> Accepts, rejects, or modifies proposal</p>
+        </div>
+        <div class="col">
+          <h3 style="color: var(--accent);">Tier 3: Manual</h3>
+          <p>Issues that neither automatic nor AI remediation can resolve.</p>
+          <p style="margin-top: 12px; font-size: 0.9rem; color: var(--text-muted);"><strong>Human:</strong> Manual review and resolution</p>
+        </div>
+      </div>
+      <p class="source animate-in" style="font-size: 1rem; color: var(--text-primary); margin-top: 32px;">Nothing changes content without a human in the loop</p>
+    </div>
+
+    <!-- SLIDE 8: USE CASE - AAP UPGRADE -->
+    <div class="slide" data-notes="<strong>Real-world scenario:</strong> Upgrading from AAP 2.4 (ansible-core 2.15) to latest AAP with newer ansible-core. The engine catches deprecated modules, removed arguments, renamed parameters — issues a developer might miss.<br><br><strong>Time savings:</strong> What took weeks of manual review now takes hours. Portal perspective shows fleet-wide upgrade readiness.">
+      <div class="slide-label animate-in">—— USE CASE</div>
+      <h2 class="animate-in">Upgrading to the <span class="accent">Latest AAP</span></h2>
+      <div class="arch-diagram animate-in" style="margin-top: 24px;">
+        <div class="arch-row">
+          <div class="arch-box">1. Scan<span class="port">Target ansible-core</span></div>
+          <div class="arch-arrow">→</div>
+          <div class="arch-box">2. Report<span class="port">Deprecated, removed</span></div>
+          <div class="arch-arrow">→</div>
+          <div class="arch-box">3. Auto-Fix<span class="port">Tier 1 patches</span></div>
+          <div class="arch-arrow">→</div>
+          <div class="arch-box">4. Review<span class="port">Human + AI</span></div>
+          <div class="arch-arrow">→</div>
+          <div class="arch-box primary">5. Confirm<span class="port">Re-scan clean</span></div>
+        </div>
+      </div>
+      <div class="content-body animate-in" style="margin-top: 32px;">
+        <p><strong>What took weeks now takes hours</strong> — the engine catches issues a developer might miss</p>
+        <ul style="margin-top: 16px; font-size: 0.95rem;">
+          <li>Platform teams see which projects are ready for target AAP version</li>
+          <li>Per-project compatibility scores show upgrade readiness across the fleet</li>
+          <li>Teams trigger scans from portal — no local install needed</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- SLIDE 9: BIG NUMBER -->
+    <div class="slide center-content" data-notes="<strong>Rule coverage:</strong> 150+ rules across four backends, including:<br>• L003–L105: Lint rules (structural, semantic)<br>• M001–M030: Module compatibility rules<br>• R101–R501: Risk rules<br>• SEC:*: 800+ Gitleaks secret patterns<br><br>Every rule has colocated tests (*_test.py, *_test.rego) for validation.">
       <div class="slide-label animate-in">—— BY THE NUMBERS</div>
-      <div class="big-number animate-in">100+</div>
+      <div class="big-number animate-in">150+</div>
       <p class="big-number-context animate-in">rules across four validation backends</p>
       <p class="source animate-in">OPA/Rego · Native Python · Ansible Runtime · Gitleaks</p>
     </div>


### PR DESCRIPTION
## Summary
- Add "What the Engine Enables" slide showing unified API consumers (Portal, CI/CD, AI Agents, IDE, CLI)
- Add "How It Works" slide explaining 3-tier remediation model with human-in-the-loop emphasis
- Add "Use Case" slide demonstrating AAP upgrade workflow
- Update rule count from 100+ to 150+ on By the Numbers slide

## Context
Aligns the quick deck (`docs/presentations/apme-quick-deck.html`) with content from the APME overview PDF that was missing from the HTML version.

## Test plan
- [ ] Open the deck in a browser and verify all slides render correctly
- [ ] Check that speaker notes display properly
- [ ] Confirm styling is consistent with existing slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)