### PR TITLE
refactor(engine): add ContentGraph.apply_yaml() public API for AI fixes

### DIFF
--- a/src/apme_engine/engine/content_graph.py
+++ b/src/apme_engine/engine/content_graph.py
@@ -737,20 +737,26 @@ class ContentGraph:
         fully-formed YAML (e.g. AI-generated fixes).  It applies
         indentation correction consistent with ``apply_transform``.
 
+        Returns False (no-op) when the node does not exist or the
+        resulting content is identical to the current ``yaml_lines``.
+
         Args:
             node_id: Graph node identifier.
             yaml_content: New YAML text for the node.
 
         Returns:
-            True if the node was found and updated.
+            True if the node content actually changed, False otherwise.
         """
         node = self.get_node(node_id)
         if node is None:
             return False
 
         text = yaml_content
-        if node.indent_depth and _detect_indent(text) != node.indent_depth:
+        if _detect_indent(text) != node.indent_depth:
             text = _reindent(text, node.indent_depth)
+
+        if text == node.yaml_lines:
+            return False
 
         node.update_from_yaml(text)
         self._dirty_nodes.add(node_id)

--- a/src/apme_engine/engine/content_graph.py
+++ b/src/apme_engine/engine/content_graph.py
@@ -730,6 +730,32 @@ class ContentGraph:
         """Reset the dirty-node set (called after a convergence pass)."""
         self._dirty_nodes.clear()
 
+    def apply_yaml(self, node_id: str, yaml_content: str) -> bool:
+        """Replace a node's YAML content and mark it dirty.
+
+        This is the public API for callers that already hold
+        fully-formed YAML (e.g. AI-generated fixes).  It applies
+        indentation correction consistent with ``apply_transform``.
+
+        Args:
+            node_id: Graph node identifier.
+            yaml_content: New YAML text for the node.
+
+        Returns:
+            True if the node was found and updated.
+        """
+        node = self.get_node(node_id)
+        if node is None:
+            return False
+
+        text = yaml_content
+        if node.indent_depth and _detect_indent(text) != node.indent_depth:
+            text = _reindent(text, node.indent_depth)
+
+        node.update_from_yaml(text)
+        self._dirty_nodes.add(node_id)
+        return True
+
     def collect_violations(self) -> list[ViolationDict]:
         """Collect all remaining (open) violations from the graph.
 

