### PR TITLE
refactor(engine): defer scanner module-level logger setup

### DIFF
--- a/src/apme_engine/engine/logger.py
+++ b/src/apme_engine/engine/logger.py
@@ -15,23 +15,33 @@ log_level_map = {
 }
 
 
-def set_logger_channel(channel: str = "") -> None:
+def set_logger_channel(channel: str = "") -> bool:
     """Configure the module logger with a channel name and stdout handler.
 
-    Idempotent: if the logger has already been configured, subsequent calls
-    are no-ops (the channel, handler, and formatter are unchanged).
+    Idempotent: if the module logger has already been configured, subsequent
+    calls are no-ops. If the underlying stdlib logger already has handlers
+    (e.g. configured by the embedding application via dictConfig), no new
+    handler is added and the caller's configuration is preserved.
 
     Args:
         channel: Logger name (e.g. module path). Empty for root logger.
+
+    Returns:
+        True if this call performed first-time initialization, False if
+        the logger was already configured (either by a prior call or by
+        the embedding application).
     """
     global _logger
     if _logger is not None:
-        return
+        return False
     _logger = logging.getLogger(channel)
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
-    handler.setFormatter(formatter)
-    _logger.addHandler(handler)
+    if not _logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+        handler.setFormatter(formatter)
+        _logger.addHandler(handler)
+        _logger.propagate = False
+    return True
 
 
 def is_configured() -> bool:

--- a/src/apme_engine/engine/logger.py
+++ b/src/apme_engine/engine/logger.py
@@ -18,13 +18,17 @@ log_level_map = {
 def set_logger_channel(channel: str = "") -> None:
     """Configure the module logger with a channel name and stdout handler.
 
+    Idempotent: subsequent calls reuse the existing handler rather than
+    adding duplicates.
+
     Args:
         channel: Logger name (e.g. module path). Empty for root logger.
     """
     global _logger
+    if _logger is not None:
+        return
     _logger = logging.getLogger(channel)
     handler = logging.StreamHandler(sys.stdout)
-    # default formatter
     formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
     handler.setFormatter(formatter)
     _logger.addHandler(handler)

--- a/src/apme_engine/engine/logger.py
+++ b/src/apme_engine/engine/logger.py
@@ -34,6 +34,15 @@ def set_logger_channel(channel: str = "") -> None:
     _logger.addHandler(handler)
 
 
+def is_configured() -> bool:
+    """Return whether the module logger has been initialized.
+
+    Returns:
+        True if the logger has been set up via set_logger_channel().
+    """
+    return _logger is not None
+
+
 def set_log_level(level_str: str = "info") -> None:
     """Set the log level for the module logger.
 

--- a/src/apme_engine/engine/logger.py
+++ b/src/apme_engine/engine/logger.py
@@ -18,8 +18,8 @@ log_level_map = {
 def set_logger_channel(channel: str = "") -> None:
     """Configure the module logger with a channel name and stdout handler.
 
-    Idempotent: subsequent calls reuse the existing handler rather than
-    adding duplicates.
+    Idempotent: if the logger has already been configured, subsequent calls
+    are no-ops (the channel, handler, and formatter are unchanged).
 
     Args:
         channel: Logger name (e.g. module path). Empty for root logger.

--- a/src/apme_engine/engine/logger.py
+++ b/src/apme_engine/engine/logger.py
@@ -35,12 +35,13 @@ def set_logger_channel(channel: str = "") -> bool:
     if _logger is not None:
         return False
     _logger = logging.getLogger(channel)
-    if not _logger.handlers:
-        handler = logging.StreamHandler(sys.stdout)
-        formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
-        handler.setFormatter(formatter)
-        _logger.addHandler(handler)
-        _logger.propagate = False
+    if _logger.handlers:
+        return False
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+    handler.setFormatter(formatter)
+    _logger.addHandler(handler)
+    _logger.propagate = False
     return True
 
 

--- a/src/apme_engine/engine/logger.py
+++ b/src/apme_engine/engine/logger.py
@@ -19,23 +19,24 @@ def set_logger_channel(channel: str = "") -> bool:
     """Configure the module logger with a channel name and stdout handler.
 
     Idempotent: if the module logger has already been configured, subsequent
-    calls are no-ops. If the underlying stdlib logger already has handlers
-    (e.g. configured by the embedding application via dictConfig), no new
-    handler is added and the caller's configuration is preserved.
+    calls are no-ops. If the underlying stdlib logger (or any ancestor in the
+    hierarchy) already has handlers — e.g. configured by the embedding
+    application via basicConfig() or dictConfig() — no new handler is added
+    and the caller's configuration is preserved.
 
     Args:
         channel: Logger name (e.g. module path). Empty for root logger.
 
     Returns:
-        True if this call performed first-time initialization, False if
-        the logger was already configured (either by a prior call or by
-        the embedding application).
+        True if this call installed a fresh handler, False if the logger was
+        already configured (either by a prior call or by the embedding
+        application's hierarchy).
     """
     global _logger
     if _logger is not None:
         return False
     _logger = logging.getLogger(channel)
-    if _logger.handlers:
+    if _logger.hasHandlers():
         return False
     handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")

--- a/src/apme_engine/engine/scanner.py
+++ b/src/apme_engine/engine/scanner.py
@@ -78,8 +78,12 @@ class AnsibleProjectLoader:
 
     def __post_init__(self) -> None:
         """Initialize RAM client, parser, and logger."""
+        from . import logger as _logger_mod
+
+        needs_level = _logger_mod._logger is None
         logger.set_logger_channel("apme.loader")
-        logger.set_log_level("info")
+        if needs_level:
+            logger.set_log_level("info")
         if not self.root_dir:
             self.root_dir = os.path.expanduser("~/.apme-data")
         if not self.ram_client:

--- a/src/apme_engine/engine/scanner.py
+++ b/src/apme_engine/engine/scanner.py
@@ -78,9 +78,7 @@ class AnsibleProjectLoader:
 
     def __post_init__(self) -> None:
         """Initialize RAM client, parser, and logger."""
-        from . import logger as _logger_mod
-
-        needs_level = _logger_mod._logger is None
+        needs_level = not logger.is_configured()
         logger.set_logger_channel("apme.loader")
         if needs_level:
             logger.set_log_level("info")

--- a/src/apme_engine/engine/scanner.py
+++ b/src/apme_engine/engine/scanner.py
@@ -78,9 +78,8 @@ class AnsibleProjectLoader:
 
     def __post_init__(self) -> None:
         """Initialize RAM client, parser, and logger."""
-        needs_level = not logger.is_configured()
-        logger.set_logger_channel("apme.loader")
-        if needs_level:
+        first_init = logger.set_logger_channel("apme.loader")
+        if first_init:
             logger.set_log_level("info")
         if not self.root_dir:
             self.root_dir = os.path.expanduser("~/.apme-data")

--- a/src/apme_engine/engine/scanner.py
+++ b/src/apme_engine/engine/scanner.py
@@ -26,9 +26,6 @@ from .utils import (
     summarize_findings,
 )
 
-logger.set_logger_channel("apme.loader")
-logger.set_log_level("info")
-
 
 @dataclass
 class AnsibleProjectLoader:
@@ -80,7 +77,9 @@ class AnsibleProjectLoader:
     _current: SingleScan | None = None
 
     def __post_init__(self) -> None:
-        """Initialize RAM client and parser."""
+        """Initialize RAM client, parser, and logger."""
+        logger.set_logger_channel("apme.loader")
+        logger.set_log_level("info")
         if not self.root_dir:
             self.root_dir = os.path.expanduser("~/.apme-data")
         if not self.ram_client:

--- a/tests/test_engine_logger.py
+++ b/tests/test_engine_logger.py
@@ -35,3 +35,25 @@ def test_set_logger_channel_idempotent() -> None:
     result = logger_mod.set_logger_channel("test.idempotent")
     assert result is False
     assert len(stdlib_logger.handlers) == handler_count
+
+
+def test_preconfigured_logger_preserved() -> None:
+    """When the stdlib logger already has handlers, set_logger_channel is a no-op."""
+    import apme_engine.engine.logger as logger_mod
+
+    importlib.reload(logger_mod)
+
+    channel = "test.preconfigured"
+    stdlib_logger = logging.getLogger(channel)
+    existing_handler = logging.StreamHandler(sys.stderr)
+    stdlib_logger.addHandler(existing_handler)
+    stdlib_logger.setLevel(logging.DEBUG)
+
+    try:
+        result = logger_mod.set_logger_channel(channel)
+        assert result is False
+        assert len(stdlib_logger.handlers) == 1
+        assert stdlib_logger.handlers[0] is existing_handler
+        assert stdlib_logger.level == logging.DEBUG
+    finally:
+        stdlib_logger.removeHandler(existing_handler)

--- a/tests/test_engine_logger.py
+++ b/tests/test_engine_logger.py
@@ -26,15 +26,23 @@ def test_set_logger_channel_idempotent() -> None:
 
     importlib.reload(logger_mod)
 
-    result = logger_mod.set_logger_channel("test.idempotent")
-    assert result is True
+    root = logging.getLogger()
+    saved_root_handlers = root.handlers[:]
+    root.handlers.clear()
+    try:
+        result = logger_mod.set_logger_channel("test.idempotent")
+        assert result is True
 
-    stdlib_logger = logging.getLogger("test.idempotent")
-    handler_count = len(stdlib_logger.handlers)
+        stdlib_logger = logging.getLogger("test.idempotent")
+        handler_count = len(stdlib_logger.handlers)
 
-    result = logger_mod.set_logger_channel("test.idempotent")
-    assert result is False
-    assert len(stdlib_logger.handlers) == handler_count
+        result = logger_mod.set_logger_channel("test.idempotent")
+        assert result is False
+        assert len(stdlib_logger.handlers) == handler_count
+    finally:
+        logging.getLogger("test.idempotent").handlers.clear()
+        logging.getLogger("test.idempotent").propagate = True
+        root.handlers = saved_root_handlers
 
 
 def test_preconfigured_logger_preserved() -> None:

--- a/tests/test_engine_logger.py
+++ b/tests/test_engine_logger.py
@@ -53,6 +53,8 @@ def test_preconfigured_logger_preserved() -> None:
 
     channel = "test.preconfigured"
     stdlib_logger = logging.getLogger(channel)
+    saved_level = stdlib_logger.level
+    saved_propagate = stdlib_logger.propagate
     existing_handler = logging.StreamHandler(sys.stderr)
     stdlib_logger.addHandler(existing_handler)
     stdlib_logger.setLevel(logging.DEBUG)
@@ -65,3 +67,5 @@ def test_preconfigured_logger_preserved() -> None:
         assert stdlib_logger.level == logging.DEBUG
     finally:
         stdlib_logger.removeHandler(existing_handler)
+        stdlib_logger.setLevel(saved_level)
+        stdlib_logger.propagate = saved_propagate

--- a/tests/test_engine_logger.py
+++ b/tests/test_engine_logger.py
@@ -3,19 +3,22 @@
 from __future__ import annotations
 
 import importlib
+import sys
 
 
 def test_no_import_time_logger_setup() -> None:
     """Importing scanner does not configure the module logger."""
     import apme_engine.engine.logger as logger_mod
 
-    # Reset logger state then reload scanner to simulate a fresh import
+    # Reset logger state to simulate a clean slate
     importlib.reload(logger_mod)
     assert logger_mod._logger is None
 
+    # Evict scanner so the next import re-executes its module-level code
+    sys.modules.pop("apme_engine.engine.scanner", None)
     import apme_engine.engine.scanner  # noqa: F401
 
-    importlib.reload(logger_mod)
+    # Check _logger *without* reloading logger_mod — reload would reset it
     assert logger_mod._logger is None
 
 

--- a/tests/test_engine_logger.py
+++ b/tests/test_engine_logger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 
 
@@ -10,16 +11,13 @@ def test_no_import_time_logger_setup() -> None:
     """Importing scanner does not configure the module logger."""
     import apme_engine.engine.logger as logger_mod
 
-    # Reset logger state to simulate a clean slate
     importlib.reload(logger_mod)
-    assert logger_mod._logger is None
+    assert not logger_mod.is_configured()
 
-    # Evict scanner so the next import re-executes its module-level code
     sys.modules.pop("apme_engine.engine.scanner", None)
-    import apme_engine.engine.scanner  # noqa: F401
+    importlib.import_module("apme_engine.engine.scanner")
 
-    # Check _logger *without* reloading logger_mod — reload would reset it
-    assert logger_mod._logger is None
+    assert not logger_mod.is_configured()
 
 
 def test_set_logger_channel_idempotent() -> None:
@@ -28,10 +26,12 @@ def test_set_logger_channel_idempotent() -> None:
 
     importlib.reload(logger_mod)
 
-    logger_mod.set_logger_channel("test.channel")
-    assert logger_mod._logger is not None
-    handler_count = len(logger_mod._logger.handlers)
+    result = logger_mod.set_logger_channel("test.idempotent")
+    assert result is True
 
-    # Second call should be a no-op
-    logger_mod.set_logger_channel("test.channel")
-    assert len(logger_mod._logger.handlers) == handler_count
+    stdlib_logger = logging.getLogger("test.idempotent")
+    handler_count = len(stdlib_logger.handlers)
+
+    result = logger_mod.set_logger_channel("test.idempotent")
+    assert result is False
+    assert len(stdlib_logger.handlers) == handler_count

--- a/tests/test_engine_logger.py
+++ b/tests/test_engine_logger.py
@@ -1,0 +1,29 @@
+"""Tests for apme_engine.engine.logger — no import-time side effects."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_no_import_time_logger_setup() -> None:
+    """Importing scanner does not configure the module logger."""
+    import apme_engine.engine.logger as logger_mod
+
+    # Reload to simulate fresh import
+    importlib.reload(logger_mod)
+    assert logger_mod._logger is None
+
+
+def test_set_logger_channel_idempotent() -> None:
+    """Calling set_logger_channel multiple times does not add duplicate handlers."""
+    import apme_engine.engine.logger as logger_mod
+
+    importlib.reload(logger_mod)
+
+    logger_mod.set_logger_channel("test.channel")
+    assert logger_mod._logger is not None
+    handler_count = len(logger_mod._logger.handlers)
+
+    # Second call should be a no-op
+    logger_mod.set_logger_channel("test.channel")
+    assert len(logger_mod._logger.handlers) == handler_count

--- a/tests/test_engine_logger.py
+++ b/tests/test_engine_logger.py
@@ -69,3 +69,40 @@ def test_preconfigured_logger_preserved() -> None:
         stdlib_logger.removeHandler(existing_handler)
         stdlib_logger.setLevel(saved_level)
         stdlib_logger.propagate = saved_propagate
+
+
+def test_ancestor_handler_prevents_handler_installation() -> None:
+    """When a root/ancestor logger has handlers, set_logger_channel skips installation.
+
+    Regression test: hasHandlers() walks up the logger hierarchy, so a root
+    logger configured via basicConfig()/dictConfig() prevents duplicate handler
+    installation even when the named logger itself has no direct handlers.
+    """
+    import apme_engine.engine.logger as logger_mod
+
+    importlib.reload(logger_mod)
+
+    channel = "test.ancestor.child"
+    stdlib_logger = logging.getLogger(channel)
+    saved_handlers = stdlib_logger.handlers[:]
+    saved_propagate = stdlib_logger.propagate
+    stdlib_logger.handlers.clear()
+    stdlib_logger.propagate = True
+
+    root = logging.getLogger()
+    saved_root_handlers = root.handlers[:]
+    root_handler = logging.StreamHandler(sys.stderr)
+    root.addHandler(root_handler)
+
+    try:
+        assert stdlib_logger.hasHandlers() is True
+        assert len(stdlib_logger.handlers) == 0
+
+        result = logger_mod.set_logger_channel(channel)
+        assert result is False
+        assert len(stdlib_logger.handlers) == 0
+    finally:
+        root.removeHandler(root_handler)
+        root.handlers = saved_root_handlers
+        stdlib_logger.handlers = saved_handlers
+        stdlib_logger.propagate = saved_propagate

--- a/tests/test_engine_logger.py
+++ b/tests/test_engine_logger.py
@@ -9,7 +9,12 @@ def test_no_import_time_logger_setup() -> None:
     """Importing scanner does not configure the module logger."""
     import apme_engine.engine.logger as logger_mod
 
-    # Reload to simulate fresh import
+    # Reset logger state then reload scanner to simulate a fresh import
+    importlib.reload(logger_mod)
+    assert logger_mod._logger is None
+
+    import apme_engine.engine.scanner  # noqa: F401
+
     importlib.reload(logger_mod)
     assert logger_mod._logger is None
 


### PR DESCRIPTION
## Summary

- Move `set_logger_channel("apme.loader")` and `set_log_level("info")` from module scope into `AnsibleProjectLoader.__post_init__()`
- Prevents importing `scanner.py` from unconditionally installing a StreamHandler and forcing INFO level, which could override the caller's logging configuration
- `set_logger_channel()` returns a bool: `True` only when it installs a fresh handler; `False` when already called or when the logger hierarchy has pre-existing handlers
- Uses `Logger.hasHandlers()` to detect handlers anywhere in the hierarchy (including ancestor/root loggers from `basicConfig()` or `dictConfig()`)
- Disables propagation only when installing our own handler
- Tests use only public APIs, clean up logger state in `finally` blocks, and cover the pre-configured handler regression boundary

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2559 tests)

Fixes #246

Made with [Cursor](https://cursor.com)