### PR TITLE
refactor(engine): remove dead save_rule_result and ari_result references

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(gh pr *)",
-      "Bash(git fetch *)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr *)",
+      "Bash(git fetch *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ apme-cache/
 # Generated artifacts
 graph.html
 
+# Local Claude/Cursor settings
+.claude/settings.local.json
+
 # OS
 .DS_Store
 Thumbs.db

--- a/src/apme_engine/engine/findings.py
+++ b/src/apme_engine/engine/findings.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from copy import deepcopy
 from dataclasses import dataclass, field
 
@@ -85,26 +84,6 @@ class Findings:
                 unlock_file(lock)
                 remove_lock_file(lock)
         return str(json_str)
-
-    def save_rule_result(self, fpath: str = "") -> str:
-        """Save the rule result from report as JSON to a file.
-
-        Creates parent directories if needed. Uses standard JSON (not jsonpickle).
-
-        Args:
-            fpath: Path to write the rule result JSON. If empty, only returns string.
-
-        Returns:
-            JSON string of the rule result.
-        """
-        json_str: str = jsonpickle.encode(self.report.get("ari_result", {}), make_refs=False, unpicklable=False)
-        if fpath:
-            rule_result_dir = os.path.dirname(fpath)
-            if not os.path.exists(rule_result_dir):
-                os.makedirs(rule_result_dir, exist_ok=True)
-            with open(fpath, "w") as file:
-                file.write(json_str)
-        return json_str
 
     @staticmethod
     def load(fpath: str = "", json_str: str = "") -> Findings:

--- a/src/apme_engine/engine/result_writer.py
+++ b/src/apme_engine/engine/result_writer.py
@@ -1,4 +1,4 @@
-"""Disk I/O helpers for saving scan artifacts (definitions, rule results)."""
+"""Disk I/O helpers for saving scan artifacts (definitions)."""
 
 from __future__ import annotations
 
@@ -6,27 +6,6 @@ import os
 from pathlib import Path
 
 import jsonpickle
-
-from .findings import Findings
-
-
-def save_rule_result(findings: Findings, out_dir: str) -> None:
-    """Save rule result JSON to out_dir.
-
-    Args:
-        findings: Findings containing rule results.
-        out_dir: Output directory path.
-
-    Raises:
-        ValueError: If out_dir is empty.
-    """
-    if out_dir == "":
-        raise ValueError("output dir must be a non-empty value")
-
-    if not os.path.exists(out_dir):
-        os.makedirs(out_dir, exist_ok=True)
-
-    findings.save_rule_result(fpath=os.path.join(out_dir, "rule_result.json"))
 
 
 def save_definitions(definitions: dict[str, object], out_dir: str) -> None:

--- a/src/apme_engine/engine/scanner.py
+++ b/src/apme_engine/engine/scanner.py
@@ -394,7 +394,7 @@ class AnsibleProjectLoader:
         if scandata.out_dir is not None and scandata.out_dir != "" and findings is not None and objects:
             self.save_definitions(cast(dict[str, object], scandata.root_definitions), scandata.out_dir)
             if not self.silent:
-                print(f"The objects is saved at {scandata.out_dir}")
+                print(f"Object definitions saved to {scandata.out_dir}")
 
         if not self.silent and findings is not None:
             summary = summarize_findings(findings, self.show_all)

--- a/src/apme_engine/engine/scanner.py
+++ b/src/apme_engine/engine/scanner.py
@@ -391,15 +391,10 @@ class AnsibleProjectLoader:
             self.register_findings_to_ram(findings)
             self.register_indices_to_ram(findings, include_test_contents)
 
-        if scandata.out_dir is not None and scandata.out_dir != "" and findings is not None:
-            self.save_rule_result(findings, scandata.out_dir)
+        if scandata.out_dir is not None and scandata.out_dir != "" and findings is not None and objects:
+            self.save_definitions(cast(dict[str, object], scandata.root_definitions), scandata.out_dir)
             if not self.silent:
-                print(f"The rule result is saved at {scandata.out_dir}")
-
-            if objects:
-                self.save_definitions(cast(dict[str, object], scandata.root_definitions), scandata.out_dir)
-                if not self.silent:
-                    print(f"The objects is saved at {scandata.out_dir}")
+                print(f"The objects is saved at {scandata.out_dir}")
 
         if not self.silent and findings is not None:
             summary = summarize_findings(findings, self.show_all)
@@ -495,18 +490,6 @@ class AnsibleProjectLoader:
         """
         if self.ram_client is not None:
             self.ram_client.save_findings(findings, out_dir)
-
-    def save_rule_result(self, findings: Findings, out_dir: str) -> None:
-        """Save rule result JSON to out_dir.
-
-        Args:
-            findings: Findings containing rule results.
-            out_dir: Output directory path.
-
-        """
-        from .result_writer import save_rule_result
-
-        save_rule_result(findings, out_dir)
 
     def save_definitions(self, definitions: dict[str, object], out_dir: str) -> None:
         """Save definition objects to objects.json in out_dir.


### PR DESCRIPTION
## Summary

- Remove `Findings.save_rule_result()`, `result_writer.save_rule_result()`, and `AnsibleProjectLoader.save_rule_result()`
- The `ari_result` report key was never written (report stores `hierarchy_payload`), so the method always serialized `{}`
- The call site was guarded by `out_dir != ""` which APME never sets, making the entire chain dead code

## Test plan

- [x] `tox -e lint` passes
- [x] No tests reference `save_rule_result` or `ari_result` (confirmed via grep)
- [ ] `tox -e unit` passes

Fixes #245

Made with [Cursor](https://cursor.com)