### PR TITLE
feat(helm): add Abbenay provider config and GCP Vertex AI support

### DIFF
--- a/deploy/helm/apme/templates/abbenay-configmap.yaml
+++ b/deploy/helm/apme/templates/abbenay-configmap.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.abbenay.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "apme.fullname" . }}-abbenay-config
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: abbenay
+data:
+  config.yaml: |
+    providers:
+    {{- if .Values.abbenay.apiKeys.openrouterApiKey }}
+      openrouter:
+        engine: openrouter
+        models:
+        {{- range .Values.abbenay.openrouterModels }}
+          {{ . }}: {}
+        {{- end }}
+        api_key_env: OPENROUTER_API_KEY
+    {{- end }}
+    {{- if .Values.abbenay.vertexAnthropic.enabled }}
+      vertex-anthropic:
+        engine: vertex-anthropic
+        project: {{ .Values.abbenay.vertexAnthropic.project | quote }}
+        region: {{ .Values.abbenay.vertexAnthropic.region | quote }}
+        models:
+        {{- range .Values.abbenay.vertexAnthropic.models }}
+          {{ . }}: {}
+        {{- end }}
+    {{- end }}
+    consumers:
+      apme:
+        token_env: APME_ABBENAY_TOKEN
+        capabilities:
+          inline_policy: true
+{{- end }}

--- a/deploy/helm/apme/templates/abbenay-deployment.yaml
+++ b/deploy/helm/apme/templates/abbenay-deployment.yaml
@@ -60,6 +60,12 @@ spec:
             {{- end }}
             - name: XDG_RUNTIME_DIR
               value: /tmp/abbenay-run
+            - name: XDG_CONFIG_HOME
+              value: /etc/abbenay-config
+            {{- if and .Values.abbenay.vertexAnthropic.enabled (or .Values.abbenay.vertexAnthropic.serviceAccountKey .Values.abbenay.vertexAnthropic.existingGcpSecret) }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /gcp-credentials/service-account-key.json
+            {{- end }}
           ports:
             - name: grpc
               containerPort: 50057
@@ -76,4 +82,23 @@ spec:
             periodSeconds: 30
           resources:
             {{- toYaml .Values.abbenay.resources | nindent 12 }}
+          volumeMounts:
+            - name: abbenay-config
+              mountPath: /etc/abbenay-config/abbenay/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            {{- if and .Values.abbenay.vertexAnthropic.enabled (or .Values.abbenay.vertexAnthropic.serviceAccountKey .Values.abbenay.vertexAnthropic.existingGcpSecret) }}
+            - name: gcp-credentials
+              mountPath: /gcp-credentials
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: abbenay-config
+          configMap:
+            name: {{ include "apme.fullname" . }}-abbenay-config
+        {{- if and .Values.abbenay.vertexAnthropic.enabled (or .Values.abbenay.vertexAnthropic.serviceAccountKey .Values.abbenay.vertexAnthropic.existingGcpSecret) }}
+        - name: gcp-credentials
+          secret:
+            secretName: {{ if .Values.abbenay.vertexAnthropic.serviceAccountKey }}{{ include "apme.fullname" . }}-gcp-credentials{{ else }}{{ .Values.abbenay.vertexAnthropic.existingGcpSecret }}{{ end }}
+        {{- end }}
 {{- end }}

--- a/deploy/helm/apme/templates/abbenay-deployment.yaml
+++ b/deploy/helm/apme/templates/abbenay-deployment.yaml
@@ -84,8 +84,7 @@ spec:
             {{- toYaml .Values.abbenay.resources | nindent 12 }}
           volumeMounts:
             - name: abbenay-config
-              mountPath: /etc/abbenay-config/abbenay/config.yaml
-              subPath: config.yaml
+              mountPath: /etc/abbenay-config/abbenay
               readOnly: true
             {{- if and .Values.abbenay.vertexAnthropic.enabled (or .Values.abbenay.vertexAnthropic.serviceAccountKey .Values.abbenay.vertexAnthropic.existingGcpSecret) }}
             - name: gcp-credentials

--- a/deploy/helm/apme/templates/gcp-credentials-secret.yaml
+++ b/deploy/helm/apme/templates/gcp-credentials-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.abbenay.enabled .Values.abbenay.vertexAnthropic.enabled .Values.abbenay.vertexAnthropic.serviceAccountKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "apme.fullname" . }}-gcp-credentials
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: abbenay
+type: Opaque
+data:
+  service-account-key.json: {{ .Values.abbenay.vertexAnthropic.serviceAccountKey | b64enc | quote }}
+{{- end }}

--- a/deploy/helm/apme/templates/gcp-credentials-secret.yaml
+++ b/deploy/helm/apme/templates/gcp-credentials-secret.yaml
@@ -7,6 +7,6 @@ metadata:
     {{- include "apme.labels" . | nindent 4 }}
     app.kubernetes.io/component: abbenay
 type: Opaque
-data:
-  service-account-key.json: {{ .Values.abbenay.vertexAnthropic.serviceAccountKey | b64enc | quote }}
+stringData:
+  service-account-key.json: {{ .Values.abbenay.vertexAnthropic.serviceAccountKey | quote }}
 {{- end }}

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -156,6 +156,22 @@ abbenay:
   apiKeys:
     openrouterApiKey: ""
     vertexAnthropicApiKey: ""
+  # -- OpenRouter model IDs to expose (when openrouterApiKey is set)
+  openrouterModels:
+    - anthropic/claude-sonnet-4
+    - anthropic/claude-opus-4.6
+  # -- Vertex AI Anthropic configuration (keyless — uses GCP ADC)
+  vertexAnthropic:
+    enabled: false
+    project: ""
+    region: us-east5
+    # -- Vertex AI model names (e.g. claude-sonnet-4@20250929)
+    models: []
+    # -- Raw service account key JSON (helm creates the secret)
+    serviceAccountKey: ""
+    # -- Name of an existing Secret with service-account-key.json key
+    # (use instead of serviceAccountKey to avoid putting the key in values)
+    existingGcpSecret: ""
   resources:
     requests:
       cpu: 250m


### PR DESCRIPTION
The Helm chart enabled Abbenay but deployed it without any provider configuration, resulting in zero models available in the UI. This change makes Abbenay functional out of the box by:

1. Adding a ConfigMap template (abbenay-configmap.yaml) that generates the Abbenay config.yaml from Helm values, supporting both OpenRouter and Vertex AI Anthropic providers.

2. Adding GCP credentials support via a Secret template or reference to an existing Secret (gcp-credentials-secret.yaml), enabling the keyless vertex-anthropic engine to use GCP ADC via service account keys.

3. Updating the Abbenay deployment to:
   - Mount the generated config.yaml via ConfigMap (using XDG_CONFIG_HOME for OpenShift SCC compatibility — avoids permission issues with /home/abbenay under restricted-v2 SCC)
   - Mount GCP credentials as GOOGLE_APPLICATION_CREDENTIALS when Vertex AI is enabled
   - Conditionally create volumes and volumeMounts based on provider config

4. Extending values.yaml with:
   - openrouterModels: list of OpenRouter model IDs
   - vertexAnthropic: sub-section with project, region, models, serviceAccountKey (inline), and existingGcpSecret (reference)

Tested on SNO with Vertex AI Anthropic (claude-sonnet-4-5@20250929) using GCP service account key authentication.