### PR TITLE
docs: simplify README and restructure documentation

### DIFF
--- a/.sdlc/context/architecture.md
+++ b/.sdlc/context/architecture.md
@@ -5,7 +5,7 @@
 APME is a multi-container gRPC microservice deployed as a single Podman pod. The Primary service runs the engine (parse → annotate → hierarchy), then fans validation out in parallel to six independent validator backends over a unified gRPC contract. The CLI is ephemeral — run on-the-fly with the project directory mounted.
 
 **Key principles:**
-- All inter-service communication is **gRPC** — no REST, no message queue, no service discovery
+- Validator fan-out and engine orchestration use **gRPC**; Galaxy Proxy is HTTP (PEP 503); Gateway exposes REST (:8080) for external consumers
 - Containers in the same pod share **localhost**; addresses are fixed by convention
 - All gRPC servers use **grpc.aio** (fully async)
 - Blocking work is dispatched via `asyncio.get_event_loop().run_in_executor()`

--- a/.sdlc/context/architecture.md
+++ b/.sdlc/context/architecture.md
@@ -365,7 +365,7 @@ With `--json`, the `diagnostics` key is included when `-v` or `-vv` is set.
 The CLI `health-check` subcommand calls `Health` on all services and reports status:
 
 ```bash
-apme health-check --primary-addr 127.0.0.1:50051
+APME_PRIMARY_ADDRESS=127.0.0.1:50051 apme health-check
 ```
 
 Primary, Native, OPA, Ansible, Gitleaks, Collection Health, and Dep Audit all implement the `Health` RPC. A service returning `status: "ok"` is healthy; any gRPC error marks it degraded.

--- a/.sdlc/context/architecture.md
+++ b/.sdlc/context/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-APME is a multi-container gRPC microservice deployed as a single Podman pod. The Primary service runs the engine (parse → annotate → hierarchy), then fans validation out in parallel to four independent validator backends over a unified gRPC contract. The CLI is ephemeral — run on-the-fly with the project directory mounted.
+APME is a multi-container gRPC microservice deployed as a single Podman pod. The Primary service runs the engine (parse → annotate → hierarchy), then fans validation out in parallel to six independent validator backends over a unified gRPC contract. The CLI is ephemeral — run on-the-fly with the project directory mounted.
 
 **Key principles:**
 - All inter-service communication is **gRPC** — no REST, no message queue, no service discovery
@@ -14,28 +14,33 @@ APME is a multi-container gRPC microservice deployed as a single Podman pod. The
 ## Container Topology
 
 ```
-┌──────────────────────────────── apme-pod ─────────────────────────────┐
-│                                                                        │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐ │
-│  │ Primary  │  │  Native  │  │   OPA    │  │ Ansible  │  │ Gitleaks │ │
-│  │  :50051  │  │  :50055  │  │  :50054  │  │  :50053  │  │  :50056  │ │
-│  │          │  │          │  │          │  │          │  │          │ │
-│  │ engine + │  │ Python   │  │ OPA bin  │  │ ansible- │  │ gitleaks │ │
-│  │ orchestr │  │ rules on │  │ + gRPC   │  │ core     │  │ + gRPC   │ │
-│  │ session  │  │ scandata │  │ wrapper  │  │ venvs    │  │ wrapper  │ │
-│  │  venvs   │  │          │  │          │  │ (ro)     │  │          │ │
-│  └────┬─────┘  └──────────┘  └──────────┘  └──────────┘  └──────────┘ │
-│       │                                                                │
-│  ┌────┴─────────────────────────────────────┐  ┌──────────┐          │
-│  │      Galaxy Proxy :8765 (PEP 503)       │  │ Abbenay  │          │
-│  │  Ansible Galaxy → Python wheels on      │  │  :50057  │          │
-│  │  demand; caching handled by proxy + uv  │  └──────────┘          │
-│  └──────────────────────────────────────────┘                         │
-│  ┌──────────────────────┐  ┌──────────┐                              │
-│  │ Gateway :50060/:8080 │  │ UI :8081 │                              │
-│  │ REST + gRPC + DB     │  │ (nginx)  │                              │
-│  └──────────────────────┘  └──────────┘                              │
-└────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────── apme-pod ──────────────────────────────────┐
+│                                                                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐        │
+│  │ Primary  │  │  Native  │  │   OPA    │  │ Ansible  │  │ Gitleaks │        │
+│  │  :50051  │  │  :50055  │  │  :50054  │  │  :50053  │  │  :50056  │        │
+│  │          │  │          │  │          │  │          │  │          │        │
+│  │ engine + │  │ Python   │  │ OPA bin  │  │ ansible- │  │ gitleaks │        │
+│  │ orchestr │  │ rules on │  │ + gRPC   │  │ core     │  │ + gRPC   │        │
+│  │ session  │  │ scandata │  │ wrapper  │  │ venvs    │  │ wrapper  │        │
+│  │  venvs   │  │          │  │          │  │ (ro)     │  │          │        │
+│  └────┬─────┘  └──────────┘  └──────────┘  └──────────┘  └──────────┘        │
+│       │                                                                         │
+│       │         ┌──────────────┐  ┌──────────────┐                              │
+│       │         │ Coll. Health │  │  Dep Audit   │                              │
+│       │         │    :50058    │  │    :50059    │                              │
+│       │         └──────────────┘  └──────────────┘                              │
+│       │                                                                         │
+│  ┌────┴─────────────────────────────────────┐  ┌──────────┐                    │
+│  │      Galaxy Proxy :8765 (PEP 503)       │  │ Abbenay  │                    │
+│  │  Ansible Galaxy → Python wheels on      │  │  :50057  │                    │
+│  │  demand; caching handled by proxy + uv  │  └──────────┘                    │
+│  └──────────────────────────────────────────┘                                   │
+│  ┌──────────────────────┐  ┌──────────┐                                        │
+│  │ Gateway :50060/:8080 │  │ UI :8081 │                                        │
+│  │ REST + gRPC + DB     │  │ (nginx)  │                                        │
+│  └──────────────────────┘  └──────────┘                                        │
+└─────────────────────────────────────────────────────────────────────────────────┘
 
      ┌──────────┐
      │   CLI    │  podman run --rm --pod apme-pod
@@ -53,10 +58,13 @@ APME is a multi-container gRPC microservice deployed as a single Podman pod. The
 | **OPA** | apme-opa | 50054 | OPA binary (invoked via subprocess) + Python gRPC wrapper. Rego rules L003–L025, M006/M008/M009/M011, R118 on the hierarchy JSON |
 | **Ansible** | apme-ansible | 50053 | Ansible-runtime checks using session-scoped venvs (shared read-only via `/sessions` volume). Rules L057–L059, M001–M004 |
 | **Gitleaks** | apme-gitleaks | 50056 | Gitleaks binary + Python gRPC wrapper. Scans raw files for hardcoded secrets, API keys, private keys. Filters vault-encrypted content and Jinja2 expressions. Rules SEC:* (800+ patterns) |
+| **Collection Health** | apme-collection-health | 50058 | Scans installed Ansible collections for quality issues (deprecated modules, missing argument specs, FQCN violations). Findings cached by FQCN+version |
+| **Dep Audit** | apme-dep-audit | 50059 | Python dependency auditor via pip-audit. Checks packages in session venvs against CVE databases |
 | **Galaxy Proxy** | apme-galaxy-proxy | 8765 | PEP 503 simple repository API that converts Galaxy collection tarballs to pip-installable Python wheels. Caching is the proxy's concern — the engine has zero cache management code |
 | **Gateway** | apme-gateway | 50060 (gRPC), 8080 (HTTP) | REST API + gRPC Reporting service + SQLAlchemy/SQLite persistence. Receives engine events via `GrpcReportingSink`; serves scan history, project management, and rule catalog to UI and external consumers (ADR-029, ADR-038) |
 | **UI** | apme-ui | 8081 | nginx-served React/PatternFly SPA. Consumes Gateway REST API. No direct engine communication (ADR-030, ADR-037) |
-| **CLI** | apme-cli | — | Ephemeral. Reads project files, chunks uploads, drives **`FixSession`** for user **check** and **remediate** (ADR-039). Unary `Primary.Scan`/`ScanRequest`/`ScanResponse` remain for engine-aligned clients. Run with `--pod apme-pod` and CWD mounted |
+| **Abbenay** | abbenay | 50057 | AI provider for Tier 2 remediation. Receives fix requests from Primary, queries LLM providers, returns proposed patches |
+| **CLI** | apme-cli | — | Ephemeral. Reads project files, chunks uploads, drives **`FixSession`** for user **check** and **remediate** (ADR-039). Run with `--pod apme-pod` and CWD mounted |
 
 ---
 
@@ -123,18 +131,22 @@ Each validator ignores the data fields it doesn't need. This keeps the contract 
 Primary calls all configured validators concurrently using `asyncio.gather()` with async gRPC stubs:
 
 ```
-              ┌─► Native   ─── violations ──┐
-              │                              │
-Primary ──────┼─► OPA      ─── violations ──┼──► merge + dedup + sort
-  (async)     │                              │
-              ├─► Ansible  ─── violations ──┤
-              │                              │
-              └─► Gitleaks ─── violations ──┘
+              ┌─► Native          ─── violations ──┐
+              │                                     │
+              ├─► OPA             ─── violations ──┤
+              │                                     │
+Primary ──────┼─► Ansible         ─── violations ──┼──► merge + dedup + sort
+  (async)     │                                     │
+              ├─► Gitleaks        ─── violations ──┤
+              │                                     │
+              ├─► Collection Hlth ─── findings ────┤
+              │                                     │
+              └─► Dep Audit       ─── findings ────┘
 ```
 
-**Wall-clock time = max(native, opa, ansible, gitleaks)** instead of sum.
+**Wall-clock time = max(validators)** instead of sum.
 
-Each validator is discovered by environment variable (`NATIVE_GRPC_ADDRESS`, `OPA_GRPC_ADDRESS`, `ANSIBLE_GRPC_ADDRESS`, `GITLEAKS_GRPC_ADDRESS`). If a variable is unset, that validator is skipped.
+Each validator is discovered by environment variable (`NATIVE_GRPC_ADDRESS`, `OPA_GRPC_ADDRESS`, `ANSIBLE_GRPC_ADDRESS`, `GITLEAKS_GRPC_ADDRESS`, `COLLECTION_HEALTH_GRPC_ADDRESS`, `DEP_AUDIT_GRPC_ADDRESS`). If a variable is unset, that validator is skipped.
 
 ---
 
@@ -235,13 +247,19 @@ The wrapper adds **Ansible-aware filtering**:
 | 50054 | OPA | gRPC (wrapper; OPA binary invoked via subprocess) |
 | 50055 | Native | gRPC |
 | 50056 | Gitleaks | gRPC (wrapper; gitleaks binary for detection) |
+| 50057 | Abbenay | gRPC (AI provider for Tier 2 remediation) |
+| 50058 | Collection Health | gRPC |
+| 50059 | Dep Audit | gRPC |
+| 50060 | Gateway | gRPC (Reporting service) |
+| 8080 | Gateway | HTTP (REST API) |
+| 8081 | UI | HTTP (nginx-served SPA) |
 | 8765 | Galaxy Proxy | HTTP (PEP 503 simple repository API) |
 
 ---
 
 ## Scaling
 
-**Scale pods, not services within a pod.** Each pod is a self-contained stack (Primary + Native + OPA + Ansible + Gitleaks + Galaxy Proxy) that can process a scan request end-to-end.
+**Scale pods, not services within a pod.** Each pod is a self-contained stack (Primary + Native + OPA + Ansible + Gitleaks + Collection Health + Dep Audit + Galaxy Proxy) that can process a scan request end-to-end.
 
 ```
                     ┌─────────────┐
