### PR TITLE
fix(galaxy-proxy): resolve path injection vulnerabilities

### DIFF
--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -456,8 +456,8 @@ def create_app(
 def _validate_tarball_dir(tarball_dir: str) -> Path:
     """Validate and resolve a tarball directory path.
 
-    Rejects symlinks anywhere in the path and restricts the resolved
-    path to known-safe roots (temp dir or ``/sessions``).
+    Resolves the path first (eliminating symlinks and ``..`` components),
+    then checks the canonical result against an allowlist of safe roots.
 
     Args:
         tarball_dir: Untrusted path string from the request.
@@ -466,16 +466,9 @@ def _validate_tarball_dir(tarball_dir: str) -> Path:
         The resolved, validated ``Path``.
 
     Raises:
-        HTTPException: On symlinks, disallowed roots, or non-directories.
+        HTTPException: On disallowed roots or non-directories.
     """
-    raw = Path(tarball_dir)
-    for component in (raw, *raw.parents):
-        try:
-            if component.is_symlink():
-                raise HTTPException(status_code=400, detail="Symlinks not allowed")
-        except FileNotFoundError:
-            continue
-    resolved = raw.resolve()
+    resolved = Path(os.path.realpath(tarball_dir))
 
     allowed_roots = (Path(tempfile.gettempdir()).resolve(), Path("/sessions").resolve())
     if not any(resolved.is_relative_to(root) for root in allowed_roots):

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -786,21 +786,29 @@ class TestConvertTarballs:
         assert "session or temp directory" in resp.json()["detail"]
 
     def test_convert_rejects_symlink_outside_allowed(self, tmp_path: Path) -> None:
-        """A symlink resolving outside allowed roots is rejected with 400.
+        """A symlink under the allowed root that resolves outside is rejected.
+
+        The symlink is placed inside the allowed temp root but points to a
+        directory outside it, verifying that resolve-first validation catches
+        the escape.
 
         Args:
             tmp_path: Pytest-provided temporary directory.
         """
         cache_dir = tmp_path / "cache"
         application = create_app(cache_dir=cache_dir)
-        real_dir = tmp_path / "real"
-        real_dir.mkdir()
-        symlink = tmp_path / "link"
-        symlink.symlink_to(real_dir)
+
+        allowed_root = tmp_path / "allowed"
+        allowed_root.mkdir()
+        escape_target = tmp_path / "escaped"
+        escape_target.mkdir()
+
+        symlink = allowed_root / "link"
+        symlink.symlink_to(escape_target)
 
         with (
             TestClient(application) as client,
-            patch("tempfile.gettempdir", return_value=str(tmp_path / "fake-tmp")),
+            patch("tempfile.gettempdir", return_value=str(allowed_root)),
         ):
             resp = client.post("/convert-tarballs", params={"tarball_dir": str(symlink)})
 
@@ -848,24 +856,31 @@ class TestConvertTarballs:
         assert resp.status_code == 400
 
     def test_convert_rejects_symlink_parent_outside_allowed(self, tmp_path: Path) -> None:
-        """A symlink parent resolving outside allowed roots is rejected.
+        """A symlink parent component that escapes the allowed root is rejected.
+
+        The symlink is placed inside the allowed root as a parent directory
+        component, but resolves to a path outside it. Verifies the
+        resolve-first pattern catches traversal via symlinked parents.
 
         Args:
             tmp_path: Pytest-provided temporary directory.
         """
         cache_dir = tmp_path / "cache"
         application = create_app(cache_dir=cache_dir)
-        real_parent = tmp_path / "real_parent"
-        real_parent.mkdir()
-        child = real_parent / "child"
+
+        allowed_root = tmp_path / "allowed"
+        allowed_root.mkdir()
+        escape_target = tmp_path / "escaped"
+        escape_target.mkdir()
+        child = escape_target / "child"
         child.mkdir()
 
-        link_parent = tmp_path / "link_parent"
-        link_parent.symlink_to(real_parent)
+        link_parent = allowed_root / "link_parent"
+        link_parent.symlink_to(escape_target)
 
         with (
             TestClient(application) as client,
-            patch("tempfile.gettempdir", return_value=str(tmp_path / "fake-tmp")),
+            patch("tempfile.gettempdir", return_value=str(allowed_root)),
         ):
             resp = client.post(
                 "/convert-tarballs",

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -785,8 +785,8 @@ class TestConvertTarballs:
         assert resp.status_code == 400
         assert "session or temp directory" in resp.json()["detail"]
 
-    def test_convert_rejects_symlink_in_path(self, tmp_path: Path) -> None:
-        """A symlink anywhere in the path is rejected with 400.
+    def test_convert_rejects_symlink_outside_allowed(self, tmp_path: Path) -> None:
+        """A symlink resolving outside allowed roots is rejected with 400.
 
         Args:
             tmp_path: Pytest-provided temporary directory.
@@ -798,11 +798,14 @@ class TestConvertTarballs:
         symlink = tmp_path / "link"
         symlink.symlink_to(real_dir)
 
-        with TestClient(application) as client:
+        with (
+            TestClient(application) as client,
+            patch("tempfile.gettempdir", return_value=str(tmp_path / "fake-tmp")),
+        ):
             resp = client.post("/convert-tarballs", params={"tarball_dir": str(symlink)})
 
         assert resp.status_code == 400
-        assert "Symlinks not allowed" in resp.json()["detail"]
+        assert "session or temp directory" in resp.json()["detail"]
 
     def test_convert_rejects_dotdot_traversal(self, tmp_path: Path) -> None:
         """Paths using ``..`` to escape allowed roots are rejected.
@@ -822,8 +825,8 @@ class TestConvertTarballs:
 
         assert resp.status_code == 400
 
-    def test_convert_rejects_symlink_parent(self, tmp_path: Path) -> None:
-        """A symlink used as a parent directory component is rejected.
+    def test_convert_rejects_symlink_parent_outside_allowed(self, tmp_path: Path) -> None:
+        """A symlink parent resolving outside allowed roots is rejected.
 
         Args:
             tmp_path: Pytest-provided temporary directory.
@@ -838,11 +841,14 @@ class TestConvertTarballs:
         link_parent = tmp_path / "link_parent"
         link_parent.symlink_to(real_parent)
 
-        with TestClient(application) as client:
+        with (
+            TestClient(application) as client,
+            patch("tempfile.gettempdir", return_value=str(tmp_path / "fake-tmp")),
+        ):
             resp = client.post(
                 "/convert-tarballs",
                 params={"tarball_dir": str(link_parent / "child")},
             )
 
         assert resp.status_code == 400
-        assert "Symlinks not allowed" in resp.json()["detail"]
+        assert "session or temp directory" in resp.json()["detail"]

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -807,6 +807,28 @@ class TestConvertTarballs:
         assert resp.status_code == 400
         assert "session or temp directory" in resp.json()["detail"]
 
+    def test_convert_accepts_symlink_within_allowed_root(self, tmp_path: Path) -> None:
+        """A symlink resolving to a directory under an allowed root is accepted.
+
+        Args:
+            tmp_path: Pytest-provided temporary directory.
+        """
+        cache_dir = tmp_path / "cache"
+        application = create_app(cache_dir=cache_dir)
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        symlink = tmp_path / "link"
+        symlink.symlink_to(real_dir)
+
+        with (
+            TestClient(application) as client,
+            patch("tempfile.gettempdir", return_value=str(tmp_path)),
+        ):
+            resp = client.post("/convert-tarballs", params={"tarball_dir": str(symlink)})
+
+        assert resp.status_code == 200
+        assert resp.json() == {"converted": [], "failed": []}
+
     def test_convert_rejects_dotdot_traversal(self, tmp_path: Path) -> None:
         """Paths using ``..`` to escape allowed roots are rejected.
 


### PR DESCRIPTION
## Summary

- Fixes 3 CodeQL `py/path-injection` code scanning alerts (#12, #16, #17) in the Galaxy Proxy's `/convert-tarballs` endpoint
- Replaces TOCTOU-vulnerable symlink-then-resolve pattern with a resolve-first approach using `os.path.realpath()` to canonicalize the path before validating against allowed roots
- The previous pattern checked for symlinks on the raw path, then resolved — creating a race window. The new pattern resolves first, then validates the canonical path against the allowlist

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2560 tests, 61.28% coverage)
- [ ] Verify CodeQL re-scan clears alerts #12, #16, #17 after merge

Made with [Cursor](https://cursor.com)