### PR TITLE
docs(venv-manager): document unsafe-best-match index strategy trade-off

### DIFF
--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -227,6 +227,31 @@ Collections are installed into the venv's `site-packages/ansible_collections/` d
 
 The Ansible validator requires a `venv_path` from the Primary orchestrator. If none is provided (e.g., standalone testing without Primary), the validator returns an infrastructure error and skips validation.
 
+### Galaxy Proxy index strategy (`unsafe-best-match`)
+
+When the venv manager installs collections into session-scoped venvs via
+`uv pip install`, it uses `--index-strategy unsafe-best-match`.  This is a
+deliberate trade-off:
+
+- Galaxy Proxy serves collection tarballs as Python wheels under
+  collection-namespaced package names (e.g.
+  `ansible-collection-community-vmware`).  These names do not exist on PyPI,
+  so dependency-confusion risk is low in practice.
+- The alternative strategy (`first-match`) causes transitive dependencies to
+  fail resolution when they exist only on PyPI but not on the Galaxy Proxy
+  index.
+
+**Risk assessment:** Because the Galaxy Proxy acts as a `--extra-index-url`
+alongside PyPI, `unsafe-best-match` picks the highest version across both
+indexes.  In theory an attacker who registered matching package names on PyPI
+could hijack resolution.  In practice the collection-namespaced names are not
+on PyPI, and the transitive deps (standard Python packages) resolve correctly
+from PyPI.
+
+If your environment has stricter dependency policies (e.g. air-gapped or
+internal registries), you can override the strategy by setting the
+`UV_INDEX_STRATEGY` environment variable in the Primary container.
+
 ## Local development (daemon mode)
 
 For development and testing without the Podman pod, the CLI can start a

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -249,8 +249,11 @@ on PyPI, and the transitive deps (standard Python packages) resolve correctly
 from PyPI.
 
 If your environment has stricter dependency policies (e.g. air-gapped or
-internal registries), you can override the strategy by setting the
-`UV_INDEX_STRATEGY` environment variable in the Primary container.
+internal registries), note that the `UV_INDEX_STRATEGY` environment variable
+**will not** override this setting because the CLI flag takes precedence.
+To change the strategy, set the `APME_UV_INDEX_STRATEGY` environment variable
+in the Primary container — the venv manager reads this at runtime and passes
+it as the `--index-strategy` argument to `uv pip install`.
 
 ## Local development (daemon mode)
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -230,8 +230,8 @@ The Ansible validator requires a `venv_path` from the Primary orchestrator. If n
 ### Galaxy Proxy index strategy (`unsafe-best-match`)
 
 When the venv manager installs collections into session-scoped venvs via
-`uv pip install`, it uses `--index-strategy unsafe-best-match`.  This is a
-deliberate trade-off:
+`uv pip install`, it defaults to `--index-strategy unsafe-best-match`.  This is
+a deliberate trade-off:
 
 - Galaxy Proxy serves collection tarballs as Python wheels under
   collection-namespaced package names (e.g.

--- a/src/apme_engine/venv_manager/session.py
+++ b/src/apme_engine/venv_manager/session.py
@@ -187,7 +187,7 @@ def _run_pip_install(
             "--extra-index-url",
             simple_url,
             "--index-strategy",
-            "unsafe-best-match",
+            os.environ.get("APME_UV_INDEX_STRATEGY", "unsafe-best-match"),
         ]
         if exclude_file is not None:
             cmd.extend(["--excludes", str(exclude_file)])

--- a/src/apme_engine/venv_manager/session.py
+++ b/src/apme_engine/venv_manager/session.py
@@ -187,7 +187,7 @@ def _run_pip_install(
             "--extra-index-url",
             simple_url,
             "--index-strategy",
-            os.environ.get("APME_UV_INDEX_STRATEGY", "unsafe-best-match"),
+            os.environ.get("APME_UV_INDEX_STRATEGY", "").strip() or "unsafe-best-match",
         ]
         if exclude_file is not None:
             cmd.extend(["--excludes", str(exclude_file)])

--- a/tests/test_venv_session.py
+++ b/tests/test_venv_session.py
@@ -1,6 +1,7 @@
 """Tests for session-scoped venv manager (multi-version layout)."""
 
 import json
+import os
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -569,6 +570,68 @@ class TestProtoRoundTrip:
 
         opts = FixOptions(session_id="ci-job-42", ansible_core_version="2.17.0")
         assert opts.session_id == "ci-job-42"
+
+
+class TestRunPipInstallIndexStrategy:
+    """Tests for APME_UV_INDEX_STRATEGY env var override in _run_pip_install."""
+
+    def test_default_strategy(self) -> None:
+        """Default index strategy is unsafe-best-match when env var is unset."""
+        from apme_engine.venv_manager.session import _run_pip_install
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("apme_engine.venv_manager.session.subprocess.run", return_value=mock_result) as mock_run,
+        ):
+            os.environ.pop("APME_UV_INDEX_STRATEGY", None)
+            _run_pip_install(Path("/venv/bin/python"), ["pkg"], "http://proxy", use_uv=True)
+
+        cmd = mock_run.call_args[0][0]
+        idx = cmd.index("--index-strategy")
+        assert cmd[idx + 1] == "unsafe-best-match"
+
+    def test_custom_strategy(self) -> None:
+        """APME_UV_INDEX_STRATEGY overrides the default strategy."""
+        from apme_engine.venv_manager.session import _run_pip_install
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with (
+            patch.dict(os.environ, {"APME_UV_INDEX_STRATEGY": "first-match"}),
+            patch("apme_engine.venv_manager.session.subprocess.run", return_value=mock_result) as mock_run,
+        ):
+            _run_pip_install(Path("/venv/bin/python"), ["pkg"], "http://proxy", use_uv=True)
+
+        cmd = mock_run.call_args[0][0]
+        idx = cmd.index("--index-strategy")
+        assert cmd[idx + 1] == "first-match"
+
+    def test_empty_env_var_falls_back_to_default(self) -> None:
+        """Empty or whitespace-only APME_UV_INDEX_STRATEGY falls back to default."""
+        from apme_engine.venv_manager.session import _run_pip_install
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with (
+            patch.dict(os.environ, {"APME_UV_INDEX_STRATEGY": "  "}),
+            patch("apme_engine.venv_manager.session.subprocess.run", return_value=mock_result) as mock_run,
+        ):
+            _run_pip_install(Path("/venv/bin/python"), ["pkg"], "http://proxy", use_uv=True)
+
+        cmd = mock_run.call_args[0][0]
+        idx = cmd.index("--index-strategy")
+        assert cmd[idx + 1] == "unsafe-best-match"
 
 
 class TestListInstalledPackages:


### PR DESCRIPTION
## Summary

- Add a new section to `docs/guides/DEPLOYMENT.md` explaining why the venv manager defaults to `--index-strategy unsafe-best-match` when invoking `uv pip install`
- Documents the dependency-confusion risk assessment and the `APME_UV_INDEX_STRATEGY` override for stricter environments
- Add runtime support for `APME_UV_INDEX_STRATEGY` env var to override the default index strategy in `_run_pip_install`, with `.strip()`/empty-string guard to fall back to `unsafe-best-match`
- Add unit tests for the env var override (default, custom, whitespace fallback)

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit -- -k TestRunPipInstallIndexStrategy --no-cov` — 3 tests pass (default strategy, custom override, whitespace fallback)
- [x] Docs wording reflects `unsafe-best-match` as default, not unconditional

Fixes #262

Made with [Cursor](https://cursor.com)