### PR TITLE
ci(containers): update Docker actions to Node 24 and pin image tags

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -20,21 +20,21 @@ jobs:
     outputs:
       base-image: ${{ steps.base-ref.outputs.image }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - id: owner
         run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-base
           tags: |
@@ -47,7 +47,7 @@ jobs:
       - id: base-ref
         run: echo "image=${{ env.REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-base:${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: containers/base/Dockerfile
@@ -83,21 +83,21 @@ jobs:
           - name: ui
             file: containers/ui/Dockerfile
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - id: owner
         run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-${{ matrix.image.name }}
           tags: |
@@ -107,7 +107,7 @@ jobs:
             type=semver,pattern={{major}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
 
-      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ${{ matrix.image.file }}

--- a/containers/gitleaks/Dockerfile
+++ b/containers/gitleaks/Dockerfile
@@ -1,7 +1,7 @@
 # Gitleaks validator: gitleaks binary + Python gRPC shim.
 # Multi-stage: copies gitleaks from the official image.
 ARG BASE_IMAGE=localhost/apme-base:latest
-FROM docker.io/zricethezav/gitleaks:latest AS gitleaks-bin
+FROM docker.io/zricethezav/gitleaks:v8.30.1 AS gitleaks-bin
 FROM $BASE_IMAGE
 
 COPY --from=gitleaks-bin /usr/bin/gitleaks /usr/local/bin/gitleaks

--- a/containers/opa/Dockerfile
+++ b/containers/opa/Dockerfile
@@ -1,7 +1,7 @@
 # OPA validator: gRPC wrapper over OPA REST API.
 # Multi-stage: copies the OPA binary from the official image.
 ARG BASE_IMAGE=localhost/apme-base:latest
-FROM docker.io/openpolicyagent/opa:latest AS opa-bin
+FROM docker.io/openpolicyagent/opa:1.17.1 AS opa-bin
 FROM $BASE_IMAGE
 
 COPY --from=opa-bin /opa /usr/local/bin/opa

--- a/src/apme_engine/opa_client.py
+++ b/src/apme_engine/opa_client.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from apme_engine.engine.models import ViolationDict, YAMLDict
 
-OPA_IMAGE = "docker.io/openpolicyagent/opa:latest"
+OPA_IMAGE = "docker.io/openpolicyagent/opa:1.17.1"
 
 _consecutive_timeouts = 0
 _opa_disabled = False

--- a/tests/test_ci_workflow_hygiene.py
+++ b/tests/test_ci_workflow_hygiene.py
@@ -1,0 +1,188 @@
+"""Validate CI workflow files for common hygiene issues.
+
+Catches problems like deprecated action versions and unpinned image tags
+before they cause CI failures in production.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+CONTAINERS_DIR = REPO_ROOT / "containers"
+
+KNOWN_ACTION_MINIMUM_VERSIONS: dict[str, int] = {
+    "actions/checkout": 6,
+    "docker/setup-buildx-action": 4,
+    "docker/login-action": 4,
+    "docker/metadata-action": 6,
+    "docker/build-push-action": 7,
+}
+
+
+def _parse_action_ref(uses: str) -> tuple[str, str]:
+    """Split a 'uses' value into (action_name, ref).
+
+    Args:
+        uses: The full action reference string (e.g. 'actions/checkout@abc123 # v6').
+
+    Returns:
+        Tuple of (action_name, ref_or_sha).
+    """
+    comment_stripped = uses.split("#")[0].strip()
+    if "@" not in comment_stripped:
+        return comment_stripped, ""
+    action, ref = comment_stripped.rsplit("@", 1)
+    return action, ref.strip()
+
+
+def _extract_version_comment(line: str) -> int | None:
+    """Extract major version from a trailing # vN comment.
+
+    Args:
+        line: YAML line containing a uses directive.
+
+    Returns:
+        The major version number or None if no comment found.
+    """
+    match = re.search(r"#\s*v(\d+)", line)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _collect_workflow_actions() -> list[tuple[Path, str, str, int | None]]:
+    """Collect all action references from workflow files.
+
+    Returns:
+        List of (file_path, action_name, ref, version_from_comment) tuples.
+    """
+    results: list[tuple[Path, str, str, int | None]] = []
+    if not WORKFLOWS_DIR.exists():
+        return results
+
+    for wf_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        content = wf_path.read_text()
+        lines = content.splitlines()
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("- uses:") or stripped.startswith("uses:"):
+                uses_value = stripped.split("uses:", 1)[1].strip()
+                action, ref = _parse_action_ref(uses_value)
+                version = _extract_version_comment(line)
+                results.append((wf_path, action, ref, version))
+    return results
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+def workflow_actions() -> list[tuple[Path, str, str, int | None]]:
+    """All action references found in workflow files.
+
+    Returns:
+        List of (path, action, ref, version) tuples.
+    """
+    return _collect_workflow_actions()
+
+
+class TestActionVersions:
+    """Ensure GitHub Actions are pinned to supported major versions."""
+
+    def test_actions_pinned_to_sha(self, workflow_actions: list[tuple[Path, str, str, int | None]]) -> None:
+        """All actions must be pinned to a full SHA, not a mutable tag.
+
+        This prevents supply-chain attacks from tag re-pointing.
+
+        Args:
+            workflow_actions: Collected action references from workflows.
+        """
+        unpinned: list[str] = []
+        for path, action, ref, _version in workflow_actions:
+            if not action.startswith(".") and not re.match(r"^[0-9a-f]{40}$", ref):
+                unpinned.append(f"{path.name}: {action}@{ref}")
+        assert not unpinned, "Actions must be pinned to full SHA:\n" + "\n".join(unpinned)
+
+    def test_actions_have_version_comments(self, workflow_actions: list[tuple[Path, str, str, int | None]]) -> None:
+        """SHA-pinned actions must have a # vN comment for auditability.
+
+        Args:
+            workflow_actions: Collected action references from workflows.
+        """
+        missing_comments: list[str] = []
+        for path, action, ref, version in workflow_actions:
+            if action.startswith("."):
+                continue
+            if re.match(r"^[0-9a-f]{40}$", ref) and version is None:
+                missing_comments.append(f"{path.name}: {action}@{ref[:12]}...")
+        assert not missing_comments, "SHA-pinned actions need version comments (# vN):\n" + "\n".join(missing_comments)
+
+    def test_actions_meet_minimum_versions(self, workflow_actions: list[tuple[Path, str, str, int | None]]) -> None:
+        """Actions must meet minimum required major versions.
+
+        This catches deprecated Node.js runtime issues before CI runs.
+
+        Args:
+            workflow_actions: Collected action references from workflows.
+        """
+        outdated: list[str] = []
+        for path, action, _ref, version in workflow_actions:
+            if action in KNOWN_ACTION_MINIMUM_VERSIONS and version is not None:
+                min_ver = KNOWN_ACTION_MINIMUM_VERSIONS[action]
+                if version < min_ver:
+                    outdated.append(f"{path.name}: {action} is v{version}, minimum required is v{min_ver}")
+        assert not outdated, "Actions below minimum supported versions:\n" + "\n".join(outdated)
+
+
+class TestDockerfileImagePinning:
+    """Ensure Dockerfiles use pinned image versions."""
+
+    @pytest.fixture  # type: ignore[untyped-decorator]
+    def dockerfiles(self) -> list[Path]:
+        """All Dockerfiles in containers/.
+
+        Returns:
+            List of Dockerfile paths.
+        """
+        return sorted(CONTAINERS_DIR.glob("*/Dockerfile"))
+
+    def test_no_latest_tags(self, dockerfiles: list[Path]) -> None:
+        """FROM directives must not use :latest — pin to a specific version.
+
+        Unpinned tags cause non-reproducible builds and intermittent failures
+        when upstream images change or registry pulls become inconsistent.
+
+        Args:
+            dockerfiles: Paths to all Dockerfiles under containers/.
+        """
+        violations: list[str] = []
+        for df in dockerfiles:
+            content = df.read_text()
+            for i, line in enumerate(content.splitlines(), 1):
+                if re.match(r"^\s*FROM\s+\S+:latest(\s|$)", line):
+                    violations.append(f"{df.relative_to(REPO_ROOT)}:{i}: {line.strip()}")
+        assert not violations, "Dockerfiles must pin image versions (not :latest):\n" + "\n".join(violations)
+
+    def test_no_untagged_images(self, dockerfiles: list[Path]) -> None:
+        """FROM directives must specify a tag or use a build arg.
+
+        Images without tags implicitly pull :latest.
+
+        Args:
+            dockerfiles: Paths to all Dockerfiles under containers/.
+        """
+        violations: list[str] = []
+        for df in dockerfiles:
+            content = df.read_text()
+            for i, line in enumerate(content.splitlines(), 1):
+                stripped = line.strip()
+                if not stripped.startswith("FROM "):
+                    continue
+                image_ref = stripped.split()[1]
+                if image_ref.startswith("$"):
+                    continue
+                if ":" not in image_ref and "@" not in image_ref:
+                    violations.append(f"{df.relative_to(REPO_ROOT)}:{i}: {stripped} (missing tag/digest)")
+        assert not violations, "Dockerfiles must specify image tags:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary
- Fix the Container Images CI workflow failure on main caused by deprecated `docker/setup-buildx-action@v3` (Node.js 20 runtime) intermittently failing to bootstrap buildkit
- Update all Docker GitHub Actions to their latest Node 24 releases and pin external Docker images to specific versions
- Add CI workflow hygiene tests to prevent regression

## Changes
- **Workflow updates**: `docker/setup-buildx-action` v3→v4, `docker/login-action` v3→v4, `docker/metadata-action` v5→v6, `docker/build-push-action` v6→v7, `actions/checkout` v4→v6
- **Dockerfile pinning**: OPA image pinned to `1.17.1` (was `:latest`), Gitleaks image pinned to `v8.30.1` (was `:latest`)
- **Runtime pinning**: `opa_client.py` Podman image updated to `1.17.1`
- **New tests**: `tests/test_ci_workflow_hygiene.py` validates:
  - All actions are SHA-pinned (supply-chain security)
  - SHA-pinned actions have version comments (auditability)
  - Actions meet minimum major version requirements (catches Node.js deprecation)
  - Dockerfiles don't use `:latest` tags (reproducibility)
  - Dockerfiles don't use untagged images (implicit `:latest`)

## Root cause
The OPA container image build job failed with:
```
Error response from daemon: Head "https://registry-1.docker.io/v2/moby/buildkit/manifests/buildx-stable-1": unknown
```
This occurred because `setup-buildx-action@v3` uses the deprecated Node.js 20 runtime with a less resilient buildkit bootstrap mechanism. The v4 release (Node 24) uses an updated actions-toolkit with improved registry error handling.

## Test plan
- [x] `tox -e lint` passes (pre-existing `skillmark` failure only)
- [x] `tox -e unit -- tests/test_ci_workflow_hygiene.py` — all 5 tests pass
- [x] No breaking changes in action upgrades (verified release notes)
- [ ] Re-run Container Images workflow after merge to confirm fix


Made with [Cursor](https://cursor.com)