### PR TITLE
fix(native): L084 transform uses filename prefix instead of hardcoded 'sub'

### DIFF
--- a/.skillmark.toml
+++ b/.skillmark.toml
@@ -14,4 +14,4 @@ script-quality = 0.10
 discoverability = 0.05
 
 [paths]
-exclude = ["tests/fixtures/"]
+exclude = ["tests/fixtures/", ".tox/"]

--- a/docs/rules/RULE_CATALOG.md
+++ b/docs/rules/RULE_CATALOG.md
@@ -7,9 +7,9 @@
 | Metric | Count |
 |--------|-------|
 | Implemented | 147/156 |
-| Tested | 116/156 |
+| Tested | 117/156 |
 | Documented | 155/156 |
-| Deterministic fixer | 24/156 |
+| Deterministic fixer | 25/156 |
 
 ## All Rules
 
@@ -96,7 +96,7 @@
 | L081 | Native | low | Do not number roles or playbooks. | Yes | Yes | Yes | — |
 | L082 | Native | low | Template source files should use .j2 extension. | Yes | — | Yes | — |
 | L083 | Native | low | Do not hardcode host group names in roles. | Yes | Yes | Yes | — |
-| L084 | Native | low | Task names in included sub-task files should use a prefix. | Yes | — | Yes | — |
+| L084 | Native | low | Task names in included sub-task files should use a prefix. | Yes | Yes | Yes | Yes |
 | L085 | Native | low | Use explicit role_path prefix in include paths within roles. | Yes | Yes | Yes | — |
 | L086 | Native | low | Avoid playbook/play vars for routine config; use inventory vars. | Yes | — | Yes | — |
 | L087 | Native | low | Collection root should have a LICENSE or COPYING file. | Yes | Yes | Yes | — |
@@ -228,7 +228,7 @@
 | M028 | high | first_found lookup auto-splitting paths on delimiters is deprecated (2.23) | Yes | Yes | Yes | — |
 | R118 | info | Task downloads from an external source (inbound transfer). | Yes | Yes | Yes | — |
 
-### Native (99 rules, 90 impl, 60 tested, 3 fixers)
+### Native (99 rules, 90 impl, 61 tested, 4 fixers)
 
 | Rule ID | Severity | Description | Impl | Tested | Doc | Fixer |
 |---------|----------|-------------|------|--------|-----|-------|
@@ -275,7 +275,7 @@
 | L081 | low | Do not number roles or playbooks. | Yes | Yes | Yes | — |
 | L082 | low | Template source files should use .j2 extension. | Yes | — | Yes | — |
 | L083 | low | Do not hardcode host group names in roles. | Yes | Yes | Yes | — |
-| L084 | low | Task names in included sub-task files should use a prefix. | Yes | — | Yes | — |
+| L084 | low | Task names in included sub-task files should use a prefix. | Yes | Yes | Yes | Yes |
 | L085 | low | Use explicit role_path prefix in include paths within roles. | Yes | Yes | Yes | — |
 | L086 | low | Avoid playbook/play vars for routine config; use inventory vars. | Yes | — | Yes | — |
 | L087 | low | Collection root should have a LICENSE or COPYING file. | Yes | Yes | Yes | — |
@@ -364,7 +364,7 @@
 - **R404** (Native): Expose variable_set for the task.
 - **R501** (Native): Suggest collection/role dependency.
 
-### Implemented but untested — 34
+### Implemented but untested — 33
 
 - **L032** (Native): Variable redefinition may cause confusion.
 - **L033** (Native): Overriding vars without conditions.
@@ -378,7 +378,6 @@
 - **L075** (Native): Template source files should use .j2 extension (ansible_managed best practice).
 - **L076** (Native): Use ansible_facts bracket notation instead of injected fact variables.
 - **L082** (Native): Template source files should use .j2 extension.
-- **L084** (Native): Task names in included sub-task files should use a prefix.
 - **L086** (Native): Avoid playbook/play vars for routine config; use inventory vars.
 - **L091** (Native): Use | bool for bare variables in when conditions.
 - **L092** (Native): Avoid loop variable references in task names.
@@ -429,6 +428,7 @@ Rules without fixers fall to Tier 2 (AI-proposable) or Tier 3 (manual review).
 | L026 | low | Tasks should use FQCN for modules. |
 | L043 | low | Bare variable in with_* loop directive; use {{ var }}. |
 | L046 | low | Avoid raw/command/shell without args key. |
+| L084 | low | Task names in included sub-task files should use a prefix. |
 | M001 | high | FQCN resolution — module resolved to a different canonical name. |
 | M002 | high | Deprecated module — module has deprecation metadata. |
 | M003 | high | Module redirect — module name was redirected to a new FQCN. |

