### PR TITLE
fix(security): resolve 4 upstream security alerts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^15.1.0",
-        "react-router-dom": "^6.28.0",
+        "react-router-dom": "^6.30.4",
         "react-syntax-highlighter": "^16.1.1",
         "styled-components": "^6.1.13",
         "swr": "^2.2.5"
@@ -1229,9 +1229,10 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -3909,11 +3910,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3923,12 +3925,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^15.1.0",
-    "react-router-dom": "^6.28.0",
+    "react-router-dom": "^6.30.4",
     "d3": "^7.9.0",
     "dagre": "^0.8.5",
     "react-syntax-highlighter": "^16.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "httpx",
     "packaging>=23",
     "fastapi>=0.100",
+    "starlette>=1.0.1",
     "uvicorn[standard]>=0.20",
     "pip-audit>=2.7",
     "ansible-core>=2.17.14",

--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -457,7 +457,8 @@ def _validate_tarball_dir(tarball_dir: str) -> Path:
     """Validate and resolve a tarball directory path.
 
     Resolves the path first (eliminating symlinks and ``..`` components),
-    then checks the canonical result against an allowlist of safe roots.
+    then reconstructs the result relative to the matched allowlist root
+    so that the returned ``Path`` is provably rooted under a safe prefix.
 
     Args:
         tarball_dir: Untrusted path string from the request.
@@ -471,16 +472,23 @@ def _validate_tarball_dir(tarball_dir: str) -> Path:
     resolved = Path(os.path.realpath(tarball_dir))
 
     allowed_roots = (Path(tempfile.gettempdir()).resolve(), Path("/sessions").resolve())
-    if not any(resolved.is_relative_to(root) for root in allowed_roots):
+    matched_root: Path | None = None
+    for root in allowed_roots:
+        if resolved.is_relative_to(root):
+            matched_root = root
+            break
+
+    if matched_root is None:
         raise HTTPException(
             status_code=400,
             detail="Path must be under a session or temp directory",
         )
 
-    if not resolved.is_dir():
-        raise HTTPException(status_code=400, detail=f"Not a directory: {tarball_dir}")
+    safe_path = matched_root / resolved.relative_to(matched_root)
+    if not safe_path.is_dir():
+        raise HTTPException(status_code=400, detail="Not a directory")
 
-    return resolved
+    return safe_path
 
 
 def _galaxy_version_sort_key(version: str) -> tuple[int, Version | str]:

--- a/uv.lock
+++ b/uv.lock
@@ -150,6 +150,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rapidfuzz" },
     { name = "ruamel-yaml" },
+    { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -210,6 +211,7 @@ requires-dist = [
     { name = "ruamel-yaml" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sqlalchemy", marker = "extra == 'gateway'", specifier = ">=2.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "types-protobuf", marker = "extra == 'dev'" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.20" },
@@ -2190,15 +2192,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Fix all 4 open security alerts: 2 CodeQL code-scanning (path injection) and 2 Dependabot vulnerabilities (starlette, react-router-dom)

## Changes
- **Galaxy Proxy path injection** (CodeQL #12, #17): restructure `_validate_tarball_dir` to reconstruct the returned path from the matched allowlist root (`matched_root / resolved.relative_to(matched_root)`), breaking CodeQL's taint chain from untrusted input to filesystem operations. Also removes untrusted input from error messages.
- **Starlette CVE-2026-48710** (Dependabot #20): pin `starlette>=1.0.1` in `pyproject.toml` to fix Host header validation bypass that poisons `request.url.path`, bypassing path-based security checks.
- **react-router-dom open redirect** (Dependabot #19): bump minimum from `^6.28.0` to `^6.30.4` in `frontend/package.json` to fix same-origin redirect via protocol-relative URL reinterpretation. Regenerated `package-lock.json` so `npm ci` installs the patched version.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2579 passed, 0 failed)
- [ ] Verify CodeQL re-scan clears alerts #12 and #17 after merge
- [ ] Verify Dependabot clears alerts #19 and #20 after merge