@@ -350,7 +368,7 @@ The CLI `health-check` subcommand calls `Health` on all services and reports sta
 apme health-check --primary-addr 127.0.0.1:50051
 ```
 
-Primary, Native, OPA, Ansible, and Gitleaks all implement the `Health` RPC. A service returning `status: "ok"` is healthy; any gRPC error marks it degraded.
+Primary, Native, OPA, Ansible, Gitleaks, Collection Health, and Dep Audit all implement the `Health` RPC. A service returning `status: "ok"` is healthy; any gRPC error marks it degraded.
 
 ---
 

--- a/.sdlc/context/architecture.md
+++ b/.sdlc/context/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-APME is a multi-container gRPC microservice deployed as a single Podman pod. The Primary service runs the engine (parse → annotate → hierarchy), then fans validation out in parallel to six independent validator backends over a unified gRPC contract. The CLI is ephemeral — run on-the-fly with the project directory mounted.
+APME is a multi-container gRPC microservice system. The reference deployment is a single Podman pod, but bootc (systemd-managed VM) and Helm (Kubernetes/OpenShift) topologies are also supported. The Primary service runs the engine (parse → annotate → hierarchy), then fans validation out in parallel to six independent validator backends over a unified gRPC contract. The CLI is ephemeral — run on-the-fly with the project directory mounted.
 
 **Key principles:**
 - Validator fan-out and engine orchestration use **gRPC**; Galaxy Proxy is HTTP (PEP 503); Gateway exposes REST (:8080) for external consumers

--- a/.sdlc/context/deployment.md
+++ b/.sdlc/context/deployment.md
@@ -84,7 +84,7 @@ tox -e wipe                             # stop pod and delete DB + session cache
 ### Health Check
 
 ```bash
-apme health-check --primary-addr 127.0.0.1:50051
+APME_PRIMARY_ADDRESS=127.0.0.1:50051 apme health-check
 ```
 
 Reports status of all services (Primary, Native, OPA, Ansible, Gitleaks, Collection Health, Dep Audit) with latency.

--- a/.sdlc/context/deployment.md
+++ b/.sdlc/context/deployment.md
@@ -1,6 +1,21 @@
 # Deployment
 
-## Podman Pod (Recommended)
+> **Canonical user-facing guide:** [docs/guides/DEPLOYMENT.md](/docs/guides/DEPLOYMENT.md)
+>
+> This file provides AI-agent context. For the most complete and current
+> deployment instructions (including bootc VM and Helm chart), see the
+> canonical guide linked above.
+
+## Deployment Methods
+
+| Method | Best for | Guide |
+|--------|----------|-------|
+| CLI daemon | Quick evaluation, CI | [docs/guides/CLI.md](/docs/guides/CLI.md) |
+| Podman pod | Development, full features | [docs/guides/DEPLOYMENT.md](/docs/guides/DEPLOYMENT.md) |
+| bootc VM | Production single-node | [deploy/bootc/README.md](/deploy/bootc/README.md) |
+| Helm chart | Kubernetes / OpenShift | [deploy/helm/apme/README.md](/deploy/helm/apme/README.md) |
+
+## Podman Pod
 
 The primary deployment target is a **Podman pod**. All backend services run in a single pod sharing localhost; the CLI is run on-the-fly outside the pod with the project directory mounted.
 
@@ -18,7 +33,7 @@ From the repo root:
 tox -e build
 ```
 
-This builds nine images:
+This builds eleven images:
 
 | Image | Dockerfile | Purpose |
 |-------|------------|---------|
@@ -27,10 +42,14 @@ This builds nine images:
 | `apme-opa:latest` | `containers/opa/Dockerfile` | OPA + gRPC wrapper |
 | `apme-ansible:latest` | `containers/ansible/Dockerfile` | Ansible validator (reads session venvs) |
 | `apme-gitleaks:latest` | `containers/gitleaks/Dockerfile` | Gitleaks secret scanner + gRPC wrapper |
+| `apme-collection-health:latest` | `containers/collection-health/Dockerfile` | Installed collection health scanner |
+| `apme-dep-audit:latest` | `containers/dep-audit/Dockerfile` | Python CVE scanner (pip-audit) |
 | `apme-galaxy-proxy:latest` | `containers/galaxy-proxy/Dockerfile` | PEP 503 proxy: Galaxy tarballs → Python wheels |
 | `apme-gateway:latest` | `containers/gateway/Dockerfile` | REST/gRPC gateway + SQLite persistence |
 | `apme-ui:latest` | `containers/ui/Dockerfile` | React SPA dashboard (nginx) |
 | `apme-cli:latest` | `containers/cli/Dockerfile` | CLI client |
+
+The Abbenay AI image (`ghcr.io/redhat-developer/abbenay`) is pulled from the registry.
 
 ### Start the Pod
 
@@ -38,7 +57,7 @@ This builds nine images:
 tox -e up
 ```
 
-This runs `podman play kube containers/podman/pod.yaml`, which starts the pod `apme-pod` with eight containers (Primary, Native, OPA, Ansible, Gitleaks, Galaxy Proxy, Gateway, UI). A sessions directory and gateway data directory are created for session-scoped venvs and persistent activity data.
+This runs `podman play kube containers/podman/pod.yaml`, which starts the pod `apme-pod` with all service containers (Primary, Native, OPA, Ansible, Gitleaks, Collection Health, Dep Audit, Galaxy Proxy, Gateway, UI, Abbenay). A sessions directory and gateway data directory are created for session-scoped venvs and persistent activity data.
 
 ### Run CLI Commands
 
@@ -68,7 +87,7 @@ tox -e wipe                             # stop pod and delete DB + session cache
 apme health-check --primary-addr 127.0.0.1:50051
 ```
 
-Reports status of all services (Primary, Native, OPA, Ansible, Gitleaks) with latency.
+Reports status of all services (Primary, Native, OPA, Ansible, Gitleaks, Collection Health, Dep Audit) with latency.
 
 ---
 
@@ -84,6 +103,11 @@ Reports status of all services (Primary, Native, OPA, Ansible, Gitleaks) with la
 | `NATIVE_GRPC_ADDRESS` | — | Native validator address (e.g., `127.0.0.1:50055`) |
 | `OPA_GRPC_ADDRESS` | — | OPA validator address (e.g., `127.0.0.1:50054`) |
 | `ANSIBLE_GRPC_ADDRESS` | — | Ansible validator address (e.g., `127.0.0.1:50053`) |
+| `GITLEAKS_GRPC_ADDRESS` | — | Gitleaks validator address (e.g., `127.0.0.1:50056`) |
+| `COLLECTION_HEALTH_GRPC_ADDRESS` | — | Collection Health validator address (e.g., `127.0.0.1:50058`) |
+| `DEP_AUDIT_GRPC_ADDRESS` | — | Dep Audit validator address (e.g., `127.0.0.1:50059`) |
+| `APME_ABBENAY_ADDR` | — | Abbenay AI daemon address (e.g., `127.0.0.1:50057`) |
+| `APME_REPORTING_ENDPOINT` | — | Gateway gRPC Reporting address (e.g., `127.0.0.1:50060`) |
 
 > If a validator address is unset, that validator is skipped during fan-out.
 
@@ -174,9 +198,10 @@ apme remediate .
 apme daemon stop
 ```
 
-**Daemon mode** starts a local Primary server with Native, OPA, and Ansible
-validators running in-process. Gitleaks is excluded (requires the gitleaks binary). OPA runs via the local `opa` binary (no container
-needed); skip it with `--no-opa` if `opa` is not installed.
+**Daemon mode** starts a local Primary server with Native, OPA, Ansible, and
+Galaxy Proxy validators running in-process. Gitleaks is excluded (requires the
+gitleaks binary). OPA runs via the local `opa` binary; if `opa` is not
+installed, the OPA validator is automatically skipped.
 
 The CLI is a **thin gRPC client** — it sends file bytes to the daemon and
 receives results. It does not import engine internals.
@@ -215,8 +240,11 @@ tox -e wipe                             # stop + wipe DB/sessions
 | 50054 | OPA | `APME_OPA_VALIDATOR_LISTEN` |
 | 50055 | Native | `APME_NATIVE_VALIDATOR_LISTEN` |
 | 50056 | Gitleaks | `APME_GITLEAKS_VALIDATOR_LISTEN` |
+| 50057 | Abbenay AI | `--grpc-port` (CLI flag) |
+| 50058 | Collection Health | `APME_COLLECTION_HEALTH_VALIDATOR_LISTEN` |
+| 50059 | Dep Audit | `APME_DEP_AUDIT_VALIDATOR_LISTEN` |
 | 50060 | Gateway (gRPC) | `APME_GATEWAY_GRPC_LISTEN` |
-| 8080 | Gateway (HTTP) | `APME_GATEWAY_HTTP_LISTEN` |
+| 8080 | Gateway (HTTP) | `APME_GATEWAY_HTTP_PORT` |
 | 8081 | UI (nginx) | — |
 | 8765 | Galaxy Proxy | `APME_GALAXY_PROXY_URL` |
 

--- a/.sdlc/context/deployment.md
+++ b/.sdlc/context/deployment.md
@@ -198,10 +198,12 @@ apme remediate .
 apme daemon stop
 ```
 
-**Daemon mode** starts a local Primary server with Native, OPA, Ansible, and
-Galaxy Proxy validators running in-process. Gitleaks is excluded (requires the
-gitleaks binary). OPA runs via the local `opa` binary; if `opa` is not
-installed, the OPA validator is automatically skipped.
+**Daemon mode** starts a local Primary server with Native, OPA, and Ansible
+validators as in-process gRPC servers, plus Galaxy Proxy as an HTTP service
+(uvicorn). Optional validators (Gitleaks, Collection Health, Dep Audit) are
+not started by the daemon. OPA uses Podman by default (`OPA_USE_PODMAN=1`);
+if Podman is unavailable it falls back to a local `opa` binary; if neither is
+available, OPA validation is skipped.
 
 The CLI is a **thin gRPC client** — it sends file bytes to the daemon and
 receives results. It does not import engine internals.

--- a/.sdlc/context/deployment.md
+++ b/.sdlc/context/deployment.md
@@ -242,7 +242,7 @@ tox -e wipe                             # stop + wipe DB/sessions
 | 50054 | OPA | `APME_OPA_VALIDATOR_LISTEN` |
 | 50055 | Native | `APME_NATIVE_VALIDATOR_LISTEN` |
 | 50056 | Gitleaks | `APME_GITLEAKS_VALIDATOR_LISTEN` |
-| 50057 | Abbenay AI | `--grpc-port` (CLI flag) |
+| 50057 | Abbenay AI | `--grpc-port` (Abbenay daemon flag) |
 | 50058 | Collection Health | `APME_COLLECTION_HEALTH_VALIDATOR_LISTEN` |
 | 50059 | Dep Audit | `APME_DEP_AUDIT_VALIDATOR_LISTEN` |
 | 50060 | Gateway (gRPC) | `APME_GATEWAY_GRPC_LISTEN` |

--- a/.sdlc/context/project-overview.md
+++ b/.sdlc/context/project-overview.md
@@ -57,7 +57,7 @@ APME provides:
 
 ## Architecture
 
-APME is deployed as a single pod (Podman, Kubernetes, or bootc VM) with 11 containers sharing localhost. The CLI can also run as a standalone daemon for quick evaluation.
+APME runs as a set of cooperating containers. In **Podman** and **bootc**, all 11 containers share a single pod on localhost. In **Kubernetes** (Helm chart), the engine stack (Primary + validators + Galaxy Proxy) runs as a multi-container pod, while Gateway, UI, and Abbenay are separate Deployments with their own Services. The CLI can also run as a standalone daemon for quick evaluation.
 
 Key services:
 - **Primary** (:50051) — orchestrator, engine, session venv manager

--- a/.sdlc/context/project-overview.md
+++ b/.sdlc/context/project-overview.md
@@ -57,7 +57,7 @@ APME provides:
 
 ## Architecture
 
-APME is deployed as a single pod (Podman, Kubernetes, or bootc VM) with 12 containers sharing localhost. The CLI can also run as a standalone daemon for quick evaluation.
+APME is deployed as a single pod (Podman, Kubernetes, or bootc VM) with 11 containers sharing localhost. The CLI can also run as a standalone daemon for quick evaluation.
 
 Key services:
 - **Primary** (:50051) — orchestrator, engine, session venv manager

--- a/.sdlc/context/project-overview.md
+++ b/.sdlc/context/project-overview.md
@@ -2,66 +2,80 @@
 
 ## What is APME?
 
-The **Ansible Playbook Modernization Engine (APME)** is an automated tool designed to help organizations modernize their Ansible playbooks for compatibility with Ansible Automation Platform (AAP) 2.5 and beyond.
+The **Ansible Policy & Modernization Engine (APME)** is a multi-validator static analysis platform for Ansible content. It parses playbooks, roles, collections, and task files into a structured hierarchy, then fans validation out in parallel across independent backends to produce a unified list of violations — with optional automated remediation.
 
 ## Problem Statement
 
-Organizations with large Ansible codebases face significant challenges when upgrading to AAP 2.5+:
+Organizations with large Ansible codebases face significant challenges when upgrading across ansible-core versions:
 