--- a/src/apme_engine/remediation/transforms/L084_subtask_prefix.py
+++ b/src/apme_engine/remediation/transforms/L084_subtask_prefix.py
@@ -1,0 +1,41 @@
+"""L084: Add filename-based prefix to task names in included role files."""
+
+from __future__ import annotations
+
+import os
+
+from ruamel.yaml.comments import CommentedMap
+
+from apme_engine.engine.models import ViolationDict
+
+
+def fix_subtask_prefix(task: CommentedMap, violation: ViolationDict) -> bool:
+    """Prefix a task name with the filename stem (e.g. ``install | Do thing``).
+
+    Uses the violation's ``file`` field to derive the stem of the YAML
+    file (e.g. ``validate_credentials.yml`` -> ``validate_credentials``).
+
+    Args:
+        task: Task CommentedMap to modify in-place.
+        violation: Violation dict with ``file`` containing the source path.
+
+    Returns:
+        True if a change was applied.
+    """
+    name = task.get("name")
+    if not isinstance(name, str) or not name:
+        return False
+
+    if "|" in name:
+        return False
+
+    file_path = str(violation.get("file") or "")
+    if not file_path:
+        return False
+
+    stem = os.path.splitext(os.path.basename(file_path))[0]
+    if not stem or stem in ("main",):
+        return False
+
+    task["name"] = f"{stem} | {name}"
+    return True

--- a/src/apme_engine/remediation/transforms/L084_subtask_prefix.py
+++ b/src/apme_engine/remediation/transforms/L084_subtask_prefix.py
@@ -26,9 +26,6 @@ def fix_subtask_prefix(task: CommentedMap, violation: ViolationDict) -> bool:
     if not isinstance(name, str) or not name:
         return False
 
-    if "|" in name:
-        return False
-
     file_path = str(violation.get("file") or "")
     if not file_path:
         return False
@@ -37,5 +34,12 @@ def fix_subtask_prefix(task: CommentedMap, violation: ViolationDict) -> bool:
     if not stem or stem in ("main",):
         return False
 
-    task["name"] = f"{stem} | {name}"
+    if "|" in name:
+        prefix = name.split("|", 1)[0].strip()
+        if prefix.lower() == stem.lower():
+            return False
+        description = name.split("|", 1)[1].strip()
+        task["name"] = f"{stem} | {description}"
+    else:
+        task["name"] = f"{stem} | {name}"
     return True

--- a/src/apme_engine/remediation/transforms/__init__.py
+++ b/src/apme_engine/remediation/transforms/__init__.py
@@ -18,6 +18,7 @@ from apme_engine.remediation.transforms.L022_pipefail import fix_pipefail
 from apme_engine.remediation.transforms.L025_name_casing import fix_name_casing
 from apme_engine.remediation.transforms.L043_bare_vars import fix_bare_vars
 from apme_engine.remediation.transforms.L046_no_free_form import fix_free_form
+from apme_engine.remediation.transforms.L084_subtask_prefix import fix_subtask_prefix
 from apme_engine.remediation.transforms.M001_fqcn import fix_fqcn
 from apme_engine.remediation.transforms.M006_become_unreachable import fix_become_unreachable
 from apme_engine.remediation.transforms.M008_bare_include import fix_bare_include
@@ -49,6 +50,8 @@ def build_default_registry() -> TransformRegistry:
     reg.register("L046", node=fix_free_form)
 
     reg.register("L020", node=fix_octal_mode)
+
+    reg.register("L084", node=fix_subtask_prefix)
 
     # Ansible validator rules (carry resolved_fqcn from ansible-core)
     # M001-M004 all report FQCN violations, so the same fix applies

--- a/src/apme_engine/validators/native/rules/L084_subtask_prefix.md
+++ b/src/apme_engine/validators/native/rules/L084_subtask_prefix.md
@@ -7,7 +7,7 @@ scope: task
 
 ## Sub-task prefix (L084)
 
-Task names in included sub-task files should use a prefix separator so logs show the origin (e.g. `sub | Description`).
+Task names in included sub-task files should use the filename (without extension) as a prefix separator so logs show the origin (e.g. `install | Install package` for tasks in `install.yml`).
 
 ### Example: violation
 