--- a/src/apme_engine/engine/content_graph.py
+++ b/src/apme_engine/engine/content_graph.py
@@ -734,8 +734,10 @@ class ContentGraph:
         """Replace a node's YAML content and mark it dirty.
 
         This is the public API for callers that already hold
-        fully-formed YAML (e.g. AI-generated fixes).  It applies
-        indentation correction consistent with ``apply_transform``.
+        fully-formed YAML (e.g. AI-generated fixes).  It normalizes
+        indentation to match the node's ``indent_depth`` (including
+        depth 0, unlike ``apply_transform`` which skips depth 0
+        because ruamel already serializes at the correct base indent).
 
         Returns False (no-op) when the node does not exist or the
         resulting content is identical to the current ``yaml_lines``.

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -585,11 +585,11 @@ class GraphRemediationEngine:
             if node is None:
                 continue
 
-            proposed_node_ids.add(node_id)
             applied = graph.apply_yaml(node_id, fix.fixed_snippet)
             if not applied:
                 logger.debug("AI apply_yaml was a no-op for node %s", node_id)
                 continue
+            proposed_node_ids.add(node_id)
             node.record_state(pass_num, "transformed", source="ai")
 
             proposals.append(

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -586,7 +586,10 @@ class GraphRemediationEngine:
                 continue
 
             proposed_node_ids.add(node_id)
-            graph.apply_yaml(node_id, fix.fixed_snippet)
+            applied = graph.apply_yaml(node_id, fix.fixed_snippet)
+            if not applied:
+                logger.debug("AI apply_yaml was a no-op for node %s", node_id)
+                continue
             node.record_state(pass_num, "transformed", source="ai")
 
             proposals.append(
@@ -594,7 +597,7 @@ class GraphRemediationEngine:
                     node_id=node_id,
                     file_path=node.file_path,
                     before_yaml=before_yaml,
-                    after_yaml=fix.fixed_snippet,
+                    after_yaml=node.yaml_lines,
                     rule_ids=fix.rule_ids,
                     explanation=fix.explanation,
                     confidence=fix.confidence,

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -586,8 +586,7 @@ class GraphRemediationEngine:
                 continue
 
             proposed_node_ids.add(node_id)
-            node.update_from_yaml(fix.fixed_snippet)
-            graph._dirty_nodes.add(node_id)  # noqa: SLF001
+            graph.apply_yaml(node_id, fix.fixed_snippet)
             node.record_state(pass_num, "transformed", source="ai")
 
             proposals.append(

--- a/tests/test_node_state.py
+++ b/tests/test_node_state.py
@@ -1194,7 +1194,7 @@ class TestApplyYaml:
 
         result = graph.apply_yaml(node.node_id, "- name: test\n")
         assert result is False
-        assert node.node_id not in graph._dirty_nodes
+        assert node.node_id not in graph.dirty_nodes
 
     def test_content_change_returns_true(self) -> None:
         """apply_yaml returns True and marks dirty when content changes."""
@@ -1205,7 +1205,7 @@ class TestApplyYaml:
 
         result = graph.apply_yaml(node.node_id, "- name: new\n")
         assert result is True
-        assert node.node_id in graph._dirty_nodes
+        assert node.node_id in graph.dirty_nodes
         assert "new" in node.yaml_lines
 
     def test_indent_correction_at_zero(self) -> None:

--- a/tests/test_node_state.py
+++ b/tests/test_node_state.py
@@ -1175,3 +1175,57 @@ class TestIndentPreservation:
 
         restored = _node_from_dict(d)
         assert restored.indent_depth == 4
+
+
+class TestApplyYaml:
+    """Tests for ContentGraph.apply_yaml public API."""
+
+    def test_nonexistent_node_returns_false(self) -> None:
+        """apply_yaml returns False for a node that doesn't exist."""
+        graph = ContentGraph()
+        assert graph.apply_yaml("no-such-node", "- name: test\n") is False
+
+    def test_noop_returns_false(self) -> None:
+        """apply_yaml returns False when content is identical (no dirty mark)."""
+        graph = ContentGraph()
+        node = _make_task(yaml_lines="- name: test\n")
+        node.indent_depth = 0
+        graph.add_node(node)
+
+        result = graph.apply_yaml(node.node_id, "- name: test\n")
+        assert result is False
+        assert node.node_id not in graph._dirty_nodes
+
+    def test_content_change_returns_true(self) -> None:
+        """apply_yaml returns True and marks dirty when content changes."""
+        graph = ContentGraph()
+        node = _make_task(yaml_lines="- name: old\n")
+        node.indent_depth = 0
+        graph.add_node(node)
+
+        result = graph.apply_yaml(node.node_id, "- name: new\n")
+        assert result is True
+        assert node.node_id in graph._dirty_nodes
+        assert "new" in node.yaml_lines
+
+    def test_indent_correction_at_zero(self) -> None:
+        """apply_yaml corrects indentation even when indent_depth is 0."""
+        graph = ContentGraph()
+        node = _make_task(yaml_lines="- name: test\n")
+        node.indent_depth = 0
+        graph.add_node(node)
+
+        result = graph.apply_yaml(node.node_id, "  - name: changed\n")
+        assert result is True
+        assert _detect_indent(node.yaml_lines) == 0
+
+    def test_indent_correction_at_depth(self) -> None:
+        """apply_yaml reindents to match node's indent_depth."""
+        graph = ContentGraph()
+        node = _make_task(yaml_lines="    - name: test\n")
+        node.indent_depth = 4
+        graph.add_node(node)
+
+        result = graph.apply_yaml(node.node_id, "- name: changed\n")
+        assert result is True
+        assert _detect_indent(node.yaml_lines) == 4


### PR DESCRIPTION
## Summary

- Add `ContentGraph.apply_yaml(node_id, yaml_content) -> bool` method that wraps `node.update_from_yaml()`, applies indentation correction (consistent with `apply_transform`), and marks the node dirty via internal state
- Replace the private `graph._dirty_nodes.add(node_id)  # noqa: SLF001` pattern in `GraphRemediationEngine._apply_ai_transforms()` with the new public API

## Test plan

- [x] `tox -e lint` passes (no more `SLF001` suppression needed)
- [ ] `tox -e unit` passes
- [ ] Verify AI remediation still works end-to-end

Fixes #237

Made with [Cursor](https://cursor.com)