### PR TITLE
fix(engine): prevent L095 false positives on EDA rulebooks

### DIFF
--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -13,12 +13,13 @@ valid_playbook_re = re.compile(r"^\s*?-?\s*?(?:hosts|include|import_playbook):\s
 # 1. List item start: "- name:" at column 0 indicates ruleset definition
 # 2. Ruleset-level keys: "sources:" or "rules:" at exactly 2-space indent
 # 3. Playbook-only keys at 2-space indent reject EDA classification
-# 4. "rules:" alone requires a following "condition:" or "action:" at 4-space indent
+# 4. "rules:" alone requires a following "condition:" or "action:" under the
+#    rule entry (typically 6 spaces, but allow a small 4-8 space range)
 _eda_list_item_re = re.compile(r"^-\s+name:\s*\S")
 _eda_ruleset_key_re = re.compile(r"^  (?:sources|rules):\s*(?:\S.*)?$")
 _eda_sources_key_re = re.compile(r"^  sources:\s*(?:\S.*)?$")
 _eda_playbook_section_re = re.compile(r"^  (?:tasks|roles|handlers|pre_tasks|post_tasks):")
-_eda_rule_structure_re = re.compile(r"^    (?:condition|action):")
+_eda_rule_structure_re = re.compile(r"^\s{4,8}(?:condition|action):")
 
 # Keys that identify a play, not an EDA ruleset (first list item dict).
 _PLAYBOOK_SECTION_KEYS = frozenset({"tasks", "roles", "handlers", "pre_tasks", "post_tasks"})

--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -95,8 +95,13 @@ def _read_yaml_header_lines(fpath: str, max_lines: int = 101) -> list[str] | Non
         Lines read from the file, or None on I/O error.
     """
     try:
+        lines: list[str] = []
         with open(fpath, encoding="utf-8", errors="ignore") as f:
-            return [line for n, line in enumerate(f) if n < max_lines]
+            for line in f:
+                lines.append(line)
+                if len(lines) >= max_lines:
+                    break
+        return lines
     except OSError:
         return None
 

--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -8,15 +8,22 @@ valid_playbook_re = re.compile(r"^\s*?-?\s*?(?:hosts|include|import_playbook):\s
 
 # EDA rulebook detection: look for 'sources:' or 'rules:' at ruleset level
 # These keys are valid in EDA rulebooks but not in Ansible playbooks
-_eda_rulebook_re = re.compile(r"^\s{2,4}(?:sources|rules):\s*$")
+# Allow any trailing content (inline values like [], comments, etc.)
+_eda_rulebook_re = re.compile(r"^\s{1,8}(?:sources|rules):\s*(?:\S.*)?$")
 
 
 def could_be_eda_rulebook(fpath: str) -> bool:
     """Check if a file is an EDA rulebook based on path and content.
 
-    EDA rulebooks have 'sources' and/or 'rules' keys at the ruleset level,
-    which are not valid Ansible playbook keywords. This function is called
-    before could_be_playbook() to prevent EDA files from being misclassified.
+    Uses a two-tier detection approach:
+    1. Path-based: Files under /rulebooks/ or /extensions/eda/ directories
+       are assumed to be EDA content regardless of their internal structure.
+    2. Content-based: For files outside those directories, looks for 'sources'
+       or 'rules' keys at ruleset level (indented 1-8 spaces).
+
+    This function is called before could_be_playbook() to prevent EDA files
+    from being misclassified as playbooks (which would cause L095 false
+    positives for 'unknown play keyword' on sources/rules).
 
     Args:
         fpath: Path to the file to check.

--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -1,6 +1,5 @@
 """AWX-derived utilities for playbook detection and directory filtering."""
 
-import codecs
 import os
 import re
 
@@ -85,54 +84,110 @@ def looks_like_eda_ruleset(ruleset: YAMLDict) -> bool:
     return False
 
 
-def _load_first_ruleset_dict(fpath: str) -> YAMLDict | None:
-    """Load the first list-item mapping from a YAML file, if present.
+def _read_yaml_header_lines(fpath: str, max_lines: int = 101) -> list[str] | None:
+    """Read up to *max_lines* from a YAML file for heuristic scans.
 
     Args:
         fpath: Path to the YAML file.
+        max_lines: Maximum number of lines to read.
+
+    Returns:
+        Lines read from the file, or None on I/O error.
+    """
+    try:
+        with open(fpath, encoding="utf-8", errors="ignore") as f:
+            return [line for n, line in enumerate(f) if n < max_lines]
+    except OSError:
+        return None
+
+
+def _playbook_like_from_lines(lines: list[str]) -> bool:
+    """Return True when *lines* contain playbook markers or a vault header.
+
+    Args:
+        lines: First portion of a YAML file.
+
+    Returns:
+        True when hosts/include/import_playbook or a vault header is present.
+    """
+    for n, line in enumerate(lines):
+        if valid_playbook_re.match(line) or (n == 0 and line.startswith("$ANSIBLE_VAULT;")):
+            return True
+    return False
+
+
+def _lines_might_contain_eda_keys(lines: list[str]) -> bool:
+    """Return True when *lines* may contain ruleset-level EDA keys.
+
+    Args:
+        lines: First portion of a YAML file.
+
+    Returns:
+        True when a ruleset-level ``sources:`` or ``rules:`` line appears.
+    """
+    return any(
+        _eda_sources_key_re.match(line) or (_eda_ruleset_key_re.match(line) and "rules:" in line) for line in lines
+    )
+
+
+def _eda_from_lines(lines: list[str]) -> bool:
+    """Content-based EDA detection via line patterns (no YAML parse).
+
+    Args:
+        lines: First portion of a YAML file.
+
+    Returns:
+        True when line patterns match an EDA ruleset and no playbook sections appear.
+    """
+    saw_list_item = False
+    saw_rules_key = False
+    for line in lines:
+        if _eda_playbook_section_re.match(line):
+            return False
+        if _eda_list_item_re.match(line):
+            saw_list_item = True
+        elif saw_list_item and _eda_sources_key_re.match(line):
+            return True
+        elif saw_list_item and _eda_ruleset_key_re.match(line) and "rules:" in line:
+            saw_rules_key = True
+        elif saw_rules_key and _eda_rule_structure_re.match(line):
+            return True
+    return False
+
+
+def _load_first_ruleset_from_lines(lines: list[str]) -> YAMLDict | None:
+    """Load the first list-item mapping from YAML text, if present.
+
+    Args:
+        lines: YAML source lines.
 
     Returns:
         The first mapping when the document is a non-empty list, else None.
     """
     try:
-        with open(fpath, encoding="utf-8", errors="ignore") as f:
-            data = yaml.safe_load(f)
-    except (OSError, yaml.YAMLError):
+        data = yaml.safe_load("".join(lines))
+    except yaml.YAMLError:
         return None
     if isinstance(data, list) and data and isinstance(data[0], dict):
         return data[0]
     return None
 
 
-def _eda_content_regex_scan(fpath: str) -> bool:
-    """Content-based EDA detection via line scan when YAML parsing fails.
+def _eda_content_from_lines(lines: list[str]) -> bool:
+    """Return True when *lines* describe EDA content (regex, then optional YAML parse).
 
     Args:
-        fpath: Path to the YAML file.
+        lines: First portion of a YAML file.
 
     Returns:
-        True when line patterns match an EDA ruleset and no playbook sections appear.
+        True when the content matches EDA ruleset structure.
     """
-    try:
-        saw_list_item = False
-        saw_rules_key = False
-        with codecs.open(fpath, "r", encoding="utf-8", errors="ignore") as f:
-            for n, line in enumerate(f):
-                if n > 100:
-                    break
-                if _eda_playbook_section_re.match(line):
-                    return False
-                if _eda_list_item_re.match(line):
-                    saw_list_item = True
-                elif saw_list_item and _eda_sources_key_re.match(line):
-                    return True
-                elif saw_list_item and _eda_ruleset_key_re.match(line) and "rules:" in line:
-                    saw_rules_key = True
-                elif saw_rules_key and _eda_rule_structure_re.match(line):
-                    return True
-    except OSError:
+    if _eda_from_lines(lines):
+        return True
+    if not _lines_might_contain_eda_keys(lines):
         return False
-    return False
+    ruleset = _load_first_ruleset_from_lines(lines)
+    return ruleset is not None and looks_like_eda_ruleset(ruleset)
 
 
 def could_be_eda_rulebook(fpath: str) -> bool:
@@ -168,11 +223,10 @@ def could_be_eda_rulebook(fpath: str) -> bool:
     if is_eda_rulebook_path(fpath):
         return True
 
-    # Content-based detection: parsed ruleset shape, then regex fallback
-    ruleset = _load_first_ruleset_dict(fpath)
-    if ruleset is not None:
-        return looks_like_eda_ruleset(ruleset)
-    return _eda_content_regex_scan(fpath)
+    lines = _read_yaml_header_lines(fpath)
+    if lines is None:
+        return False
+    return _eda_content_from_lines(lines)
 
 
 # this method is based on awx code
@@ -193,23 +247,20 @@ def could_be_playbook(fpath: str) -> bool:
     if ext not in [".yml", ".yaml"]:
         return False
 
-    # EDA rulebooks should not be treated as playbooks
-    if could_be_eda_rulebook(fpath):
+    # Path-based EDA directories are never playbooks (no file read).
+    if is_eda_rulebook_path(fpath):
         return False
 
-    # Filter files that do not have either hosts or top-level
-    # includes. Use regex to allow files with invalid YAML to
-    # show up.
-    matched = False
-    try:
-        with codecs.open(fpath, "r", encoding="utf-8", errors="ignore") as f:
-            for n, line in enumerate(f):
-                if valid_playbook_re.match(line) or n == 0 and line.startswith("$ANSIBLE_VAULT;"):
-                    matched = True
-                    break
-    except OSError:
+    lines = _read_yaml_header_lines(fpath)
+    if lines is None:
         return False
-    return matched
+
+    # Cheap playbook heuristic first; skip YAML parse for vars/manifests, etc.
+    if not _playbook_like_from_lines(lines):
+        return False
+
+    # Playbook-shaped files may still be EDA rulebooks (hosts + sources/rules).
+    return not _eda_content_from_lines(lines)
 
 
 # this method is based on awx code

--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -71,15 +71,9 @@ def looks_like_eda_ruleset(ruleset: YAMLDict) -> bool:
     """
     if _PLAYBOOK_SECTION_KEYS & ruleset.keys():
         return False
-    if "sources" in ruleset:
-        sources = ruleset["sources"]
-        if sources is None or isinstance(sources, list):
-            return True
     if "rules" in ruleset:
         rules = ruleset["rules"]
         if isinstance(rules, list):
-            if not rules:
-                return "sources" in ruleset
             return any(isinstance(item, dict) and ("condition" in item or "action" in item) for item in rules)
     return False
 
@@ -146,18 +140,17 @@ def _eda_from_lines(lines: list[str]) -> bool:
     """
     saw_list_item = False
     saw_rules_key = False
+    saw_rule_structure = False
     for line in lines:
         if _eda_playbook_section_re.match(line):
             return False
         if _eda_list_item_re.match(line):
             saw_list_item = True
-        elif saw_list_item and _eda_sources_key_re.match(line):
-            return True
         elif saw_list_item and _eda_ruleset_key_re.match(line) and "rules:" in line:
             saw_rules_key = True
         elif saw_rules_key and _eda_rule_structure_re.match(line):
-            return True
-    return False
+            saw_rule_structure = True
+    return saw_rule_structure
 
 
 def _load_first_ruleset_from_lines(lines: list[str]) -> YAMLDict | None:
@@ -203,9 +196,10 @@ def could_be_eda_rulebook(fpath: str) -> bool:
        (absolute or relative) are assumed to be EDA content regardless of
        their internal structure.
     2. Content-based: For files outside those directories, requires EDA
-       rulebook structure: a list item (``- name: ...``) followed by
-       ``sources:`` or ``rules:`` at exactly 2-space indent (ruleset-level
-       keys, not nested in vars or module parameters).
+       rulebook structure with an actual rule definition (for example,
+       ``rules:`` entries containing ``condition`` or ``action``). A stray
+       ``sources:`` key alone is not enough because invalid playbooks should
+       still reach L095 validation.
 
     This tightened heuristic avoids false positives on Kubernetes manifests
     (``spec.rules:``) or playbooks with nested ``vars: {rules: ...}``.

--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -4,14 +4,25 @@ import codecs
 import os
 import re
 
+import yaml
+
+from .models import YAMLDict
+
 valid_playbook_re = re.compile(r"^\s*?-?\s*?(?:hosts|include|import_playbook):\s*?.*?$")
 
-# EDA rulebook detection patterns:
+# EDA rulebook detection patterns (regex fallback when YAML does not parse):
 # 1. List item start: "- name:" at column 0 indicates ruleset definition
 # 2. Ruleset-level keys: "sources:" or "rules:" at exactly 2-space indent
-#    (child of the list item, not nested deeper in vars/module params)
+# 3. Playbook-only keys at 2-space indent reject EDA classification
+# 4. "rules:" alone requires a following "condition:" or "action:" at 4-space indent
 _eda_list_item_re = re.compile(r"^-\s+name:\s*\S")
 _eda_ruleset_key_re = re.compile(r"^  (?:sources|rules):\s*(?:\S.*)?$")
+_eda_sources_key_re = re.compile(r"^  sources:\s*(?:\S.*)?$")
+_eda_playbook_section_re = re.compile(r"^  (?:tasks|roles|handlers|pre_tasks|post_tasks):")
+_eda_rule_structure_re = re.compile(r"^    (?:condition|action):")
+
+# Keys that identify a play, not an EDA ruleset (first list item dict).
+_PLAYBOOK_SECTION_KEYS = frozenset({"tasks", "roles", "handlers", "pre_tasks", "post_tasks"})
 
 
 def _normalize_eda_path(fpath: str) -> str:
@@ -47,6 +58,83 @@ def is_eda_rulebook_path(fpath: str) -> bool:
     )
 
 