-1. **FQCN Requirements**: AAP 2.5 requires Fully Qualified Collection Names for all modules
-2. **Deprecated Modules**: Many legacy modules are deprecated or removed
-3. **Syntax Changes**: Various syntax changes between Ansible versions
-4. **Scale**: Manual remediation doesn't scale for thousands of playbooks
+1. **Module lifecycle**: Modules are deprecated, removed, or redirected across versions; argument specs change
+2. **Syntax evolution**: Includes become imports, short-form module names require FQCNs, connection plugins change
+3. **Security compliance**: Hardcoded credentials, policy violations, and supply-chain risks in dependencies
+4. **Scale**: Manual audit and remediation does not scale for hundreds of roles and collections
 
 ## Solution
 
 APME provides:
 
-1. **Automated checking**: Wraps ARI so the engine scans content and surfaces compatibility issues
-2. **Intelligent remediation**: Uses LangGraph agents to apply appropriate fixes
-3. **Progress Tracking**: Dashboard showing modernization status
-4. **CI/CD Integration**: Automated pre-flight checks
+1. **Multi-backend static analysis**: Six validators (Native Python, OPA/Rego, Ansible runtime, Gitleaks secrets, Collection Health, Dependency Audit) run in parallel behind a unified gRPC contract
+2. **Automated remediation**: Deterministic Tier 1 transforms with multi-pass convergence, plus optional AI-assisted Tier 2 fixes via Abbenay
+3. **YAML formatting**: Comment-preserving normalization (indentation, key ordering, Jinja spacing)
+4. **Web UI**: React dashboard for project management, live operations, and cross-project analytics
+5. **CI/CD integration**: JSON, SARIF output; pre-commit hooks; GitHub Actions workflows
+6. **Multiple deployment targets**: CLI (pip install), Podman pod, bootc VM, Helm chart
 
 ## Scope
 
 ### In Scope
 
-- FQCN detection and automatic conversion
-- Deprecated module detection and replacement suggestions
-- Syntax modernization for AAP 2.5 compatibility
-- Check result aggregation and reporting
-- Interactive dashboard for progress tracking
-- GitHub Actions integration
-- AAP pre-flight check integration
+- Module compatibility checking (deprecated, removed, redirected, argspec validation)
+- FQCN detection and conversion
+- Syntax modernization across ansible-core versions
+- Secret scanning (800+ patterns via Gitleaks)
+- Dependency health (collection quality + Python CVE audit)
+- Organizational policy enforcement (OPA/Rego rules)
+- Automated remediation (deterministic transforms + AI-assisted fixes)
+- YAML formatting with comment preservation
+- Web dashboard with persistent scan history
+- CI/CD integration (JSON, SARIF, pre-commit, GitHub Actions)
+- Multiple deployment methods (CLI, Podman, bootc, Helm)
 
 ### Out of Scope
 
 - Custom module development
-- Playbook logic changes (only syntax/module updates)
+- Playbook logic changes (only structural/compatibility)
 - Performance optimization of playbooks
-- Secret management or vault handling
+- Runtime verification (whether playbooks achieve desired state)
 - Inventory management
 
 ## Target Users
 
-1. **Platform Engineers**: Managing AAP infrastructure upgrades
-2. **DevOps Teams**: Maintaining playbook repositories
-3. **Automation Architects**: Planning migration strategies
+1. **Platform Engineers**: Managing AAP infrastructure upgrades across ansible-core versions
+2. **DevOps Teams**: Maintaining playbook repositories with quality gates in CI
+3. **Automation Architects**: Planning migration strategies with full project visibility
+4. **Security Teams**: Enforcing credential hygiene and dependency health policies
 
-## Success Metrics
+## Architecture
 
-- Check accuracy matches ARI baseline
-- 90%+ of FQCN issues automatically fixable
-- Dashboard loads 1000+ results in < 3 seconds
-- CI integration runs in < 60 seconds per playbook
+APME is deployed as a single pod (Podman, Kubernetes, or bootc VM) with 12 containers sharing localhost. The CLI can also run as a standalone daemon for quick evaluation.
 
-## Project Timeline
+Key services:
+- **Primary** (:50051) — orchestrator, engine, session venv manager
+- **Native** (:50055) — Python rule validator
+- **OPA** (:50054) — Rego rule validator (subprocess, not REST)
+- **Ansible** (:50053) — runtime checks against session venvs
+- **Gitleaks** (:50056) — secret scanner
+- **Collection Health** (:50058) — installed collection quality checks
+- **Dep Audit** (:50059) — Python CVE audit via pip-audit
+- **Galaxy Proxy** (:8765) — PEP 503 collection → wheel proxy
+- **Gateway** (:8080/:50060) — REST API + persistence
+- **UI** (:8081) — React dashboard
+- **Abbenay** (:50057) — AI provider for Tier 2 remediation
 
-- **Week 1**: Foundation + Scanner implementation
-- **Week 2**: Rewriter + Dashboard + Integration
+See [architecture.md](architecture.md) for the full topology and contracts.
 
 ## Related Projects
 
