### PR TITLE
feat(cli): implement ADR-055 violation fingerprinting and suppression

### DIFF
--- a/src/apme_engine/cli/__init__.py
+++ b/src/apme_engine/cli/__init__.py
@@ -50,6 +50,10 @@ def main() -> None:
         from apme_engine.cli.sbom_cmd import run_sbom
 
         run_sbom(args)
+    elif cmd == "suppress":
+        from apme_engine.cli.suppress_cmd import run_suppress
+
+        run_suppress(args)
     else:
         parser.print_help()
         sys.exit(EXIT_ERROR)

--- a/src/apme_engine/cli/_convert.py
+++ b/src/apme_engine/cli/_convert.py
@@ -54,7 +54,7 @@ def violation_proto_to_dict(
     if v.HasField("line_range"):
         line = [v.line_range.start, v.line_range.end]
     metadata = dict(v.metadata) if v.metadata else {}
-    module_fqcn = metadata.get("resolved_fqcn") or metadata.get("original_module") or ""
+    module_fqcn = metadata.get("resolved_fqcn") or metadata.get("original_module") or metadata.get("fqcn") or ""
     return {
         "rule_id": v.rule_id,
         "severity": severity_to_label(severity_from_proto(v.severity)),

--- a/src/apme_engine/cli/_convert.py
+++ b/src/apme_engine/cli/_convert.py
@@ -53,6 +53,8 @@ def violation_proto_to_dict(
     line: int | list[int] | None = v.line if v.HasField("line") else None
     if v.HasField("line_range"):
         line = [v.line_range.start, v.line_range.end]
+    metadata = dict(v.metadata) if v.metadata else {}
+    module_fqcn = metadata.get("resolved_fqcn") or metadata.get("original_module") or ""
     return {
         "rule_id": v.rule_id,
         "severity": severity_to_label(severity_from_proto(v.severity)),
@@ -72,4 +74,6 @@ def violation_proto_to_dict(
             v.scope,
             "task",
         ),
+        "original_yaml": v.original_yaml or None,
+        "module_fqcn": module_fqcn or None,
     }

--- a/src/apme_engine/cli/_suppressions.py
+++ b/src/apme_engine/cli/_suppressions.py
@@ -1,0 +1,255 @@
+"""Load and evaluate violation suppressions from ``.apme/suppressions.yml`` (ADR-055)."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from apme_engine.engine.models import ViolationDict
+from apme_engine.fingerprint import canonicalize_rule_id, compute_fingerprint
+
+SUPPRESSIONS_YML_PATH = Path(".apme") / "suppressions.yml"
+
+_VALID_MODES = frozenset(("full", "rule_module", "rule_only"))
+
+
+@dataclass(frozen=True, slots=True)
+class Suppression:
+    """A single suppression entry from the suppressions file.
+
+    Attributes:
+        fingerprint: SHA-256 hex digest identifying the suppressed content.
+        rule_id: Rule that produced the violation.
+        mode: Fingerprint granularity mode.
+        reason: Human-provided justification.
+        created: ISO 8601 date string.
+    """
+
+    fingerprint: str
+    rule_id: str
+    mode: str = "full"
+    reason: str = ""
+    created: str = ""
+
+
+@dataclass(slots=True)
+class SuppressionResult:
+    """Result of applying suppressions to a violation list.
+
+    Attributes:
+        active: Violations that are not suppressed.
+        suppressed: Violations that matched a suppression entry.
+    """
+
+    active: list[ViolationDict] = field(default_factory=list)
+    suppressed: list[ViolationDict] = field(default_factory=list)
+
+
+def load_suppressions(project_root: Path) -> list[Suppression]:
+    """Parse ``<project_root>/.apme/suppressions.yml`` into Suppression objects.
+
+    The file is optional. On missing path, returns an empty list. On parse
+    errors, writes a warning to stderr and returns an empty list.
+
+    Args:
+        project_root: Resolved project root path.
+
+    Returns:
+        List of Suppression entries, possibly empty.
+    """
+    path = project_root / SUPPRESSIONS_YML_PATH
+    if not path.is_file():
+        return []
+
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = yaml.safe_load(text)
+    except OSError as e:
+        sys.stderr.write(f"Warning: could not read {path}: {e}\n")
+        return []
+    except yaml.YAMLError as e:
+        sys.stderr.write(f"Warning: could not parse {path}: {e}\n")
+        return []
+
+    if data is None:
+        return []
+
+    if not isinstance(data, dict):
+        sys.stderr.write(f"Warning: {path}: expected a mapping at top level\n")
+        return []
+
+    version = data.get("version")
+    if version is not None and version != 1:
+        sys.stderr.write(f"Warning: {path}: unsupported version {version}, ignoring suppressions\n")
+        return []
+
+    entries = data.get("suppressions")
+    if entries is None:
+        return []
+
+    if not isinstance(entries, list):
+        sys.stderr.write(f"Warning: {path}: 'suppressions' must be a list\n")
+        return []
+
+    suppressions: list[Suppression] = []
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            sys.stderr.write(f"Warning: {path}: entry {i} is not a mapping, skipping\n")
+            continue
+
+        fp = entry.get("fingerprint")
+        if not fp or not isinstance(fp, str):
+            sys.stderr.write(f"Warning: {path}: entry {i} missing 'fingerprint', skipping\n")
+            continue
+
+        fp = fp.strip().lower()
+        if len(fp) != 64 or not all(c in "0123456789abcdef" for c in fp):
+            sys.stderr.write(f"Warning: {path}: entry {i} has invalid fingerprint format, skipping\n")
+            continue
+
+        raw_rule_id = entry.get("rule_id")
+        rule_id = raw_rule_id if isinstance(raw_rule_id, str) else ""
+        raw_mode = entry.get("mode")
+        mode = raw_mode if isinstance(raw_mode, str) else "full"
+        if mode not in _VALID_MODES:
+            sys.stderr.write(
+                f"Warning: {path}: entry {i} has invalid mode {mode!r}, defaulting to 'full'\n",
+            )
+            mode = "full"
+
+        raw_reason = entry.get("reason")
+        reason = raw_reason if isinstance(raw_reason, str) else ""
+        raw_created = entry.get("created")
+        created = raw_created if isinstance(raw_created, str) else ""
+
+        suppressions.append(
+            Suppression(
+                fingerprint=fp,
+                rule_id=rule_id,
+                mode=mode,
+                reason=reason,
+                created=created,
+            ),
+        )
+
+    return suppressions
+
+
+def apply_suppressions(
+    violations: Sequence[ViolationDict],
+    suppressions: list[Suppression],
+    enforced_rules: set[str] | None = None,
+) -> SuppressionResult:
+    """Partition violations into active and suppressed based on fingerprint matching.
+
+    Violations for enforced rules (ADR-041) bypass suppression entirely.
+
+    Args:
+        violations: Sequence of violation dicts (must include ``rule_id``,
+            ``original_yaml``, and optionally ``module_fqcn`` or
+            ``resolved_fqcn``/``original_module``).
+        suppressions: Loaded suppression entries.
+        enforced_rules: Set of rule IDs that cannot be suppressed.
+
+    Returns:
+        SuppressionResult with active and suppressed lists.
+    """
+    if not suppressions:
+        return SuppressionResult(active=list(violations), suppressed=[])
+
+    enforced = enforced_rules or set()
+
+    fp_index_full: dict[str, Suppression] = {}
+    fp_index_module: dict[str, Suppression] = {}
+    fp_index_rule: dict[str, Suppression] = {}
+
+    for s in suppressions:
+        if s.mode == "full":
+            fp_index_full[s.fingerprint] = s
+        elif s.mode == "rule_module":
+            fp_index_module[s.fingerprint] = s
+        elif s.mode == "rule_only":
+            fp_index_rule[s.fingerprint] = s
+
+    result = SuppressionResult()
+
+    for v in violations:
+        rule_id = str(v.get("rule_id", ""))
+        canonical_id = canonicalize_rule_id(rule_id)
+
+        if canonical_id in enforced or rule_id in enforced:
+            result.active.append(v)
+            continue
+
+        original_yaml = str(v.get("original_yaml") or "")
+        module_fqcn = str(
+            v.get("module_fqcn") or v.get("resolved_fqcn") or v.get("original_module") or "",
+        )
+
+        suppressed = False
+
+        if fp_index_full:
+            fp_full = compute_fingerprint(rule_id, original_yaml, mode="full")
+            if fp_full in fp_index_full:
+                suppressed = True
+
+        if not suppressed and fp_index_module and module_fqcn:
+            fp_module = compute_fingerprint(
+                rule_id,
+                original_yaml,
+                mode="rule_module",
+                module_fqcn=module_fqcn,
+            )
+            if fp_module in fp_index_module:
+                suppressed = True
+
+        if not suppressed and fp_index_rule:
+            fp_rule = compute_fingerprint(rule_id, original_yaml, mode="rule_only")
+            if fp_rule in fp_index_rule:
+                suppressed = True
+
+        if suppressed:
+            result.suppressed.append(v)
+        else:
+            result.active.append(v)
+
+    return result
+
+
+def write_suppressions(project_root: Path, suppressions: list[Suppression]) -> None:
+    """Write suppression entries to ``.apme/suppressions.yml``.
+
+    Creates the ``.apme/`` directory if it does not exist.
+
+    Args:
+        project_root: Resolved project root path.
+        suppressions: List of suppression entries to write.
+    """
+    path = project_root / SUPPRESSIONS_YML_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    entries: list[dict[str, str]] = []
+    for s in suppressions:
+        entry: dict[str, str] = {
+            "fingerprint": s.fingerprint,
+            "rule_id": s.rule_id,
+        }
+        if s.mode != "full":
+            entry["mode"] = s.mode
+        if s.reason:
+            entry["reason"] = s.reason
+        if s.created:
+            entry["created"] = s.created
+        entries.append(entry)
+
+    data: dict[str, object] = {
+        "version": 1,
+        "suppressions": entries,
+    }
+
+    with path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)

--- a/src/apme_engine/cli/_suppressions.py
+++ b/src/apme_engine/cli/_suppressions.py
@@ -187,14 +187,14 @@ def apply_suppressions(
 
         original_yaml = str(v.get("original_yaml") or "")
         module_fqcn = str(
-            v.get("module_fqcn") or v.get("resolved_fqcn") or v.get("original_module") or "",
+            v.get("module_fqcn") or v.get("resolved_fqcn") or v.get("original_module") or v.get("fqcn") or "",
         )
 
         suppressed = False
 
-        if fp_index_full:
-            fp_full = compute_fingerprint(rule_id, original_yaml, mode="full")
-            if fp_full in fp_index_full:
+        if fp_index_rule:
+            fp_rule = compute_fingerprint(rule_id, original_yaml, mode="rule_only")
+            if fp_rule in fp_index_rule:
                 suppressed = True
 
         if not suppressed and fp_index_module and module_fqcn:
@@ -207,9 +207,9 @@ def apply_suppressions(
             if fp_module in fp_index_module:
                 suppressed = True
 
-        if not suppressed and fp_index_rule:
-            fp_rule = compute_fingerprint(rule_id, original_yaml, mode="rule_only")
-            if fp_rule in fp_index_rule:
+        if not suppressed and fp_index_full:
+            fp_full = compute_fingerprint(rule_id, original_yaml, mode="full")
+            if fp_full in fp_index_full:
                 suppressed = True
 
         if suppressed:

--- a/src/apme_engine/cli/_suppressions.py
+++ b/src/apme_engine/cli/_suppressions.py
@@ -113,7 +113,11 @@ def load_suppressions(project_root: Path) -> list[Suppression]:
             continue
 
         raw_rule_id = entry.get("rule_id")
-        rule_id = raw_rule_id if isinstance(raw_rule_id, str) else ""
+        rule_id = raw_rule_id.strip() if isinstance(raw_rule_id, str) else ""
+        if not rule_id:
+            sys.stderr.write(f"Warning: {path}: entry {i} missing 'rule_id', skipping\n")
+            continue
+
         raw_mode = entry.get("mode")
         mode = raw_mode if isinstance(raw_mode, str) else "full"
         if mode not in _VALID_MODES:

--- a/src/apme_engine/cli/_suppressions.py
+++ b/src/apme_engine/cli/_suppressions.py
@@ -156,8 +156,9 @@ def apply_suppressions(
 
     Args:
         violations: Sequence of violation dicts (must include ``rule_id``,
-            ``original_yaml``, and optionally ``module_fqcn`` or
-            ``resolved_fqcn``/``original_module``).
+            ``original_yaml``, and optionally one of ``module_fqcn``,
+            ``resolved_fqcn``, ``original_module``, or ``fqcn`` as the
+            module identifier.
         suppressions: Loaded suppression entries.
         enforced_rules: Set of rule IDs that cannot be suppressed.
 

--- a/src/apme_engine/cli/_suppressions.py
+++ b/src/apme_engine/cli/_suppressions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from datetime import date, datetime
 from pathlib import Path
 
 import yaml
@@ -124,7 +125,12 @@ def load_suppressions(project_root: Path) -> list[Suppression]:
         raw_reason = entry.get("reason")
         reason = raw_reason if isinstance(raw_reason, str) else ""
         raw_created = entry.get("created")
-        created = raw_created if isinstance(raw_created, str) else ""
+        if isinstance(raw_created, str):
+            created = raw_created
+        elif isinstance(raw_created, datetime | date):
+            created = raw_created.isoformat()
+        else:
+            created = ""
 
         suppressions.append(
             Suppression(

--- a/src/apme_engine/cli/check.py
+++ b/src/apme_engine/cli/check.py
@@ -25,6 +25,7 @@ from apme_engine.cli._galaxy_config import discover_galaxy_servers
 from apme_engine.cli._models import ViolationDict
 from apme_engine.cli._project_root import derive_session_id, discover_project_root
 from apme_engine.cli._rules_yml import load_rule_configs_from_project
+from apme_engine.cli._suppressions import apply_suppressions, load_suppressions
 from apme_engine.cli.ansi import dim, red, yellow
 from apme_engine.cli.discovery import resolve_primary
 from apme_engine.cli.output import (
@@ -242,6 +243,15 @@ def run_check(args: argparse.Namespace) -> None:
     violations = deduplicate_violations(sort_violations(violations))
     scan_id = scan_id_holder[0]
 
+    show_suppressed = getattr(args, "show_suppressed", False)
+    suppressed_count = 0
+    if not show_suppressed:
+        suppressions = load_suppressions(project_root)
+        enforced_rules = {cfg.rule_id for cfg in (rule_cfgs or []) if cfg.enforced}
+        suppression_result = apply_suppressions(violations, suppressions, enforced_rules)
+        suppressed_count = len(suppression_result.suppressed)
+        violations = suppression_result.active
+
     if getattr(args, "sarif", False):
         from apme_engine.engine._version import __version__ as _engine_version
 
@@ -288,5 +298,7 @@ def run_check(args: argparse.Namespace) -> None:
 
     display_summary = _ScanSummaryCompat(tier1_report)
     render_check_results(violations, scan_id=scan_id, scan_time_ms=None, summary=display_summary)
+    if suppressed_count and not show_suppressed:
+        sys.stderr.write(dim(f"  ({suppressed_count} suppressed violation(s) hidden — use --show-suppressed)\n"))
     if violations:
         sys.exit(EXIT_VIOLATIONS)

--- a/src/apme_engine/cli/parser.py
+++ b/src/apme_engine/cli/parser.py
@@ -2,6 +2,8 @@
 
 import argparse
 
+from apme_engine.cli.suppress_cmd import register_suppress_parser
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Build and return the CLI argument parser.
@@ -83,6 +85,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Disable Python CVE audit only",
+    )
+    check_p.add_argument(
+        "--show-suppressed",
+        action="store_true",
+        default=False,
+        help="Include suppressed violations in output (ADR-055)",
     )
 
     # ── format ──
@@ -167,6 +175,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=False,
         help="Disable Python CVE audit only",
     )
+    remediate_p.add_argument(
+        "--show-suppressed",
+        action="store_true",
+        default=False,
+        help="Include suppressed violations in output (ADR-055)",
+    )
 
     # ── daemon ──
     daemon_p = subparsers.add_parser(
@@ -212,5 +226,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Gateway URL (default: $APME_GATEWAY_URL or http://localhost:8080)",
     )
+
+    # ── suppress ──
+    register_suppress_parser(subparsers, global_opts)
 
     return parser

--- a/src/apme_engine/cli/remediate.py
+++ b/src/apme_engine/cli/remediate.py
@@ -32,6 +32,7 @@ from apme_engine.cli._exit_codes import EXIT_ERROR, EXIT_VIOLATIONS
 from apme_engine.cli._galaxy_config import discover_galaxy_servers
 from apme_engine.cli._project_root import derive_session_id, discover_project_root
 from apme_engine.cli._rules_yml import load_rule_configs_from_project
+from apme_engine.cli._suppressions import apply_suppressions, load_suppressions
 from apme_engine.cli.ansi import dim, red, yellow
 from apme_engine.cli.discovery import resolve_primary
 from apme_engine.daemon.chunked_fs import yield_scan_chunks
@@ -128,6 +129,7 @@ def run_remediate(args: argparse.Namespace) -> None:
     tier1_report: FixReport | None = None
     result_violations: list[ViolationDict] = []
     result_patches: list[object] = []
+    got_result = False
 
     try:
         responses = stub.FixSession(command_iter(), timeout=1800)
@@ -181,11 +183,8 @@ def run_remediate(args: argparse.Namespace) -> None:
                 result = event.result
                 result_violations = [violation_proto_to_dict(v) for v in result.remaining_violations]
                 result_patches = list(result.patches)
-                if not use_json:
-                    _write_patches(target, result.patches)
-                    _render_remaining(result)
-                else:
-                    _write_patches(target, result.patches)
+                got_result = True
+                _write_patches(target, result.patches)
                 cmd_queue.put(SessionCommand(close=CloseRequest()))
 
             elif oneof == "expiring":
@@ -209,8 +208,31 @@ def run_remediate(args: argparse.Namespace) -> None:
         cmd_queue.put(None)
         channel.close()
 
+    if not got_result:
+        sys.stderr.write("Error: no session result received from engine\n")
+        sys.exit(EXIT_ERROR)
+
+    show_suppressed = getattr(args, "show_suppressed", False)
+    suppressed_count = 0
+    if not show_suppressed:
+        suppressions = load_suppressions(project_root)
+        enforced_rules = {cfg.rule_id for cfg in (rule_cfgs or []) if cfg.enforced}
+        suppression_result = apply_suppressions(result_violations, suppressions, enforced_rules)
+        suppressed_count = len(suppression_result.suppressed)
+        result_violations = suppression_result.active
+
     if use_json:
         _emit_json(result_violations, result_patches, tier1_report)
+    elif result_violations:
+        ai_count = sum(1 for v in result_violations if v.get("remediation_class") == "ai-candidate")
+        manual_count = len(result_violations) - ai_count
+        if ai_count:
+            sys.stderr.write(f"\n{ai_count} violation(s) may be fixable with --ai (Tier 2)\n")
+        if manual_count:
+            sys.stderr.write(f"{manual_count} violation(s) require manual review (Tier 3)\n")
+
+    if suppressed_count and not show_suppressed and not use_json:
+        sys.stderr.write(dim(f"  ({suppressed_count} suppressed violation(s) hidden — use --show-suppressed)\n"))
 
     if result_violations:
         sys.exit(EXIT_VIOLATIONS)

--- a/src/apme_engine/cli/suppress_cmd.py
+++ b/src/apme_engine/cli/suppress_cmd.py
@@ -1,0 +1,192 @@
+"""Suppress subcommand: manage violation suppressions in ``.apme/suppressions.yml`` (ADR-055)."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date
+
+from apme_engine.cli._exit_codes import EXIT_ERROR
+from apme_engine.cli._project_root import discover_project_root
+from apme_engine.cli._suppressions import (
+    Suppression,
+    load_suppressions,
+    write_suppressions,
+)
+from apme_engine.fingerprint import compute_fingerprint
+
+
+def run_suppress(args: argparse.Namespace) -> None:
+    """Execute the suppress subcommand.
+
+    Args:
+        args: Parsed CLI arguments.
+    """
+    subcmd = getattr(args, "suppress_command", None)
+    if subcmd == "add":
+        _suppress_add(args)
+    elif subcmd == "list":
+        _suppress_list(args)
+    elif subcmd == "remove":
+        _suppress_remove(args)
+    else:
+        sys.stderr.write("Error: suppress requires a subcommand (add, list, remove)\n")
+        sys.exit(EXIT_ERROR)
+
+
+def _suppress_add(args: argparse.Namespace) -> None:
+    """Add a suppression entry.
+
+    Args:
+        args: Parsed CLI arguments.
+    """
+    target = getattr(args, "target", ".")
+    project_root = discover_project_root(target)
+
+    rule_id = args.rule_id
+    mode = getattr(args, "mode", "full") or "full"
+    reason = getattr(args, "reason", "") or ""
+    original_yaml = getattr(args, "original_yaml", None) or ""
+    module_fqcn = getattr(args, "module_fqcn", None) or ""
+    fingerprint_arg = getattr(args, "fingerprint", None)
+
+    if fingerprint_arg:
+        fingerprint_arg = fingerprint_arg.strip().lower()
+        if len(fingerprint_arg) != 64 or not all(c in "0123456789abcdef" for c in fingerprint_arg):
+            sys.stderr.write(
+                "Error: --fingerprint must be a 64-character hex SHA-256 digest\n",
+            )
+            sys.exit(EXIT_ERROR)
+        fp = fingerprint_arg
+    else:
+        if mode == "full" and not original_yaml:
+            sys.stderr.write(
+                "Error: --original-yaml is required for 'full' mode (or provide --fingerprint directly)\n",
+            )
+            sys.exit(EXIT_ERROR)
+        if mode == "rule_module" and not module_fqcn:
+            sys.stderr.write("Error: --module-fqcn is required for 'rule_module' mode\n")
+            sys.exit(EXIT_ERROR)
+        fp = compute_fingerprint(rule_id, original_yaml, mode=mode, module_fqcn=module_fqcn)
+
+    existing = load_suppressions(project_root)
+
+    for s in existing:
+        if s.fingerprint == fp:
+            sys.stderr.write(f"Suppression already exists for fingerprint {fp[:12]}...\n")
+            return
+
+    new_entry = Suppression(
+        fingerprint=fp,
+        rule_id=rule_id,
+        mode=mode,
+        reason=reason,
+        created=date.today().isoformat(),
+    )
+    existing.append(new_entry)
+    write_suppressions(project_root, existing)
+    sys.stdout.write(f"Added suppression: {rule_id} [{mode}] fingerprint={fp[:12]}...\n")
+
+
+def _suppress_list(args: argparse.Namespace) -> None:
+    """List all suppression entries.
+
+    Args:
+        args: Parsed CLI arguments.
+    """
+    target = getattr(args, "target", ".")
+    project_root = discover_project_root(target)
+    suppressions = load_suppressions(project_root)
+
+    if not suppressions:
+        sys.stdout.write("No suppressions configured.\n")
+        return
+
+    for s in suppressions:
+        mode_tag = f" [{s.mode}]" if s.mode != "full" else ""
+        reason_tag = f" — {s.reason}" if s.reason else ""
+        sys.stdout.write(f"  {s.rule_id}{mode_tag}  {s.fingerprint[:16]}...{reason_tag}\n")
+
+    sys.stdout.write(f"\n{len(suppressions)} suppression(s) total.\n")
+
+
+def _suppress_remove(args: argparse.Namespace) -> None:
+    """Remove a suppression entry by fingerprint prefix.
+
+    Args:
+        args: Parsed CLI arguments.
+    """
+    target = getattr(args, "target", ".")
+    project_root = discover_project_root(target)
+    suppressions = load_suppressions(project_root)
+    fp_prefix = args.fingerprint.strip().lower()
+
+    matches = [s for s in suppressions if s.fingerprint.startswith(fp_prefix)]
+
+    if not matches:
+        sys.stderr.write(f"No suppression found matching fingerprint prefix {fp_prefix!r}\n")
+        sys.exit(EXIT_ERROR)
+
+    if len(matches) > 1:
+        sys.stderr.write(
+            f"Ambiguous: {len(matches)} suppressions match prefix {fp_prefix!r}. Provide a longer prefix.\n",
+        )
+        sys.exit(EXIT_ERROR)
+
+    remaining = [s for s in suppressions if s.fingerprint != matches[0].fingerprint]
+    write_suppressions(project_root, remaining)
+    sys.stdout.write(f"Removed suppression: {matches[0].rule_id} {matches[0].fingerprint[:16]}...\n")
+
+
+def register_suppress_parser(
+    subparsers: argparse._SubParsersAction,  # type: ignore[type-arg]
+    global_opts: argparse.ArgumentParser,
+) -> None:
+    """Register the suppress subcommand on the CLI parser.
+
+    Args:
+        subparsers: Subparsers action from the main argument parser.
+        global_opts: Parent parser with shared global options.
+    """
+    suppress_p = subparsers.add_parser(
+        "suppress",
+        parents=[global_opts],
+        help="Manage violation suppressions (.apme/suppressions.yml)",
+    )
+    suppress_sub = suppress_p.add_subparsers(dest="suppress_command", required=True)
+
+    # ── suppress add ──
+    add_p = suppress_sub.add_parser("add", help="Add a suppression entry")
+    add_p.add_argument("--rule-id", required=True, help="Rule ID to suppress (e.g. L046)")
+    add_p.add_argument(
+        "--fingerprint",
+        default=None,
+        help="Pre-computed fingerprint hash (skips computation)",
+    )
+    add_p.add_argument(
+        "--original-yaml",
+        default=None,
+        help="Original YAML content to fingerprint (for 'full' mode)",
+    )
+    add_p.add_argument(
+        "--module-fqcn",
+        default=None,
+        help="Module FQCN (for 'rule_module' mode)",
+    )
+    add_p.add_argument(
+        "--mode",
+        default="full",
+        choices=["full", "rule_module", "rule_only"],
+        help="Fingerprint granularity (default: full)",
+    )
+    add_p.add_argument("--reason", default="", help="Justification for the suppression")
+    add_p.add_argument("target", nargs="?", default=".", help="Project root")
+
+    # ── suppress list ──
+    list_p = suppress_sub.add_parser("list", help="List all suppressions")
+    list_p.add_argument("target", nargs="?", default=".", help="Project root")
+
+    # ── suppress remove ──
+    rm_p = suppress_sub.add_parser("remove", help="Remove a suppression by fingerprint prefix")
+    rm_p.add_argument("fingerprint", help="Fingerprint prefix (at least 8 chars recommended)")
+    rm_p.add_argument("target", nargs="?", default=".", help="Project root")

--- a/src/apme_engine/cli/suppress_cmd.py
+++ b/src/apme_engine/cli/suppress_cmd.py
@@ -13,7 +13,7 @@ from apme_engine.cli._suppressions import (
     load_suppressions,
     write_suppressions,
 )
-from apme_engine.fingerprint import compute_fingerprint
+from apme_engine.fingerprint import canonicalize_rule_id, compute_fingerprint
 
 
 def run_suppress(args: argparse.Namespace) -> None:
@@ -43,7 +43,7 @@ def _suppress_add(args: argparse.Namespace) -> None:
     target = getattr(args, "target", ".")
     project_root = discover_project_root(target)
 
-    rule_id = args.rule_id
+    rule_id = canonicalize_rule_id(args.rule_id)
     mode = getattr(args, "mode", "full") or "full"
     reason = getattr(args, "reason", "") or ""
     original_yaml = getattr(args, "original_yaml", None) or ""

--- a/src/apme_engine/fingerprint.py
+++ b/src/apme_engine/fingerprint.py
@@ -144,7 +144,8 @@ def compute_fingerprint(
         SHA-256 hex digest string.
 
     Raises:
-        ValueError: If mode is not one of the three valid values.
+        ValueError: If mode is not one of the three valid values, or if
+            ``mode="rule_module"`` is used without a non-empty ``module_fqcn``.
     """
     canonical_id = canonicalize_rule_id(rule_id)
 

--- a/src/apme_engine/fingerprint.py
+++ b/src/apme_engine/fingerprint.py
@@ -1,0 +1,163 @@
+"""Content-based violation fingerprinting (ADR-055).
+
+Provides deterministic SHA-256 fingerprints for violations based on
+rule ID and normalized task YAML content. Shared by CLI and Gateway.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+from io import StringIO
+
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+
+_LEGACY_PREFIX_RE = re.compile(r"^(native|opa|ansible|gitleaks):")
+_BLANK_LINE_RUN_RE = re.compile(r"\n{3,}")
+
+
+def canonicalize_rule_id(raw_id: str) -> str:
+    """Strip legacy validator prefixes to produce a bare rule ID.
+
+    Args:
+        raw_id: Raw rule ID possibly prefixed with ``native:``, ``opa:``, etc.
+
+    Returns:
+        Canonical rule ID (e.g. ``L046``).
+    """
+    return _LEGACY_PREFIX_RE.sub("", raw_id.strip())
+
+
+def _strip_comments(data: object) -> None:
+    """Recursively remove all YAML comments from a ruamel data structure.
+
+    Args:
+        data: A ruamel.yaml CommentedMap, CommentedSeq, or scalar.
+    """
+    if isinstance(data, CommentedMap):
+        data.ca.comment = None
+        for key in data.ca.items:
+            data.ca.items[key] = [None, None, None, None]
+        for val in data.values():
+            _strip_comments(val)
+    elif isinstance(data, CommentedSeq):
+        data.ca.comment = None
+        for idx in list(data.ca.items):
+            data.ca.items[idx] = [None, None, None, None]
+        for item in data:
+            _strip_comments(item)
+
+
+def normalize_yaml(text: str) -> str:
+    """Normalize YAML for fingerprinting: strip comments, normalize whitespace.
+
+    Preserves block scalar bodies verbatim (content inside ``|``/``>`` is
+    runtime data). Does NOT re-order keys, change quoting, or alter values.
+
+    Args:
+        text: Raw YAML text (single node/task).
+
+    Returns:
+        Normalized YAML string (UTF-8 NFC, LF line endings).
+    """
+    if not text or not text.strip():
+        return ""
+
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = unicodedata.normalize("NFC", text)
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+
+    try:
+        data = yaml.load(text)
+    except Exception:
+        return _fallback_normalize(text)
+
+    if data is None:
+        return ""
+
+    _strip_comments(data)
+
+    out_yaml = YAML()
+    out_yaml.preserve_quotes = True
+    out_yaml.width = 4096
+    out_yaml.indent(mapping=2, sequence=2, offset=2)
+
+    try:
+        buf = StringIO()
+        out_yaml.dump(data, buf)
+        result = buf.getvalue()
+    except Exception:
+        return _fallback_normalize(text)
+
+    result = result.replace("\r\n", "\n")
+    result = _BLANK_LINE_RUN_RE.sub("\n\n", result)
+    result = result.strip()
+
+    return unicodedata.normalize("NFC", result)
+
+
+def _fallback_normalize(text: str) -> str:
+    """Best-effort normalization when YAML parsing fails.
+
+    Strips unindented comment lines, normalizes whitespace, preserves content.
+    Indented ``#`` lines are kept because they may be block-scalar content.
+
+    Args:
+        text: Raw YAML text that failed to parse.
+
+    Returns:
+        Normalized text.
+    """
+    lines: list[str] = []
+    for line in text.split("\n"):
+        if line.startswith("#"):
+            continue
+        lines.append(line.rstrip())
+
+    result = "\n".join(lines)
+    result = _BLANK_LINE_RUN_RE.sub("\n\n", result)
+    return result.strip()
+
+
+def compute_fingerprint(
+    rule_id: str,
+    original_yaml: str,
+    mode: str = "full",
+    module_fqcn: str = "",
+) -> str:
+    """Compute a SHA-256 fingerprint for a violation.
+
+    Args:
+        rule_id: Canonical or raw rule ID (will be canonicalized).
+        original_yaml: Full node YAML as originally written.
+        mode: Fingerprint mode — ``"full"``, ``"rule_module"``, or ``"rule_only"``.
+        module_fqcn: Resolved module FQCN (required for ``rule_module`` mode).
+
+    Returns:
+        SHA-256 hex digest string.
+
+    Raises:
+        ValueError: If mode is not one of the three valid values.
+    """
+    canonical_id = canonicalize_rule_id(rule_id)
+
+    if mode == "full":
+        normalized = normalize_yaml(original_yaml)
+        payload = canonical_id + "\x00" + normalized
+    elif mode == "rule_module":
+        if not module_fqcn:
+            msg = "module_fqcn is required for 'rule_module' mode (empty value collides with 'rule_only')."
+            raise ValueError(msg)
+        payload = canonical_id + "\x00" + module_fqcn
+    elif mode == "rule_only":
+        payload = canonical_id + "\x00"
+    else:
+        msg = f"Invalid fingerprint mode: {mode!r}. Must be 'full', 'rule_module', or 'rule_only'."
+        raise ValueError(msg)
+
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/src/apme_engine/fingerprint.py
+++ b/src/apme_engine/fingerprint.py
@@ -68,8 +68,9 @@ def normalize_yaml(text: str) -> str:
     text = text.replace("\r\n", "\n").replace("\r", "\n")
     text = unicodedata.normalize("NFC", text)
 
-    yaml = YAML()
+    yaml = YAML(typ="rt", pure=True)
     yaml.preserve_quotes = True
+    yaml.allow_duplicate_keys = True
     yaml.width = 4096
 
     try:
@@ -82,8 +83,9 @@ def normalize_yaml(text: str) -> str:
 
     _strip_comments(data)
 
-    out_yaml = YAML()
+    out_yaml = YAML(typ="rt", pure=True)
     out_yaml.preserve_quotes = True
+    out_yaml.allow_duplicate_keys = True
     out_yaml.width = 4096
     out_yaml.indent(mapping=2, sequence=2, offset=2)
 

--- a/src/apme_engine/fingerprint.py
+++ b/src/apme_engine/fingerprint.py
@@ -71,7 +71,6 @@ def normalize_yaml(text: str) -> str:
     yaml = YAML(typ="rt", pure=True)
     yaml.preserve_quotes = True
     yaml.allow_duplicate_keys = True
-    yaml.width = 4096
 
     try:
         data = yaml.load(text)

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -342,6 +342,27 @@ class TestLoadSuppressions:
         assert len(result) == 1
         assert result[0].rule_id == "L047"
 
+    def test_missing_or_blank_rule_id_skipped(self, tmp_path: Path) -> None:
+        """Entries without a usable rule_id are skipped.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        (tmp_path / ".apme").mkdir()
+        data = {
+            "version": 1,
+            "suppressions": [
+                {"fingerprint": "c" * 64},
+                {"fingerprint": "d" * 64, "rule_id": "   "},
+                {"fingerprint": "e" * 64, "rule_id": "L047"},
+            ],
+        }
+        (tmp_path / ".apme" / "suppressions.yml").write_text(yaml.safe_dump(data))
+
+        result = load_suppressions(tmp_path)
+        assert len(result) == 1
+        assert result[0].rule_id == "L047"
+
     def test_invalid_mode_defaults_to_full(self, tmp_path: Path) -> None:
         """Invalid mode value defaults to 'full' with warning.
 

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -264,6 +264,32 @@ class TestLoadSuppressions:
         assert result[0].mode == "full"
         assert result[0].reason == "Accepted"
 
+    def test_unquoted_created_date_is_preserved(self, tmp_path: Path) -> None:
+        """Unquoted YAML dates are normalized back to ISO strings.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        fp = "b" * 64
+        (tmp_path / ".apme").mkdir()
+        (tmp_path / ".apme" / "suppressions.yml").write_text(
+            "\n".join(
+                (
+                    "version: 1",
+                    "suppressions:",
+                    f"  - fingerprint: {fp}",
+                    "    rule_id: L046",
+                    "    created: 2026-05-21",
+                    "",
+                ),
+            ),
+        )
+
+        result = load_suppressions(tmp_path)
+
+        assert len(result) == 1
+        assert result[0].created == "2026-05-21"
+
     def test_mode_defaults_to_full(self, tmp_path: Path) -> None:
         """Missing mode field defaults to 'full'.
 

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,539 @@
+"""Unit tests for ADR-055 fingerprinting and suppression."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from apme_engine.cli._suppressions import (
+    Suppression,
+    apply_suppressions,
+    load_suppressions,
+    write_suppressions,
+)
+from apme_engine.engine.models import ViolationDict
+from apme_engine.fingerprint import (
+    canonicalize_rule_id,
+    compute_fingerprint,
+    normalize_yaml,
+)
+
+
+class TestCanonicalizeRuleId:
+    """Tests for canonicalize_rule_id."""
+
+    def test_no_prefix(self) -> None:
+        """Bare rule ID is returned unchanged."""
+        assert canonicalize_rule_id("L046") == "L046"
+
+    def test_native_prefix(self) -> None:
+        """Strips native: prefix."""
+        assert canonicalize_rule_id("native:L046") == "L046"
+
+    def test_opa_prefix(self) -> None:
+        """Strips opa: prefix."""
+        assert canonicalize_rule_id("opa:P001") == "P001"
+
+    def test_ansible_prefix(self) -> None:
+        """Strips ansible: prefix."""
+        assert canonicalize_rule_id("ansible:R001") == "R001"
+
+    def test_gitleaks_prefix(self) -> None:
+        """Strips gitleaks: prefix."""
+        assert canonicalize_rule_id("gitleaks:SEC001") == "SEC001"
+
+    def test_whitespace_stripped(self) -> None:
+        """Leading/trailing whitespace is removed."""
+        assert canonicalize_rule_id("  native:L046  ") == "L046"
+
+    def test_unknown_prefix_kept(self) -> None:
+        """Non-validator prefixes are preserved."""
+        assert canonicalize_rule_id("custom:EXT-001") == "custom:EXT-001"
+
+
+class TestNormalizeYaml:
+    """Tests for normalize_yaml."""
+
+    def test_empty_string(self) -> None:
+        """Empty input returns empty string."""
+        assert normalize_yaml("") == ""
+
+    def test_whitespace_only(self) -> None:
+        """Whitespace-only input returns empty string."""
+        assert normalize_yaml("   \n  \n  ") == ""
+
+    def test_strips_comments(self) -> None:
+        """YAML comments outside scalars are removed."""
+        text = "# This is a comment\nname: Install nginx\n# Another comment\n"
+        result = normalize_yaml(text)
+        assert "comment" not in result
+        assert "Install nginx" in result
+
+    def test_preserves_values(self) -> None:
+        """Scalar values are preserved verbatim."""
+        text = "name: Install nginx\nansible.builtin.shell: apt install nginx\n"
+        result = normalize_yaml(text)
+        assert "Install nginx" in result
+        assert "apt install nginx" in result
+
+    def test_block_scalar_literal(self) -> None:
+        """Block scalar (|) bodies are preserved including comment-like lines."""
+        text = "script: |\n  #!/bin/bash\n  # This is runtime content\n  echo hello\n"
+        result = normalize_yaml(text)
+        assert "# This is runtime content" in result
+        assert "echo hello" in result
+
+    def test_block_scalar_folded(self) -> None:
+        """Folded scalar (>) bodies are preserved."""
+        text = "msg: >\n  This is a long\n  message that spans\n  multiple lines\n"
+        result = normalize_yaml(text)
+        assert "long" in result
+        assert "message" in result
+
+    def test_jinja2_expression(self) -> None:
+        """Jinja2 expressions in values are preserved."""
+        text = 'name: "{{ item.name }}"\nwhen: item.enabled\n'
+        result = normalize_yaml(text)
+        assert "{{ item.name }}" in result
+        assert "item.enabled" in result
+
+    def test_comment_like_in_scalar(self) -> None:
+        """Hash characters inside scalar values are not stripped."""
+        text = 'msg: "Use # to indicate a comment in YAML"\n'
+        result = normalize_yaml(text)
+        assert "# to indicate" in result
+
+    def test_does_not_reorder_keys(self) -> None:
+        """Key order is preserved (no alphabetical sorting)."""
+        text = "zebra: 1\nalpha: 2\nmiddle: 3\n"
+        result = normalize_yaml(text)
+        lines = [line for line in result.split("\n") if line.strip()]
+        keys = [line.split(":")[0] for line in lines]
+        assert keys == ["zebra", "alpha", "middle"]
+
+    def test_crlf_normalized_to_lf(self) -> None:
+        """CRLF line endings are converted to LF."""
+        text = "name: test\r\nvalue: foo\r\n"
+        result = normalize_yaml(text)
+        assert "\r" not in result
+
+    def test_blank_line_collapse(self) -> None:
+        """Runs of blank lines are collapsed."""
+        text = "name: test\n\n\n\n\nvalue: foo\n"
+        result = normalize_yaml(text)
+        assert "\n\n\n" not in result
+
+    def test_multiline_string_value(self) -> None:
+        """Quoted multiline string values are preserved."""
+        text = 'command: "echo hello && echo world"\n'
+        result = normalize_yaml(text)
+        assert "echo hello" in result
+        assert "echo world" in result
+
+
+class TestComputeFingerprint:
+    """Tests for compute_fingerprint."""
+
+    def test_full_mode_basic(self) -> None:
+        """Full mode produces a valid 64-char hex digest."""
+        fp = compute_fingerprint(
+            "L046",
+            "name: Install nginx\nansible.builtin.shell: apt install nginx\n",
+        )
+        assert len(fp) == 64
+        assert all(c in "0123456789abcdef" for c in fp)
+
+    def test_full_mode_deterministic(self) -> None:
+        """Same inputs always produce the same fingerprint."""
+        yaml_text = "name: Install nginx\nansible.builtin.shell: apt install nginx\n"
+        fp1 = compute_fingerprint("L046", yaml_text)
+        fp2 = compute_fingerprint("L046", yaml_text)
+        assert fp1 == fp2
+
+    def test_different_content_different_fingerprint(self) -> None:
+        """Different YAML content produces different fingerprints."""
+        fp1 = compute_fingerprint("L046", "ansible.builtin.shell: apt install nginx\n")
+        fp2 = compute_fingerprint("L046", "ansible.builtin.shell: rm -rf /data\n")
+        assert fp1 != fp2
+
+    def test_different_rule_different_fingerprint(self) -> None:
+        """Different rule IDs produce different fingerprints for same content."""
+        yaml_text = "name: test\n"
+        fp1 = compute_fingerprint("L046", yaml_text)
+        fp2 = compute_fingerprint("L047", yaml_text)
+        assert fp1 != fp2
+
+    def test_comment_does_not_affect_fingerprint(self) -> None:
+        """Adding comments does not change the fingerprint."""
+        yaml1 = "name: Install nginx\nansible.builtin.shell: apt install nginx\n"
+        yaml2 = "# Comment here\nname: Install nginx\nansible.builtin.shell: apt install nginx\n"
+        fp1 = compute_fingerprint("L046", yaml1)
+        fp2 = compute_fingerprint("L046", yaml2)
+        assert fp1 == fp2
+
+    def test_rule_module_mode(self) -> None:
+        """Rule-module mode produces a valid fingerprint."""
+        fp = compute_fingerprint(
+            "L046",
+            "",
+            mode="rule_module",
+            module_fqcn="ansible.builtin.shell",
+        )
+        assert len(fp) == 64
+
+    def test_rule_module_mode_different_modules(self) -> None:
+        """Different modules produce different fingerprints in rule_module mode."""
+        fp1 = compute_fingerprint("L046", "", mode="rule_module", module_fqcn="ansible.builtin.shell")
+        fp2 = compute_fingerprint("L046", "", mode="rule_module", module_fqcn="ansible.builtin.command")
+        assert fp1 != fp2
+
+    def test_rule_only_mode(self) -> None:
+        """Rule-only mode ignores content and module."""
+        fp1 = compute_fingerprint("L046", "name: anything\n", mode="rule_only")
+        fp2 = compute_fingerprint("L046", "name: something else\n", mode="rule_only")
+        assert fp1 == fp2
+
+    def test_rule_only_mode_different_rules(self) -> None:
+        """Different rules produce different fingerprints in rule_only mode."""
+        fp1 = compute_fingerprint("L046", "", mode="rule_only")
+        fp2 = compute_fingerprint("L047", "", mode="rule_only")
+        assert fp1 != fp2
+
+    def test_rule_module_mode_empty_fqcn_raises(self) -> None:
+        """Rule-module mode with empty module_fqcn raises ValueError."""
+        with pytest.raises(ValueError, match="module_fqcn is required"):
+            compute_fingerprint("L046", "", mode="rule_module", module_fqcn="")
+
+    def test_rule_module_mode_none_fqcn_raises(self) -> None:
+        """Rule-module mode with no module_fqcn raises ValueError."""
+        with pytest.raises(ValueError, match="module_fqcn is required"):
+            compute_fingerprint("L046", "", mode="rule_module")
+
+    def test_invalid_mode_raises(self) -> None:
+        """Invalid mode raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid fingerprint mode"):
+            compute_fingerprint("L046", "name: test\n", mode="bogus")
+
+    def test_canonicalizes_rule_id(self) -> None:
+        """Prefixed and bare rule IDs produce the same fingerprint."""
+        fp1 = compute_fingerprint("native:L046", "name: test\n")
+        fp2 = compute_fingerprint("L046", "name: test\n")
+        assert fp1 == fp2
+
+
+class TestLoadSuppressions:
+    """Tests for suppression file loading."""
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        """Missing suppressions file returns empty list.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        result = load_suppressions(tmp_path)
+        assert result == []
+
+    def test_valid_file(self, tmp_path: Path) -> None:
+        """Valid suppressions file is parsed correctly.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        fp = "a" * 64
+        (tmp_path / ".apme").mkdir()
+        data = {
+            "version": 1,
+            "suppressions": [
+                {
+                    "fingerprint": fp,
+                    "rule_id": "L046",
+                    "mode": "full",
+                    "reason": "Accepted",
+                    "created": "2026-05-21",
+                },
+            ],
+        }
+        (tmp_path / ".apme" / "suppressions.yml").write_text(yaml.safe_dump(data))
+
+        result = load_suppressions(tmp_path)
+        assert len(result) == 1
+        assert result[0].fingerprint == fp
+        assert result[0].rule_id == "L046"
+        assert result[0].mode == "full"
+        assert result[0].reason == "Accepted"
+
+    def test_mode_defaults_to_full(self, tmp_path: Path) -> None:
+        """Missing mode field defaults to 'full'.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        fp = "b" * 64
+        (tmp_path / ".apme").mkdir()
+        data = {
+            "version": 1,
+            "suppressions": [
+                {"fingerprint": fp, "rule_id": "L046"},
+            ],
+        }
+        (tmp_path / ".apme" / "suppressions.yml").write_text(yaml.safe_dump(data))
+
+        result = load_suppressions(tmp_path)
+        assert result[0].mode == "full"
+
+    def test_invalid_yaml_returns_empty(self, tmp_path: Path) -> None:
+        """Malformed YAML returns empty list with warning.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        (tmp_path / ".apme").mkdir()
+        (tmp_path / ".apme" / "suppressions.yml").write_text("{{invalid yaml")
+
+        result = load_suppressions(tmp_path)
+        assert result == []
+
+    def test_missing_fingerprint_skipped(self, tmp_path: Path) -> None:
+        """Entries without fingerprint are skipped.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        (tmp_path / ".apme").mkdir()
+        fp = "c" * 64
+        data = {
+            "version": 1,
+            "suppressions": [
+                {"rule_id": "L046"},
+                {"fingerprint": fp, "rule_id": "L047"},
+            ],
+        }
+        (tmp_path / ".apme" / "suppressions.yml").write_text(yaml.safe_dump(data))
+
+        result = load_suppressions(tmp_path)
+        assert len(result) == 1
+        assert result[0].rule_id == "L047"
+
+    def test_invalid_mode_defaults_to_full(self, tmp_path: Path) -> None:
+        """Invalid mode value defaults to 'full' with warning.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        fp = "d" * 64
+        (tmp_path / ".apme").mkdir()
+        data = {
+            "version": 1,
+            "suppressions": [
+                {"fingerprint": fp, "rule_id": "L046", "mode": "bogus"},
+            ],
+        }
+        (tmp_path / ".apme" / "suppressions.yml").write_text(yaml.safe_dump(data))
+
+        result = load_suppressions(tmp_path)
+        assert result[0].mode == "full"
+
+    def test_unsupported_version_returns_empty(self, tmp_path: Path) -> None:
+        """Unsupported version field causes all suppressions to be ignored.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        (tmp_path / ".apme").mkdir()
+        data = {
+            "version": 2,
+            "suppressions": [
+                {"fingerprint": "a" * 64, "rule_id": "L046"},
+            ],
+        }
+        (tmp_path / ".apme" / "suppressions.yml").write_text(yaml.safe_dump(data))
+
+        result = load_suppressions(tmp_path)
+        assert result == []
+
+    def test_invalid_fingerprint_format_skipped(self, tmp_path: Path) -> None:
+        """Entries with non-SHA256 fingerprints are skipped during load.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        (tmp_path / ".apme").mkdir()
+        data = {
+            "version": 1,
+            "suppressions": [
+                {"fingerprint": "short", "rule_id": "L046"},
+                {"fingerprint": "a" * 64, "rule_id": "L047"},
+            ],
+        }
+        (tmp_path / ".apme" / "suppressions.yml").write_text(yaml.safe_dump(data))
+
+        result = load_suppressions(tmp_path)
+        assert len(result) == 1
+        assert result[0].rule_id == "L047"
+
+
+class TestWriteSuppressions:
+    """Tests for writing suppression files."""
+
+    def test_creates_directory_and_file(self, tmp_path: Path) -> None:
+        """Creates .apme/ directory and suppressions.yml.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        fp = "e" * 64
+        entries = [
+            Suppression(
+                fingerprint=fp,
+                rule_id="L046",
+                mode="full",
+                reason="Test",
+                created="2026-05-21",
+            ),
+        ]
+        write_suppressions(tmp_path, entries)
+
+        path = tmp_path / ".apme" / "suppressions.yml"
+        assert path.exists()
+        data = yaml.safe_load(path.read_text())
+        assert data["version"] == 1
+        assert len(data["suppressions"]) == 1
+        assert data["suppressions"][0]["fingerprint"] == fp
+
+    def test_omits_mode_when_full(self, tmp_path: Path) -> None:
+        """Mode 'full' is omitted from output (it's the default).
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        entries = [Suppression(fingerprint="f" * 64, rule_id="L046", mode="full")]
+        write_suppressions(tmp_path, entries)
+
+        data = yaml.safe_load((tmp_path / ".apme" / "suppressions.yml").read_text())
+        assert "mode" not in data["suppressions"][0]
+
+    def test_includes_mode_when_not_full(self, tmp_path: Path) -> None:
+        """Non-default mode is included in output.
+
+        Args:
+            tmp_path: Pytest temporary directory.
+        """
+        entries = [Suppression(fingerprint="0" * 64, rule_id="L046", mode="rule_module")]
+        write_suppressions(tmp_path, entries)
+
+        data = yaml.safe_load((tmp_path / ".apme" / "suppressions.yml").read_text())
+        assert data["suppressions"][0]["mode"] == "rule_module"
+
+
+class TestApplySuppressions:
+    """Tests for suppression matching logic."""
+
+    def test_no_suppressions_all_active(self) -> None:
+        """With no suppressions, all violations remain active."""
+        violations: list[ViolationDict] = [{"rule_id": "L046", "original_yaml": "name: test\n"}]
+        result = apply_suppressions(violations, [])
+        assert len(result.active) == 1
+        assert len(result.suppressed) == 0
+
+    def test_matching_full_fingerprint_suppresses(self) -> None:
+        """Violation matching a full-mode suppression is filtered out."""
+        yaml_text = "name: Install nginx\nansible.builtin.shell: apt install nginx\n"
+        fp = compute_fingerprint("L046", yaml_text)
+        violations: list[ViolationDict] = [{"rule_id": "L046", "original_yaml": yaml_text}]
+        suppressions = [Suppression(fingerprint=fp, rule_id="L046", mode="full")]
+
+        result = apply_suppressions(violations, suppressions)
+        assert len(result.active) == 0
+        assert len(result.suppressed) == 1
+
+    def test_non_matching_fingerprint_stays_active(self) -> None:
+        """Violation not matching any suppression stays active."""
+        violations: list[ViolationDict] = [{"rule_id": "L046", "original_yaml": "name: test\n"}]
+        suppressions = [Suppression(fingerprint="0" * 64, rule_id="L046", mode="full")]
+
+        result = apply_suppressions(violations, suppressions)
+        assert len(result.active) == 1
+        assert len(result.suppressed) == 0
+
+    def test_enforced_rule_cannot_be_suppressed(self) -> None:
+        """Enforced rules bypass suppression even when fingerprint matches."""
+        yaml_text = "name: test\n"
+        fp = compute_fingerprint("L046", yaml_text)
+        violations: list[ViolationDict] = [{"rule_id": "L046", "original_yaml": yaml_text}]
+        suppressions = [Suppression(fingerprint=fp, rule_id="L046", mode="full")]
+
+        result = apply_suppressions(violations, suppressions, enforced_rules={"L046"})
+        assert len(result.active) == 1
+        assert len(result.suppressed) == 0
+
+    def test_rule_only_mode_suppresses_any_content(self) -> None:
+        """Rule-only mode suppresses all violations for that rule regardless of content."""
+        fp = compute_fingerprint("L046", "", mode="rule_only")
+        violations: list[ViolationDict] = [
+            {"rule_id": "L046", "original_yaml": "name: first\n"},
+            {"rule_id": "L046", "original_yaml": "name: second\n"},
+        ]
+        suppressions = [Suppression(fingerprint=fp, rule_id="L046", mode="rule_only")]
+
+        result = apply_suppressions(violations, suppressions)
+        assert len(result.active) == 0
+        assert len(result.suppressed) == 2
+
+    def test_rule_module_mode_uses_module_fqcn(self) -> None:
+        """Rule-module mode matches on module_fqcn field."""
+        fp = compute_fingerprint("L046", "", mode="rule_module", module_fqcn="ansible.builtin.shell")
+        violations: list[ViolationDict] = [
+            {
+                "rule_id": "L046",
+                "original_yaml": "name: test\n",
+                "module_fqcn": "ansible.builtin.shell",
+            },
+        ]
+        suppressions = [Suppression(fingerprint=fp, rule_id="L046", mode="rule_module")]
+
+        result = apply_suppressions(violations, suppressions)
+        assert len(result.active) == 0
+        assert len(result.suppressed) == 1
+
+    def test_rule_module_mode_different_module_not_suppressed(self) -> None:
+        """Rule-module mode does not suppress violations for a different module."""
+        fp = compute_fingerprint("L046", "", mode="rule_module", module_fqcn="ansible.builtin.shell")
+        violations: list[ViolationDict] = [
+            {
+                "rule_id": "L046",
+                "original_yaml": "name: test\n",
+                "module_fqcn": "ansible.builtin.command",
+            },
+        ]
+        suppressions = [Suppression(fingerprint=fp, rule_id="L046", mode="rule_module")]
+
+        result = apply_suppressions(violations, suppressions)
+        assert len(result.active) == 1
+        assert len(result.suppressed) == 0
+
+    def test_missing_original_yaml_uses_empty(self) -> None:
+        """None original_yaml is treated as empty string for fingerprinting."""
+        fp = compute_fingerprint("L046", "")
+        violations: list[ViolationDict] = [{"rule_id": "L046", "original_yaml": None}]
+        suppressions = [Suppression(fingerprint=fp, rule_id="L046", mode="full")]
+
+        result = apply_suppressions(violations, suppressions)
+        assert len(result.suppressed) == 1
+
+    def test_mixed_violations_partitioned_correctly(self) -> None:
+        """Suppressed and active violations are separated correctly."""
+        yaml1 = "name: suppress me\n"
+        yaml2 = "name: keep me\n"
+        fp1 = compute_fingerprint("L046", yaml1)
+        violations: list[ViolationDict] = [
+            {"rule_id": "L046", "original_yaml": yaml1},
+            {"rule_id": "L046", "original_yaml": yaml2},
+        ]
+        suppressions = [Suppression(fingerprint=fp1, rule_id="L046", mode="full")]
+
+        result = apply_suppressions(violations, suppressions)
+        assert len(result.active) == 1
+        assert len(result.suppressed) == 1
+        assert result.active[0]["original_yaml"] == yaml2


### PR DESCRIPTION
## Summary
- Implements ADR-055 Phases 1+2: content-based SHA-256 violation fingerprinting and CLI suppression via `.apme/suppressions.yml`
- Enables accept/ignore decisions that survive line-number changes, reformatting, file moves, and transfer across projects with identical content
- Hardens suppression loading so YAML timestamp values in `created` survive `safe_load` normalization and malformed suppression entries are skipped instead of being rewritten with blank rule IDs
- No engine changes required; fingerprinting uses existing `rule_id` + `original_yaml` proto fields

## Changes
- **`src/apme_engine/fingerprint.py`**: shared fingerprint library with `normalize_yaml()`, `canonicalize_rule_id()`, and `compute_fingerprint()` (`full` / `rule_module` / `rule_only`)
- **`src/apme_engine/cli/_suppressions.py`**: suppression file loader, matcher, and writer, including YAML timestamp normalization for `created` and stricter `rule_id` validation on load
- **`src/apme_engine/cli/suppress_cmd.py`**: `apme suppress add/list/remove` subcommand
- **`src/apme_engine/cli/_convert.py`**: added `original_yaml` and `module_fqcn` fields to violation dict for downstream fingerprinting
- **`src/apme_engine/cli/check.py`** / **`remediate.py`**: wired suppression filtering after deduplication and preserved ADR-041 enforced-rule bypass
- **`src/apme_engine/cli/parser.py`**: added `--show-suppressed` flag to check and remediate, and registered the suppress subcommand
- **`tests/test_fingerprint.py`**: expanded regression coverage for normalization, canonicalization, suppression matching, unquoted YAML `created` dates, and invalid suppression entries without a usable `rule_id`
- Clarified docstrings for `compute_fingerprint()` error behavior and `apply_suppressions()` module identifier lookup to match the merged implementation and close review feedback

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (`2415 passed, 0 failed`)
- [x] No proto changes needed
- [x] Preserves block scalar content (`|` / `>`) as runtime data during normalization
- [x] Enforced rules (ADR-041) bypass suppression