+def looks_like_eda_ruleset(ruleset: YAMLDict) -> bool:
+    """Return True when *ruleset* is an EDA ruleset, not a play with stray keys.
+
+    Playbooks that accidentally include ``sources``/``rules`` at the play level
+    without EDA structure should remain playbooks so L095 can report unknown keys.
+
+    Args:
+        ruleset: First mapping from a YAML list (ruleset / play dict).
+
+    Returns:
+        True if the dict matches EDA ruleset structure.
+    """
+    if _PLAYBOOK_SECTION_KEYS & ruleset.keys():
+        return False
+    if "sources" in ruleset:
+        sources = ruleset["sources"]
+        if sources is None or isinstance(sources, list):
+            return True
+    if "rules" in ruleset:
+        rules = ruleset["rules"]
+        if isinstance(rules, list):
+            if not rules:
+                return "sources" in ruleset
+            return any(isinstance(item, dict) and ("condition" in item or "action" in item) for item in rules)
+    return False
+
+
+def _load_first_ruleset_dict(fpath: str) -> YAMLDict | None:
+    """Load the first list-item mapping from a YAML file, if present.
+
+    Args:
+        fpath: Path to the YAML file.
+
+    Returns:
+        The first mapping when the document is a non-empty list, else None.
+    """
+    try:
+        with open(fpath, encoding="utf-8", errors="ignore") as f:
+            data = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError):
+        return None
+    if isinstance(data, list) and data and isinstance(data[0], dict):
+        return data[0]
+    return None
+
+
+def _eda_content_regex_scan(fpath: str) -> bool:
+    """Content-based EDA detection via line scan when YAML parsing fails.
+
+    Args:
+        fpath: Path to the YAML file.
+
+    Returns:
+        True when line patterns match an EDA ruleset and no playbook sections appear.
+    """
+    try:
+        saw_list_item = False
+        saw_rules_key = False
+        with codecs.open(fpath, "r", encoding="utf-8", errors="ignore") as f:
+            for n, line in enumerate(f):
+                if n > 100:
+                    break
+                if _eda_playbook_section_re.match(line):
+                    return False
+                if _eda_list_item_re.match(line):
+                    saw_list_item = True
+                elif saw_list_item and _eda_sources_key_re.match(line):
+                    return True
+                elif saw_list_item and _eda_ruleset_key_re.match(line) and "rules:" in line:
+                    saw_rules_key = True
+                elif saw_rules_key and _eda_rule_structure_re.match(line):
+                    return True
+    except OSError:
+        return False
+    return False
+
+
 def could_be_eda_rulebook(fpath: str) -> bool:
     """Check if a file is an EDA rulebook based on path and content.
 
@@ -72,7 +160,7 @@ def could_be_eda_rulebook(fpath: str) -> bool:
     Returns:
         True if the file appears to be an EDA rulebook.
     """
