### PR TITLE
fix(collection-health): narrow dependency scan to risk and deprecated rules

### DIFF
--- a/.sdlc/adrs/ADR-051-dependency-health-scanning.md
+++ b/.sdlc/adrs/ADR-051-dependency-health-scanning.md
@@ -81,26 +81,27 @@ content.
 3. For each collection, builds a `ContentGraph` of the collection's roles,
    modules, plugins, and metadata — the same loader pipeline the engine uses
    for project content.
-4. Runs a **curated rule subset** against the collection graph. Not all rules
-   apply to collection internals (e.g. play-level rules are irrelevant). The
-   initial rule selection focuses on:
-   - **Galaxy metadata quality:** L095, L103, L104, L105 (schema, changelog,
-     runtime, repository)
-   - **Module quality:** L089, L090 (type hints, return types)
-   - **Role quality:** L027 (role without metadata), L053 (meta structure),
-     L077 (argument specs), L079 (role var prefix)
-   - **FQCN usage within collection:** M001-M004
-   - **Deprecated patterns:** M005-M010
-   - **Risk indicators:** R101 (command/shell usage guidance and related
-     risk patterns)
+4. Runs a **curated rule subset** against the collection graph. The scope is
+   limited to **security/runtime risks** and **deprecated patterns** — not
+   authoring-quality lint (galaxy metadata, role structure, type hints, FQCN
+   hygiene). Findings in dependencies should be actionable signals, not noise
+   from code the user does not own. The curated set:
+   - **Deprecated patterns:** M005 (Jinja data tagging 2.19+), M010 (Python 2
+     interpreter dropped 2.18+)
+   - **Risk / security indicators:** R101, R103-R109, R111-R115, R117, R401
+     (command execution, transfers, privilege escalation, package install risks,
+     file changes, external roles)
+   - **Deferred:** M004 (removed modules) requires Ansible introspection, not
+     available in the native GraphRule scanner. M006, M008, M009 are OPA rules.
+     These will be added when cross-validator wiring is implemented.
 5. Emits `Violation` messages scoped to `RuleScope.COLLECTION` with the
    collection FQCN in `metadata["collection_fqcn"]` and
    `metadata["collection_version"]`. The `file` field is relative to the
    collection root, not the project root.
 