-- **ARI (Ansible Risk Insights)**: The underlying scanning engine
-- **x2a-convertor**: Reference implementation for conversion patterns
-- **ansible-lint**: Complementary linting tool
+- **ansible-lint**: Complementary linting tool (different rule set and approach)
+- **Abbenay**: AI provider daemon for Tier 2 remediation
+- **Molecule**: Execution-time testing (complementary to APME's static analysis)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ pip install apme-engine@git+https://github.com/ansible/apme.git@v2026.4.1
 apme check /path/to/your/project
 ```
 
-The CLI automatically starts a local daemon with all validators — no containers required. See the [CLI Guide](docs/guides/CLI.md) for full usage, CI integration, and limitations compared to deployment methods.
+The CLI automatically starts a local daemon with core validators (Native, OPA, Ansible) and Galaxy Proxy — no containers required. Optional validators (Gitleaks, Collection Health, Dep Audit) are not started by the daemon. See the [CLI Guide](docs/guides/CLI.md) for full usage, CI integration, and limitations compared to deployment methods.
 
 ### Remediation
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ pip install apme-engine@git+https://github.com/ansible/apme.git@v2026.4.1
 apme check /path/to/your/project
 ```
 
-The CLI automatically starts a local daemon with core validators (Native, OPA, Ansible) and Galaxy Proxy — no containers required. Optional validators (Gitleaks, Collection Health, Dep Audit) are not started by the daemon. See the [CLI Guide](docs/guides/CLI.md) for full usage, CI integration, and limitations compared to deployment methods.
+The CLI automatically starts a local daemon with core validators (Native, OPA, Ansible) and Galaxy Proxy — no full pod required. OPA uses a Podman container by default; set `OPA_USE_PODMAN=0` to use a local `opa` binary, or it is skipped if neither is available. Optional validators (Gitleaks, Collection Health, Dep Audit) are not started by the daemon. See the [CLI Guide](docs/guides/CLI.md) for full usage, CI integration, and limitations compared to deployment methods.
 
 ### Remediation
 
@@ -123,6 +123,8 @@ apme remediate --ai /path/to/project
 ## Project layout
 
 ```
+proto/                  gRPC protobuf definitions (.proto files)
+src/apme/v1/           Generated Python gRPC stubs (do not edit by hand)
 src/apme_engine/
   ├── cli/              CLI (check, format, remediate, health-check, sbom, suppress)
   ├── engine/           Project loader (parse, annotate, hierarchy, graph)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For organizations managing hundreds of roles and collections across ansible-core
                             └───────────┘
 ```
 
-All inter-service communication is gRPC. The engine parses content once, then validators consume the hierarchy independently and in parallel. See the [architecture series](docs/architecture/) for the full pipeline walkthrough.
+Validator fan-out uses gRPC; Galaxy Proxy is HTTP (PEP 503). The engine parses content once, then validators consume the hierarchy independently and in parallel. See the [architecture series](docs/architecture/) for the full pipeline walkthrough.
 
 ## Getting started
 
@@ -126,7 +126,7 @@ apme remediate --ai /path/to/project
 src/apme_engine/
   ├── cli/              CLI (check, format, remediate, health-check, sbom, suppress)
   ├── engine/           Project loader (parse, annotate, hierarchy, graph)
-  ├── validators/       Rule implementations (native/, opa/, ansible/, gitleaks/)
+  ├── validators/       Rule implementations (native/, opa/, ansible/, gitleaks/, collection_health/, dep_audit/)
   ├── daemon/           gRPC server implementations
   ├── remediation/      Tier 1 transforms + AI escalation
   └── venv_manager/     Session-scoped venv lifecycle

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ docs/                   Architecture, design, guides, rule reference
 | Document | Description |
 |----------|-------------|
 | [CLI Guide](docs/guides/CLI.md) | Installation, commands, daemon mode, CI usage, limitations |
-| [Deployment Guide](docs/guides/DEPLOYMENT.md) | Podman pod setup, configuration, troubleshooting |
+| [Deployment Guide](docs/guides/DEPLOYMENT.md) | Podman, bootc, Helm, and CLI daemon deployment |
 | [bootc Deployment](deploy/bootc/README.md) | Atomic VM image with systemd quadlets |
 | [Helm Chart](deploy/helm/apme/README.md) | Kubernetes/OpenShift deployment |
 | [Architecture series](docs/architecture/) | Pipeline walkthrough, container topology, gRPC contracts, scaling |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 > commits. If you are evaluating this project, expect things to move fast
 > and break often.
 
-Ansible Policy & Modernization Engine — a multi-validator static analysis platform for Ansible content. It parses playbooks, roles, collections, and task files into a structured hierarchy, then fans validation out in parallel across four independent backends (OPA/Rego, native Python, Ansible-runtime, and Gitleaks) to produce a single, unified list of violations.
+Ansible Policy & Modernization Engine — a multi-validator static analysis platform for Ansible content. It parses playbooks, roles, collections, and task files into a structured hierarchy, then fans validation out in parallel across independent backends to produce a single, unified list of violations.
 
 ## What APME is
 
@@ -33,9 +33,18 @@ It answers questions like:
 
 APME is not a test framework, a deployment tool, or a runtime verification system.
 
-It cannot tell you whether a playbook will **achieve its desired outcome** on your infrastructure. A playbook's intended outcome — packages installed, services configured, files in the right state — depends on target host state, inventory variables, network reachability, external APIs, and runtime facts that only exist during execution. No static analysis tool can evaluate those.
+It cannot tell you whether a playbook will **achieve its desired outcome** on your infrastructure — that depends on target host state, inventory variables, network reachability, and runtime facts that only exist during execution. A clean APME scan means no *known* incompatibilities were detected — not that every runtime path will succeed.
 
-APME also cannot guarantee a playbook will **run successfully**, even if it reports zero violations. A clean APME scan means no *known* incompatibilities were detected — not that every runtime path will succeed.
+**What still requires execution-time tools:**
+
+| Concern | Tool |
+|---------|------|
+| Does the playbook produce the correct end state? | Molecule, integration tests |
+| Is the playbook idempotent? | `--check` mode, Molecule |
+| Do templates render correctly with real variables? | Integration tests |
+| Does it work with my specific inventory and vault? | Staging dry-run |
+
+APME and these tools are complementary. APME runs in seconds without infrastructure; execution-time tools validate behavior against real systems. Use both.
 
 ## Where APME fits
 
@@ -49,443 +58,103 @@ APME provides a **compatibility and quality floor**. It catches the preventable 
 
 For organizations managing hundreds of roles and collections across ansible-core version upgrades, this shift-left is the difference between a planned migration and an emergency one.
 
-**What still requires execution-time tools:**
+## Key features
 
-| Concern | Tool |
-|---------|------|
-| Does the playbook produce the correct end state? | Molecule, integration tests |
-| Is the playbook idempotent (safe to run twice)? | `--check` mode, Molecule converge+idempotence |
-| Do templates render correctly with real variables? | Integration tests against test inventory |
-| Does the playbook handle failure paths gracefully? | Molecule verify, side-effect testing |
-| Does it work with my specific inventory and vault? | Staging environment dry-run |
-
-APME and these tools are complementary. APME runs in seconds without infrastructure and catches structural and compatibility issues early. Execution-time tools validate behavior and correctness against real systems. Use both.
+- **Single parse, multiple validators** — parse once, fan out to independent backends
+- **Parallel validation** — Native (Python), OPA (Rego), Ansible (runtime), Gitleaks (secrets), Collection Health, and Dependency Audit run concurrently; latency = max, not sum
+- **100+ rules** — lint (L), modernize (M), risk (R), policy (P), and secrets (SEC) categories
+- **Secret scanning** — 800+ patterns via Gitleaks with vault/Jinja filtering
+- **Dependency health** — collection quality checks + Python CVE audit via pip-audit
+- **Multi ansible-core version support** — session-scoped venvs per target version
+- **Automated remediation** — deterministic Tier 1 transforms with multi-pass convergence
+- **AI-assisted fixes** — optional Tier 2 escalation via [Abbenay](https://github.com/redhat-developer/abbenay) for violations without deterministic transforms
+- **YAML formatter** — normalize indentation, key ordering, Jinja spacing with comment preservation
+- **Structured diagnostics** — per-rule timing data (`-v` summary, `-vv` full breakdown)
+- **Unified gRPC contract** — adding a validator means implementing one RPC
 
 ## Architecture at a glance
 
 ```
 ┌─────────┐      gRPC       ┌────────────┐      gRPC (parallel)      ┌────────────┐
-│   CLI   │ ──────────────► │  Primary   │ ──────────────────────►   │   Native   │ :50055
-│ (on-the │  ScanRequest    │ (orchestr) │   ValidateRequest         │  (Python)  │
-│  -fly)  │  chunked fs     │            │ ┌─────────────────────►   ├────────────┤
-└─────────┘                 │   Engine   │ │                         │    OPA     │ :50054
-     ▲                      │  ┌──────┐  │ │  ┌──────────────────►   │  (Rego)    │
-     │   ScanResponse       │  │parse │  │ │  │                      ├────────────┤
-     │   violations         │  │annot.│  │ │  │  ┌───────────────►   │  Ansible   │ :50053
-     └──────────────────────│  │hier. │  ├─┘  │  │                   │ (runtime)  │
-                            │  └──────┘  ├────┘  │                   ├────────────┤
-                            └────────────┘───────┘                   │  Gitleaks  │ :50056
-                                 │                                   │ (secrets)  │
-                            ┌────┴────┐                              └────────────┘
-                            │ Galaxy  │ :8765
-                            │ Proxy   │ (PEP 503)
-                            └─────────┘
+│   CLI   │ ──────────────► │  Primary   │ ──────────────────────►   │   Native   │
+│         │                 │ (orchestr) │                           │    OPA     │
+└─────────┘                 │   Engine   │                           │  Ansible   │
+                            │  parse →   │                           │  Gitleaks  │
+                            │  annotate →│                           │  Coll.Hlth │
+                            │  fan-out   │                           │  Dep.Audit │
+                            └─────┬──────┘                           └────────────┘
+                                  │
+                            ┌─────┴─────┐
+                            │  Galaxy   │
+                            │  Proxy    │ (PEP 503)
+                            └───────────┘
 ```
 
-Six app containers, one pod. All inter-service communication is gRPC. The Galaxy Proxy serves Ansible collections as Python wheels (PEP 503). The CLI is run on-the-fly with the project directory mounted. See [docs/architecture/](docs/architecture/) for the full design.
+All inter-service communication is gRPC. The engine parses content once, then validators consume the hierarchy independently and in parallel. See the [architecture series](docs/architecture/) for the full pipeline walkthrough.
 
-## Key features
+## Getting started
 
-- **Single parse, multiple validators** — the engine parses Ansible content once and produces a hierarchy payload + scandata; validators consume it independently.
-- **Parallel fan-out** — Primary calls Native, OPA, Ansible, and Gitleaks validators concurrently via `asyncio.gather()`; total latency = max(validators), not sum.
-- **Unified gRPC contract** — every validator implements the same `Validator` service (`validate.proto`); adding a new validator means implementing one RPC.
-- **100+ rules** across four backends: OPA Rego (L003–L025, L061–L072, M006/M008/M009/M011, R118), native Python (L026–L105, M005/M010, R101–R501), Ansible runtime (L057–L059, M001–M004), Gitleaks (SEC:* — 800+ secret patterns).
-- **Secret scanning** — Gitleaks binary wrapped in gRPC; scans all project files for hardcoded credentials, API keys, private keys. Vault-encrypted files and Jinja2 expressions are automatically filtered.
-- **Dependency health scanning** — Two optional validators assess supply-chain risk inline during `apme check`: the Collection Health Validator scans installed Ansible collections for quality issues (deprecated modules, missing argument specs, FQCN violations), and the Python Dependency Auditor checks packages against CVE databases via pip-audit. Findings are grouped separately from project violations, and collection scans are cached by FQCN+version for fast subsequent runs.
-- **Multi ansible-core version support** — the Primary orchestrator builds session-scoped venvs per ansible-core version (UV-cached); argspec and deprecation checks run against the requested version. Venvs are shared read-only with validators via a `/sessions` volume.
-- **Structured diagnostics** — every validator reports per-rule timing data via the gRPC contract; use `-v` for summaries or `-vv` for full per-rule breakdowns.
-- **Galaxy Proxy** — converts Ansible Galaxy collection tarballs into pip-installable Python wheels (PEP 503/427); collections are `uv pip install`'d into session venvs, leveraging standard Python caching and dependency resolution.
-- **YAML formatter** — normalize indentation, key ordering, Jinja spacing, and tab removal with comment preservation. Idempotent by design; runs as a pre-pass before semantic fixes.
-- **Colocated tests** — every rule has a `*_test.py` (native), `*_test.rego` (OPA), or `.md` doc with violation/pass examples usable as integration tests.
+| Method | Best for | Guide |
+|--------|----------|-------|
+| **CLI** (`pip install`) | Quick evaluation, CI pipelines, single-user | [CLI Guide](docs/guides/CLI.md) |
+| **Podman pod** | Development, full feature set (UI, AI, persistence) | [Deployment Guide](docs/guides/DEPLOYMENT.md) |
+| **bootc VM** | Production single-node, atomic upgrades, systemd lifecycle | [bootc Guide](deploy/bootc/README.md) |
+| **Helm chart** | Kubernetes / OpenShift production | [Helm Guide](deploy/helm/apme/README.md) |
 
-## Quick start
-
-### Install
+### Try it now
 
 ```bash
-# Install a specific release (recommended)
 pip install apme-engine@git+https://github.com/ansible/apme.git@v2026.4.1
-
-# Install with AI escalation support
-pip install "apme-engine[ai] @ git+https://github.com/ansible/apme.git@v2026.4.1"
-
-# Install the latest development version (main branch)
-pip install apme-engine@git+https://github.com/ansible/apme.git@main
+apme check /path/to/your/project
 ```
 
-Replace the tag with any [release version](https://github.com/ansible/apme/releases).
-The CLI automatically starts a local daemon with all validators when you run a
-command. No containers required for basic usage.
+The CLI automatically starts a local daemon with all validators — no containers required. See the [CLI Guide](docs/guides/CLI.md) for full usage, CI integration, and limitations compared to deployment methods.
 
-### Basic usage
+### Remediation
 
 ```bash
-# Scan a playbook or project
-apme check /path/to/playbook-or-project
+# Deterministic transforms (Tier 1)
+apme remediate /path/to/project
 
-# JSON output
-apme check --json .
-
-# Diagnostics: summary + top 10 slowest rules
-apme check -v .
-
-# Diagnostics: full per-rule breakdown
-apme check -vv .
-
-# Skip all dependency scanning (collection health + Python CVE)
-apme check --skip-dep-scan .
-
-# Skip only collection health scanning
-apme check --skip-collection-scan .
-
-# Skip only Python CVE audit
-apme check --skip-python-audit .
-
-# Format YAML files (show diff)
-apme format /path/to/project
-
-# Format and apply changes in place
-apme format --apply /path/to/project
-
-# CI check mode (exit 1 if changes needed)
-apme format --check /path/to/project
-
-# Full remediate pipeline: format → idempotency check → re-scan → modernize
-apme remediate /path/to/playbook-or-project
-
-# AI-assisted remediation (requires Abbenay daemon)
-apme remediate --ai /path/to/playbook-or-project
-
-# AI with auto-approve (no interactive review)
-apme remediate --ai --auto-approve /path/to/playbook-or-project
+# Include AI-assisted fixes (Tier 2, requires Abbenay)
+apme remediate --ai /path/to/project
 ```
-
-### Container deployment (Podman)
-
-For the web UI, persistent scan history, or AI-assisted remediation, run the
-full pod. This is also required for APME development.
-
-The pod runs 9 containers: engine services (Primary, Native, OPA, Ansible,
-Gitleaks, Galaxy Proxy), Gateway (REST API + persistence), UI (React dashboard),
-and Abbenay (AI provider).
-
-```
-Container        Port   Role
-─────────────────────────────────────────────────────
-primary          50051  Engine orchestrator (gRPC)
-native           50055  Python rule validator (gRPC)
-opa              50054  Rego rule validator (gRPC)
-ansible          50053  Ansible runtime validator (gRPC)
-gitleaks         50056  Secret scanner (gRPC)
-galaxy-proxy      8765  Collection → wheel proxy (PEP 503)
-gateway     8080/50060  REST API + WebSocket + persistence
-ui                8081  React dashboard (nginx)
-abbenay          50057  AI provider (gRPC)
-```
-
-#### Build and start
-
-```bash
-tox -e up                    # build all images and start the pod
-tox -e up -- --no-cache      # rebuild from scratch
-tox -e up-clean              # wipe state + rebuild + start (clean slate)
-```
-
-This builds a shared base image, nine service images, pulls the Abbenay AI
-image, then starts all containers. Cache defaults to
-`${XDG_CACHE_HOME:-$HOME/.cache}/apme` (override with `APME_CACHE_HOST_PATH`).
-
-#### Pod architecture
-
-```
-                                 APME Pod Architecture
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                                  apme-pod                                       │
-│                                                                                 │
-│   ┌─────────────────────────────────────────────────────────────────────────┐   │
-│   │                         User Entry Points                               │   │
-│   │                                                                         │   │
-│   │    Browser ──► http://localhost:8081 ──► UI (React/nginx)               │   │
-│   │                                              │                          │   │
-│   │    Terminal ──► tox -e cli ────────────────┐ │ REST/WebSocket           │   │
-│   │                      │                     │ ▼                          │   │
-│   │                      │              ┌──────────────┐                    │   │
-│   │                      │              │   Gateway    │ ◄── SQLite DB      │   │
-│   │                      │              │  :8080/:50060│     /data/apme.db  │   │
-│   │                      │              └──────┬───────┘                    │   │
-│   │                      │                     │ gRPC                       │   │
-│   └──────────────────────┼─────────────────────┼────────────────────────────┘   │
-│                          │                     │                                │
-│                          ▼                     ▼                                │
-│   ┌──────────────────────────────────────────────────────────────────────────┐  │
-│   │                        Engine Layer                                      │  │
-│   │                                                                          │  │
-│   │    ┌────────────────────────────────────────────────────────────────┐    │  │
-│   │    │                      Primary :50051                            │    │  │
-│   │    │    • Orchestrator: parse → annotate → fan-out → aggregate     │    │  │
-│   │    │    • Session venv management (ansible-core versions)          │    │  │
-│   │    └────────────────────────────┬───────────────────────────────────┘    │  │
-│   │                                 │                                        │  │
-│   │              gRPC parallel fan-out (asyncio.gather)                      │  │
-│   │                 ┌────────┬──────┴──────┬─────────┐                       │  │
-│   │                 ▼        ▼             ▼         ▼                       │  │
-│   │    ┌─────────┐ ┌─────────┐ ┌──────────┐ ┌─────────────┐                  │  │
-│   │    │ Native  │ │   OPA   │ │ Ansible  │ │  Gitleaks   │                  │  │
-│   │    │ :50055  │ │ :50054  │ │  :50053  │ │   :50056    │                  │  │
-│   │    │         │ │         │ │          │ │             │                  │  │
-│   │    │ Python  │ │  Rego   │ │ Runtime  │ │  Secrets    │                  │  │
-│   │    │  rules  │ │  rules  │ │  checks  │ │   scan      │                  │  │
-│   │    │ L026+   │ │ L003+   │ │ L057-59  │ │   SEC:*     │                  │  │
-│   │    │ R101+   │ │ R118    │ │ M001-04  │ │ 800+ rules  │                  │  │
-│   │    └─────────┘ └─────────┘ └──────────┘ └─────────────┘                  │  │
-│   │                                                                          │  │
-│   └──────────────────────────────────────────────────────────────────────────┘  │
-│                                                                                 │
-│   ┌──────────────────────────────────────────────────────────────────────────┐  │
-│   │                      Supporting Services                                 │  │
-│   │                                                                          │  │
-│   │    ┌────────────────────┐              ┌─────────────────────┐           │  │
-│   │    │   Galaxy Proxy    │              │      Abbenay        │           │  │
-│   │    │      :8765        │              │       :50057        │           │  │
-│   │    │                   │              │                     │           │  │
-│   │    │ Collections → PEP │              │   AI Provider for   │           │  │
-│   │    │ 503 Python wheels │              │   Tier 2 remediation│           │  │
-│   │    └────────────────────┘              └─────────────────────┘           │  │
-│   │                                                                          │  │
-│   └──────────────────────────────────────────────────────────────────────────┘  │
-│                                                                                 │
-│   Shared Volumes:                                                               │
-│   • /sessions  ─ Session venvs (Primary ↔ Ansible validator)                    │
-│   • /cache     ─ UV cache + Galaxy collections (~/.cache/apme on host)          │
-│   • /data      ─ Gateway SQLite database                                        │
-│                                                                                 │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-CLI Container (ephemeral, joins pod network on each invocation)
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│  tox -e cli -- [command]                                                        │
-│  • Mounts $(pwd) → /workspace                                                   │
-│  • Connects to Primary at 127.0.0.1:50051                                       │
-│  • Commands: check, remediate, format, health-check                             │
-└─────────────────────────────────────────────────────────────────────────────────┘
-```
-
-**Data flow:**
-1. **Check/Scan**: CLI or UI → Gateway → Primary → validators (parallel) → aggregated violations
-2. **Remediate**: Check + Tier 1 transforms in Primary + Tier 2 AI proposals via Abbenay
-3. **Collections**: Primary/Ansible → Galaxy Proxy → galaxy.ansible.com → wheels
-
-#### Access the UI
-
-Once the pod is running, open **http://localhost:8081** in your browser.
-The UI proxies API calls to the Gateway on port 8080. No authentication
-is required for local development.
-
-The dashboard provides project management, live scan/remediate operations
-with real-time progress, interactive AI proposal review, dependency
-tracking, and cross-project analytics. See
-[.sdlc/research/ui-capabilities-assessment.md](.sdlc/research/ui-capabilities-assessment.md)
-for a full capabilities inventory.
-
-#### Run CLI scans (on-the-fly container)
-
-The CLI container is **not** part of the pod — it joins the pod network
-on each invocation with your current directory mounted at `/workspace`.
-
-```bash
-tox -e cli                              # default: check .
-tox -e cli -- check --json .            # JSON output
-tox -e cli -- remediate .               # Tier 1 deterministic fixes
-tox -e cli -- remediate --ai .          # include AI proposals (Tier 2)
-tox -e cli -- format --check .          # YAML format dry-run
-tox -e cli -- health-check              # health check all services
-```
-
-#### AI setup (optional)
-
-To enable AI-assisted remediation, create `containers/abbenay/.env` from
-the example and add your API key:
-
-```bash
-cp containers/abbenay/.env.example containers/abbenay/.env
-# Edit .env: set OPENROUTER_API_KEY=your-key
-```
-
-The `up.sh` script sources this file automatically. The Abbenay container
-starts on port 50057 and Primary connects to it for Tier 2 AI proposals.
-
-#### Stop the pod
-
-```bash
-tox -e down                              # stop and remove pod
-tox -e wipe                              # also delete database + session cache
-```
-
-#### Health check
-
-```bash
-apme health-check                        # local daemon
-tox -e cli -- health-check               # from pod
-```
-
-## AI escalation
-
-APME can escalate Tier 2 violations (no deterministic transform) to an AI provider for proposed fixes. This requires the [Abbenay](https://github.com/redhat-developer/abbenay) daemon.
-
-### Prerequisites
-
-```bash
-pip install apme-engine[ai]
-
-# Consumer auth token (required for inline policy)
-export APME_ABBENAY_TOKEN="your-token"
-```
-
-### Binary daemon
-
-```bash
-# Start Abbenay daemon (auto-discovers socket at $XDG_RUNTIME_DIR/abbenay/)
-abbenay daemon start
-# Or from a Sea binary:
-./abbenay-daemon-linux-x64 start
-
-# Set consumer auth token for inline policy (required)
-export APME_ABBENAY_TOKEN="your-token"
-
-# Remediate with AI
-apme remediate --ai /path/to/playbook-or-project
-```
-
-### Container daemon
-
-See the [Abbenay container documentation](https://github.com/redhat-developer/abbenay/blob/main/docs/CONTAINER.md) for full container setup instructions.
-
-```bash
-# Pull the pre-built multi-arch image (amd64 + arm64)
-podman pull ghcr.io/redhat-developer/abbenay:latest
-
-# Standalone: Abbenay defaults to gRPC on :50051.
-# When running inside the APME pod, use -p 50057:50051 to avoid
-# colliding with APME Primary (also :50051).
-podman run -d --name abbenay \
-  -v ./config.yaml:/home/abbenay/.config/abbenay/config.yaml:ro \
-  -e OPENROUTER_API_KEY="$OPENROUTER_API_KEY" \
-  -p 8787:8787 -p 50057:50051 \
-  ghcr.io/redhat-developer/abbenay:latest
-
-# Point APME at the Abbenay container via gRPC TCP
-APME_ABBENAY_ADDR=localhost:50057 apme remediate --ai .
-```
-
-### CLI flags
-
-| Flag | Description |
-|------|-------------|
-| `--ai` | Enable AI escalation (opt-in) |
-| `--auto-approve` | Approve all AI proposals without prompting (CI mode) |
-| `--max-passes N` | Max convergence passes (default: 5) |
-| `--json` | Output structured data payloads as JSON |
-| `--session ID` | Explicit session ID for venv reuse (default: auto-derived from project root) |
-
-### Remediation flow
-
-1. **Tier 1 (deterministic)**: convergence loop applies transforms until stable
-2. **Tier 2 (AI)**: remaining violations are sent to the AI provider one at a time; each proposal is re-validated, cleaned with Tier 1 transforms, and retried with feedback if needed
-3. **Interactive review**: accepted proposals are applied (or previewed with `check --diff`)
-4. **Tier 3 (manual)**: violations that neither transforms nor AI can fix are reported for human review
-
-## Scaling
-
-Scale pods, not services within a pod. Each pod is a self-contained stack that can process check and remediate workloads end-to-end. For more throughput, run multiple pods behind a load balancer. See [docs/architecture/17-scaling-and-deployment.md](docs/architecture/17-scaling-and-deployment.md).
-
-## Tests
-
-```bash
-# Install tox (one-time setup)
-uv tool install tox --with tox-uv
-
-# Unit tests with coverage
-tox -e unit
-
-# Integration tests (requires OPA binary)
-tox -e integration
-
-# All default environments (lint + unit + integration + ai + ui)
-tox
-```
-
-See [docs/guides/DEVELOPMENT.md](docs/guides/DEVELOPMENT.md) for the full tox environment reference.
 
 ## Project layout
 
 ```
-proto/apme/v1/          gRPC service definitions (.proto)
-src/apme/v1/            generated Python gRPC stubs
 src/apme_engine/
-  ├── engine/           project loader (parse, annotate, hierarchy)
-  │   └── annotators/   per-module risk annotators
-  ├── validators/
-  │   ├── base.py       Validator protocol + ScanContext
-  │   ├── native/       Python rules (L026–L105, M005/M010, R101–R501)
-  │   ├── opa/          Rego bundle (L003–L025, L061–L072, M006/M008/M009/M011, R118)
-  │   ├── ansible/      Ansible-runtime rules (L057–L059, M001–M004)
-  │   └── gitleaks/     Gitleaks wrapper (SEC:* — secret detection)
+  ├── cli/              CLI (check, format, remediate, health-check, sbom, suppress)
+  ├── engine/           Project loader (parse, annotate, hierarchy, graph)
+  ├── validators/       Rule implementations (native/, opa/, ansible/, gitleaks/)
   ├── daemon/           gRPC server implementations
-  ├── venv_manager/     Session-scoped venv lifecycle (VenvSessionManager)
   ├── remediation/      Tier 1 transforms + AI escalation
-  ├── formatter.py      YAML formatter (phase 1 remediation)
-  ├── cli/              CLI entry point (check, format, remediate, health-check)
-  └── runner.py         scan orchestration (engine-internal pipeline)
+  └── venv_manager/     Session-scoped venv lifecycle
 src/apme_gateway/       API gateway (FastAPI, REST/WebSocket, SQLite)
 src/galaxy_proxy/       Galaxy → PEP 503 wheel proxy
 frontend/               React operator UI (Vite + TypeScript)
+deploy/                 Helm chart + bootc VM image
 containers/             Containerfiles + Podman pod config
-docs/                   architecture, design, rule mapping
-tests/                  unit, integration, rule doc coverage
+docs/                   Architecture, design, guides, rule reference
 ```
 
 ## Documentation
 
 | Document | Description |
 |----------|-------------|
-| [Architecture series](docs/architecture/) | Pipeline walkthrough, container topology, gRPC contracts, data flow, scaling model |
-| [Design docs](docs/design/) | Remediation engine, AI escalation, validator abstraction — design rationale |
-| [Guides](docs/guides/) | Development setup, deployment, troubleshooting |
-| [Rule reference](docs/rules/) | Rule catalog, ID mapping, doc format, ansible-lint coverage |
-| [ADRs](.sdlc/adrs/) | Architecture Decision Records — key design decisions with context, alternatives, and rationale |
+| [CLI Guide](docs/guides/CLI.md) | Installation, commands, daemon mode, CI usage, limitations |
+| [Deployment Guide](docs/guides/DEPLOYMENT.md) | Podman pod setup, configuration, troubleshooting |
+| [bootc Deployment](deploy/bootc/README.md) | Atomic VM image with systemd quadlets |
+| [Helm Chart](deploy/helm/apme/README.md) | Kubernetes/OpenShift deployment |
+| [Architecture series](docs/architecture/) | Pipeline walkthrough, container topology, gRPC contracts, scaling |
+| [Design docs](docs/design/) | Remediation engine, AI escalation, validator abstraction |
+| [Rule reference](docs/rules/) | Rule catalog, ID mapping, ansible-lint coverage |
+| [Development guide](docs/guides/DEVELOPMENT.md) | Local setup, tox environments, testing |
+| [ADRs](.sdlc/adrs/) | Architecture Decision Records |
 
-## Roadmap
+## Contributing
 
-### Phase 1 — YAML Formatter (done)
-
-`format` subcommand with `--diff`/`--apply`/`--check` modes, idempotency guarantees, gRPC `Format` RPC.
-
-### Phase 2 — Modernization Engine
-
-- `remediate` subcommand: format → idempotency gate → re-scan → semantic transforms.
-- **`is_finding_resolvable()` partition**: each rule declares a `fixable` attribute; the remediate pipeline splits findings into auto-fixable vs manual/AI.
-- **Multi-pass convergence loop**: remediate applies transforms and re-runs the internal scan pipeline until stable or oscillation detected (max N passes).
-- **`module_metadata.json`**: machine-readable module lifecycle data (introduced, deprecated, removed, parameter renames) generated from `ansible-doc` across core versions. M-series rules become data-driven lookups instead of per-rule hardcoded logic.
-
-### Phase 2a — New Rules
-
-- **Secret scanning** (done) — Gitleaks validator: 800+ patterns for credentials, API keys, private keys via dedicated container + gRPC wrapper. Vault and Jinja filtering built in.
-- **EE compatibility rules** (R505–R507): undeclared collections, system path assumptions, undeclared Python deps. Requires static `ee_baseline.json` from `ee-supported-rhel9` inspection.
-- **Version auto-detection**: infer source Ansible version from playbook signals (short-form module names → ≤2.9, `include:` → ≤2.7, `tower_*` → ≤2.13). Auto-scope M-rules without an explicit `--ansible-core-version` flag.
-
-### Phase 3 — AI Integration (in progress)
-
-- **Abbenay daemon** as the AI backend via gRPC: `pip install apme-engine[ai]`.
-- **AIProvider Protocol** (`ADR-024`): pluggable abstraction for LLM providers; `AbbenayProvider` is the default.
-- **Hybrid validation loop**: AI proposals are re-scanned through APME validators, cleaned up with Tier 1 transforms, and retried with feedback if issues persist (max 2 attempts).
-- **Interactive review** (`--ai` flag): per-fix diff review (y/n/skip) like `git add -p`, or `--auto-approve` for automatic application.
-- **Structured best practices**: curated Ansible guidelines injected into prompts for higher-quality fixes.
-- **Preflight checks**: auto-discover Abbenay daemon socket, health check before AI calls.
-- See [DESIGN_AI_ESCALATION.md](docs/design/DESIGN_AI_ESCALATION.md) for the full design.
-
-### Phase 4 — Web UI (in progress)
-
-Operator UI for **check** and **remediate** sessions, **Activity** (history), health monitoring, and findings management. API gateway (FastAPI), REST/WebSocket API (`/api/v1/activity`, etc.), persistence (SQLite), and React frontend. Operation streaming uses `FixSession` gRPC (ADR-039). See [docs/architecture/13-gateway-and-persistence.md](docs/architecture/13-gateway-and-persistence.md) and [14-ui-integration.md](docs/architecture/14-ui-integration.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, coding standards, and PR process.
 
 ## License
 

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -23,6 +23,7 @@ helm install apme ./deploy/helm/apme/ \
 helm install apme ./deploy/helm/apme/ \
   --set image.tag=sha-7cb2464 \
   --set abbenay.enabled=true \
+  --set abbenay.token=$APME_ABBENAY_TOKEN \
   --set abbenay.apiKeys.openrouterApiKey=$OPENROUTER_API_KEY
 ```
 
@@ -59,6 +60,7 @@ helm install apme ./deploy/helm/apme/ \
 | `depAudit.enabled` | `true` | Enable Dependency Audit validator |
 | `gateway.replicas` | `1` | Gateway replicas |
 | `abbenay.enabled` | `false` | Enable AI provider |
+| `abbenay.token` | `""` | Abbenay service token (required when `abbenay.enabled=true`) |
 | `abbenay.image` | `ghcr.io/redhat-developer/abbenay:2026.4.1-alpha` | Abbenay image |
 | `abbenay.apiKeys.openrouterApiKey` | `""` | OpenRouter API key |
 | `abbenay.aiModel` | `""` | Default AI model ID |

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -1,0 +1,170 @@
+# APME Helm Chart
+
+Deploy APME on Kubernetes or OpenShift. The chart models the architecture
+as defined in [ADR-054](../../.sdlc/adrs/ADR-054-production-deployment.md):
+the engine stack runs as sidecar containers in a single pod (preserving
+localhost networking per ADR-005 and pod-level scaling per ADR-012).
+
+## Prerequisites
+
+- Kubernetes 1.26+ or OpenShift 4.14+
+- Helm 3.x
+- Access to `ghcr.io/ansible` container registry (or mirror images locally)
+- A published image tag (CI tags images by git SHA, e.g. `sha-7cb2464`)
+
+## Quick start
+
+```bash
+# From the repository root
+helm install apme ./deploy/helm/apme/ \
+  --set image.tag=sha-7cb2464
+
+# With AI enabled
+helm install apme ./deploy/helm/apme/ \
+  --set image.tag=sha-7cb2464 \
+  --set abbenay.enabled=true \
+  --set abbenay.apiKeys.openrouterApiKey=$OPENROUTER_API_KEY
+```
+
+## Architecture
+
+```
+┌─────────── Engine Pod (scaled as unit) ──────────┐
+│  Primary  Native  OPA  Ansible  Gitleaks         │
+│  Collection-Health  Dep-Audit  Galaxy-Proxy      │
+│  (all communicate via localhost gRPC)            │
+└──────────────────────────────────────────────────┘
+
+┌──────────┐   ┌──────────┐   ┌──────────┐
+│ Gateway  │   │    UI    │   │ Abbenay  │
+│ (deploy) │   │ (deploy) │   │ (deploy) │
+└──────────┘   └──────────┘   └──────────┘
+```
+
+- **Engine Deployment**: All validators run as sidecars in one pod. HPA scales
+  the entire engine stack together.
+- **Gateway Deployment**: REST API + gRPC Reporting + SQLite persistence.
+- **UI Deployment**: nginx-served React SPA, proxies `/api/` to Gateway.
+- **Abbenay Deployment** (optional): AI provider for Tier 2 remediation.
+
+## Key values
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `image.registry` | `ghcr.io/ansible` | Container registry |
+| `image.tag` | `""` | Image tag (required — set explicitly) |
+| `engine.replicas` | `1` | Engine pod replicas |
+| `gitleaks.enabled` | `true` | Enable Gitleaks validator |
+| `collectionHealth.enabled` | `true` | Enable Collection Health validator |
+| `depAudit.enabled` | `true` | Enable Dependency Audit validator |
+| `gateway.replicas` | `1` | Gateway replicas |
+| `abbenay.enabled` | `false` | Enable AI provider |
+| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:2026.4.1-alpha` | Abbenay image |
+| `abbenay.apiKeys.openrouterApiKey` | `""` | OpenRouter API key |
+| `abbenay.aiModel` | `""` | Default AI model ID |
+| `ingress.enabled` | `false` | Create Kubernetes Ingress |
+| `route.enabled` | `false` | Create OpenShift Route |
+| `autoscaling.enabled` | `false` | Enable HPA for engine |
+| `autoscaling.maxReplicas` | `5` | Max engine replicas under HPA |
+| `networkPolicy.enabled` | `false` | Enable NetworkPolicy |
+| `podDisruptionBudget.enabled` | `false` | Enable PDB |
+| `persistence.sessions.size` | `10Gi` | Session venv PVC size |
+| `persistence.gateway.size` | `5Gi` | Gateway DB PVC size |
+
+See [`values.yaml`](values.yaml) for the complete reference with all resource
+limits, tolerations, affinity, and topology spread constraints.
+
+## Exposing the UI and API
+
+### Kubernetes Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: apme.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+          service: gateway
+        - path: /
+          pathType: Prefix
+          service: ui
+  tls:
+    - secretName: apme-tls
+      hosts:
+        - apme.example.com
+```
+
+### OpenShift Route
+
+```yaml
+route:
+  enabled: true
+  host: apme.apps.ocp.example.com
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+```
+
+When `host` is empty, OpenShift auto-assigns separate hosts per Route.
+
+## Scaling
+
+Enable the HPA to auto-scale the engine based on CPU/memory:
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+```
+
+Each engine replica is a complete stack — scale pods, not individual
+services within a pod (ADR-012).
+
+For multi-replica deployments, override the engine strategy:
+
+```yaml
+engine:
+  strategy:
+    type: RollingUpdate
+```
+
+## OpenShift compatibility
+
+The chart works under OpenShift's `restricted-v2` SCC without modification:
+
+- `podSecurityContext` and `securityContext` default to empty (OCP injects UID/GID)
+- The UI container mounts emptyDir volumes for nginx writable paths
+- No privilege escalation is required
+
+For vanilla Kubernetes, set explicit security contexts:
+
+```yaml
+podSecurityContext:
+  fsGroup: 1000
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+```
+
+## Uninstall
+
+```bash
+helm uninstall apme
+```
+
+PVCs are not deleted automatically. Remove them manually if desired:
+
+```bash
+kubectl delete pvc -l app.kubernetes.io/instance=apme
+```
+
+## Related
+
+- [Deployment Guide](../../docs/guides/DEPLOYMENT.md) — Overview of all deployment methods
+- [ADR-054](../../.sdlc/adrs/ADR-054-production-deployment.md) — Architecture rationale
+- [Scaling docs](../../docs/architecture/17-scaling-and-deployment.md) — Scaling model

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -1,7 +1,7 @@
 # APME Helm Chart
 
 Deploy APME on Kubernetes or OpenShift. The chart models the architecture
-as defined in [ADR-054](../../.sdlc/adrs/ADR-054-production-deployment.md):
+as defined in [ADR-054](../../../.sdlc/adrs/ADR-054-production-deployment.md):
 the engine stack runs as sidecar containers in a single pod (preserving
 localhost networking per ADR-005 and pod-level scaling per ADR-012).
 
@@ -167,6 +167,6 @@ kubectl delete pvc -l app.kubernetes.io/instance=apme
 
 ## Related
 
-- [Deployment Guide](../../docs/guides/DEPLOYMENT.md) — Overview of all deployment methods
-- [ADR-054](../../.sdlc/adrs/ADR-054-production-deployment.md) — Architecture rationale
-- [Scaling docs](../../docs/architecture/17-scaling-and-deployment.md) — Scaling model
+- [Deployment Guide](../../../docs/guides/DEPLOYMENT.md) — Overview of all deployment methods
+- [ADR-054](../../../.sdlc/adrs/ADR-054-production-deployment.md) — Architecture rationale
+- [Scaling docs](../../../docs/architecture/17-scaling-and-deployment.md) — Scaling model

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -32,7 +32,7 @@ helm install apme ./deploy/helm/apme/ \
 ┌─────────── Engine Pod (scaled as unit) ──────────┐
 │  Primary  Native  OPA  Ansible  Gitleaks         │
 │  Collection-Health  Dep-Audit  Galaxy-Proxy      │
-│  (all communicate via localhost gRPC)            │
+│  (validators via localhost gRPC; Galaxy Proxy via HTTP) │
 └──────────────────────────────────────────────────┘
 
 ┌──────────┐   ┌──────────┐   ┌──────────┐

--- a/docs/guides/CLI.md
+++ b/docs/guides/CLI.md
@@ -22,15 +22,15 @@ Replace the tag with any [release version](https://github.com/ansible/apme/relea
 ### Requirements
 
 - Python 3.10+
-- OPA binary on `$PATH` (optional — OPA validator is skipped if not found)
+- Podman **or** `opa` binary on `$PATH` (optional — OPA uses Podman by default; falls back to local `opa`; skipped if neither is available)
 
 ## How it works
 
 The CLI uses a **daemon architecture**:
 
 1. On first use, `apme` starts a background daemon process
-2. The daemon runs Primary, Native, OPA, Ansible validators, and Galaxy Proxy as
-   in-process gRPC servers on localhost
+2. The daemon runs Primary, Native, OPA, and Ansible as in-process gRPC servers,
+   plus Galaxy Proxy as an HTTP service (uvicorn), all on localhost
 3. The CLI sends file bytes to the daemon over gRPC and receives results
 4. The daemon stays running between commands for fast subsequent scans
 
@@ -163,12 +163,14 @@ Upload the SARIF file to GitHub Code Scanning via the
 ```yaml
 # .pre-commit-config.yaml
 repos:
-  - repo: https://github.com/ansible/apme
-    rev: v2026.4.1
+  - repo: local
     hooks:
       - id: apme-check
+        name: APME check
         entry: apme check
+        language: system
         types: [yaml]
+        pass_filenames: false
 ```
 
 ### GitHub Actions example
@@ -210,7 +212,7 @@ production use or full feature access, use a [deployment method](DEPLOYMENT.md).
 | Check (scan for violations) | Yes | Yes |
 | Remediate (Tier 1 transforms) | Yes | Yes |
 | Format (YAML normalization) | Yes | Yes |
-| Secret scanning (Gitleaks) | Requires `gitleaks` binary | Built-in |
+| Secret scanning (Gitleaks) | Not available (daemon does not start gitleaks validator) | Built-in |
 | AI-assisted remediation | Requires Abbenay daemon | Built-in (pod) |
 | Web UI dashboard | No | Yes |
 | Persistent scan history | No | Yes (Gateway + SQLite) |

--- a/docs/guides/CLI.md
+++ b/docs/guides/CLI.md
@@ -1,8 +1,10 @@
 # CLI Guide
 
 APME's CLI is a thin gRPC client that communicates with a local daemon process.
-When you run any command, the CLI auto-starts the daemon if it isn't already
-running. No containers, no infrastructure — just `pip install` and go.
+For scan commands (`check`, `remediate`, `format`, `health-check`), the CLI
+auto-starts the daemon if it isn't already running. Commands like `sbom` and
+`suppress` do not use the daemon. No containers, no infrastructure — just
+`pip install` and go.
 
 ## Installation
 
@@ -129,7 +131,6 @@ Suppressions are stored in `.apme/suppressions.yml` within your project.
 
 ```bash
 apme sbom PROJECT_ID                      # CycloneDX SBOM (requires Gateway)
-apme sbom PROJECT_ID --format json        # JSON format
 apme sbom PROJECT_ID -o sbom.json         # write to file
 ```
 
@@ -217,8 +218,8 @@ production use or full feature access, use a [deployment method](DEPLOYMENT.md).
 | Web UI dashboard | No | Yes |
 | Persistent scan history | No | Yes (Gateway + SQLite) |
 | Multi-user / shared service | No (single-user) | Yes |
-| Collection Health scanning | Yes | Yes |
-| Python CVE audit | Yes | Yes |
+| Collection Health scanning | Not available (daemon does not start optional validators) | Yes |
+| Python CVE audit | Not available (daemon does not start optional validators) | Yes |
 | SBOM generation | Requires Gateway | Yes |
 | Atomic upgrades / rollback | No | Yes (bootc) |
 | Horizontal scaling | No | Yes (Helm) |

--- a/docs/guides/CLI.md
+++ b/docs/guides/CLI.md
@@ -121,10 +121,10 @@ apme health-check --timeout 5             # custom timeout (seconds)
 ### `apme suppress` — manage violation suppressions
 
 ```bash
-apme suppress add --rule-id L046 .                  # suppress a rule (full fingerprint)
-apme suppress add --rule-id L046 --mode rule_only . # suppress all instances of a rule
-apme suppress list .                                # show active suppressions
-apme suppress remove FINGERPRINT_PREFIX .           # remove a suppression
+apme suppress add --rule-id L046 --mode rule_only .                # suppress all instances of a rule
+apme suppress add --rule-id L046 --original-yaml 'name: example' . # suppress a specific occurrence (full mode)
+apme suppress list .                                               # show active suppressions
+apme suppress remove FINGERPRINT_PREFIX .                          # remove a suppression
 ```
 
 Suppressions are stored in `.apme/suppressions.yml` within your project.

--- a/docs/guides/CLI.md
+++ b/docs/guides/CLI.md
@@ -1,0 +1,266 @@
+# CLI Guide
+
+APME's CLI is a thin gRPC client that communicates with a local daemon process.
+When you run any command, the CLI auto-starts the daemon if it isn't already
+running. No containers, no infrastructure — just `pip install` and go.
+
+## Installation
+
+```bash
+# Install a specific release (recommended)
+pip install apme-engine@git+https://github.com/ansible/apme.git@v2026.4.1
+
+# Install with AI escalation support (requires Abbenay daemon)
+pip install "apme-engine[ai] @ git+https://github.com/ansible/apme.git@v2026.4.1"
+
+# Install the latest development version (main branch)
+pip install apme-engine@git+https://github.com/ansible/apme.git@main
+```
+
+Replace the tag with any [release version](https://github.com/ansible/apme/releases).
+
+### Requirements
+
+- Python 3.10+
+- OPA binary on `$PATH` (optional — OPA validator is skipped if not found)
+
+## How it works
+
+The CLI uses a **daemon architecture**:
+
+1. On first use, `apme` starts a background daemon process
+2. The daemon runs Primary, Native, OPA, Ansible validators, and Galaxy Proxy as
+   in-process gRPC servers on localhost
+3. The CLI sends file bytes to the daemon over gRPC and receives results
+4. The daemon stays running between commands for fast subsequent scans
+
+```
+┌───────────┐  gRPC   ┌──────────────────────────────────────────┐
+│  apme CLI │ ──────► │          Local Daemon (Primary)          │
+│  (client) │         │  ┌────────┬───────┬─────────┬────────┐  │
+└───────────┘         │  │ Native │  OPA  │ Ansible │ Galaxy │  │
+                      │  │        │       │         │ Proxy  │  │
+                      │  └────────┴───────┴─────────┴────────┘  │
+                      └──────────────────────────────────────────┘
+```
+
+### Daemon management
+
+```bash
+apme daemon start     # start explicitly (auto-starts on first command)
+apme daemon status    # check if running
+apme daemon stop      # stop the background daemon
+```
+
+## Commands
+
+### `apme check` — scan for violations
+
+```bash
+apme check /path/to/playbook-or-project
+apme check .                              # scan current directory
+apme check --json .                       # JSON output
+apme check --sarif .                      # SARIF 2.1.0 output (for GitHub/IDE)
+apme check -v .                           # summary diagnostics + top 10 slow rules
+apme check -vv .                          # full per-rule timing breakdown
+apme check --diff .                       # show what remediate would change
+apme check --ansible-version 2.17 .       # target a specific ansible-core version
+```
+
+**Exit codes:** 0 = clean, 1 = violations found, 2 = error.
+
+#### Dependency scanning options
+
+```bash
+apme check --skip-dep-scan .              # skip collection health + Python CVE
+apme check --skip-collection-scan .       # skip only collection health scanning
+apme check --skip-python-audit .          # skip only Python CVE audit
+```
+
+### `apme remediate` — fix violations automatically
+
+```bash
+apme remediate /path/to/project           # Tier 1 deterministic transforms
+apme remediate --ai .                     # include Tier 2 AI-assisted fixes
+apme remediate --ai --auto-approve .      # no interactive review (CI mode)
+apme remediate --max-passes 3 .           # limit convergence iterations
+```
+
+The remediation pipeline:
+1. **Format** — normalize YAML style
+2. **Idempotency gate** — verify formatting is stable
+3. **Scan** — detect violations
+4. **Tier 1** — apply deterministic transforms in a convergence loop
+5. **Tier 2** (with `--ai`) — escalate remaining violations to AI provider
+6. **Interactive review** — approve/reject AI proposals (or `--auto-approve`)
+
+### `apme format` — normalize YAML style
+
+```bash
+apme format /path/to/project              # show diffs (no changes written)
+apme format --apply /path/to/project      # apply changes in place
+apme format --check /path/to/project      # CI mode: exit 1 if changes needed
+apme format --exclude "vendor/**" .       # exclude paths
+```
+
+Normalizes indentation, key ordering, Jinja spacing, and removes tabs while
+preserving YAML comments. Idempotent by design.
+
+### `apme health-check` — service status
+
+```bash
+apme health-check                         # human-readable status
+apme health-check --json                  # machine-readable
+apme health-check --timeout 5             # custom timeout (seconds)
+```
+
+### `apme suppress` — manage violation suppressions
+
+```bash
+apme suppress add --rule-id L046 .                  # suppress a rule (full fingerprint)
+apme suppress add --rule-id L046 --mode rule_only . # suppress all instances of a rule
+apme suppress list .                                # show active suppressions
+apme suppress remove FINGERPRINT_PREFIX .           # remove a suppression
+```
+
+Suppressions are stored in `.apme/suppressions.yml` within your project.
+
+### `apme sbom` — software bill of materials
+
+```bash
+apme sbom PROJECT_ID                      # CycloneDX SBOM (requires Gateway)
+apme sbom PROJECT_ID --format json        # JSON format
+apme sbom PROJECT_ID -o sbom.json         # write to file
+```
+
+## CI usage
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No violations (check), no changes needed (format --check) |
+| 1 | Violations found (check), changes needed (format --check) |
+| 2 | Runtime error |
+
+### JSON output for automation
+
+```bash
+apme check --json . | jq '.violations | length'
+```
+
+### SARIF for GitHub Code Scanning
+
+```bash
+apme check --sarif . > results.sarif
+```
+
+Upload the SARIF file to GitHub Code Scanning via the
+[upload-sarif action](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github).
+
+### Pre-commit hook
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/ansible/apme
+    rev: v2026.4.1
+    hooks:
+      - id: apme-check
+        entry: apme check
+        types: [yaml]
+```
+
+### GitHub Actions example
+
+```yaml
+- name: Install APME
+  run: pip install apme-engine@git+https://github.com/ansible/apme.git@v2026.4.1
+
+- name: Run APME check
+  run: apme check --sarif . > results.sarif
+
+- name: Upload SARIF
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: results.sarif
+```
+
+See [examples/ci/](../../examples/ci/) for complete workflow examples.
+
+## Common options
+
+| Flag | Commands | Description |
+|------|----------|-------------|
+| `--json` | check, remediate, health-check | Machine-readable JSON output |
+| `--sarif` | check | SARIF 2.1.0 output |
+| `--no-ansi` | all | Disable colored output |
+| `--session ID` | check, format, remediate | Explicit session ID for venv reuse |
+| `--ansible-version` | check, remediate | Target ansible-core version |
+| `--collections` | check, remediate | Additional collection specs to install |
+| `--timeout` | check, health-check | gRPC timeout in seconds |
+
+## Limitations vs full deployment
+
+The CLI daemon is designed for quick evaluation and CI pipelines. For
+production use or full feature access, use a [deployment method](DEPLOYMENT.md).
+
+| Capability | CLI (daemon) | Podman / bootc / Helm |
+|------------|:------------:|:---------------------:|
+| Check (scan for violations) | Yes | Yes |
+| Remediate (Tier 1 transforms) | Yes | Yes |
+| Format (YAML normalization) | Yes | Yes |
+| Secret scanning (Gitleaks) | Requires `gitleaks` binary | Built-in |
+| AI-assisted remediation | Requires Abbenay daemon | Built-in (pod) |
+| Web UI dashboard | No | Yes |
+| Persistent scan history | No | Yes (Gateway + SQLite) |
+| Multi-user / shared service | No (single-user) | Yes |
+| Collection Health scanning | Yes | Yes |
+| Python CVE audit | Yes | Yes |
+| SBOM generation | Requires Gateway | Yes |
+| Atomic upgrades / rollback | No | Yes (bootc) |
+| Horizontal scaling | No | Yes (Helm) |
+
+### When to use the CLI
+
+- Evaluating APME on a project for the first time
+- CI/CD pipelines (GitHub Actions, GitLab CI, Jenkins)
+- Developer workstation pre-commit checks
+- Scripted automation with JSON/SARIF output
+
+### When to deploy
+
+- You need the web UI for team visibility
+- You want persistent scan history and analytics
+- You need AI-assisted remediation without managing Abbenay separately
+- You're running APME as a shared service for multiple teams
+- You want atomic upgrades and production reliability (bootc/Helm)
+
+## Configuration
+
+The CLI reads configuration from these sources (in priority order):
+
+1. CLI flags (highest priority)
+2. Environment variables (`APME_PRIMARY_ADDRESS`, `APME_ABBENAY_ADDR`, etc.)
+3. Project-level `.apme/rules.yml` for rule configuration
+
+### Rule configuration
+
+Create `.apme/rules.yml` in your project root to customize rule behavior:
+
+```yaml
+rules:
+  L003:
+    enabled: false
+  R101:
+    severity: warning
+```
+
+See [Rule Configuration](RULE_CONFIGURATION.md) for the full reference.
+
+## Related
+
+- [Deployment Guide](DEPLOYMENT.md) — Podman pod, bootc VM, Helm chart
+- [Development Guide](DEVELOPMENT.md) — Contributing, tox environments, testing
+- [Rule Catalog](../rules/RULE_CATALOG.md) — Complete rule listing
+- [Architecture](../architecture/) — Pipeline design and service contracts

--- a/docs/guides/CLI.md
+++ b/docs/guides/CLI.md
@@ -5,8 +5,10 @@ discovers the Primary using a three-tier strategy: (1) `APME_PRIMARY_ADDRESS`
 env var, (2) a running local daemon, (3) auto-start a local daemon. For scan
 commands (`check`, `remediate`, `format`, `health-check`), this discovery
 happens automatically. Commands like `sbom` and `suppress` talk to the Gateway
-REST API or operate locally without a Primary. No containers, no
-infrastructure — just `pip install` and go.
+REST API or operate locally without a Primary. No full pod required — just
+`pip install` and go (OPA uses a Podman container by default; set
+`OPA_USE_PODMAN=0` for a local binary, or OPA is skipped if neither is
+available).
 
 ## Installation
 

--- a/docs/guides/CLI.md
+++ b/docs/guides/CLI.md
@@ -1,10 +1,12 @@
 # CLI Guide
 
-APME's CLI is a thin gRPC client that communicates with a local daemon process.
-For scan commands (`check`, `remediate`, `format`, `health-check`), the CLI
-auto-starts the daemon if it isn't already running. Commands like `sbom` and
-`suppress` do not use the daemon. No containers, no infrastructure — just
-`pip install` and go.
+APME's CLI is a thin gRPC client that connects to a Primary service. It
+discovers the Primary using a three-tier strategy: (1) `APME_PRIMARY_ADDRESS`
+env var, (2) a running local daemon, (3) auto-start a local daemon. For scan
+commands (`check`, `remediate`, `format`, `health-check`), this discovery
+happens automatically. Commands like `sbom` and `suppress` talk to the Gateway
+REST API or operate locally without a Primary. No containers, no
+infrastructure — just `pip install` and go.
 
 ## Installation
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -273,8 +273,9 @@ it as the `--index-strategy` argument to `uv pip install`.
 ## Local development (daemon mode)
 
 For development and testing without the Podman pod, the CLI can start a
-local daemon that runs the Primary, Native, OPA, Ansible, and Galaxy Proxy services
-as localhost gRPC servers (ADR-024). Gitleaks is excluded (requires the gitleaks binary).
+local daemon that runs Primary, Native, OPA, and Ansible as localhost gRPC
+servers plus Galaxy Proxy as an HTTP service (ADR-024). Optional validators
+(Gitleaks, Collection Health, Dep Audit) are not started by the daemon.
 
 ```bash
 # Install tox + project (one-time)
@@ -293,7 +294,7 @@ apme remediate .
 apme daemon stop
 ```
 
-**Daemon mode** starts a local Primary server with Native, OPA, and Ansible validators plus the Galaxy Proxy running in-process. OPA runs via the local `opa` binary; if `opa` is not installed, the OPA validator is automatically skipped.
+**Daemon mode** starts a local Primary server with Native, OPA, and Ansible validators as in-process gRPC servers, plus Galaxy Proxy as an HTTP service (uvicorn). Optional validators (Gitleaks, Collection Health, Dep Audit) are not started. OPA uses Podman by default; falls back to a local `opa` binary if Podman is unavailable; skipped if neither is found.
 
 ## Troubleshooting
 
@@ -387,14 +388,15 @@ per ADR-012).
 - HPA for engine scaling, PDB for disruption budget
 - Ingress/Route support (OpenShift Routes included)
 - NetworkPolicy for pod isolation
-- PVC for Gateway persistence, emptyDir for session venvs
+- PVC for Gateway persistence; PVC for session venvs (single replica), emptyDir when scaling to multiple replicas
 
 ### Quick start
 
 ```bash
 helm install apme ./deploy/helm/apme/ \
   --set image.tag=sha-7cb2464 \
-  --set abbenay.apiKey=$OPENROUTER_API_KEY
+  --set abbenay.enabled=true \
+  --set abbenay.apiKeys.openrouterApiKey=$OPENROUTER_API_KEY
 ```
 
 ### Key values
@@ -403,8 +405,8 @@ helm install apme ./deploy/helm/apme/ \
 |-------|-------------|
 | `image.tag` | Image tag for all containers (required — no default) |
 | `engine.replicas` | Engine pod replicas (default: 1) |
-| `abbenay.enabled` | Enable AI provider (default: true) |
-| `abbenay.apiKey` | LLM provider API key |
+| `abbenay.enabled` | Enable AI provider (default: false) |
+| `abbenay.apiKeys.openrouterApiKey` | OpenRouter LLM provider API key |
 | `ingress.enabled` | Create Ingress resource (default: false) |
 | `route.enabled` | Create OpenShift Route (default: false) |
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -9,9 +9,10 @@ APME supports multiple deployment methods depending on your environment and need
 | **Helm chart** | Kubernetes / OpenShift | [Helm section](#helm--kubernetes) / [full guide](../../deploy/helm/apme/README.md) |
 | **CLI daemon** | Quick evaluation, CI | [CLI Guide](CLI.md) |
 
-All deployment methods run the same engine stack (Primary + validators + Galaxy
-Proxy). The difference is lifecycle management, persistence, and additional
-services (UI, Gateway, Abbenay AI).
+Full deployment methods (Podman, bootc, Helm) run the complete engine stack
+(Primary + all validators + Galaxy Proxy). The CLI daemon runs only core
+validators (Native, OPA, Ansible) + Galaxy Proxy. The difference is lifecycle
+management, persistence, and additional services (UI, Gateway, Abbenay AI).
 
 ---
 
@@ -313,7 +314,7 @@ See [PODMAN_OPA_ISSUES.md](PODMAN_OPA_ISSUES.md) for common Podman rootless issu
 | 50054 | OPA | `APME_OPA_VALIDATOR_LISTEN` |
 | 50055 | Native | `APME_NATIVE_VALIDATOR_LISTEN` |
 | 50056 | Gitleaks | `APME_GITLEAKS_VALIDATOR_LISTEN` |
-| 50057 | Abbenay AI | `--grpc-port` (CLI flag) |
+| 50057 | Abbenay AI | `--grpc-port` (Abbenay daemon flag) |
 | 50058 | Collection Health | `APME_COLLECTION_HEALTH_VALIDATOR_LISTEN` |
 | 50059 | Dep Audit | `APME_DEP_AUDIT_VALIDATOR_LISTEN` |
 | 50060 | Gateway (gRPC) | `APME_GATEWAY_GRPC_LISTEN` |

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -1,6 +1,21 @@
-# Deployment
+# Deployment Guide
 
-## Podman pod (recommended)
+APME supports multiple deployment methods depending on your environment and needs.
+
+| Method | Best for | Details |
+|--------|----------|---------|
+| **Podman pod** | Development, full feature set | [Below](#podman-pod) |
+| **bootc VM** | Production single-node, atomic upgrades | [bootc section](#bootc-vm) / [full guide](../../deploy/bootc/README.md) |
+| **Helm chart** | Kubernetes / OpenShift | [Helm section](#helm--kubernetes) / [full guide](../../deploy/helm/apme/README.md) |
+| **CLI daemon** | Quick evaluation, CI | [CLI Guide](CLI.md) |
+
+All deployment methods run the same engine stack (Primary + validators + Galaxy
+Proxy). The difference is lifecycle management, persistence, and additional
+services (UI, Gateway, Abbenay AI).
+
+---
+
+## Podman pod
 
 The primary deployment target is a Podman pod. All backend services run in a single pod sharing `localhost`; the CLI is run on-the-fly outside the pod with the project directory mounted.
 
@@ -307,4 +322,91 @@ See [PODMAN_OPA_ISSUES.md](PODMAN_OPA_ISSUES.md) for common Podman rootless issu
 
 ## Related Documents
 
-- [ADR-006](../.sdlc/adrs/ADR-006-ephemeral-venvs.md) — Ephemeral venvs for Ansible (superseded by ADR-022/ADR-031)
+- [CLI Guide](CLI.md) — CLI installation, commands, and limitations
+- [bootc full guide](../../deploy/bootc/README.md) — Complete bootc VM documentation
+- [Helm chart full guide](../../deploy/helm/apme/README.md) — Complete Helm documentation
+- [ADR-006](../../.sdlc/adrs/ADR-006-ephemeral-venvs.md) — Ephemeral venvs for Ansible (superseded by ADR-022/ADR-031)
+- [ADR-054](../../.sdlc/adrs/ADR-054-production-deployment.md) — Production Deployment (Helm + bootc)
+
+---
+
+## bootc VM
+
+Deploy APME as an atomic, image-based Linux VM using
+[bootc](https://containers.github.io/bootc/). The VM ships Podman and quadlet
+definitions for all APME services. Container images are pulled from the registry
+on first boot. Systemd manages automatic startup and lifecycle.
+
+**Highlights:**
+
+- CentOS Stream 10 base image
+- Systemd quadlet files for each service (automatic restart, dependency ordering)
+- Atomic upgrades with automatic rollback on failure (`bootc switch`)
+- Persistent storage at `/var/lib/apme/`
+- Firewall rules expose only ports 8080 (REST), 8081 (UI), 50051 (gRPC)
+
+### Quick start
+
+```bash
+# Build the bootc OCI image
+podman build -f deploy/bootc/Containerfile -t apme-bootc:latest .
+
+# Convert to disk image (qcow2, raw, or AMI)
+sudo podman run --rm -it --privileged \
+  -v ./output:/output \
+  -v /var/lib/containers/storage:/var/lib/containers/storage \
+  quay.io/centos-bootc/bootc-image-builder:latest \
+  --type qcow2 --local apme-bootc:latest
+
+# Boot the VM — APME starts automatically
+```
+
+### Upgrading
+
+```bash
+sudo bootc switch --transport containers-storage apme-bootc:latest
+sudo systemctl reboot
+```
+
+See [deploy/bootc/README.md](../../deploy/bootc/README.md) for full
+configuration, service management, and troubleshooting.
+
+---
+
+## Helm / Kubernetes
+
+Deploy APME on Kubernetes or OpenShift using the Helm chart at
+`deploy/helm/apme/`. The chart models the engine stack as sidecar containers
+in a single pod (preserving localhost networking per ADR-005 and pod scaling
+per ADR-012).
+
+**Highlights:**
+
+- Engine pod: Primary + Native + OPA + Ansible + Gitleaks + Collection Health + Dep Audit + Galaxy Proxy as sidecars
+- Separate deployments for Gateway, UI, and Abbenay (AI)
+- HPA for engine scaling, PDB for disruption budget
+- Ingress/Route support (OpenShift Routes included)
+- NetworkPolicy for pod isolation
+- PVC for Gateway persistence, emptyDir for session venvs
+
+### Quick start
+
+```bash
+helm install apme ./deploy/helm/apme/ \
+  --set image.tag=sha-7cb2464 \
+  --set abbenay.apiKey=$OPENROUTER_API_KEY
+```
+
+### Key values
+
+| Value | Description |
+|-------|-------------|
+| `image.tag` | Image tag for all containers (required — no default) |
+| `engine.replicas` | Engine pod replicas (default: 1) |
+| `abbenay.enabled` | Enable AI provider (default: true) |
+| `abbenay.apiKey` | LLM provider API key |
+| `ingress.enabled` | Create Ingress resource (default: false) |
+| `route.enabled` | Create OpenShift Route (default: false) |
+
+See [deploy/helm/apme/README.md](../../deploy/helm/apme/README.md) for the
+full values reference and architecture details.

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -397,6 +397,7 @@ per ADR-012).
 helm install apme ./deploy/helm/apme/ \
   --set image.tag=sha-7cb2464 \
   --set abbenay.enabled=true \
+  --set abbenay.token=$APME_ABBENAY_TOKEN \
   --set abbenay.apiKeys.openrouterApiKey=$OPENROUTER_API_KEY
 ```
 
@@ -407,6 +408,7 @@ helm install apme ./deploy/helm/apme/ \
 | `image.tag` | Image tag for all containers (required — no default) |
 | `engine.replicas` | Engine pod replicas (default: 1) |
 | `abbenay.enabled` | Enable AI provider (default: false) |
+| `abbenay.token` | Abbenay service token (required when `abbenay.enabled=true`) |
 | `abbenay.apiKeys.openrouterApiKey` | OpenRouter LLM provider API key |
 | `ingress.enabled` | Create Ingress resource (default: false) |
 | `route.enabled` | Create OpenShift Route (default: false) |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -7,9 +7,10 @@ troubleshoot APME.
 
 | Document | Description |
 |----------|-------------|
+| [CLI.md](CLI.md) | CLI installation, commands, daemon mode, CI usage, limitations |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Podman pod, bootc VM, Helm chart — setup and configuration |
 | [DEVELOPMENT.md](DEVELOPMENT.md) | Local setup, tox environments, adding rules, testing |
-| [DEPLOYMENT.md](DEPLOYMENT.md) | Podman pod setup, configuration, environment variables |
-| [RULE_CONFIGURATION.md](RULE_CONFIGURATION.md) | Rule blacklisting, custom rules, AI confidence scoring |
+| [RULE_CONFIGURATION.md](RULE_CONFIGURATION.md) | Rule configuration, suppression, dependency scan options |
 | [PODMAN_OPA_ISSUES.md](PODMAN_OPA_ISSUES.md) | Podman rootless troubleshooting for OPA |
 
 ## When to Add a Document Here


### PR DESCRIPTION
## Summary

- Simplify the main README from ~500 lines to ~160 lines, focusing on value proposition ("what/why") rather than operational details
- Create dedicated guides for CLI usage and each deployment method (Podman, bootc, Helm)
- Ensure all documentation is cross-linked and up to date with current architecture (12 services, not 6)

## Changes

- **README.md**: Rewritten to cover what APME is, why you want it, key features, architecture at a glance, and a getting-started table linking to deployment guides. Removed all operational content (env vars, container topology details, AI setup, scaling, roadmap, full test instructions).
- **docs/guides/CLI.md** (new): CLI installation, daemon architecture, all commands with examples, CI usage (JSON/SARIF/pre-commit/GitHub Actions), limitations vs full deployment comparison table.
- **deploy/helm/apme/README.md** (new): Helm chart quick-start, architecture overview, key values reference, Ingress/Route configuration, scaling, OpenShift compatibility.
- **docs/guides/DEPLOYMENT.md**: Added deployment methods comparison table at top, bootc VM section, and Helm/Kubernetes section at bottom with cross-links to dedicated READMEs.
- **docs/guides/README.md**: Updated index to include new CLI guide.
- **.sdlc/context/project-overview.md**: Fully rewritten — removed outdated LangGraph/week-1-2 timeline content, updated to reflect current 12-service architecture.
- **.sdlc/context/architecture.md**: Added Collection Health (:50058), Dep Audit (:50059), Abbenay (:50057), Gateway, and UI to topology diagram, services table, fan-out diagram, and port map.
- **.sdlc/context/deployment.md**: Added canonical guide link header, updated image count (9→11+Abbenay), added missing services/ports to tables.

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2560 passed)
- [x] All relative links verified against actual file paths
- [x] Port numbers, CLI flags, and environment variables verified against source code
- [ ] Visual review of rendered markdown on GitHub


Made with [Cursor](https://cursor.com)