-    basename, ext = os.path.splitext(fpath)
+    _, ext = os.path.splitext(fpath)
     if ext not in [".yml", ".yaml"]:
         return False
 
@@ -80,22 +168,11 @@ def could_be_eda_rulebook(fpath: str) -> bool:
     if is_eda_rulebook_path(fpath):
         return True
 
-    # Content-based detection: look for EDA rulebook structure
-    # Requires seeing "- name:" list item followed by "sources:" or "rules:"
-    # at exactly 2-space indent (ruleset-level, not nested in vars/params)
-    try:
-        saw_list_item = False
-        with codecs.open(fpath, "r", encoding="utf-8", errors="ignore") as f:
-            for n, line in enumerate(f):
-                if n > 100:
-                    break
-                if _eda_list_item_re.match(line):
-                    saw_list_item = True
-                elif saw_list_item and _eda_ruleset_key_re.match(line):
-                    return True
-    except OSError:
-        return False
-    return False
+    # Content-based detection: parsed ruleset shape, then regex fallback
+    ruleset = _load_first_ruleset_dict(fpath)
+    if ruleset is not None:
+        return looks_like_eda_ruleset(ruleset)
+    return _eda_content_regex_scan(fpath)
 
 
 # this method is based on awx code
@@ -112,7 +189,7 @@ def could_be_playbook(fpath: str) -> bool:
     Returns:
         True if the file has .yml/.yaml extension and appears playbook-like.
     """
-    basename, ext = os.path.splitext(fpath)
+    _, ext = os.path.splitext(fpath)
     if ext not in [".yml", ".yaml"]:
         return False
 

--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -6,6 +6,45 @@ import re
 
 valid_playbook_re = re.compile(r"^\s*?-?\s*?(?:hosts|include|import_playbook):\s*?.*?$")
 
+# EDA rulebook detection: look for 'sources:' or 'rules:' at ruleset level
+# These keys are valid in EDA rulebooks but not in Ansible playbooks
+_eda_rulebook_re = re.compile(r"^\s{2,4}(?:sources|rules):\s*$")
+
+
+def could_be_eda_rulebook(fpath: str) -> bool:
+    """Check if a file is an EDA rulebook based on path and content.
+
+    EDA rulebooks have 'sources' and/or 'rules' keys at the ruleset level,
+    which are not valid Ansible playbook keywords. This function is called
+    before could_be_playbook() to prevent EDA files from being misclassified.
+
+    Args:
+        fpath: Path to the file to check.
+
+    Returns:
+        True if the file appears to be an EDA rulebook.
+    """
+    basename, ext = os.path.splitext(fpath)
+    if ext not in [".yml", ".yaml"]:
+        return False
+
+    # Path-based detection: files in rulebooks/ or extensions/eda/ directories
+    path_lower = fpath.lower()
+    if "/rulebooks/" in path_lower or "/extensions/eda/" in path_lower:
+        return True
+
+    # Content-based detection: look for EDA-specific keywords
+    try:
+        with codecs.open(fpath, "r", encoding="utf-8", errors="ignore") as f:
+            for n, line in enumerate(f):
+                if n > 100:
+                    break
+                if _eda_rulebook_re.match(line):
+                    return True
+    except OSError:
+        return False
+    return False
+
 
 # this method is based on awx code
 # awx/main/utils/ansible.py#L42-L64 in ansible/awx
@@ -24,6 +63,11 @@ def could_be_playbook(fpath: str) -> bool:
     basename, ext = os.path.splitext(fpath)
     if ext not in [".yml", ".yaml"]:
         return False
+
+    # EDA rulebooks should not be treated as playbooks
+    if could_be_eda_rulebook(fpath):
+        return False
+
     # Filter files that do not have either hosts or top-level
     # includes. Use regex to allow files with invalid YAML to
     # show up.

--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -6,10 +6,12 @@ import re
 
 valid_playbook_re = re.compile(r"^\s*?-?\s*?(?:hosts|include|import_playbook):\s*?.*?$")
 
-# EDA rulebook detection: look for 'sources:' or 'rules:' at ruleset level
-# These keys are valid in EDA rulebooks but not in Ansible playbooks
-# Allow any trailing content (inline values like [], comments, etc.)
-_eda_rulebook_re = re.compile(r"^\s{1,8}(?:sources|rules):\s*(?:\S.*)?$")
+# EDA rulebook detection patterns:
+# 1. List item start: "- name:" at column 0 indicates ruleset definition
+# 2. Ruleset-level keys: "sources:" or "rules:" at exactly 2-space indent
+#    (child of the list item, not nested deeper in vars/module params)
+_eda_list_item_re = re.compile(r"^-\s+name:\s*\S")
+_eda_ruleset_key_re = re.compile(r"^  (?:sources|rules):\s*(?:\S.*)?$")
 
 
 def _normalize_eda_path(fpath: str) -> str:
@@ -52,8 +54,13 @@ def could_be_eda_rulebook(fpath: str) -> bool:
     1. Path-based: Files under ``rulebooks/`` or ``extensions/eda/`` directories
        (absolute or relative) are assumed to be EDA content regardless of
        their internal structure.
-    2. Content-based: For files outside those directories, looks for 'sources'
-       or 'rules' keys at ruleset level (indented 1-8 spaces).
+    2. Content-based: For files outside those directories, requires EDA
+       rulebook structure: a list item (``- name: ...``) followed by
+       ``sources:`` or ``rules:`` at exactly 2-space indent (ruleset-level
+       keys, not nested in vars or module parameters).
+
+    This tightened heuristic avoids false positives on Kubernetes manifests
+    (``spec.rules:``) or playbooks with nested ``vars: {rules: ...}``.
 
     This function is called before could_be_playbook() to prevent EDA files
     from being misclassified as playbooks (which would cause L095 false
@@ -73,13 +80,18 @@ def could_be_eda_rulebook(fpath: str) -> bool:
     if is_eda_rulebook_path(fpath):
         return True
 
-    # Content-based detection: look for EDA-specific keywords
+    # Content-based detection: look for EDA rulebook structure
+    # Requires seeing "- name:" list item followed by "sources:" or "rules:"
+    # at exactly 2-space indent (ruleset-level, not nested in vars/params)
     try:
+        saw_list_item = False
         with codecs.open(fpath, "r", encoding="utf-8", errors="ignore") as f:
             for n, line in enumerate(f):
                 if n > 100:
                     break
-                if _eda_rulebook_re.match(line):
+                if _eda_list_item_re.match(line):
+                    saw_list_item = True
+                elif saw_list_item and _eda_ruleset_key_re.match(line):
                     return True
     except OSError:
         return False

--- a/src/apme_engine/engine/awx_utils.py
+++ b/src/apme_engine/engine/awx_utils.py
@@ -12,12 +12,46 @@ valid_playbook_re = re.compile(r"^\s*?-?\s*?(?:hosts|include|import_playbook):\s
 _eda_rulebook_re = re.compile(r"^\s{1,8}(?:sources|rules):\s*(?:\S.*)?$")
 
 
+def _normalize_eda_path(fpath: str) -> str:
+    """Normalize a file path for EDA directory matching.
+
+    Args:
+        fpath: Path to normalize.
+
+    Returns:
+        Lowercase path with OS separators replaced by ``/``.
+    """
+    return fpath.replace(os.sep, "/").lower()
+
+
+def is_eda_rulebook_path(fpath: str) -> bool:
+    """Return True if *fpath* lies under a conventional EDA rulebook directory.
+
+    Matches both absolute segments (``/rulebooks/``) and relative paths
+    (``rulebooks/foo.yml``, ``extensions/eda/...``) after normalizing separators.
+
+    Args:
+        fpath: Path to check.
+
+    Returns:
+        True when the path is under ``rulebooks/`` or ``extensions/eda/``.
+    """
+    norm = _normalize_eda_path(fpath)
+    return (
+        norm.startswith("rulebooks/")
+        or "/rulebooks/" in norm
+        or norm.startswith("extensions/eda/")
+        or "/extensions/eda/" in norm
+    )
+
+
 def could_be_eda_rulebook(fpath: str) -> bool:
     """Check if a file is an EDA rulebook based on path and content.
 
     Uses a two-tier detection approach:
