### PR TITLE
fix(validators): reduce false positives in L025, L043, L039, and M014

### DIFF
--- a/docs/rules/LINT_RULE_MAPPING.md
+++ b/docs/rules/LINT_RULE_MAPPING.md
@@ -72,7 +72,7 @@ L002 was removed — its FQCN check (syntactic dot-count) is superseded by **M00
 | L040 | L040_no_tabs.py | No tabs in YAML |
 | L041 | L041_key_order.py | Key ordering (e.g. name before module) |
 | L042 | L042_complexity.py | Play/block task count (complexity) |
-| L043 | L043_deprecated_bare_vars.py | Deprecated bare variables {{ foo }} |
+| L043 | L043_deprecated_bare_vars.py | Bare variable in with_* loop directive; use {{ var }} |
 | L044 | L044_avoid_implicit.py | Avoid implicit state (set state explicitly) |
 | L045 | L045_inline_env_var.py | Avoid inline environment in tasks |
 | L046 | L046_no_free_form.py | Avoid raw/command/shell without args key |

--- a/docs/rules/RULE_CATALOG.md
+++ b/docs/rules/RULE_CATALOG.md
@@ -55,7 +55,7 @@
 | L040 | Native | info | YAML should not contain tabs; use spaces. | Yes | Yes | Yes | — |
 | L041 | Native | low | Task keys should follow canonical order (e.g. name before module). | Yes | Yes | Yes | — |
 | L042 | Native | info | Play/block has high task count. | Yes | Yes | Yes | — |
-| L043 | Native | low | Avoid {{ foo }}; prefer explicit form. | Yes | Yes | Yes | Yes |
+| L043 | Native | low | Bare variable in with_* loop directive; use {{ var }}. | Yes | Yes | Yes | Yes |
 | L044 | Native | low | Set state explicitly where it matters. | Yes | Yes | Yes | — |
 | L045 | Native | low | Avoid inline environment in tasks. | Yes | Yes | Yes | — |
 | L046 | Native | low | Avoid raw/command/shell without args key. | Yes | Yes | Yes | Yes |
@@ -249,7 +249,7 @@
 | L040 | info | YAML should not contain tabs; use spaces. | Yes | Yes | Yes | — |
 | L041 | low | Task keys should follow canonical order (e.g. name before module). | Yes | Yes | Yes | — |
 | L042 | info | Play/block has high task count. | Yes | Yes | Yes | — |
-| L043 | low | Avoid {{ foo }}; prefer explicit form. | Yes | Yes | Yes | Yes |
+| L043 | low | Bare variable in with_* loop directive; use {{ var }}. | Yes | Yes | Yes | Yes |
 | L044 | low | Set state explicitly where it matters. | Yes | Yes | Yes | — |
 | L045 | low | Avoid inline environment in tasks. | Yes | Yes | Yes | — |
 | L046 | low | Avoid raw/command/shell without args key. | Yes | Yes | Yes | Yes |
@@ -427,7 +427,7 @@ Rules without fixers fall to Tier 2 (AI-proposable) or Tier 3 (manual review).
 | L022 | low | Shell with pipe should set set -o pipefail. |
 | L025 | low | Task/play name should start with uppercase. |
 | L026 | low | Tasks should use FQCN for modules. |
-| L043 | low | Avoid {{ foo }}; prefer explicit form. |
+| L043 | low | Bare variable in with_* loop directive; use {{ var }}. |
 | L046 | low | Avoid raw/command/shell without args key. |
 | M001 | high | FQCN resolution — module resolved to a different canonical name. |
 | M002 | high | Deprecated module — module has deprecation metadata. |