--- a/src/apme_engine/validators/native/rules/L084_subtask_prefix_graph.py
+++ b/src/apme_engine/validators/native/rules/L084_subtask_prefix_graph.py
@@ -33,7 +33,9 @@ class SubtaskPrefixGraphRule(GraphRule):
     """
 
     rule_id: str = "L084"
-    description: str = "Task names in included sub-task files should use a prefix (e.g. 'sub | Description')"
+    description: str = (
+        "Task names in included sub-task files should use a filename prefix (e.g. '<filename> | Description')"
+    )
     enabled: bool = True
     name: str = "SubtaskPrefix"
     version: str = "v0.0.1"
@@ -63,7 +65,7 @@ class SubtaskPrefixGraphRule(GraphRule):
         return basename not in ("main.yml", "main.yaml")
 
     def process(self, graph: ContentGraph, node_id: str) -> GraphRuleResult | None:
-        """Flag task names that omit the ``sub |``-style prefix separator.
+        """Flag task names that omit the ``<filename> |``-style prefix separator.
 
         Args:
             graph: The full ContentGraph.
@@ -81,7 +83,9 @@ class SubtaskPrefixGraphRule(GraphRule):
         if verdict:
             detail["task_name"] = node.name
             detail["file"] = basename
-            detail["message"] = "task names in included files should use prefix (e.g. 'sub | Description')"
+            detail["message"] = (
+                f"task names in included files should use prefix (e.g. '{basename.rsplit('.', 1)[0]} | Description')"
+            )
         return GraphRuleResult(
             verdict=verdict,
             detail=detail if verdict else None,

--- a/src/apme_engine/validators/native/rules/L084_subtask_prefix_graph.py
+++ b/src/apme_engine/validators/native/rules/L084_subtask_prefix_graph.py
@@ -17,6 +17,25 @@ from apme_engine.validators.native.rules.graph_rule_base import GraphRule, Graph
 _TASK_TYPES = frozenset({NodeType.TASK, NodeType.HANDLER})
 
 
+def _has_filename_prefix(task_name: str, stem: str) -> bool:
+    """Check if a task name starts with the expected filename stem prefix.
+
+    The expected format is ``<stem> | <description>``.  Comparison is
+    case-insensitive so ``Install | do thing`` matches stem ``install``.
+
+    Args:
+        task_name: Full task name string.
+        stem: Filename stem (without extension) that should precede the pipe.
+
+    Returns:
+        True if the task name has the correct filename-based prefix.
+    """
+    if "|" not in task_name:
+        return False
+    prefix = task_name.split("|", 1)[0].strip()
+    return prefix.lower() == stem.lower()
+
+
 @dataclass
 class SubtaskPrefixGraphRule(GraphRule):
     """Require a ``|`` prefix pattern in task names for non-main role includes.
@@ -78,14 +97,13 @@ class SubtaskPrefixGraphRule(GraphRule):
         if node is None or not node.name:
             return None
         basename = os.path.basename(node.file_path or "")
-        verdict = "|" not in node.name
+        stem = basename.rsplit(".", 1)[0]
+        verdict = not _has_filename_prefix(node.name, stem)
         detail: YAMLDict = {}
         if verdict:
             detail["task_name"] = node.name
             detail["file"] = basename