-    1. Path-based: Files under /rulebooks/ or /extensions/eda/ directories
-       are assumed to be EDA content regardless of their internal structure.
+    1. Path-based: Files under ``rulebooks/`` or ``extensions/eda/`` directories
+       (absolute or relative) are assumed to be EDA content regardless of
+       their internal structure.
     2. Content-based: For files outside those directories, looks for 'sources'
        or 'rules' keys at ruleset level (indented 1-8 spaces).
 
@@ -36,8 +70,7 @@ def could_be_eda_rulebook(fpath: str) -> bool:
         return False
 
     # Path-based detection: files in rulebooks/ or extensions/eda/ directories
-    path_lower = fpath.lower()
-    if "/rulebooks/" in path_lower or "/extensions/eda/" in path_lower:
+    if is_eda_rulebook_path(fpath):
         return True
 
     # Content-based detection: look for EDA-specific keywords

--- a/src/apme_engine/engine/content_graph.py
+++ b/src/apme_engine/engine/content_graph.py
@@ -67,6 +67,8 @@ class NodeType(str, Enum):
         LOOKUP_PLUGIN: Lookup plugin.
         VARS_FILE: Variables file node.
         COLLECTION: Collection metadata node.
+        RULEBOOK: EDA rulebook file.
+        RULESET: Ruleset within an EDA rulebook (analogous to PLAY).
     """
 
     PLAYBOOK = "playbook"
@@ -83,6 +85,8 @@ class NodeType(str, Enum):
     LOOKUP_PLUGIN = "lookup_plugin"
     VARS_FILE = "vars_file"
     COLLECTION = "collection"
+    RULEBOOK = "rulebook"
+    RULESET = "ruleset"
 
 
 class EdgeType(str, Enum):

--- a/src/apme_engine/engine/finder.py
+++ b/src/apme_engine/engine/finder.py
@@ -743,6 +743,10 @@ def could_be_playbook_detail(body: str = "", data: YAMLValue | None = None, fpat
     if not isinstance(data[0], dict):
         return False
 
+    # EDA rulebooks have 'sources' or 'rules' keys - these are not playbooks
+    if "sources" in data[0] or "rules" in data[0]:
+        return False
+
     if "hosts" in data[0]:
         return True
 

--- a/src/apme_engine/engine/finder.py
+++ b/src/apme_engine/engine/finder.py
@@ -25,7 +25,7 @@ except Exception:
 import contextlib
 
 from . import logger
-from .awx_utils import could_be_playbook, search_playbooks
+from .awx_utils import could_be_eda_rulebook, could_be_playbook, is_eda_rulebook_path, search_playbooks
 from .safe_glob import safe_glob
 
 fqcn_module_name_re = re.compile(r"^[a-z0-9_]+\.[a-z0-9_]+\.[a-z0-9_]+$")
@@ -743,14 +743,42 @@ def could_be_playbook_detail(body: str = "", data: YAMLValue | None = None, fpat
     if not isinstance(data[0], dict):
         return False
 
-    # EDA rulebooks have 'sources' or 'rules' keys - these are not playbooks
-    if "sources" in data[0] or "rules" in data[0]:
-        return False
-
     if "hosts" in data[0]:
         return True
 
     return bool("import_playbook" in data[0] or "ansible.builtin.import_playbook" in data[0])
+
+
+def could_be_eda_rulebook_detail(body: str = "", data: YAMLValue | None = None, fpath: str = "") -> bool:
+    """Return True if content looks like an EDA rulebook (path or ruleset keys).
+
+    Args:
+        body: Optional raw YAML string.
+        data: Optional parsed YAML value.
+        fpath: Path used for directory-based detection and file reads.
+
+    Returns:
+        True if the file appears to be an EDA rulebook.
+
+    """
+    if fpath:
+        if is_eda_rulebook_path(fpath):
+            return True
+        if not body and not data:
+            return could_be_eda_rulebook(fpath)
+
+    body, data, fpath = _get_body_data(body, data, fpath)
+
+    if not body or not data:
+        return False
+
+    if not isinstance(data, list) or len(data) == 0:
+        return False
+
+    if not isinstance(data[0], dict):
+        return False
+
+    return "sources" in data[0] or "rules" in data[0]
 
 
 def could_be_taskfile(body: str = "", data: YAMLValue | None = None, fpath: str = "") -> bool:
@@ -771,6 +799,9 @@ def could_be_taskfile(body: str = "", data: YAMLValue | None = None, fpath: str 
         return False
 
     if not data:
+        return False
+
+    if could_be_eda_rulebook_detail(body, data, fpath):
         return False
 
     if not isinstance(data, list):
@@ -798,9 +829,12 @@ def label_empty_file_by_path(fpath: str) -> str:
         fpath: Path to the file.
 
     Returns:
-        'taskfile', 'playbook', or empty string.
+        ``taskfile``, ``playbook``, ``rulebook``, or empty string.
 
     """
+    if is_eda_rulebook_path(fpath):
+        return "rulebook"
+
     taskfile_dir = ["/tasks/", "/handlers/"]
     for t_d in taskfile_dir:
         if t_d in fpath:
@@ -1031,9 +1065,11 @@ def label_yml_file(
         label = label_by_path if label_by_path else "others"
     elif data and not isinstance(data, list):
         label = "others"
+    elif could_be_eda_rulebook_detail(body, data, yml_path):
+        label = "rulebook"
     elif could_be_playbook_detail(body, data):
         label = "playbook"
-    elif could_be_taskfile(body, data):
+    elif could_be_taskfile(body, data, yml_path):
         label = "taskfile"
     else:
         label = "others"

--- a/src/apme_engine/engine/finder.py
+++ b/src/apme_engine/engine/finder.py
@@ -25,7 +25,13 @@ except Exception:
 import contextlib
 
 from . import logger
-from .awx_utils import could_be_eda_rulebook, could_be_playbook, is_eda_rulebook_path, search_playbooks
+from .awx_utils import (
+    could_be_eda_rulebook,
+    could_be_playbook,
+    is_eda_rulebook_path,
+    looks_like_eda_ruleset,
+    search_playbooks,
+)
 from .safe_glob import safe_glob
 
 fqcn_module_name_re = re.compile(r"^[a-z0-9_]+\.[a-z0-9_]+\.[a-z0-9_]+$")
@@ -778,7 +784,7 @@ def could_be_eda_rulebook_detail(body: str = "", data: YAMLValue | None = None, 
     if not isinstance(data[0], dict):
         return False
 
-    return "sources" in data[0] or "rules" in data[0]
+    return looks_like_eda_ruleset(data[0])
 
 
 def could_be_taskfile(body: str = "", data: YAMLValue | None = None, fpath: str = "") -> bool:

--- a/src/apme_engine/engine/graph_scanner.py
+++ b/src/apme_engine/engine/graph_scanner.py
@@ -155,6 +155,8 @@ _SCANNABLE_TYPES = frozenset(
         NodeType.PLAYBOOK,
         NodeType.COLLECTION,
         NodeType.MODULE,
+        NodeType.RULEBOOK,
+        NodeType.RULESET,
     }
 )
 

--- a/src/apme_engine/engine/model_loader.py
+++ b/src/apme_engine/engine/model_loader.py
@@ -21,7 +21,7 @@ except Exception:
 import contextlib
 
 from . import logger
-from .awx_utils import could_be_playbook
+from .awx_utils import could_be_eda_rulebook, could_be_playbook
 from .finder import (
     could_be_playbook_detail,
     could_be_taskfile,
@@ -1120,7 +1120,11 @@ def load_playbooks(
         if fpath in loaded:
             continue
 
-        if could_be_playbook(fpath=fpath) and could_be_playbook_detail(fpath=fpath):
+        if (
+            could_be_playbook(fpath=fpath)
+            and could_be_playbook_detail(fpath=fpath)
+            and not could_be_eda_rulebook(fpath=fpath)
+        ):
             relative_path = ""
             if fpath.startswith(path):
                 relative_path = fpath[len(path) :]

--- a/src/apme_engine/engine/model_loader.py
+++ b/src/apme_engine/engine/model_loader.py
@@ -21,7 +21,7 @@ except Exception:
 import contextlib
 
 from . import logger
-from .awx_utils import could_be_eda_rulebook, could_be_playbook
+from .awx_utils import could_be_playbook
 from .finder import (
     could_be_playbook_detail,
     could_be_taskfile,
@@ -1120,11 +1120,8 @@ def load_playbooks(
         if fpath in loaded:
             continue
 
-        if (
-            could_be_playbook(fpath=fpath)
-            and could_be_playbook_detail(fpath=fpath)
-            and not could_be_eda_rulebook(fpath=fpath)
-        ):
+        # could_be_playbook() already excludes EDA rulebooks internally
+        if could_be_playbook(fpath=fpath) and could_be_playbook_detail(fpath=fpath):
             relative_path = ""
             if fpath.startswith(path):
                 relative_path = fpath[len(path) :]

--- a/tests/test_eda_detection.py
+++ b/tests/test_eda_detection.py
@@ -115,6 +115,28 @@ class TestEdaRulebookDetection:
         assert could_be_eda_rulebook(str(playbook)) is False
         assert could_be_playbook(str(playbook)) is True
 
+    def test_playbook_with_stray_sources_before_tasks_not_eda(self, tmp_path: Path) -> None:
+        """Verify a stray play-level ``sources`` key does not suppress L095.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        content = """\
+---
+- name: Bad play
+  hosts: all
+  sources:
+    - not-an-eda-source
+  tasks:
+    - name: Debug task
+      ansible.builtin.debug:
+        msg: hello
+"""
+        playbook = tmp_path / "bad_sources_play.yml"
+        playbook.write_text(content)
+        assert could_be_eda_rulebook(str(playbook)) is False
+        assert could_be_playbook(str(playbook)) is True
+
     def test_is_eda_rulebook_path_relative_paths(self) -> None:
         """Verify path detection works without leading directory separators."""
         assert is_eda_rulebook_path("rulebooks/foo.yml") is True
@@ -231,8 +253,8 @@ class TestPlaybookDetailVsEdaExclusion:
         assert could_be_playbook_detail(body=body, data=data) is True
         assert could_be_eda_rulebook_detail(body=body, data=data) is True
 
-    def test_eda_rulebook_with_only_sources(self) -> None:
-        """Verify sources-only EDA is playbook-shaped but identified as EDA."""
+    def test_eda_rulebook_with_only_sources_not_classified_by_content(self) -> None:
+        """Verify content-only sources keys do not hide invalid playbooks."""
         body = """\
 - name: Event Source
   hosts: localhost
@@ -248,7 +270,7 @@ class TestPlaybookDetailVsEdaExclusion:
             }
         ]
         assert could_be_playbook_detail(body=body, data=data) is True
-        assert could_be_eda_rulebook_detail(body=body, data=data) is True
+        assert could_be_eda_rulebook_detail(body=body, data=data) is False
 
     def test_eda_rulebook_with_only_rules(self) -> None:
         """Verify rules-only EDA is playbook-shaped but identified as EDA."""

--- a/tests/test_eda_detection.py
+++ b/tests/test_eda_detection.py
@@ -1,0 +1,241 @@
+"""Tests for EDA rulebook detection to prevent L095 false positives."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from apme_engine.engine.awx_utils import could_be_eda_rulebook, could_be_playbook
+from apme_engine.engine.finder import could_be_playbook_detail
+from apme_engine.engine.models import YAMLValue
+
+# ---------------------------------------------------------------------------
+# EDA Rulebook Detection
+# ---------------------------------------------------------------------------
+
+
+class TestEdaRulebookDetection:
+    """Tests for EDA rulebook detection functions."""
+
+    def test_could_be_eda_rulebook_with_sources_and_rules(self, tmp_path: Path) -> None:
+        """Verify file with sources and rules is detected as EDA rulebook.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        content = """\
+---
+- name: Hello Events
+  hosts: localhost
+  sources:
+    - ansible.eda.range:
+        limit: 5
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: hello.yml
+"""
+        rulebook = tmp_path / "rulebook.yml"
+        rulebook.write_text(content)
+        assert could_be_eda_rulebook(str(rulebook)) is True
+
+    def test_could_be_eda_rulebook_path_pattern_rulebooks(self, tmp_path: Path) -> None:
+        """Verify file in rulebooks/ directory is detected as EDA.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        rulebooks_dir = tmp_path / "rulebooks"
+        rulebooks_dir.mkdir()
+        content = "---\n- name: Test\n  hosts: localhost\n"
+        rulebook = rulebooks_dir / "test.yml"
+        rulebook.write_text(content)
+        assert could_be_eda_rulebook(str(rulebook)) is True
+
+    def test_could_be_eda_rulebook_path_pattern_extensions_eda(self, tmp_path: Path) -> None:
+        """Verify file in extensions/eda/ directory is detected as EDA.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        eda_dir = tmp_path / "extensions" / "eda" / "rulebooks"
+        eda_dir.mkdir(parents=True)
+        content = "---\n- name: Test\n  hosts: localhost\n"
+        rulebook = eda_dir / "test.yml"
+        rulebook.write_text(content)
+        assert could_be_eda_rulebook(str(rulebook)) is True
+
+    def test_playbook_not_detected_as_eda_rulebook(self, tmp_path: Path) -> None:
+        """Verify standard playbook is not detected as EDA rulebook.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        content = """\
+---
+- name: Install packages
+  hosts: all
+  tasks:
+    - name: Install nginx
+      ansible.builtin.package:
+        name: nginx
+        state: present
+"""
+        playbook = tmp_path / "site.yml"
+        playbook.write_text(content)
+        assert could_be_eda_rulebook(str(playbook)) is False
+
+    def test_non_yaml_file_not_eda_rulebook(self, tmp_path: Path) -> None:
+        """Verify non-YAML files are not detected as EDA rulebooks.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        readme = tmp_path / "README.md"
+        readme.write_text("# Rulebook documentation")
+        assert could_be_eda_rulebook(str(readme)) is False
+
+
+# ---------------------------------------------------------------------------
+# Playbook Detection Excludes EDA
+# ---------------------------------------------------------------------------
+
+
+class TestPlaybookDetectionExcludesEda:
+    """Tests that playbook detection excludes EDA rulebooks."""
+
+    def test_could_be_playbook_excludes_eda_rulebook(self, tmp_path: Path) -> None:
+        """Verify EDA rulebook is not detected as playbook.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        content = """\
+---
+- name: Hello Events
+  hosts: localhost
+  sources:
+    - ansible.eda.range:
+        limit: 5
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+      action:
+        debug:
+"""
+        rulebook = tmp_path / "rulebook.yml"
+        rulebook.write_text(content)
+        # EDA rulebook should not be considered a playbook
+        assert could_be_playbook(str(rulebook)) is False
+
+    def test_could_be_playbook_includes_standard_playbook(self, tmp_path: Path) -> None:
+        """Verify standard playbook is still detected correctly.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        content = """\
+---
+- name: Install packages
+  hosts: all
+  tasks:
+    - name: Install nginx
+      ansible.builtin.package:
+        name: nginx
+"""
+        playbook = tmp_path / "site.yml"
+        playbook.write_text(content)
+        assert could_be_playbook(str(playbook)) is True
+
+
+# ---------------------------------------------------------------------------
+# Playbook Detail Detection Excludes EDA
+# ---------------------------------------------------------------------------
+
+
+class TestPlaybookDetailExcludesEda:
+    """Tests that could_be_playbook_detail excludes EDA content."""
+
+    def test_eda_rulebook_not_playbook_detail(self) -> None:
+        """Verify EDA content with sources/rules is not detected as playbook."""
+        body = """\
+- name: Hello Events
+  hosts: localhost
+  sources:
+    - ansible.eda.range:
+        limit: 5
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+"""
+        data: YAMLValue = [
+            {
+                "name": "Hello Events",
+                "hosts": "localhost",
+                "sources": [{"ansible.eda.range": {"limit": 5}}],
+                "rules": [{"name": "Say Hello", "condition": "event.i == 1"}],
+            }
+        ]
+        assert could_be_playbook_detail(body=body, data=data) is False
+
+    def test_eda_rulebook_with_only_sources(self) -> None:
+        """Verify content with sources key is not detected as playbook."""
+        body = """\
+- name: Event Source
+  hosts: localhost
+  sources:
+    - ansible.eda.webhook:
+        port: 5000
+"""
+        data: YAMLValue = [
+            {
+                "name": "Event Source",
+                "hosts": "localhost",
+                "sources": [{"ansible.eda.webhook": {"port": 5000}}],
+            }
+        ]
+        assert could_be_playbook_detail(body=body, data=data) is False
+
+    def test_eda_rulebook_with_only_rules(self) -> None:
+        """Verify content with rules key is not detected as playbook."""
+        body = """\
+- name: Rules Only
+  hosts: localhost
+  rules:
+    - name: Test
+      condition: "true"
+"""
+        data: YAMLValue = [
+            {
+                "name": "Rules Only",
+                "hosts": "localhost",
+                "rules": [{"name": "Test", "condition": "true"}],
+            }
+        ]
+        assert could_be_playbook_detail(body=body, data=data) is False
+
+    def test_standard_playbook_still_detected(self) -> None:
+        """Verify standard playbook with tasks is still detected."""
+        body = """\
+- name: Install packages
+  hosts: all
+  tasks:
+    - name: Install nginx
+      ansible.builtin.package:
+        name: nginx
+"""
+        data: YAMLValue = [
+            {
+                "name": "Install packages",
+                "hosts": "all",
+                "tasks": [{"name": "Install nginx", "ansible.builtin.package": {"name": "nginx"}}],
+            }
+        ]
+        assert could_be_playbook_detail(body=body, data=data) is True
+
+    def test_import_playbook_still_detected(self) -> None:
+        """Verify import_playbook directive is still detected."""
+        body = "- import_playbook: other.yml\n"
+        data: YAMLValue = [{"import_playbook": "other.yml"}]
+        assert could_be_playbook_detail(body=body, data=data) is True

--- a/tests/test_eda_detection.py
+++ b/tests/test_eda_detection.py
@@ -95,6 +95,26 @@ class TestEdaRulebookDetection:
         playbook.write_text(content)
         assert could_be_eda_rulebook(str(playbook)) is False
 
+    def test_playbook_with_stray_rules_key_not_eda(self, tmp_path: Path) -> None:
+        """Verify playbooks with non-EDA ``rules`` entries remain playbooks for L095.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        content = """\
+---
+- name: Bad play
+  hosts: all
+  rules:
+    - name: Debug task
+      ansible.builtin.debug:
+        msg: hello
+"""
+        playbook = tmp_path / "bad_play.yml"
+        playbook.write_text(content)
+        assert could_be_eda_rulebook(str(playbook)) is False
+        assert could_be_playbook(str(playbook)) is True
+
     def test_is_eda_rulebook_path_relative_paths(self) -> None:
         """Verify path detection works without leading directory separators."""
         assert is_eda_rulebook_path("rulebooks/foo.yml") is True
@@ -267,6 +287,26 @@ class TestPlaybookDetailVsEdaExclusion:
             }
         ]
         assert could_be_playbook_detail(body=body, data=data) is True
+
+    def test_playbook_with_stray_rules_not_eda_detail(self) -> None:
+        """Verify invalid play-level ``rules`` without EDA shape is not labeled EDA."""
+        body = """\
+- name: Bad play
+  hosts: all
+  rules:
+    - name: Debug task
+      ansible.builtin.debug:
+        msg: hello
+"""
+        data: YAMLValue = [
+            {
+                "name": "Bad play",
+                "hosts": "all",
+                "rules": [{"name": "Debug task", "ansible.builtin.debug": {"msg": "hello"}}],
+            }
+        ]
+        assert could_be_playbook_detail(body=body, data=data) is True
+        assert could_be_eda_rulebook_detail(body=body, data=data) is False
 
     def test_import_playbook_still_detected(self) -> None:
         """Verify import_playbook directive is still detected."""

--- a/tests/test_eda_detection.py
+++ b/tests/test_eda_detection.py
@@ -49,6 +49,28 @@ class TestEdaRulebookDetection:
         rulebook.write_text(content)
         assert could_be_eda_rulebook(str(rulebook)) is True
 
+    def test_could_be_eda_rulebook_regex_fallback_matches_rule_indent(self, tmp_path: Path) -> None:
+        """Verify malformed EDA YAML still matches the regex fallback.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        content = """\
+---
+- name: Hello Events
+  hosts: localhost
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+      action:
+        debug:
+  broken: [unterminated
+"""
+        rulebook = tmp_path / "broken_rulebook.yml"
+        rulebook.write_text(content)
+        assert could_be_eda_rulebook(str(rulebook)) is True
+        assert could_be_playbook(str(rulebook)) is False
+
     def test_could_be_eda_rulebook_path_pattern_rulebooks(self, tmp_path: Path) -> None:
         """Verify file in rulebooks/ directory is detected as EDA.
 

--- a/tests/test_eda_detection.py
+++ b/tests/test_eda_detection.py
@@ -4,8 +4,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from apme_engine.engine.awx_utils import could_be_eda_rulebook, could_be_playbook
-from apme_engine.engine.finder import could_be_playbook_detail
+from apme_engine.engine.awx_utils import (
+    could_be_eda_rulebook,
+    could_be_playbook,
+    is_eda_rulebook_path,
+)
+from apme_engine.engine.finder import (
+    could_be_eda_rulebook_detail,
+    could_be_playbook_detail,
+    could_be_taskfile,
+    label_yml_file,
+)
 from apme_engine.engine.models import YAMLValue
 
 # ---------------------------------------------------------------------------
@@ -86,6 +95,28 @@ class TestEdaRulebookDetection:
         playbook.write_text(content)
         assert could_be_eda_rulebook(str(playbook)) is False
 
+    def test_is_eda_rulebook_path_relative_paths(self) -> None:
+        """Verify path detection works without leading directory separators."""
+        assert is_eda_rulebook_path("rulebooks/foo.yml") is True
+        assert is_eda_rulebook_path("extensions/eda/rulebooks/foo.yml") is True
+        assert is_eda_rulebook_path("/project/rulebooks/foo.yml") is True
+        assert is_eda_rulebook_path("playbooks/site.yml") is False
+
+    def test_could_be_eda_rulebook_relative_path_without_sources(self, tmp_path: Path) -> None:
+        """Verify path-only EDA files are detected when rulebooks/ has no sources/rules keys.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        rulebooks_dir = tmp_path / "rulebooks"
+        rulebooks_dir.mkdir()
+        rulebook = rulebooks_dir / "minimal.yml"
+        rulebook.write_text("---\n- name: Minimal\n  hosts: localhost\n")
+        # Relative path from project root (no leading slash in segment check)
+        relative = f"rulebooks/{rulebook.name}"
+        assert is_eda_rulebook_path(relative) is True
+        assert could_be_eda_rulebook(str(rulebook)) is True
+
     def test_non_yaml_file_not_eda_rulebook(self, tmp_path: Path) -> None:
         """Verify non-YAML files are not detected as EDA rulebooks.
 
@@ -150,15 +181,15 @@ class TestPlaybookDetectionExcludesEda:
 
 
 # ---------------------------------------------------------------------------
-# Playbook Detail Detection Excludes EDA
+# Playbook detail vs EDA exclusion at call sites
 # ---------------------------------------------------------------------------
 
 
-class TestPlaybookDetailExcludesEda:
-    """Tests that could_be_playbook_detail excludes EDA content."""
+class TestPlaybookDetailVsEdaExclusion:
+    """Tests playbook-detail shape detection vs explicit EDA exclusion."""
 
-    def test_eda_rulebook_not_playbook_detail(self) -> None:
-        """Verify EDA content with sources/rules is not detected as playbook."""
+    def test_eda_rulebook_still_playbook_shaped(self) -> None:
+        """Verify EDA content with hosts is playbook-shaped for detail detection."""
         body = """\
 - name: Hello Events
   hosts: localhost
@@ -177,10 +208,11 @@ class TestPlaybookDetailExcludesEda:
                 "rules": [{"name": "Say Hello", "condition": "event.i == 1"}],
             }
         ]
-        assert could_be_playbook_detail(body=body, data=data) is False
+        assert could_be_playbook_detail(body=body, data=data) is True
+        assert could_be_eda_rulebook_detail(body=body, data=data) is True
 
     def test_eda_rulebook_with_only_sources(self) -> None:
-        """Verify content with sources key is not detected as playbook."""
+        """Verify sources-only EDA is playbook-shaped but identified as EDA."""
         body = """\
 - name: Event Source
   hosts: localhost
@@ -195,10 +227,11 @@ class TestPlaybookDetailExcludesEda:
                 "sources": [{"ansible.eda.webhook": {"port": 5000}}],
             }
         ]
-        assert could_be_playbook_detail(body=body, data=data) is False
+        assert could_be_playbook_detail(body=body, data=data) is True
+        assert could_be_eda_rulebook_detail(body=body, data=data) is True
 
     def test_eda_rulebook_with_only_rules(self) -> None:
-        """Verify content with rules key is not detected as playbook."""
+        """Verify rules-only EDA is playbook-shaped but identified as EDA."""
         body = """\
 - name: Rules Only
   hosts: localhost
@@ -213,7 +246,8 @@ class TestPlaybookDetailExcludesEda:
                 "rules": [{"name": "Test", "condition": "true"}],
             }
         ]