--- a/src/apme_engine/validators/native/rules/L039_undefined_variable_graph.py
+++ b/src/apme_engine/validators/native/rules/L039_undefined_variable_graph.py
@@ -30,6 +30,7 @@ _BARE_IDENT_RE = re.compile(r"\b([a-zA-Z_][a-zA-Z0-9_]*)\b")
 # variable references.
 _JINJA_BUILTINS: frozenset[str] = frozenset(
     {
+        # Jinja2 keywords / operators
         "and",
         "or",
         "not",
@@ -42,6 +43,7 @@ _JINJA_BUILTINS: frozenset[str] = frozenset(
         "import",
         "as",
         "with",
+        # Jinja2 built-in types / functions
         "bool",
         "int",
         "float",
@@ -81,24 +83,40 @@ _JINJA_BUILTINS: frozenset[str] = frozenset(
         "combine",
         "mandatory",
         "ternary",
+        # Ansible serialization / encoding filters
         "from_json",
         "from_yaml",
         "to_json",
         "to_yaml",
         "to_nice_json",
         "to_nice_yaml",
+        "to_datetime",
+        "to_uuid",
         "b64encode",
         "b64decode",
         "hash",
         "type_debug",
+        # Ansible path / network filters
         "ipaddr",
+        "ipv4",
+        "ipv6",
         "basename",
         "dirname",
         "realpath",
         "relpath",
+        "expanduser",
+        "expandvars",
+        "fileglob",
+        "splitext",
+        "win_basename",
+        "win_dirname",
+        "win_splitdrive",
+        # Ansible regex filters
         "regex_replace",
         "regex_search",
         "regex_findall",
+        "regex_escape",
+        # Ansible data / collection filters
         "password_hash",
         "comment",
         "subelements",
@@ -106,6 +124,17 @@ _JINJA_BUILTINS: frozenset[str] = frozenset(
         "zip",
         "zip_longest",
         "json_query",
+        "items2dict",
+        "dict2items",
+        "groupby",
+        "selectattr",
+        "rejectattr",
+        "extract",
+        "symmetric_difference",
+        "difference",
+        "intersect",
+        "union",
+        # Ansible result tests / filters
         "community",
         "succeeded",
         "failed",
@@ -113,6 +142,39 @@ _JINJA_BUILTINS: frozenset[str] = frozenset(
         "skipped",
         "success",
         "failure",
+        "unreachable",
+        # Ansible misc filters
+        "human_readable",
+        "human_to_bytes",
+        "quote",
+        "shuffle",
+        "random",
+        "log",
+        "pow",
+        "root",
+        "urlsplit",
+        "urlencode",
+        "ansible_native",
+        "checksum",
+        "strftime",
+        "wordcount",
+        "center",
+        "capitalize",
+        "title",
+        "truncate",
+        "indent",
+        "format",
+        "attr",
+        "batch",
+        "slice",
+        "tojson",
+        "safe",
+        "escape",
+        "xmlattr",
+        "pprint",
+        "count",
+        "reverse",
+        "sum",
     }
 )
 
@@ -232,6 +294,7 @@ def _extract_jinja_refs(texts: list[str]) -> set[str]:
 
 _QUOTED_STRING_RE = re.compile(r"""(?:'[^']*'|"[^"]*")""")
 _DOTTED_ATTR_RE = re.compile(r"\.([a-zA-Z_][a-zA-Z0-9_]*)")
+_PIPE_FILTER_RE = re.compile(r"\|\s*([a-zA-Z_][a-zA-Z0-9_]*)")
 
 
 def _extract_bare_refs(texts: list[str]) -> set[str]:
@@ -241,8 +304,9 @@ def _extract_bare_refs(texts: list[str]) -> set[str]:
     implicitly Jinja — Ansible evaluates them as expressions without
     requiring ``{{ }}`` wrappers.
 
-    Strips quoted strings and dotted attribute names before extraction
-    so that ``'RedHat'`` and ``.rc`` are not treated as variables.
+    Strips quoted strings, dotted attribute names, and Jinja filter names
+    (identifiers following ``|``) before extraction so that ``'RedHat'``,
+    ``.rc``, and ``| to_datetime`` are not treated as variables.
 
     Args:
         texts: Bare expression strings.
@@ -254,8 +318,14 @@ def _extract_bare_refs(texts: list[str]) -> set[str]:
     for text in texts:
         stripped = _QUOTED_STRING_RE.sub("", text)
         dotted_attrs = {m.group(1) for m in _DOTTED_ATTR_RE.finditer(stripped)}
+        pipe_filters = {m.group(1) for m in _PIPE_FILTER_RE.finditer(stripped)}
         for ident in _BARE_IDENT_RE.findall(stripped):
-            if ident not in _JINJA_BUILTINS and ident not in dotted_attrs and not ident[0].isdigit():
+            if (
+                ident not in _JINJA_BUILTINS
+                and ident not in dotted_attrs
+                and ident not in pipe_filters
+                and not ident[0].isdigit()
+            ):
                 refs.add(ident)
     return refs
 

--- a/src/apme_engine/validators/native/rules/L039_undefined_variable_graph.py
+++ b/src/apme_engine/validators/native/rules/L039_undefined_variable_graph.py
@@ -143,12 +143,12 @@ _JINJA_BUILTINS: frozenset[str] = frozenset(
         "success",
         "failure",
         "unreachable",
-        # Ansible misc filters
+        # Ansible misc filters. Keep this list narrow: identifiers used after
+        # ``|`` are already excluded by ``_PIPE_FILTER_RE``, so common names
+        # like ``count`` or ``random`` should not be globally reserved here.
         "human_readable",
         "human_to_bytes",
-        "quote",
         "shuffle",
-        "random",
         "log",
         "pow",
         "root",
@@ -158,23 +158,7 @@ _JINJA_BUILTINS: frozenset[str] = frozenset(
         "checksum",
         "strftime",
         "wordcount",
-        "center",
-        "capitalize",
-        "title",
-        "truncate",
-        "indent",
-        "format",
-        "attr",
-        "batch",
-        "slice",
-        "tojson",
-        "safe",
-        "escape",
         "xmlattr",
-        "pprint",
-        "count",
-        "reverse",
-        "sum",
     }
 )
 

--- a/src/apme_engine/validators/native/rules/L043_deprecated_bare_vars.md
+++ b/src/apme_engine/validators/native/rules/L043_deprecated_bare_vars.md
@@ -1,26 +1,34 @@
 ---
 rule_id: L043
 validator: native
-description: Avoid {{ foo }}; prefer explicit form.
+description: Bare variable in with_* loop directive; use {{ var }}.
 scope: task
 ---
 
 ## Deprecated bare vars (L043)
 
-Avoid {{ foo }}; prefer explicit form.
+Detects bare variable names in ``with_*`` loop directives that should be
+wrapped in Jinja2 delimiters (``{{ }}``).  Using ``{{ var }}`` inside a
+normal string value is standard Jinja2 and is **not** flagged.
 
 ### Example: violation
 
 ```yaml
-- name: Bare var
+- name: Bare var in loop
   ansible.builtin.debug:
-    msg: "{{ my_var }}"
+    msg: "{{ item }}"
+  with_items: mylist
 ```
 
 ### Example: pass
 
 ```yaml
-- name: Filtered var
+- name: Wrapped var in loop
   ansible.builtin.debug:
-    msg: "{{ my_var | default('') }}"
+    msg: "{{ item }}"
+  with_items: "{{ mylist }}"
+
+- name: Normal Jinja2 in string value
+  ansible.builtin.debug:
+    msg: "Hello {{ username }}"
 ```

--- a/src/apme_engine/validators/native/rules/L043_deprecated_bare_vars_graph.py
+++ b/src/apme_engine/validators/native/rules/L043_deprecated_bare_vars_graph.py
@@ -1,9 +1,19 @@
-"""GraphRule L043: detect deprecated bare variables (prefer explicit form).
+"""GraphRule L043: detect deprecated bare variables in loop directives.
 
-Graph-aware port of ``L043_deprecated_bare_vars.py``.
+A *bare variable* is a plain identifier used where Ansible historically
+allowed it without Jinja2 delimiters::
+
+    with_items: mylist          # bare — should be {{ mylist }}
+
+Using ``{{ var }}`` inside a string value (e.g. ``url: https://{{ host }}/``)
+is standard Jinja2 and is **not** a bare-variable violation.
+
+This rule only checks ``with_*`` directive values for bare identifiers
+that lack ``{{ }}`` wrapping.
 """
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import cast
 
@@ -14,70 +24,48 @@ from apme_engine.validators.native.rules.graph_rule_base import GraphRule, Graph
 
 _TASK_TYPES = frozenset({NodeType.TASK, NodeType.HANDLER})
 
-BARE_VAR_PATTERN = re.compile(r"\{\{\s*[\w.]+\s*\}\}")
+_BARE_VAR_RE = re.compile(r"^[a-zA-Z_]\w*(\.\w+)*$")
+
+_LOOP_KEYS = frozenset(
+    {
+        "with_items",
+        "with_list",
+        "with_dict",
+        "with_fileglob",
+        "with_subelements",
+        "with_sequence",
+        "with_nested",
+        "with_first_found",
+        "with_indexed_items",
+        "with_flattened",
+        "with_together",
+        "with_cartesian",
+        "with_random_choice",
+    }
+)
 
 
-def _find_bare_vars(text: str | None) -> list[str]:
-    """Find bare variable patterns (e.g. {{ var }}) in text.
+def _find_bare_loop_vars(options: Mapping[str, object]) -> list[tuple[str, str]]:
+    """Find ``with_*`` values that are bare variable names (no Jinja delimiters).
 
     Args:
-        text: Text to search for bare variables.
+        options: Task options dict (may contain ``with_items``, etc.).
 
     Returns:
-        List of matched bare variable strings.
+        List of ``(directive_key, bare_value)`` pairs.
     """
-    if not text or not isinstance(text, str):
-        return []
-    return BARE_VAR_PATTERN.findall(text)
-
-
-def _collect_strings_from_dict(d: object, out: list[str]) -> None:
-    """Recursively collect string values from dict into out list.
-
-    Args:
-        d: Dict or value to traverse.
-        out: List to append string values to.
-    """
-    if not isinstance(d, dict):
-        if isinstance(d, str):
-            out.append(d)
-        return
-    for v in d.values():
-        if isinstance(v, str):
-            out.append(v)
-        elif isinstance(v, dict):
-            _collect_strings_from_dict(v, out)
-        elif isinstance(v, list):
-            for item in v:
-                if isinstance(item, str):
-                    out.append(item)
-                elif isinstance(item, dict):
-                    _collect_strings_from_dict(item, out)
-
-
-def _sources_for_node(node: object) -> list[str]:
-    """Gather text sources from a task/handler node for bare-var scanning.
-
-    Args:
-        node: Content graph node (task or handler).
-
-    Returns:
-        List of string fragments to scan.
-    """
-    sources: list[str] = []
-    yaml_lines = getattr(node, "yaml_lines", "") or ""
-    if yaml_lines:
-        sources.append(yaml_lines)
-    options = getattr(node, "options", None) or {}
-    module_options = getattr(node, "module_options", None) or {}
-    _collect_strings_from_dict(options, sources)
-    _collect_strings_from_dict(module_options, sources)
-    return sources
+    bare: list[tuple[str, str]] = []
+    for key, val in options.items():
+        if key not in _LOOP_KEYS:
+            continue
+        if isinstance(val, str) and _BARE_VAR_RE.match(val.strip()):
+            bare.append((key, val.strip()))
+    return bare
 
 
 @dataclass
 class DeprecatedBareVarsGraphRule(GraphRule):
-    """Rule for deprecated bare variables (e.g. {{ foo }}); prefer explicit form.
+    """Detect bare variable names in ``with_*`` directives that need ``{{ }}`` wrapping.
 
     Attributes:
         rule_id: Rule identifier.
@@ -90,30 +78,31 @@ class DeprecatedBareVarsGraphRule(GraphRule):
     """
 
     rule_id: str = "L043"
-    description: str = "Deprecated bare variables (e.g. {{ foo }}); prefer explicit form"
+    description: str = "Deprecated bare variable in loop directive; use {{ var }}"
     enabled: bool = True
     name: str = "DeprecatedBareVars"
-    version: str = "v0.0.1"
+    version: str = "v0.0.2"
     severity: Severity = Severity.LOW
     tags: tuple[str, ...] = (Tag.VARIABLE,)
 
     def match(self, graph: ContentGraph, node_id: str) -> bool:
-        """Match task or handler nodes.
+        """Match task or handler nodes that use a ``with_*`` loop directive.
 
         Args:
             graph: The full ContentGraph.
             node_id: ID of the node to check.
 
         Returns:
-            True when the node is a task or handler.
+            True when the node is a task/handler with a ``with_*`` key in options.
         """
         node = graph.get_node(node_id)
-        if node is None:
+        if node is None or node.node_type not in _TASK_TYPES:
             return False
-        return node.node_type in _TASK_TYPES
+        opts = node.options or {}
+        return any(k in _LOOP_KEYS for k in opts)
 
     def process(self, graph: ContentGraph, node_id: str) -> GraphRuleResult | None:
-        """Check for deprecated bare variables and return result.
+        """Check ``with_*`` values for bare variable names missing ``{{ }}``.
 
         Args:
             graph: The full ContentGraph.
@@ -125,16 +114,19 @@ class DeprecatedBareVarsGraphRule(GraphRule):
         node = graph.get_node(node_id)
         if node is None:
             return None
-        bare_vars: list[str] = []
-        for s in _sources_for_node(node):
-            bare_vars.extend(_find_bare_vars(s))
-        bare_vars = list(dict.fromkeys(bare_vars))
-        verdict = len(bare_vars) > 0
-        detail: YAMLDict | None = None
-        if bare_vars:
-            detail = cast(YAMLDict, {"bare_vars": bare_vars})
+        bare = _find_bare_loop_vars(node.options or {})
+        if not bare:
+            return GraphRuleResult(
+                verdict=False,
+                node_id=node_id,
+                file=(node.file_path, node.line_start),
+            )
+        detail: YAMLDict = cast(
+            YAMLDict,
+            {"bare_vars": [f"{key}: {val}" for key, val in bare]},
+        )
         return GraphRuleResult(
-            verdict=verdict,
+            verdict=True,
             detail=detail,
             node_id=node_id,
             file=(node.file_path, node.line_start),

--- a/src/apme_engine/validators/native/rules/M014_top_level_fact_variables_graph.py
+++ b/src/apme_engine/validators/native/rules/M014_top_level_fact_variables_graph.py
@@ -1,6 +1,10 @@
 r"""GraphRule M014: top-level fact variables — use ansible_facts[\"name\"] (removed in 2.24).
 
-Graph-aware port of ``M014_top_level_fact_variables.py``.
+Only flags the specific ``ansible_*`` variables that are injected as
+top-level facts by the ``setup`` module (and related fact-gathering).
+User-defined variables that happen to start with ``ansible_`` (e.g.
+``ansible_controller_collection_installed``) are **not** deprecated
+facts and are not flagged.
 """
 
 import re
@@ -14,32 +18,94 @@ from apme_engine.validators.native.rules.graph_rule_base import GraphRule, Graph
 
 _TASK_TYPES = frozenset({NodeType.TASK, NodeType.HANDLER})
 
-MAGIC_VARS = frozenset(
+# Known deprecated top-level fact variables injected by the setup module.
+# These are the variables that Ansible injects as ``ansible_<name>`` when
+# ``INJECT_FACTS_AS_VARS`` is true (deprecated since 2.5, removal in 2.24).
+# User-defined ``ansible_*`` variables are NOT in this set.
+DEPRECATED_FACTS: frozenset[str] = frozenset(
     {
-        "ansible_check_mode",
-        "ansible_diff_mode",
-        "ansible_forks",
-        "ansible_play_batch",
-        "ansible_play_hosts",
-        "ansible_play_hosts_all",
-        "ansible_play_name",
-        "ansible_play_role_names",
-        "ansible_role_names",
-        "ansible_run_tags",
-        "ansible_skip_tags",
-        "ansible_version",
-        "ansible_loop",
-        "ansible_loop_var",
-        "ansible_index_var",
-        "ansible_parent_role_names",
-        "ansible_parent_role_paths",
-        "ansible_facts",
-        "ansible_local",
-        "ansible_verbosity",
-        "ansible_config_file",
-        "ansible_connection",
-        "ansible_become",
-        "ansible_become_method",
+        # System / OS identity
+        "ansible_architecture",
+        "ansible_bios_date",
+        "ansible_bios_version",
+        "ansible_distribution",
+        "ansible_distribution_file_variety",
+        "ansible_distribution_major_version",
+        "ansible_distribution_release",
+        "ansible_distribution_version",
+        "ansible_hostname",
+        "ansible_fqdn",
+        "ansible_domain",
+        "ansible_machine",
+        "ansible_nodename",
+        "ansible_os_family",
+        "ansible_system",
+        "ansible_system_vendor",
+        "ansible_kernel",
+        "ansible_kernel_version",
+        "ansible_product_name",
+        "ansible_product_serial",
+        "ansible_product_uuid",
+        "ansible_product_version",
+        # Package / service managers
+        "ansible_pkg_mgr",
+        "ansible_service_mgr",
+        # Python
+        "ansible_python",
+        "ansible_python_interpreter",
+        "ansible_python_version",
+        # Network
+        "ansible_default_ipv4",
+        "ansible_default_ipv6",
+        "ansible_all_ipv4_addresses",
+        "ansible_all_ipv6_addresses",
+        "ansible_interfaces",
+        "ansible_dns",
+        # Hardware / memory / CPU
+        "ansible_memfree_mb",
+        "ansible_memtotal_mb",
+        "ansible_memory_mb",
+        "ansible_swapfree_mb",
+        "ansible_swaptotal_mb",
+        "ansible_processor",
+        "ansible_processor_cores",
+        "ansible_processor_count",
+        "ansible_processor_nproc",
+        "ansible_processor_threads_per_core",
+        "ansible_processor_vcpus",
+        # Mounts / devices
+        "ansible_devices",
+        "ansible_mounts",
+        # User / env
+        "ansible_env",
+        "ansible_user_dir",
+        "ansible_user_gecos",
+        "ansible_user_gid",
+        "ansible_user_id",
+        "ansible_user_shell",
+        "ansible_user_uid",
+        "ansible_effective_group_id",
+        "ansible_effective_user_id",
+        "ansible_real_group_id",
+        "ansible_real_user_id",
+        # Date / time
+        "ansible_date_time",
+        # Virtualization / container
+        "ansible_virtualization_role",
+        "ansible_virtualization_type",
+        # SELinux / AppArmor
+        "ansible_selinux",
+        "ansible_apparmor",
+        # SSH / connection
+        "ansible_ssh_host_key_dsa_public",
+        "ansible_ssh_host_key_ecdsa_public",
+        "ansible_ssh_host_key_ed25519_public",
+        "ansible_ssh_host_key_rsa_public",
+        # Misc gathered facts
+        "ansible_cmdline",
+        "ansible_fibre_channel_wwn",
+        "ansible_lvm",
+        "ansible_uptime_seconds",
     }
 )
 
@@ -48,7 +114,7 @@ _ANSIBLE_VAR = re.compile(r"\b(ansible_\w+)\b")
 
 @dataclass
 class TopLevelFactVariablesGraphRule(GraphRule):
-    """Detect injected ansible_* fact variables that will break in 2.24.
+    """Detect deprecated injected ``ansible_*`` setup-module facts.
 
     Attributes:
         rule_id: Rule identifier.
@@ -64,7 +130,7 @@ class TopLevelFactVariablesGraphRule(GraphRule):
     description: str = 'Use ansible_facts["name"] instead of injected ansible_* fact variables (removed in 2.24)'
     enabled: bool = True
     name: str = "TopLevelFactVariables"
-    version: str = "v0.0.1"
+    version: str = "v0.0.2"
     severity: Severity = Severity.HIGH
     tags: tuple[str, ...] = (Tag.CODING,)
 
@@ -108,7 +174,7 @@ class TopLevelFactVariablesGraphRule(GraphRule):
         found: set[str] = set()
         for m in _ANSIBLE_VAR.finditer(text):
             varname = m.group(1)
-            if varname not in MAGIC_VARS and varname.startswith("ansible_"):
+            if varname in DEPRECATED_FACTS:
                 found.add(varname)
         verdict = len(found) > 0
         detail: YAMLDict | None = None

--- a/src/apme_engine/validators/opa/bundle/L025.rego
+++ b/src/apme_engine/validators/opa/bundle/L025.rego
@@ -15,20 +15,34 @@ violations contains v if {
 	v := name_casing(tree, node)
 }
 
-# Extract the first character of the meaningful portion of a name.
-# If the name contains " | ", return the first char after the last " | ".
-# Otherwise return the first char of the whole name.
-_effective_first(name) := first if {
+# Extract the meaningful portion of a name.
+# If the name contains " | " and the suffix is non-empty, use the suffix.
+# Otherwise fall back to the whole name so malformed names like "file | "
+# still evaluate deterministically instead of leaving the helper undefined.
+_name_subject(name) := subject if {
 	contains(name, " | ")
 	parts := split(name, " | ")
 	last := parts[count(parts) - 1]
 	last != ""
-	first := substring(last, 0, 1)
+	subject := last
+}
+
+_name_subject(name) := subject if {
+	not contains(name, " | ")
+	subject := name
+}
+
+_name_subject(name) := subject if {
+	contains(name, " | ")
+	parts := split(name, " | ")
+	last := parts[count(parts) - 1]
+	last == ""
+	subject := name
 }
 
 _effective_first(name) := first if {
-	not contains(name, " | ")
-	first := substring(name, 0, 1)
+	subject := _name_subject(name)
+	first := substring(subject, 0, 1)
 }
 
 name_casing(tree, node) := v if {

--- a/src/apme_engine/validators/opa/bundle/L025.rego
+++ b/src/apme_engine/validators/opa/bundle/L025.rego
@@ -1,4 +1,8 @@
 # L025: Task/play name should start with uppercase letter
+#
+# Names following the "filename | Description" convention are checked on
+# the description portion only — the filename prefix is not required to
+# be uppercase.
 
 package apme.rules
 
@@ -11,10 +15,26 @@ violations contains v if {
 	v := name_casing(tree, node)
 }
 
+# Extract the first character of the meaningful portion of a name.
+# If the name contains " | ", return the first char after the last " | ".
+# Otherwise return the first char of the whole name.
+_effective_first(name) := first if {
+	contains(name, " | ")
+	parts := split(name, " | ")
+	last := parts[count(parts) - 1]
+	last != ""
+	first := substring(last, 0, 1)
+}
+
+_effective_first(name) := first if {
+	not contains(name, " | ")
+	first := substring(name, 0, 1)
+}
+
 name_casing(tree, node) := v if {
 	node.type == "taskcall"
 	node.name != ""
-	first := substring(node.name, 0, 1)
+	first := _effective_first(node.name)
 	lower(first) == first
 	count(node.line) > 0
 	v := {
@@ -31,7 +51,7 @@ name_casing(tree, node) := v if {
 name_casing(tree, node) := v if {
 	node.type == "playcall"
 	node.name != ""
-	first := substring(node.name, 0, 1)
+	first := _effective_first(node.name)
 	lower(first) == first
 	count(node.line) > 0
 	v := {

--- a/src/apme_engine/validators/opa/bundle/L025_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L025_test.rego
@@ -23,3 +23,31 @@ test_L025_fires_when_play_name_lowercase if {
 	v := rules.name_casing(tree, node)
 	v.rule_id == "L025"
 }
+
+# Pipe-prefix convention: "filename | Description"
+# The filename portion is not checked — only the description after " | ".
+
+test_L025_no_fire_pipe_prefix_uppercase_description if {
+	tree := {"nodes": [{"type": "taskcall", "name": "handle_error | Show error and stop", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.name_casing(tree, node)
+}
+
+test_L025_fires_pipe_prefix_lowercase_description if {
+	tree := {"nodes": [{"type": "taskcall", "name": "handle_error | show error and stop", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.name_casing(tree, node)
+	v.rule_id == "L025"
+}
+
+test_L025_no_fire_pipe_prefix_multiple_pipes if {
+	tree := {"nodes": [{"type": "taskcall", "name": "role | sub | Do the thing", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.name_casing(tree, node)
+}
+
+test_L025_no_fire_play_pipe_prefix_uppercase if {
+	tree := {"nodes": [{"type": "playcall", "name": "setup | Configure hosts", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.name_casing(tree, node)
+}

--- a/src/apme_engine/validators/opa/bundle/L025_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L025_test.rego
@@ -51,3 +51,10 @@ test_L025_no_fire_play_pipe_prefix_uppercase if {
 	node := tree.nodes[0]
 	not rules.name_casing(tree, node)
 }
+
+test_L025_fires_trailing_pipe_by_falling_back_to_full_name if {
+	tree := {"nodes": [{"type": "taskcall", "name": "handle_error | ", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.name_casing(tree, node)
+	v.rule_id == "L025"
+}

--- a/tests/fixtures/terrible-playbook/site.yml
+++ b/tests/fixtures/terrible-playbook/site.yml
@@ -195,10 +195,11 @@
         path: /tmp/installer.sh
         state: absent
 
-    # L043: deprecated bare vars
-    - name: Use bare variable
+    # L043: deprecated bare vars (bare name in with_items, should be {{ mylist }})
+    - name: Use bare variable in loop
       debug:
-        msg: "Port is $Server_Port"
+        msg: "{{ item }}"
+      with_items: mylist
 
     # community.general with argspec violations (P002/P003)
     - name: Manage INI file with wrong args

--- a/tests/test_yaml_lines_graph_rules.py
+++ b/tests/test_yaml_lines_graph_rules.py
@@ -532,8 +532,8 @@ class TestL043DeprecatedBareVarsGraphRule:
         """
         return DeprecatedBareVarsGraphRule()
 
-    def test_violation_bare_jinja_var(self, rule: DeprecatedBareVarsGraphRule) -> None:
-        """Violation for bare ``{{ var }}`` without a filter.
+    def test_violation_bare_with_items(self, rule: DeprecatedBareVarsGraphRule) -> None:
+        """Violation when ``with_items`` has a bare variable name.
 
         Args:
             rule: Rule instance under test.
@@ -541,16 +541,16 @@ class TestL043DeprecatedBareVarsGraphRule:
         Returns:
             None
         """
-        g, tid = _make_task(yaml_lines='msg: "{{ myvar }}"\n')
+        g, tid = _make_task(options={"with_items": "mylist"})
         result = rule.process(g, tid)
         assert result is not None
         assert result.verdict is True
         assert result.detail is not None
         bare_vars = cast(list[str], result.detail.get("bare_vars") or [])
-        assert "{{ myvar }}" in bare_vars
+        assert any("mylist" in bv for bv in bare_vars)
 
-    def test_pass_jinja_with_filter(self, rule: DeprecatedBareVarsGraphRule) -> None:
-        """Pass when Jinja uses a filter (non-bare form).
+    def test_pass_with_items_jinja_wrapped(self, rule: DeprecatedBareVarsGraphRule) -> None:
+        """Pass when ``with_items`` uses ``{{ var }}``.
 
         Args:
             rule: Rule instance under test.
@@ -558,10 +558,52 @@ class TestL043DeprecatedBareVarsGraphRule:
         Returns:
             None
         """
-        g, tid = _make_task(yaml_lines="msg: \"{{ myvar | default('x') }}\"\n")
+        g, tid = _make_task(options={"with_items": "{{ mylist }}"})
         result = rule.process(g, tid)
         assert result is not None
         assert result.verdict is False
+
+    def test_pass_normal_jinja_in_string(self, rule: DeprecatedBareVarsGraphRule) -> None:
+        """Pass for standard ``{{ var }}`` usage in module args — not a bare variable.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None
+        """
+        g, tid = _make_task(
+            yaml_lines='msg: "{{ myvar }}"\n',
+            module_options={"msg": "{{ myvar }}"},
+        )
+        result = rule.process(g, tid)
+        assert result is None or result.verdict is False
+
+    def test_pass_no_loop_directive(self, rule: DeprecatedBareVarsGraphRule) -> None:
+        """Pass when task has no ``with_*`` directive at all.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None
+        """
+        g, tid = _make_task(options={"when": "some_condition"})
+        assert rule.match(g, tid) is False
+
+    def test_violation_bare_with_dict(self, rule: DeprecatedBareVarsGraphRule) -> None:
+        """Violation when ``with_dict`` has a bare variable name.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None
+        """
+        g, tid = _make_task(options={"with_dict": "my_mapping"})
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is True
 
 
 # ---------------------------------------------------------------------------
@@ -924,7 +966,7 @@ class TestM014TopLevelFactVariablesGraphRule:
         return TopLevelFactVariablesGraphRule()
 
     def test_violation_deprecated_ansible_fact_var(self, rule: TopLevelFactVariablesGraphRule) -> None:
-        """Violation for ``ansible_*`` fact names removed in 2.24 (not magic vars).
+        """Violation for known deprecated setup-module facts (e.g. ``ansible_distribution``).
 
         Args:
             rule: Rule instance under test.
@@ -932,13 +974,13 @@ class TestM014TopLevelFactVariablesGraphRule:
         Returns:
             None
         """
-        g, tid = _make_task(yaml_lines="msg: {{ ansible_eth0 }}\n")
+        g, tid = _make_task(yaml_lines="msg: {{ ansible_distribution }}\n")
         result = rule.process(g, tid)
         assert result is not None
         assert result.verdict is True
         assert result.detail is not None
         m014_facts = cast(list[str], result.detail.get("found_facts") or [])
-        assert "ansible_eth0" in m014_facts
+        assert "ansible_distribution" in m014_facts
 
     def test_pass_magic_ansible_var_allowed(self, rule: TopLevelFactVariablesGraphRule) -> None:
         """Pass when only allowed magic ``ansible_*`` variables appear.
@@ -950,6 +992,20 @@ class TestM014TopLevelFactVariablesGraphRule:
             None
         """
         g, tid = _make_task(yaml_lines="msg: {{ ansible_play_name }}\n")
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is False
+
+    def test_pass_user_defined_ansible_prefix(self, rule: TopLevelFactVariablesGraphRule) -> None:
+        """Pass for user-defined variables that happen to start with ``ansible_``.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None
+        """
+        g, tid = _make_task(yaml_lines="msg: {{ ansible_controller_collection_installed }}\n")
         result = rule.process(g, tid)
         assert result is not None
         assert result.verdict is False


### PR DESCRIPTION
## Summary
- Fixes widespread false positives found when scanning the Infra.Aap Configuration collection (run `253d109b`): L043 (275 hits), L039 (324), M014 (150), and L025 (40).
- L025 and L084 work together: L084 requires `filename | Description` in non-main role task files; L025 now checks capitalization only on the description portion after ` | `.
- Follow-up review fixes tighten the new L039 builtin exclusions and make L025 deterministic for malformed names ending in ` | `.

## Changes
- **L025 (OPA):** Add `_effective_first()` to skip the filename prefix before ` | ` when checking task/play name casing; add Rego tests for pipe-prefixed names.
- **L043 (native):** Restrict detection to bare variable names in `with_*` loop directives (no `{{ }}`); stop flagging normal `{{ var }}` usage in strings.
- **L039 (native):** Expand `_JINJA_BUILTINS` and exclude identifiers after `|` in bare `when`/`changed_when` expressions (filter names like `to_datetime`).
- **M014 (native):** Replace blocklist approach with explicit `DEPRECATED_FACTS` set of known setup-module facts; user-defined `ansible_*` variables no longer flagged.
- **Review follow-up:** Remove overly generic names from the L039 builtin set now that pipe filters are parsed explicitly, and add a trailing-separator regression test for L025.
- Update tests, terrible-playbook fixture, rule catalog, and lint rule mapping.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2577 passed)
- [x] OPA bundle tests for L025 pass (177/177 in container)
- [ ] Re-scan Infra.Aap Configuration to confirm violation counts drop (L025 ~0, L043 only real bare `with_*` cases)