### PR TITLE
docs(sdlc): add REQ-016 and DR-017 for inventory group hyphen detection

### DIFF
--- a/.sdlc/decisions/open/DR-017-inventory-graph-support.md
+++ b/.sdlc/decisions/open/DR-017-inventory-graph-support.md
@@ -1,0 +1,70 @@
+# DR-017: Inventory Graph Support
+
+**Status:** Open
+**Created:** 2026-06-23
+**Category:** Architecture
+**Priority:** Low
+**Blocking:** No
+
+## Context
+
+APME currently has no `NodeType.INVENTORY` or `NodeType.INVENTORY_GROUP` in the ContentGraph. This limits ability to build graph-aware rules for inventory content.
+
+Related RFE: [AAPRFE-2997](https://issues.redhat.com/browse/AAPRFE-2997) — inventory group names with hyphens cause issues with Python variable access in Jinja2 templates.
+
+Current state:
+- L074 detects dashes in role names (graph-based)
+- No equivalent for inventory group names
+- REQ-016 proposes file-based L111 rule as interim solution
+
+## Question
+
+Should APME extend ContentGraph to parse inventory files and create INVENTORY_GROUP nodes?
+
+## Options
+
+### Option A: Add NodeType.INVENTORY_GROUP
+
+**Pros:**
+- Consistent with graph-based rule architecture
+- Enables relationship tracking (group hierarchies, host membership)
+- Future-proofs for inventory-related rules
+
+**Cons:**
+- Significant parser work (INI, YAML, dynamic inventory)
+- Inventory formats are complex (children, vars, patterns)
+- May be overkill if only one rule needs it
+
+### Option B: File-Based Rules Only
+
+**Pros:**
+- Simpler implementation
+- L111 can ship faster
+- No graph schema changes
+
+**Cons:**
+- Inconsistent with graph-first direction
+- Limited cross-reference capability
+
+### Option C: Hybrid (File now, Graph later)
+
+**Pros:**
+- Ship L111 immediately (REQ-016)
+- Migrate to graph when more inventory rules justified
+
+**Cons:**
+- Two implementations to maintain temporarily
+
+## Recommendation
+
+Option C — ship file-based L111 per REQ-016, revisit graph support when additional inventory rules are needed.
+
+## Decision
+
+*Pending*
+
+## References
+
+- [AAPRFE-2997](https://issues.redhat.com/browse/AAPRFE-2997) — Inventory group hyphen normalization
+- REQ-016 — L111 file-based rule specification
+- ADR-008 — Rule ID conventions

--- a/.sdlc/specs/REQ-016-inventory-group-hyphens/README.md
+++ b/.sdlc/specs/REQ-016-inventory-group-hyphens/README.md
@@ -1,0 +1,61 @@
+# REQ-016: Inventory Group Hyphen Detection (L111)
+
+**Status:** Draft
+**Created:** 2026-06-23
+**Priority:** Medium
+**Phase:** PHASE-001
+**RFE:** [AAPRFE-2997](https://issues.redhat.com/browse/AAPRFE-2997)
+
+## Summary
+
+Add rule L111 to detect inventory group names containing hyphens. Group names with hyphens cause issues when accessed as Python variables in Jinja2 templates (e.g., `groups['web-servers']` works but `hostvars[groups.web-servers]` fails).
+
+## Background
+
+Ansible inventory group names become Python identifiers in various contexts:
+- `groups.<groupname>` magic variable access
+- Jinja2 dot notation: `{{ groups.web-servers }}` fails
+- Group variable files: `group_vars/web-servers.yml` works but access is inconsistent
+
+Recommendation: use underscores (`web_servers`) instead of hyphens (`web-servers`).
+
+## Requirements
+
+### Functional
+
+1. **L111 Rule**: Detect inventory group names containing hyphens
+2. **File Types**: Scan INI and YAML inventory files
+3. **Detection Points**:
+   - INI: `[group-name]`, `[group-name:children]`, `[group-name:vars]`
+   - YAML: Top-level keys under `all.children`, nested `children` keys
+4. **Exclusions**: Skip `all`, `ungrouped` (reserved names)
+5. **Message**: Clear explanation of Jinja2 access issues
+
+### Non-Functional
+
+1. Severity: LOW (style/compatibility, not breaking)
+2. Tags: `[style, inventory]`
+3. Scope: INVENTORY (file-based, no graph node yet — see DR-017)
+
+## Acceptance Criteria
+
+- [ ] L111 detects `[web-servers]` in INI inventory
+- [ ] L111 detects `web-servers:` under `children:` in YAML inventory
+- [ ] L111 ignores `all` and `ungrouped`
+- [ ] L111 reports file path and line number
+- [ ] Unit tests cover INI and YAML formats
+- [ ] `tox -e lint` passes
+- [ ] `tox -e unit` passes with coverage
+
+## Technical Notes
+
+- Pattern similar to L074 (role name hyphens)
+- File-based implementation initially (no graph node)
+- Future: migrate to graph-based when NodeType.INVENTORY_GROUP exists (DR-017)
+
+## References
+
+- [AAPRFE-2997](https://issues.redhat.com/browse/AAPRFE-2997) — Customer RFE
+- DR-017 — Inventory graph support (deferred)
+- L074 — Role name hyphen detection (reference implementation)
+- ADR-008 — Rule ID conventions


### PR DESCRIPTION
## Summary

- Adds REQ-016 specification for L111 rule to detect hyphens in inventory group names
- Adds DR-017 deferred decision for inventory graph node support
- Addresses [AAPRFE-2997](https://issues.redhat.com/browse/AAPRFE-2997)

## Context

Inventory group names with hyphens cause issues when accessed via Jinja2 dot notation:
- `groups['web-servers']` works
- `groups.web-servers` fails (Python syntax)

L111 will detect these and recommend underscore naming (`web_servers`).

## Artifacts

| Type | ID | Description |
|------|-----|-------------|
| REQ | REQ-016 | L111 file-based rule specification |
| DR | DR-017 | Deferred: inventory graph node support |

## Test plan

- [ ] Review REQ-016 acceptance criteria
- [ ] Review DR-017 options and recommendation

🤖 Generated with [Claude Code](https://claude.com/claude-code)