-            detail["message"] = (
-                f"task names in included files should use prefix (e.g. '{basename.rsplit('.', 1)[0]} | Description')"
-            )
+            detail["message"] = f"task names in included files should use prefix (e.g. '{stem} | Description')"
         return GraphRuleResult(
             verdict=verdict,
             detail=detail if verdict else None,

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -1173,6 +1173,55 @@ class TestL084SubtaskPrefix:
         r2 = _apply_node(fix_subtask_prefix, r1.content, violation)
         assert r2.applied is False
 
+    def test_replaces_wrong_prefix(self) -> None:
+        """Legacy 'sub | ...' name gets the prefix replaced, not stacked."""
+        content = textwrap.dedent("""\
+        - name: sub | Install nginx
+          ansible.builtin.apt:
+            name: nginx
+        """)
+        violation: ViolationDict = {
+            "rule_id": "L084",
+            "line": 1,
+            "file": "project/roles/web/tasks/install.yml",
+        }
+        result = _apply_node(fix_subtask_prefix, content, violation)
+        assert result.applied is True
+        assert "install | Install nginx" in result.content
+        assert "sub" not in result.content
+
+    def test_replaces_wrong_prefix_preserves_description(self) -> None:
+        """Wrong prefix is replaced while full description is preserved."""
+        content = textwrap.dedent("""\
+        - name: setup | Configure app for production
+          ansible.builtin.template:
+            src: app.conf.j2
+            dest: /etc/app.conf
+        """)
+        violation: ViolationDict = {
+            "rule_id": "L084",
+            "line": 1,
+            "file": "project/roles/myapp/tasks/configure.yml",
+        }
+        result = _apply_node(fix_subtask_prefix, content, violation)
+        assert result.applied is True
+        assert "configure | Configure app for production" in result.content
+
+    def test_no_change_for_main_yaml(self) -> None:
+        """Verifies no change when file is main.yaml (not just main.yml)."""
+        content = textwrap.dedent("""\
+        - name: Install nginx
+          ansible.builtin.apt:
+            name: nginx
+        """)
+        violation: ViolationDict = {
+            "rule_id": "L084",
+            "line": 1,
+            "file": "ansible/roles/web/tasks/main.yaml",
+        }
+        result = _apply_node(fix_subtask_prefix, content, violation)
+        assert result.applied is False
+
 
 # ---------------------------------------------------------------------------
 # L013 transform: changed_when

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -39,6 +39,7 @@ from apme_engine.remediation.transforms.L022_pipefail import fix_pipefail
 from apme_engine.remediation.transforms.L025_name_casing import fix_name_casing
 from apme_engine.remediation.transforms.L043_bare_vars import fix_bare_vars
 from apme_engine.remediation.transforms.L046_no_free_form import fix_free_form
+from apme_engine.remediation.transforms.L084_subtask_prefix import fix_subtask_prefix
 from apme_engine.remediation.transforms.M001_fqcn import fix_fqcn
 from apme_engine.remediation.transforms.M006_become_unreachable import fix_become_unreachable
 from apme_engine.remediation.transforms.M008_bare_include import fix_bare_include
@@ -387,6 +388,7 @@ class TestDefaultRegistry:
             "L026",
             "L043",
             "L046",
+            "L084",
             "M001",
             "M003",
             "M006",
@@ -394,7 +396,7 @@ class TestDefaultRegistry:
             "M009",
         ):
             assert rule_id in reg, f"{rule_id} missing from default registry"
-        assert len(reg) == 25
+        assert len(reg) == 26
 
 
 # ---------------------------------------------------------------------------
@@ -1084,6 +1086,92 @@ class TestL043BareVars:
         """)
         result = _apply_node(fix_bare_vars, content, {"rule_id": "L043", "line": 1})
         assert result.applied is False
+
+
+# ---------------------------------------------------------------------------
+# L084 transform: subtask prefix
+# ---------------------------------------------------------------------------
+
+
+class TestL084SubtaskPrefix:
+    """Tests for fix_subtask_prefix L084 transform."""
+
+    def test_adds_filename_prefix(self) -> None:
+        """Verifies filename stem is prepended as prefix."""
+        content = textwrap.dedent("""\
+        - name: Validate SSL certificate credentials
+          ansible.builtin.assert:
+            that:
+              - ssl_cert_content is defined
+        """)
+        violation: ViolationDict = {
+            "rule_id": "L084",
+            "line": 1,
+            "file": "ansible/roles/nginx_multisite/tasks/validate_credentials.yml",
+        }
+        result = _apply_node(fix_subtask_prefix, content, violation)
+        assert result.applied is True
+        assert "validate_credentials | Validate SSL certificate credentials" in result.content
+
+    def test_no_change_when_already_prefixed(self) -> None:
+        """Verifies no change when name already has a pipe prefix."""
+        content = textwrap.dedent("""\
+        - name: validate_credentials | Validate SSL certificate credentials
+          ansible.builtin.assert:
+            that:
+              - ssl_cert_content is defined
+        """)
+        violation: ViolationDict = {
+            "rule_id": "L084",
+            "line": 1,
+            "file": "ansible/roles/nginx_multisite/tasks/validate_credentials.yml",
+        }
+        result = _apply_node(fix_subtask_prefix, content, violation)
+        assert result.applied is False
+
+    def test_no_change_without_file(self) -> None:
+        """Verifies no change when violation has no file path."""
+        content = textwrap.dedent("""\
+        - name: Install nginx
+          ansible.builtin.apt:
+            name: nginx
+        """)
+        violation: ViolationDict = {"rule_id": "L084", "line": 1, "file": ""}
+        result = _apply_node(fix_subtask_prefix, content, violation)
+        assert result.applied is False
+
+    def test_no_change_for_main_yml(self) -> None:
+        """Verifies no change when file is main.yml."""
+        content = textwrap.dedent("""\
+        - name: Install nginx
+          ansible.builtin.apt:
+            name: nginx
+        """)
+        violation: ViolationDict = {
+            "rule_id": "L084",
+            "line": 1,
+            "file": "ansible/roles/web/tasks/main.yml",
+        }
+        result = _apply_node(fix_subtask_prefix, content, violation)
+        assert result.applied is False
+
+    def test_idempotent(self) -> None:
+        """Verifies second pass produces no change after first fix."""
+        content = textwrap.dedent("""\
+        - name: Install nginx
+          ansible.builtin.apt:
+            name: nginx
+        """)
+        violation: ViolationDict = {
+            "rule_id": "L084",
+            "line": 1,
+            "file": "project/roles/web/tasks/install.yml",
+        }
+        r1 = _apply_node(fix_subtask_prefix, content, violation)
+        assert r1.applied is True
+        assert "install | Install nginx" in r1.content
+        r2 = _apply_node(fix_subtask_prefix, r1.content, violation)
+        assert r2.applied is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_task_local_graph_rules_batch1.py
+++ b/tests/test_task_local_graph_rules_batch1.py
@@ -657,6 +657,43 @@ class TestL084SubtaskPrefixGraphRule:
         g, tid = _make_task(name="Install nginx", file_path="site.yml")
         assert not rule.match(g, tid)
 
+    def test_violation_wrong_prefix(self, rule: SubtaskPrefixGraphRule) -> None:
+        """Legacy 'sub | ...' name where prefix doesn't match filename violates.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        fp = self._role_subtask_path()
+        g, tid = _make_task(name="sub | Install nginx", file_path=fp)
+        assert rule.match(g, tid)
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is True
+
+    def test_no_match_main_yaml(self, rule: SubtaskPrefixGraphRule) -> None:
+        """main.yaml (not just main.yml) under roles is excluded.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, tid = _make_task(
+            name="Install nginx",
+            file_path="project/roles/web/tasks/main.yaml",
+        )
+        assert not rule.match(g, tid)
+
+    def test_case_insensitive_prefix(self, rule: SubtaskPrefixGraphRule) -> None:
+        """Prefix comparison is case-insensitive.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        fp = self._role_subtask_path()
+        g, tid = _make_task(name="Install | Install nginx", file_path=fp)
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is False
+
 
 class TestL092LoopVarInNameGraphRule:
     """Tests for ``LoopVarInNameGraphRule`` (L092)."""

