### PR TITLE
feat(cli): add --ansible-core-version alias for --ansible-version

### DIFF
--- a/src/apme_engine/cli/parser.py
+++ b/src/apme_engine/cli/parser.py
@@ -48,6 +48,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     check_p.add_argument(
         "--ansible-version",
+        "--ansible-core-version",
         default=None,
         help="ansible-core version for validation (e.g. 2.18, 2.20)",
     )
@@ -120,6 +121,7 @@ def build_parser() -> argparse.ArgumentParser:
     remediate_p.add_argument("--max-passes", type=int, default=5, help="Max convergence passes (default: 5)")
     remediate_p.add_argument(
         "--ansible-version",
+        "--ansible-core-version",
         default=None,
         help="ansible-core version for validation (e.g. 2.18, 2.20)",
     )


### PR DESCRIPTION
## Summary

- Accept both `--ansible-version` and `--ansible-core-version` on `check` and `remediate` subcommands
- Non-breaking: `--ansible-version` continues to work as before
- The value refers to `ansible-core` versions (e.g. 2.16, 2.18, 2.20), so the alias improves discoverability

## Test plan

- [x] `tox -e lint` passes
- [ ] `tox -e unit` passes
- [ ] Manual: `apme check . --ansible-core-version 2.18` works

Fixes #228

Made with [Cursor](https://cursor.com)