-        assert could_be_playbook_detail(body=body, data=data) is False
+        assert could_be_playbook_detail(body=body, data=data) is True
+        assert could_be_eda_rulebook_detail(body=body, data=data) is True
 
     def test_standard_playbook_still_detected(self) -> None:
         """Verify standard playbook with tasks is still detected."""
@@ -239,3 +273,72 @@ class TestPlaybookDetailExcludesEda:
         body = "- import_playbook: other.yml\n"
         data: YAMLValue = [{"import_playbook": "other.yml"}]
         assert could_be_playbook_detail(body=body, data=data) is True
+
+
+# ---------------------------------------------------------------------------
+# Taskfile / Label Classification Excludes EDA
+# ---------------------------------------------------------------------------
+
+
+class TestEdaExcludedFromTaskfileLabel:
+    """Tests that EDA rulebooks are not classified as taskfiles."""
+
+    def test_could_be_taskfile_excludes_eda_content(self) -> None:
+        """Verify EDA-shaped YAML is not treated as a taskfile."""
+        body = """\
+- name: Hello Events
+  hosts: localhost
+  sources:
+    - ansible.eda.range:
+        limit: 5
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+"""
+        data: YAMLValue = [
+            {
+                "name": "Hello Events",
+                "hosts": "localhost",
+                "sources": [{"ansible.eda.range": {"limit": 5}}],
+                "rules": [{"name": "Say Hello", "condition": "event.i == 1"}],
+            }
+        ]
+        assert could_be_eda_rulebook_detail(body=body, data=data) is True
+        assert could_be_taskfile(body=body, data=data) is False
+
+    def test_label_yml_file_marks_eda_as_rulebook(self, tmp_path: Path) -> None:
+        """Verify label_yml_file returns rulebook for EDA content.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        content = """\
+---
+- name: Hello Events
+  hosts: localhost
+  sources:
+    - ansible.eda.range:
+        limit: 5
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+"""
+        rulebook = tmp_path / "rulebook.yml"
+        rulebook.write_text(content)
+        label, _, error = label_yml_file(yml_path=str(rulebook))
+        assert error is None
+        assert label == "rulebook"
+
+    def test_label_yml_file_path_only_rulebook_directory(self, tmp_path: Path) -> None:
+        """Verify files under rulebooks/ are labeled rulebook even without sources/rules.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        rulebooks_dir = tmp_path / "rulebooks"
+        rulebooks_dir.mkdir()
+        rulebook = rulebooks_dir / "minimal.yml"
+        rulebook.write_text("---\n- name: Minimal\n  hosts: localhost\n")
+        label, _, error = label_yml_file(yml_path=str(rulebook))
+        assert error is None
+        assert label == "rulebook"