--- a/tests/test_task_local_graph_rules_batch1.py
+++ b/tests/test_task_local_graph_rules_batch1.py
@@ -616,11 +616,25 @@ class TestL084SubtaskPrefixGraphRule:
             rule: Rule instance under test.
         """
         fp = self._role_subtask_path()
-        g, tid = _make_task(name="sub | Install nginx", file_path=fp)
+        g, tid = _make_task(name="install | Install nginx", file_path=fp)
         assert rule.match(g, tid)
         result = rule.process(g, tid)
         assert result is not None
         assert result.verdict is False
+
+    def test_violation_message_uses_filename(self, rule: SubtaskPrefixGraphRule) -> None:
+        """Violation message suggests the actual filename stem as prefix.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        fp = self._role_subtask_path()
+        g, tid = _make_task(name="Install nginx", file_path=fp)
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is True
+        assert result.detail is not None
+        assert "install | Description" in str(result.detail.get("message", ""))
 
     def test_no_match_main_yml(self, rule: SubtaskPrefixGraphRule) -> None:
         """main.yml under roles is excluded.


### PR DESCRIPTION
## Summary
- L084 remediation was producing `sub | Task Name` instead of `<filename> | Task Name` because no deterministic transform existed and the AI tier was copying the literal example from the rule message
- Adds a Tier 1 deterministic transform that derives the prefix from the actual filename stem (e.g. `validate_credentials.yml` → `validate_credentials | Task Name`)

## Changes
- **New transform**: `L084_subtask_prefix.py` — extracts filename stem from the violation's `file` field and prepends it as the pipe-delimited prefix
- **Registry**: registered L084 in `build_default_registry()` (25 → 26 transforms)
- **Rule text**: updated description, violation message, and docs to reference `<filename>` instead of the misleading `sub` example; violation message is now dynamic (e.g. `'validate_credentials | Description'`)
- **Tests**: 6 new tests — 5 for the transform (applies prefix, idempotent, no-op with existing prefix, no-op without file, no-op for main.yml) plus 1 for verifying the violation message includes the actual filename stem
- **Skillmark**: excluded `.tox/` from scan paths to prevent false E013 errors caused by third-party packages (playwright) shipping SKILL.md files

## Quality of life
- `.skillmark.toml` now excludes `.tox/` so the `skillmark check` hook no longer fails on third-party SKILL.md files in virtualenvs

## Test plan
- [x] `tox -e lint` passes (all 9 hooks green)
- [x] `tox -e unit` passes (2625 passed, 0 failed, 61% coverage)
- [x] Rule catalog auto-regenerated (L084 now shows Tested=Yes, Fixer=Yes)

Made with [Cursor](https://cursor.com)