### PR TITLE
build: adopt skillmark SKILL.md validation

### DIFF
--- a/.agents/skills/adr-new/SKILL.md
+++ b/.agents/skills/adr-new/SKILL.md
@@ -181,8 +181,12 @@ Fill:
 ### 6. Update Index
 
 Edit `.sdlc/adrs/README.md`:
-- Add row: `| [ADR-NNN](ADR-NNN-slug.md) | Title | Status | YYYY-MM |`
-- Insert in numerical order
+- Add a row (insert in numerical order):
+
+```markdown
+| [ADR-NNN](ADR-NNN-slug.md) | Title | Status | YYYY-MM |
+```
+
 - Add to Changelog table
 
 ### 7. Link to DR (if applicable)

--- a/.agents/skills/check-skill-spec/SKILL.md
+++ b/.agents/skills/check-skill-spec/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: check-skill-spec
+description: >-
+  Compare the agentskills.io specification against this project's extended
+  frontmatter allowlist to determine whether the custom validation hook
+  (scripts/check_skill_frontmatter.py) is still needed. Use when checking if
+  the upstream spec has adopted the extended fields, when planning to remove
+  the custom hook, or when a new spec release is announced.
+user-invocable: true
+metadata:
+  author: APME Team
+  version: 1.0.0
+---
+
+# Check Skill Spec Alignment
+
+Determine whether the custom frontmatter validation hook can be retired
+in favor of skillmark's built-in E030 rule.
+
+## Context
+
+This project uses a custom pre-commit hook (`scripts/check_skill_frontmatter.py`)
+that validates SKILL.md frontmatter against the agentskills.io spec **plus**
+extended fields that Claude Code and VS Code support but the spec has not yet
+adopted. Skillmark's E030 is disabled in `.skillmark.toml` because it rejects
+these fields.
+
+The extended fields are:
+
+| Field | Purpose | Tracking |
+|-------|---------|----------|
+| `user-invocable` | Controls `/` menu visibility | [agentskills#105](https://github.com/agentskills/agentskills/issues/105) |
+| `argument-hint` | Autocomplete hint for arguments | [agentskills#105](https://github.com/agentskills/agentskills/issues/105) |
+| `disable-model-invocation` | Prevents agent auto-triggering | [agentskills#105](https://github.com/agentskills/agentskills/issues/105) |
+| `triggers` | Invocation phrases for discovery | [agentskills#105](https://github.com/agentskills/agentskills/issues/105) |
+
+## Workflow
+
+### Step 1: Fetch the current spec
+
+Read the upstream specification:
+
+```bash
+curl -sL https://raw.githubusercontent.com/agentskills/agentskills/main/docs/specification.mdx
+```
+
+Extract the frontmatter field table from the spec. Look for the `### Frontmatter`
+section and the table listing `Field | Required | Constraints`.
+
+### Step 2: Compare against our allowlist
+
+Read `scripts/check_skill_frontmatter.py` and compare:
+
+- `_SPEC_FIELDS` — should match what the upstream spec lists
+- `_EXTENDED_FIELDS` — check if any of these now appear in the upstream spec
+
+### Step 3: Check the tracking issue
+
+```bash
+gh issue view 105 --repo agentskills/agentskills --json state,title,comments
+```
+
+Check whether issue #105 has been closed/merged, or if there are updates
+indicating the fields have been adopted.
+
+### Step 4: Check skillmark releases
+
+```bash
+gh release list --repo michellepellon/skillmark --limit 5
+```
+
+Check whether a newer version of skillmark recognizes the extended fields
+in its E030 rule. If so, test by temporarily re-enabling E030:
+
+```bash
+skillmark check --disable "" SKILL.md
+```
+
+### Step 5: Report findings
+
+Produce a summary with one of these verdicts:
+
+- **Still needed** — the spec has not adopted the extended fields; keep the
+  custom hook and E030 disabled.
+- **Partially resolved** — some fields are now in the spec; update
+  `_SPEC_FIELDS` and `_EXTENDED_FIELDS` accordingly.
+- **Can be retired** — all extended fields are in the spec and skillmark
+  recognizes them. Follow the retirement steps below.
+
+### Retirement steps (when verdict is "Can be retired")
+
+1. Update `.skillmark.toml`: remove `E030` from the `disable` list
+2. Remove `scripts/check_skill_frontmatter.py`
+3. Remove the `check-skill-frontmatter` hook from `.pre-commit-config.yaml`
+   and `prek.toml`
+4. Remove this skill (`.agents/skills/check-skill-spec/`)
+5. Run `tox -e lint` to verify everything passes with E030 re-enabled
+6. Commit and create a PR

--- a/.agents/skills/check-skill-spec/SKILL.md
+++ b/.agents/skills/check-skill-spec/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   (scripts/check_skill_frontmatter.py) is still needed. Use when checking if
   the upstream spec has adopted the extended fields, when planning to remove
   the custom hook, or when a new spec release is announced.
+argument-hint: "[--check-releases]"
 user-invocable: true
 metadata:
   author: APME Team

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,16 @@ repos:
       - id: pydoclint
         args: [--exclude=src/apme/v1/, src/, tests/, scripts/]
         pass_filenames: false
+  - repo: https://github.com/michellepellon/skillmark
+    rev: v0.1.0
+    hooks:
+      - id: skillmark
+        language: rust
+        args: [--config, .skillmark.toml]
+      - id: skillmark-fix
+        language: rust
+        args: [--config, .skillmark.toml]
+        stages: [manual]
   - repo: local
     hooks:
       - id: adr-index
@@ -42,3 +52,11 @@ repos:
         entry: python tools/generate_rule_catalog.py
         files: ^src/apme_engine/validators/.+\.(py|rego|md)$|^src/apme_engine/remediation/transforms/
         pass_filenames: false
+      - id: check-skill-frontmatter
+        name: Validate SKILL.md frontmatter
+        language: python
+        language_version: python3.10
+        entry: python scripts/check_skill_frontmatter.py
+        additional_dependencies: [pyyaml]
+        pass_filenames: false
+        always_run: true

--- a/.skillmark.toml
+++ b/.skillmark.toml
@@ -1,0 +1,17 @@
+fail-on = "errors"
+min-score = 100
+
+[rules]
+disable = ["E030", "E033"]
+experimental = false
+
+[scoring.weights]
+spec-compliance = 0.40
+description-quality = 0.20
+content-efficiency = 0.15
+composability-clarity = 0.10
+script-quality = 0.10
+discoverability = 0.05
+
+[paths]
+exclude = ["tests/fixtures/"]

--- a/prek.toml
+++ b/prek.toml
@@ -59,6 +59,23 @@ hooks = [
 ]
 
 [[repos]]
+repo = "https://github.com/michellepellon/skillmark"
+rev = "v0.1.0"
+hooks = [
+  {
+    id = "skillmark",
+    language = "rust",
+    args = ["--config", ".skillmark.toml"]
+  },
+  {
+    id = "skillmark-fix",
+    language = "rust",
+    args = ["--config", ".skillmark.toml"],
+    stages = ["manual"]
+  }
+]
+
+[[repos]]
 repo = "local"
 hooks = [
   {
@@ -78,5 +95,15 @@ hooks = [
     entry = "python tools/generate_rule_catalog.py",
     files = '^src/apme_engine/validators/.+\.(py|rego|md)$|^src/apme_engine/remediation/transforms/',
     pass_filenames = false
+  },
+  {
+    id = "check-skill-frontmatter",
+    name = "Validate SKILL.md frontmatter",
+    language = "python",
+    language_version = "python3.10",
+    entry = "python scripts/check_skill_frontmatter.py",
+    additional_dependencies = ["pyyaml"],
+    pass_filenames = false,
+    always_run = true
   }
 ]

--- a/scripts/check_skill_frontmatter.py
+++ b/scripts/check_skill_frontmatter.py
@@ -66,13 +66,8 @@ _EXTENDED_FIELDS: frozenset[str] = frozenset(
 
 _ALLOWED_FIELDS: frozenset[str] = _SPEC_FIELDS | _EXTENDED_FIELDS
 
-_EXCLUDED_DIRS: tuple[str, ...] = (
-    ".tox",
-    ".venv",
-    "venv",
-    "node_modules",
-    "tests/fixtures",
-)
+_EXCLUDED_COMPONENTS: frozenset[str] = frozenset({".tox", ".venv", "venv", "node_modules"})
+_EXCLUDED_PREFIXES: tuple[str, ...] = ("tests/fixtures",)
 
 # Fields required by this project (beyond the spec's own requirements)
 _REQUIRED_FIELDS: frozenset[str] = frozenset(
@@ -137,7 +132,9 @@ def _is_excluded(path: Path) -> bool:
     Returns:
         Whether the path should be skipped.
     """
-    return any(path.is_relative_to(excluded) for excluded in _EXCLUDED_DIRS)
+    if _EXCLUDED_COMPONENTS & set(path.parts):
+        return True
+    return any(path.is_relative_to(prefix) for prefix in _EXCLUDED_PREFIXES)
 
 
 def main() -> int:

--- a/scripts/check_skill_frontmatter.py
+++ b/scripts/check_skill_frontmatter.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Validate SKILL.md frontmatter fields against spec + extended allowlist.
+
+This hook is a **superset of skillmark E030**. Skillmark validates strictly
+against the agentskills.io specification, which does not yet include fields
+that major agent clients (Claude Code, VS Code Copilot) already support.
+
+We disable E030 in ``.skillmark.toml`` and use this hook instead, which
+allows both the spec fields and the emerging standard fields.
+
+Spec fields (agentskills.io specification):
+    https://github.com/agentskills/agentskills/blob/main/docs/specification.mdx
+
+Extended fields (supported by Claude Code and VS Code, proposed for spec):
+    - ``user-invocable``: Controls slash-command menu visibility (default true)
+    - ``argument-hint``: Autocomplete hint for skill arguments
+    - ``disable-model-invocation``: Prevents agent auto-triggering
+    - ``triggers``: Invocation phrases for skill discovery
+
+References:
+    - Claude Code: https://code.claude.com/docs/en/skills.md
+    - VS Code:     https://code.visualstudio.com/docs/copilot/customization/agent-skills
+    - Spec issue:  https://github.com/agentskills/agentskills/issues/105
+
+Sunset plan:
+    This script exists because the agentskills.io spec has not yet adopted
+    the extended fields listed above.  Once the spec merges the proposal in
+    issue #105 and skillmark's E030 recognizes the new fields, this script
+    can be removed and E030 re-enabled in ``.skillmark.toml``.
+
+    Use the ``/check-skill-spec`` skill (see ``.agents/skills/check-skill-spec/``)
+    to periodically compare the upstream spec against this allowlist and
+    determine whether this script is still needed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+_FRONTMATTER_PARTS = 3
+
+# agentskills.io specification fields
+_SPEC_FIELDS: frozenset[str] = frozenset(
+    {
+        "name",
+        "description",
+        "license",
+        "compatibility",
+        "metadata",
+        "allowed-tools",
+    }
+)
+
+# Fields supported by Claude Code / VS Code but not yet in the spec
+_EXTENDED_FIELDS: frozenset[str] = frozenset(
+    {
+        "user-invocable",
+        "argument-hint",
+        "disable-model-invocation",
+        "triggers",
+    }
+)
+
+_ALLOWED_FIELDS: frozenset[str] = _SPEC_FIELDS | _EXTENDED_FIELDS
+
+_EXCLUDED_DIRS: tuple[str, ...] = (
+    ".tox",
+    ".venv",
+    "venv",
+    "node_modules",
+    "tests/fixtures",
+)
+
+# Fields required by this project (beyond the spec's own requirements)
+_REQUIRED_FIELDS: frozenset[str] = frozenset(
+    {
+        "name",
+        "description",
+        "user-invocable",
+    }
+)
+
+
+def extract_frontmatter(path: Path) -> dict[str, object] | None:
+    """Return parsed frontmatter dict, or None if missing/invalid.
+
+    Args:
+        path: Path to a SKILL.md file.
+
+    Returns:
+        Parsed YAML frontmatter as a dict, or None if absent/unparseable.
+    """
+    content = path.read_text(encoding="utf-8")
+    if not content.startswith("---"):
+        return None
+
+    parts = content.split("---", 2)
+    if len(parts) < _FRONTMATTER_PARTS:
+        return None
+
+    try:
+        result: dict[str, object] | None = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+    return result
+
+
+def check_skill(path: Path) -> list[str]:
+    """Validate frontmatter fields for a single SKILL.md.
+
+    Args:
+        path: Path to a SKILL.md file.
+
+    Returns:
+        List of error messages (empty if valid).
+    """
+    fm = extract_frontmatter(path)
+    if fm is None:
+        return [f"{path}: missing or invalid frontmatter"]
+
+    errors = [
+        f"{path}: unknown field '{field}'"
+        for field in sorted(fm)
+        if field not in _ALLOWED_FIELDS
+    ]
+    errors.extend(
+        f"{path}: missing required field '{field}'"
+        for field in sorted(_REQUIRED_FIELDS)
+        if field not in fm
+    )
+    return errors
+
+
+def _is_excluded(path: Path) -> bool:
+    """Return True if path is under an excluded directory.
+
+    Args:
+        path: Path to check against exclusion list.
+
+    Returns:
+        Whether the path should be skipped.
+    """
+    parts = path.parts
+    return any(excluded in parts for excluded in _EXCLUDED_DIRS)
+
+
+def main() -> int:
+    """Check all SKILL.md files for valid frontmatter fields.
+
+    Returns:
+        Exit code: 0 if all skills pass, 1 if errors found.
+    """
+    root = Path()
+    skill_files = sorted(
+        p for p in root.glob("**/SKILL.md") if not _is_excluded(p)
+    )
+
+    if not skill_files:
+        print("No SKILL.md files found")
+        return 0
+
+    all_errors: list[str] = []
+    for skill_file in skill_files:
+        all_errors.extend(check_skill(skill_file))
+
+    if all_errors:
+        print("Skill frontmatter errors:")
+        for error in all_errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"All {len(skill_files)} skills have valid frontmatter fields")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_skill_frontmatter.py
+++ b/scripts/check_skill_frontmatter.py
@@ -102,8 +102,10 @@ def extract_frontmatter(path: Path) -> dict[str, object] | None:
         return None
 
     try:
-        result: dict[str, object] | None = yaml.safe_load(parts[1])
+        result: object = yaml.safe_load(parts[1])
     except yaml.YAMLError:
+        return None
+    if not isinstance(result, dict):
         return None
     return result
 
@@ -135,8 +137,7 @@ def _is_excluded(path: Path) -> bool:
     Returns:
         Whether the path should be skipped.
     """
-    parts = path.parts
-    return any(excluded in parts for excluded in _EXCLUDED_DIRS)
+    return any(path.is_relative_to(excluded) for excluded in _EXCLUDED_DIRS)
 
 
 def main() -> int:

--- a/scripts/check_skill_frontmatter.py
+++ b/scripts/check_skill_frontmatter.py
@@ -121,16 +121,8 @@ def check_skill(path: Path) -> list[str]:
     if fm is None:
         return [f"{path}: missing or invalid frontmatter"]
 
-    errors = [
-        f"{path}: unknown field '{field}'"
-        for field in sorted(fm)
-        if field not in _ALLOWED_FIELDS
-    ]
-    errors.extend(
-        f"{path}: missing required field '{field}'"
-        for field in sorted(_REQUIRED_FIELDS)
-        if field not in fm
-    )
+    errors = [f"{path}: unknown field '{field}'" for field in sorted(fm) if field not in _ALLOWED_FIELDS]
+    errors.extend(f"{path}: missing required field '{field}'" for field in sorted(_REQUIRED_FIELDS) if field not in fm)
     return errors
 
 
@@ -154,9 +146,7 @@ def main() -> int:
         Exit code: 0 if all skills pass, 1 if errors found.
     """
     root = Path()
-    skill_files = sorted(
-        p for p in root.glob("**/SKILL.md") if not _is_excluded(p)
-    )
+    skill_files = sorted(p for p in root.glob("**/SKILL.md") if not _is_excluded(p))
 
     if not skill_files:
         print("No SKILL.md files found")

--- a/scripts/check_skill_frontmatter.py
+++ b/scripts/check_skill_frontmatter.py
@@ -105,7 +105,7 @@ def extract_frontmatter(path: Path) -> dict[str, object] | None:
         result: object = yaml.safe_load(parts[1])
     except yaml.YAMLError:
         return None
-    if not isinstance(result, dict):
+    if not isinstance(result, dict) or not all(isinstance(k, str) for k in result):
         return None
     return result
 


### PR DESCRIPTION
## Summary
- Adopt skillmark (agentskills.io spec linter) and a custom frontmatter validator from ansible/ai-forge
- Enforces SKILL.md quality across `.agents/skills/` and `.cursor/skills/` on every commit via `tox -e lint`

## Changes
- `.skillmark.toml` — skillmark config: fail on errors, score >= 100, E030/E033 disabled (extended fields not yet in spec), excludes `tests/fixtures/`
- `scripts/check_skill_frontmatter.py` — custom Python hook that validates both agentskills.io spec fields and extended fields (`user-invocable`, `argument-hint`, `triggers`, `disable-model-invocation`) supported by Claude Code and VS Code
- `.agents/skills/check-skill-spec/SKILL.md` — maintenance skill to periodically check if the custom hook can be retired once the upstream spec adopts extended fields
- `.pre-commit-config.yaml` / `prek.toml` — wired skillmark + check-skill-frontmatter hooks
- `.agents/skills/adr-new/SKILL.md` — moved template link into fenced code block to avoid skillmark E031 false positive

## Quality of life
- New `/check-skill-spec` skill provides a structured workflow for agents to determine when the E030 workaround can be retired
- All 20 existing skills already pass validation with no changes needed

## Test plan
- [x] `tox -e lint` passes (skillmark check + frontmatter validator both pass)
- [x] `tox -e unit` passes (2601 passed)
- [x] All 20 SKILL.md files validated successfully