--- a/tests/test_eda_graph_integration.py
+++ b/tests/test_eda_graph_integration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from apme_engine.engine.awx_utils import could_be_eda_rulebook, could_be_playbook
+from apme_engine.engine.awx_utils import could_be_eda_rulebook, could_be_playbook, search_playbooks
 from apme_engine.engine.content_graph import NodeType
 
 
@@ -118,6 +118,96 @@ class TestEdaGraphIntegration:
         # Rulebook should be detected as EDA, not playbook
         assert could_be_eda_rulebook(str(rulebook)) is True
         assert could_be_playbook(str(rulebook)) is False
+
+    def test_search_playbooks_excludes_eda_rulebooks(self, tmp_path: Path) -> None:
+        """Verify search_playbooks excludes EDA rulebooks from results.
+
+        This is the entry point for project scanning - if EDA rulebooks are
+        excluded here, they won't be parsed as playbooks and won't trigger
+        L095 false positives for 'unknown play keyword' on sources/rules.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        # Create a standard playbook
+        playbook = tmp_path / "site.yml"
+        playbook.write_text("""\
+---
+- name: Deploy app
+  hosts: web
+  tasks:
+    - name: Copy files
+      ansible.builtin.copy:
+        src: app/
+        dest: /opt/app/
+""")
+
+        # Create an EDA rulebook (content-based detection)
+        eda_content = tmp_path / "events.yml"
+        eda_content.write_text("""\
+---
+- name: Monitor Events
+  hosts: localhost
+  sources:
+    - ansible.eda.webhook:
+        port: 5000
+  rules:
+    - name: Handle webhook
+      condition: event.payload is defined
+      action:
+        debug:
+""")
+
+        # Create an EDA rulebook in rulebooks/ directory (path-based detection)
+        rulebooks_dir = tmp_path / "rulebooks"
+        rulebooks_dir.mkdir()
+        eda_path = rulebooks_dir / "monitor.yml"
+        eda_path.write_text("""\
+---
+- name: Path-based EDA
+  hosts: localhost
+""")
+
+        # search_playbooks should only return the standard playbook
+        playbooks = search_playbooks(str(tmp_path))
+        assert len(playbooks) == 1
+        assert playbooks[0].endswith("site.yml")
+
+    def test_eda_inline_content_detection(self, tmp_path: Path) -> None:
+        """Verify EDA detection works with inline content variants.
+
+        The regex should handle: `sources: []`, `rules:  # comment`, etc.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        # Test inline empty list
+        inline_list = tmp_path / "inline_list.yml"
+        inline_list.write_text("""\
+---
+- name: Inline List
+  hosts: localhost
+  sources: []
+  rules: []
+""")
+        assert could_be_eda_rulebook(str(inline_list)) is True
+        assert could_be_playbook(str(inline_list)) is False
+
+        # Test with trailing comment
+        with_comment = tmp_path / "with_comment.yml"
+        with_comment.write_text("""\
+---
+- name: With Comment
+  hosts: localhost
+  sources:  # event sources
+    - ansible.eda.range:
+        limit: 5
+  rules:  # event rules
+    - name: Test
+      condition: "true"
+""")
+        assert could_be_eda_rulebook(str(with_comment)) is True
+        assert could_be_playbook(str(with_comment)) is False
 
 
 class TestNodeTypeEnumIncludes:

--- a/tests/test_eda_graph_integration.py
+++ b/tests/test_eda_graph_integration.py
@@ -1,0 +1,134 @@
+"""Integration tests for EDA rulebook handling in the content graph."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from apme_engine.engine.awx_utils import could_be_eda_rulebook, could_be_playbook
+from apme_engine.engine.content_graph import NodeType
+
+
+class TestEdaGraphIntegration:
+    """Tests that EDA rulebooks are handled correctly by the graph system."""
+
+    def test_eda_rulebook_excluded_from_playbook_detection(self, tmp_path: Path) -> None:
+        """Verify EDA rulebook files are not detected as playbooks.
+
+        EDA rulebooks have 'sources' and 'rules' keys which are not valid
+        playbook keywords. These files should be excluded from playbook
+        detection to prevent L095 false positives.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        # Create an EDA rulebook
+        rulebook_content = """\
+---
+- name: Hello Events
+  hosts: localhost
+  sources:
+    - ansible.eda.range:
+        limit: 5
+  rules:
+    - name: Say Hello
+      condition: event.i == 1
+      action:
+        run_playbook:
+          name: hello.yml
+"""
+        rulebook = tmp_path / "rulebook.yml"
+        rulebook.write_text(rulebook_content)
+
+        # EDA rulebook should be detected as EDA
+        assert could_be_eda_rulebook(str(rulebook)) is True
+
+        # But should NOT be detected as a playbook
+        assert could_be_playbook(str(rulebook)) is False
+
+    def test_standard_playbook_still_detected(self, tmp_path: Path) -> None:
+        """Verify standard playbooks are still detected correctly.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        # Create a standard playbook
+        playbook_content = """\
+---
+- name: Install packages
+  hosts: all
+  tasks:
+    - name: Install nginx
+      ansible.builtin.package:
+        name: nginx
+        state: present
+"""
+        playbook = tmp_path / "site.yml"
+        playbook.write_text(playbook_content)
+
+        # Standard playbook should NOT be detected as EDA
+        assert could_be_eda_rulebook(str(playbook)) is False
+
+        # And should still be detected as a playbook
+        assert could_be_playbook(str(playbook)) is True
+
+    def test_mixed_content_directory(self, tmp_path: Path) -> None:
+        """Verify directories with both playbooks and rulebooks work correctly.
+
+        Args:
+            tmp_path: Pytest fixture providing temporary directory.
+        """
+        # Create a standard playbook
+        playbook_content = """\
+---
+- name: Deploy app
+  hosts: web
+  tasks:
+    - name: Copy files
+      ansible.builtin.copy:
+        src: app/
+        dest: /opt/app/
+"""
+        playbook = tmp_path / "deploy.yml"
+        playbook.write_text(playbook_content)
+
+        # Create an EDA rulebook in rulebooks/ subdirectory
+        rulebooks_dir = tmp_path / "rulebooks"
+        rulebooks_dir.mkdir()
+        rulebook_content = """\
+---
+- name: Monitor Events
+  hosts: localhost
+  sources:
+    - ansible.eda.webhook:
+        port: 5000
+  rules:
+    - name: Handle webhook
+      condition: event.payload is defined
+      action:
+        run_playbook:
+          name: ../deploy.yml
+"""
+        rulebook = rulebooks_dir / "monitor.yml"
+        rulebook.write_text(rulebook_content)
+
+        # Playbook should be detected as playbook
+        assert could_be_playbook(str(playbook)) is True
+        assert could_be_eda_rulebook(str(playbook)) is False
+
+        # Rulebook should be detected as EDA, not playbook
+        assert could_be_eda_rulebook(str(rulebook)) is True
+        assert could_be_playbook(str(rulebook)) is False
+
+
+class TestNodeTypeEnumIncludes:
+    """Tests that NodeType enum includes EDA types."""
+
+    def test_rulebook_node_type_exists(self) -> None:
+        """Verify RULEBOOK node type is defined."""
+        assert hasattr(NodeType, "RULEBOOK")
+        assert NodeType.RULEBOOK.value == "rulebook"
+
+    def test_ruleset_node_type_exists(self) -> None:
+        """Verify RULESET node type is defined."""
+        assert hasattr(NodeType, "RULESET")
+        assert NodeType.RULESET.value == "ruleset"

--- a/tests/test_eda_graph_integration.py
+++ b/tests/test_eda_graph_integration.py
@@ -176,12 +176,13 @@ class TestEdaGraphIntegration:
     def test_eda_inline_content_detection(self, tmp_path: Path) -> None:
         """Verify EDA detection works with inline content variants.
 
-        The regex should handle: `sources: []`, `rules:  # comment`, etc.
+        Content-based detection should ignore inline keys without EDA rule
+        structure, but still recognize inline comments on real rulebooks.
 
         Args:
             tmp_path: Pytest fixture providing temporary directory.
         """
-        # Test inline empty list
+        # Inline empty lists are not enough to classify a non-path YAML file as EDA.
         inline_list = tmp_path / "inline_list.yml"
         inline_list.write_text("""\
 ---
@@ -190,10 +191,10 @@ class TestEdaGraphIntegration:
   sources: []
   rules: []
 """)
-        assert could_be_eda_rulebook(str(inline_list)) is True
-        assert could_be_playbook(str(inline_list)) is False
+        assert could_be_eda_rulebook(str(inline_list)) is False
+        assert could_be_playbook(str(inline_list)) is True
 
-        # Test with trailing comment
+        # Trailing comments should still work when the rulebook has EDA structure.
         with_comment = tmp_path / "with_comment.yml"
         with_comment.write_text("""\
 ---


### PR DESCRIPTION
## Summary
- EDA (Event-Driven Ansible) rulebooks were incorrectly detected as playbooks, causing L095 to flag valid EDA keywords (`sources`, `rules`) as \"unknown play keyword(s)\"
- This fix adds EDA detection to exclude rulebooks from playbook validation rules
- Content-based detection is now strict enough to keep invalid playbooks with stray `sources`/empty inline `rules` on the playbook path so L095 still reports them
- The regex fallback now also recognizes typical nested EDA rule indentation when YAML parsing fails, so malformed rulebooks still avoid the playbook path

## Changes
- Add `RULEBOOK`/`RULESET` to `NodeType` enum (prepares for future E-series rules per REQ-012)
- Add `could_be_eda_rulebook()` and `is_eda_rulebook_path()` detection in `awx_utils.py` (relative and absolute path segments, separator normalization)
- Update `could_be_playbook()` to exclude EDA files
- Tighten content-based EDA heuristics so stray play-level `sources` keys and inline empty `rules` outside EDA paths are not misclassified as rulebooks
- Broaden the regex-only fallback to accept the typical 6-space `condition`/`action` indentation used under EDA `rules:` entries
- Add `could_be_playbook_detail()` and `could_be_eda_rulebook_detail()` safeguards in `finder.py`; exclude EDA from `could_be_taskfile()`
- Add `RULEBOOK`/`RULESET` to scannable types in `graph_scanner.py`
- Add comprehensive regression tests for path-based EDA detection, playbook-vs-EDA edge cases, invalid playbooks that must still reach L095, and malformed rulebooks that rely on the regex fallback

Detection is based on:
- **Path patterns**: Files under `rulebooks/` or `extensions/eda/` (relative or absolute paths)
- **Content patterns**: EDA-style `rules` entries with rule structure, while stray playbook keys remain eligible for L095

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes
- [x] EDA rulebooks in `rulebooks/` directories no longer trigger L095
- [x] Invalid playbooks with stray `sources`/empty inline `rules` still remain on the playbook path for L095
- [x] Malformed EDA rulebooks with valid rule structure still stay off the playbook path via regex fallback
- [x] EDA files labeled `rulebook` (not `taskfile`) and excluded from `search_playbooks` / scan targets