### PR TITLE
fix(catalog): escape pipe characters in auto-generated RULE_CATALOG.md

### DIFF
--- a/docs/rules/RULE_CATALOG.md
+++ b/docs/rules/RULE_CATALOG.md
@@ -103,7 +103,7 @@
 | L088 | Native | low | Collection README should document supported ansible-core versions. | Yes | Yes | Yes | — |
 | L089 | Native | low | Plugin Python files should include type hints. | Yes | Yes | Yes | — |
 | L090 | Native | low | Plugin entry files should be small; move helpers to module_utils. | Yes | Yes | Yes | — |
-| L091 | Native | low | Use | bool for bare variables in when conditions. | Yes | — | Yes | — |
+| L091 | Native | low | Use \| bool for bare variables in when conditions. | Yes | — | Yes | — |
 | L092 | Native | low | Avoid loop variable references in task names. | Yes | — | Yes | — |
 | L093 | Native | low | Do not override role defaults/vars with set_fact. | Yes | — | Yes | — |
 | L094 | Native | low | Do not put dynamic dates in templates; breaks change detection. | Yes | — | Yes | — |
@@ -282,7 +282,7 @@
 | L088 | low | Collection README should document supported ansible-core versions. | Yes | Yes | Yes | — |
 | L089 | low | Plugin Python files should include type hints. | Yes | Yes | Yes | — |
 | L090 | low | Plugin entry files should be small; move helpers to module_utils. | Yes | Yes | Yes | — |
-| L091 | low | Use | bool for bare variables in when conditions. | Yes | — | Yes | — |
+| L091 | low | Use \| bool for bare variables in when conditions. | Yes | — | Yes | — |
 | L092 | low | Avoid loop variable references in task names. | Yes | — | Yes | — |
 | L093 | low | Do not override role defaults/vars with set_fact. | Yes | — | Yes | — |
 | L094 | low | Do not put dynamic dates in templates; breaks change detection. | Yes | — | Yes | — |

--- a/tools/generate_rule_catalog.py
+++ b/tools/generate_rule_catalog.py
@@ -381,15 +381,17 @@ def _sort_key(rule: Rule) -> tuple[str, int]:
 
 
 def _escape_md_cell(text: str) -> str:
-    r"""Escape pipe characters for use inside markdown table cells.
+    r"""Escape unescaped pipe characters for use inside markdown table cells.
+
+    Idempotent: already-escaped pipes (``\|``) are left unchanged.
 
     Args:
         text: Raw cell text.
 
     Returns:
-        Text with ``|`` escaped as ``\|``.
+        Text with unescaped ``|`` escaped as ``\|``.
     """
-    return text.replace("|", "\\|")
+    return re.sub(r"(?<!\\)\|", r"\\|", text)
 
 
 def _status_icon(ok: bool) -> str:

--- a/tools/generate_rule_catalog.py
+++ b/tools/generate_rule_catalog.py
@@ -380,6 +380,18 @@ def _sort_key(rule: Rule) -> tuple[str, int]:
     return (prefix, num)
 
 
+def _escape_md_cell(text: str) -> str:
+    r"""Escape pipe characters for use inside markdown table cells.
+
+    Args:
+        text: Raw cell text.
+
+    Returns:
+        Text with ``|`` escaped as ``\|``.
+    """
+    return text.replace("|", "\\|")
+
+
 def _status_icon(ok: bool) -> str:
     """Return a checkmark or X for boolean status.
 
@@ -439,7 +451,7 @@ def generate() -> str:
 
     for r in all_rules:
         lines.append(
-            f"| {r.rule_id} | {r.validator} | {r.severity} | {r.description} "
+            f"| {r.rule_id} | {r.validator} | {r.severity} | {_escape_md_cell(r.description)} "
             f"| {_status_icon(r.has_impl)} | {_status_icon(r.has_test)} "
             f"| {_status_icon(r.has_doc)} | {_status_icon(r.has_fixer)} |"
         )
@@ -465,7 +477,7 @@ def generate() -> str:
         lines.append("|---------|----------|-------------|------|--------|-----|-------|")
         for r in vrules:
             lines.append(
-                f"| {r.rule_id} | {r.severity} | {r.description} "
+                f"| {r.rule_id} | {r.severity} | {_escape_md_cell(r.description)} "
                 f"| {_status_icon(r.has_impl)} | {_status_icon(r.has_test)} "
                 f"| {_status_icon(r.has_doc)} | {_status_icon(r.has_fixer)} |"
             )
@@ -513,7 +525,7 @@ def generate() -> str:
 
     for r in all_rules:
         if r.has_fixer:
-            lines.append(f"| {r.rule_id} | {r.severity} | {r.description} |")
+            lines.append(f"| {r.rule_id} | {r.severity} | {_escape_md_cell(r.description)} |")
 
     lines.append("")
     return "\n".join(lines)


### PR DESCRIPTION
## Summary

- Add `_escape_md_cell()` helper to `generate_rule_catalog.py` that escapes `|` as `\|` in rule descriptions rendered inside markdown table cells
- Regenerated catalog so L091's description ("Use | bool for bare variables in when conditions") no longer breaks the table layout

## Test plan

- [x] Verify L091 row in `docs/rules/RULE_CATALOG.md` renders correctly
- [x] `tox -e lint` passes

Fixes #314

Made with [Cursor](https://cursor.com)