-**Rule IDs:** Collection health findings reuse existing rule IDs (L089, M001,
+**Rule IDs:** Collection health findings reuse existing rule IDs (M005, R108,
 etc.) — the rule logic is the same. The `RuleScope.COLLECTION` and metadata
-distinguish "this M001 is in your project" from "this M001 is in a dependency."
+distinguish "this R108 is in your project" from "this R108 is in a dependency."
 
 **Caching:** Collection content is immutable at a given FQCN+version, but
 findings also depend on the scan schema: the engine version, the curated rule
@@ -373,8 +374,11 @@ _OPTIONAL_SERVICES = {
 | R200 | Risk | Known CVE in Python dependency |
 | R201 | Risk | Unmaintained Python dependency (reserved, future) |
 
-Collection health findings reuse existing rule IDs (L0xx, M0xx, R1xx) with
-`RuleScope.COLLECTION` differentiation.
+Collection health findings reuse existing rule IDs (M0xx deprecated patterns,
+R1xx risk/security) with `RuleScope.COLLECTION` differentiation. Authoring-
+quality lint rules (galaxy metadata L095/L103-L105, module quality L089/L090,
+role quality L027/L053/L077/L079, FQCN hygiene M001-M003) are excluded —
+dependency scanning targets security and runtime risks only.
 
 ### CLI integration
 

--- a/docs/rules/RULE_CATALOG.md
+++ b/docs/rules/RULE_CATALOG.md
@@ -7,7 +7,7 @@
 | Metric | Count |
 |--------|-------|
 | Implemented | 144/153 |
-| Tested | 109/153 |
+| Tested | 113/153 |
 | Documented | 152/153 |
 | Deterministic fixer | 24/153 |
 
@@ -63,7 +63,7 @@
 | L050 | Native | low | Variable names: lowercase, underscores. | Yes | Yes | Yes | — |
 | L051 | Native | low | Jinja spacing: {{ var }} not {{var}}. | Yes | Yes | Yes | — |
 | L052 | Native | low | Galaxy version in meta should be semantic. | Yes | Yes | Yes | — |
-| L053 | Native | low | Role meta should have valid structure. | Yes | — | Yes | — |
+| L053 | Native | low | Role meta should have valid structure. | Yes | Yes | Yes | — |
 | L054 | Native | low | Role meta galaxy_info should include galaxy_tags. | Yes | — | Yes | — |
 | L055 | Native | low | Role meta video_links should be valid URLs. | Yes | — | Yes | — |
 | L056 | Native | info | Path may match ignore pattern. | Yes | — | Yes | — |
@@ -89,7 +89,7 @@
 | L076 | Native | low | Use ansible_facts bracket notation instead of injected fact variables. | Yes | — | Yes | — |
 | L077 | Native | low | Roles should have meta/argument_specs.yml for fail-fast parameter validation. | Yes | Yes | Yes | — |
 | L078 | Native | low | Use bracket notation for dict key access in Jinja. | Yes | Yes | Yes | — |
-| L079 | Native | low | Role defaults/vars should be prefixed with the role name. | Yes | — | Yes | — |
+| L079 | Native | low | Role defaults/vars should be prefixed with the role name. | Yes | Yes | Yes | — |
 | L080 | Native | low | Internal role variables should be prefixed with _ (underscore). | Yes | Yes | Yes | — |
 | L081 | Native | low | Do not number roles or playbooks. | Yes | Yes | Yes | — |
 | L082 | Native | low | Template source files should use .j2 extension. | Yes | — | Yes | — |
@@ -100,7 +100,7 @@
 | L087 | Native | low | Collection root should have a LICENSE or COPYING file. | Yes | Yes | Yes | — |
 | L088 | Native | low | Collection README should document supported ansible-core versions. | Yes | Yes | Yes | — |
 | L089 | Native | low | Plugin Python files should include type hints. | Yes | Yes | Yes | — |
-| L090 | Native | low | Plugin entry files should be small; move helpers to module_utils. | Yes | — | Yes | — |
+| L090 | Native | low | Plugin entry files should be small; move helpers to module_utils. | Yes | Yes | Yes | — |
 | L091 | Native | low | Use | bool for bare variables in when conditions. | Yes | — | Yes | — |
 | L092 | Native | low | Avoid loop variable references in task names. | Yes | — | Yes | — |
 | L093 | Native | low | Do not override role defaults/vars with set_fact. | Yes | — | Yes | — |
@@ -114,7 +114,7 @@
 | L101 | Native | medium | Variable names must not collide with Ansible reserved names. | Yes | — | Yes | — |
 | L102 | Native | medium | Do not set read-only Ansible variables. | Yes | — | Yes | — |
 | L103 | Native | low | Collection should have a CHANGELOG file. | Yes | Yes | Yes | — |
-| L104 | Native | low | Collection should have meta/runtime.yml. | Yes | — | Yes | — |
+| L104 | Native | low | Collection should have meta/runtime.yml. | Yes | Yes | Yes | — |
 | L105 | Native | low | galaxy.yml should have a repository key. | Yes | Yes | Yes | — |
 | L106 | OPA | medium | set_fact with loop and when is a scaling anti-pattern. | Yes | Yes | Yes | — |
 | M001 | Ansible | high | FQCN resolution — module resolved to a different canonical name. | Yes | Yes | Yes | Yes |
@@ -225,7 +225,7 @@
 | M028 | high | first_found lookup auto-splitting paths on delimiters is deprecated (2.23) | Yes | Yes | Yes | — |
 | R118 | info | Task downloads from an external source (inbound transfer). | Yes | Yes | Yes | — |
 
-### Native (96 rules, 87 impl, 53 tested, 3 fixers)
+### Native (96 rules, 87 impl, 57 tested, 3 fixers)
 
 | Rule ID | Severity | Description | Impl | Tested | Doc | Fixer |
 |---------|----------|-------------|------|--------|-----|-------|
@@ -254,7 +254,7 @@
 | L050 | low | Variable names: lowercase, underscores. | Yes | Yes | Yes | — |
 | L051 | low | Jinja spacing: {{ var }} not {{var}}. | Yes | Yes | Yes | — |
 | L052 | low | Galaxy version in meta should be semantic. | Yes | Yes | Yes | — |
-| L053 | low | Role meta should have valid structure. | Yes | — | Yes | — |
+| L053 | low | Role meta should have valid structure. | Yes | Yes | Yes | — |
 | L054 | low | Role meta galaxy_info should include galaxy_tags. | Yes | — | Yes | — |
 | L055 | low | Role meta video_links should be valid URLs. | Yes | — | Yes | — |
 | L056 | info | Path may match ignore pattern. | Yes | — | Yes | — |
@@ -265,7 +265,7 @@
 | L076 | low | Use ansible_facts bracket notation instead of injected fact variables. | Yes | — | Yes | — |
 | L077 | low | Roles should have meta/argument_specs.yml for fail-fast parameter validation. | Yes | Yes | Yes | — |
 | L078 | low | Use bracket notation for dict key access in Jinja. | Yes | Yes | Yes | — |
-| L079 | low | Role defaults/vars should be prefixed with the role name. | Yes | — | Yes | — |
+| L079 | low | Role defaults/vars should be prefixed with the role name. | Yes | Yes | Yes | — |
 | L080 | low | Internal role variables should be prefixed with _ (underscore). | Yes | Yes | Yes | — |
 | L081 | low | Do not number roles or playbooks. | Yes | Yes | Yes | — |
 | L082 | low | Template source files should use .j2 extension. | Yes | — | Yes | — |
@@ -276,7 +276,7 @@
 | L087 | low | Collection root should have a LICENSE or COPYING file. | Yes | Yes | Yes | — |
 | L088 | low | Collection README should document supported ansible-core versions. | Yes | Yes | Yes | — |
 | L089 | low | Plugin Python files should include type hints. | Yes | Yes | Yes | — |
-| L090 | low | Plugin entry files should be small; move helpers to module_utils. | Yes | — | Yes | — |
+| L090 | low | Plugin entry files should be small; move helpers to module_utils. | Yes | Yes | Yes | — |
 | L091 | low | Use | bool for bare variables in when conditions. | Yes | — | Yes | — |
 | L092 | low | Avoid loop variable references in task names. | Yes | — | Yes | — |
 | L093 | low | Do not override role defaults/vars with set_fact. | Yes | — | Yes | — |
@@ -290,7 +290,7 @@
 | L101 | medium | Variable names must not collide with Ansible reserved names. | Yes | — | Yes | — |
 | L102 | medium | Do not set read-only Ansible variables. | Yes | — | Yes | — |
 | L103 | low | Collection should have a CHANGELOG file. | Yes | Yes | Yes | — |
-| L104 | low | Collection should have meta/runtime.yml. | Yes | — | Yes | — |
+| L104 | low | Collection should have meta/runtime.yml. | Yes | Yes | Yes | — |
 | L105 | low | galaxy.yml should have a repository key. | Yes | Yes | Yes | — |
 | M005 | high | Registered variable used in Jinja template may be untrusted in 2.19+. | Yes | Yes | Yes | — |
 | M010 | high | ansible_python_interpreter set to Python 2; dropped in 2.18+. | Yes | Yes | Yes | — |
@@ -358,25 +358,22 @@
 - **R404** (Native): Expose variable_set for the task.
 - **R501** (Native): Suggest collection/role dependency.
 
-### Implemented but untested — 38
+### Implemented but untested — 34
 
 - **L032** (Native): Variable redefinition may cause confusion.
 - **L033** (Native): Overriding vars without conditions.
 - **L034** (Native): Lower-precedence override may be unused.
 - **L038** (Native): Role could not be resolved.
 - **L039** (Native): Variable use may be undefined.
-- **L053** (Native): Role meta should have valid structure.
 - **L054** (Native): Role meta galaxy_info should include galaxy_tags.
 - **L055** (Native): Role meta video_links should be valid URLs.
 - **L056** (Native): Path may match ignore pattern.
 - **L073** (Native): YAML should use 2-space indentation.
 - **L075** (Native): Template source files should use .j2 extension (ansible_managed best practice).
 - **L076** (Native): Use ansible_facts bracket notation instead of injected fact variables.
-- **L079** (Native): Role defaults/vars should be prefixed with the role name.
 - **L082** (Native): Template source files should use .j2 extension.
 - **L084** (Native): Task names in included sub-task files should use a prefix.
 - **L086** (Native): Avoid playbook/play vars for routine config; use inventory vars.
-- **L090** (Native): Plugin entry files should be small; move helpers to module_utils.
 - **L091** (Native): Use | bool for bare variables in when conditions.
 - **L092** (Native): Avoid loop variable references in task names.
 - **L093** (Native): Do not override role defaults/vars with set_fact.
@@ -384,7 +381,6 @@
 - **L097** (Native): Task names should be unique within a play.
 - **L101** (Native): Variable names must not collide with Ansible reserved names.
 - **L102** (Native): Do not set read-only Ansible variables.
-- **L104** (Native): Collection should have meta/runtime.yml.
 - **M004** (Ansible): Removed module — tombstoned module that raises AnsiblePluginRemovedError.
 - **M014** (Native): Use ansible_facts["name"] instead of injected ansible_* fact variables (removed in 2.24)
 - **M015** (Native): Use ansible_play_batch instead of deprecated play_hosts variable (removed in 2.23)

--- a/src/apme_engine/validators/collection_health/scanner.py
+++ b/src/apme_engine/validators/collection_health/scanner.py
@@ -18,30 +18,8 @@ from apme_engine.engine.models import ViolationDict
 logger = logging.getLogger("apme.collection_health")
 
 CURATED_RULE_IDS: tuple[str, ...] = (
-    # Galaxy metadata quality
-    "L095",
-    "L103",
-    "L104",
-    "L105",
-    # Module quality
-    "L089",
-    "L090",
-    # Role quality
-    "L027",
-    "L053",
-    "L077",
-    "L079",
-    # FQCN usage within collection
-    "M001",
-    "M002",
-    "M003",
-    "M004",
-    # Deprecated patterns
+    # Deprecated patterns (native GraphRule implementations only)
     "M005",
-    "M006",
-    "M007",
-    "M008",
-    "M009",
     "M010",
     # Risk / security indicators
     "R101",

--- a/tests/test_collection_health.py
+++ b/tests/test_collection_health.py
@@ -284,17 +284,36 @@ class TestCollectionHealthServicer:
 class TestCuratedRuleIds:
     """Tests for the curated rule ID set."""
 
-    def test_curated_rules_are_sorted_categories(self) -> None:
-        """Curated rules cover galaxy metadata, module, role, FQCN, deprecated, risk."""
-        assert "L095" in CURATED_RULE_IDS
-        assert "M001" in CURATED_RULE_IDS
+    def test_curated_rules_cover_deprecated_and_risk(self) -> None:
+        """Curated rules cover deprecated patterns and risk/security indicators only."""
+        assert "M005" in CURATED_RULE_IDS
+        assert "M010" in CURATED_RULE_IDS
         assert "R101" in CURATED_RULE_IDS
-        assert "L089" in CURATED_RULE_IDS
+        assert "R108" in CURATED_RULE_IDS
 
     def test_no_play_level_rules(self) -> None:
         """Play-level rules are excluded from collection scanning."""
         play_rules = {"L001", "L002", "L003", "L004", "L005"}
         assert not play_rules.intersection(CURATED_RULE_IDS)
+
+    def test_no_authoring_lint_rules(self) -> None:
+        """Galaxy metadata, module/role quality, and FQCN hygiene rules are excluded."""
+        authoring_lint = {
+            "L027",
+            "L053",
+            "L077",
+            "L079",  # role quality
+            "L089",
+            "L090",  # module quality
+            "L095",
+            "L103",
+            "L104",
+            "L105",  # galaxy metadata
+            "M001",
+            "M002",
+            "M003",  # FQCN hygiene
+        }
+        assert not authoring_lint.intersection(CURATED_RULE_IDS)
 
 
 def _scaffold_collection(

--- a/tests/test_collection_health.py
+++ b/tests/test_collection_health.py
@@ -296,6 +296,11 @@ class TestCuratedRuleIds:
         play_rules = {"L001", "L002", "L003", "L004", "L005"}
         assert not play_rules.intersection(CURATED_RULE_IDS)
 
+    def test_curated_rules_sorted_and_unique(self) -> None:
+        """CURATED_RULE_IDS is sorted and contains no duplicates."""
+        assert list(CURATED_RULE_IDS) == sorted(CURATED_RULE_IDS)
+        assert len(CURATED_RULE_IDS) == len(set(CURATED_RULE_IDS))
+
     def test_no_authoring_lint_rules(self) -> None:
         """Galaxy metadata, module/role quality, and FQCN hygiene rules are excluded."""
         authoring_lint = {


### PR DESCRIPTION
## Summary
- Reduce collection health dependency scanning from 40 curated rules to 17, focusing only on security/runtime risks and deprecated patterns
- Remove authoring-quality lint (galaxy metadata, module/role quality, FQCN hygiene) that creates noise for third-party collections the user cannot fix

## Changes
- Trim `CURATED_RULE_IDS` in `scanner.py` to M005, M010, and R101-R401 risk indicators (17 rules)
- Add `test_no_authoring_lint_rules` to guard against re-adding lint rules to the dependency scan set
- Add `test_curated_rules_sorted_and_unique` to ensure rule list stays sorted and deduplicated
- Update ADR-051 to document the narrowed scope and note M004/M006/M009 as deferred until cross-validator wiring exists
- Regenerate `RULE_CATALOG.md` (tested-count updates from catalog hook)

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2416 passed)
- [x] ADR-051 updated
- [x] Collection health integration test still fires R108 on scaffolded collection with `become: true`