### PR TITLE
docs(adr): add ADR-058 for R501 collection dependency suggestion

### DIFF
--- a/.sdlc/adrs/ADR-058-collection-dependency-suggestion.md
+++ b/.sdlc/adrs/ADR-058-collection-dependency-suggestion.md
@@ -1,0 +1,178 @@
+# ADR-058: Collection Dependency Suggestion for Unresolved Modules (R501)
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-23
+
+## Context
+
+Rule R501 ("Suggest collection/role dependency") is a planned advisory rule that suggests which Ansible collection provides a given module when the module cannot be resolved. Today, the engine handles FQCN modules well (ADR-032 extracts `collection_set` from FQCN usage), but **short module names** (e.g. `nmcli`, `lvg`, `firewalld`) cannot be resolved without knowing which collection provides them.
+
+When the native validator encounters an unresolved module (L037), users get a "module could not be resolved" finding but no actionable guidance on which collection to install. R501 would close this gap by suggesting the providing collection.
+
+### Forces
+
+- **Short module names are common in legacy content**: Content written for Ansible < 2.10 uses bare module names everywhere. These are the projects most likely to need modernization guidance.
+- **The engine never queries out** (invariant 11): The engine cannot call Galaxy's REST API at scan time. Any lookup data must be available locally within the pod.
+- **Galaxy Proxy owns collection data** (ADR-031): Collections are installed via the Galaxy Proxy. The proxy already downloads and converts Galaxy tarballs to wheels — it has access to collection metadata.
+- **Session venvs contain installed collections** (ADR-022): After `VenvSessionManager.acquire()`, the venv has all discovered collections installed. `ansible-doc --list` in that venv can enumerate available modules.
+- **Performance matters**: Module resolution happens in the scanner's hot loop. Any lookup must be fast (microsecond-scale hash lookup, not subprocess or network call).
+
+## Decision
+
+**We will build a static module-to-collection mapping bundled with the engine image, and expose it to R501 via a lightweight lookup function.**
+
+The mapping is a JSON file (`module_collection_map.json`) generated at image build time by querying a reference set of popular collections. R501 applies the same unresolved-module detection criteria as L037 (short module name on a task or handler, not an include/import action, not a resolved FQCN) and consults the static map — if the short name appears in the map, R501 emits an advisory finding suggesting the collection.
+
+### Mapping structure
+
+```json
+{
+  "nmcli": "community.general",
+  "lvg": "community.general",
+  "firewalld": "ansible.posix",
+  "win_copy": "ansible.windows",
+  "ec2_instance": "amazon.aws"
+}
+```
+
+When a module name maps to more than one collection in the curated set, the map stores a single entry using this disambiguation order: prefer collections in the `ansible` meta-package namespace, then `community.*`, then alphabetical by `namespace.collection`. Ambiguous names that cannot be resolved to one collection are omitted from the map (R501 does not fire).
+
+### Generation
+
+A build-time script (`tools/generate_module_map.py`) installs a curated list of collections into a temporary venv and runs `ansible-doc --list --json` to enumerate all modules. The output is filtered to exclude `ansible.builtin` (always available) and written to a JSON file shipped with the engine image.
+
+`ansible-doc --list` enumerates module names as exposed by installed collections; it does not fully capture `meta/runtime.yml` routing redirects or action-plugin aliases. The generator should also walk `meta/runtime.yml` in each installed collection where present to include redirect targets. Modules only reachable via routing with no direct listing may still be absent from the map.
+
+### Rule behavior
+
+R501 is an **advisory/suggestion** rule (severity INFO, consistent with other reporting rules such as R401):
+
+- Fires once per PLAYBOOK node (aggregate, not per-task), walking all task and handler descendants — same pattern as R401
+- Collects unresolved short module names that match L037's detection criteria and appear in the static map
+- Emits one finding per playbook listing suggested collections (e.g. `Unresolved modules may require: community.general (nmcli, lvg), ansible.posix (firewalld). Consider adding them to requirements.yml.`)
+- Violation detail includes the module names and file/line references so users can locate affected tasks
+- Does not fire for FQCN modules (already resolved by ADR-032)
+- Does not fire for `ansible.builtin` modules
+- Does not depend on L037 having fired — R501 runs its own `match()` logic independently, but complements L037 when both are enabled
+
+## Alternatives Considered
+
+### Alternative 1: Query Galaxy Proxy at scan time
+
+**Description**: Have the native validator call the Galaxy Proxy's API to look up module-to-collection mappings dynamically.
+
+**Pros**:
+- Always up-to-date with latest collection versions
+- No static mapping to maintain
+
+**Cons**:
+- Violates invariant 11 (engine never queries out)
+- Galaxy Proxy serves PEP 503 (package index), not module metadata — would need a new endpoint
+- Network call in the scan path adds latency
+- Creates a runtime dependency on Galaxy Proxy availability for a non-critical advisory rule
+
+**Why not chosen**: Violates the engine's outbound-query prohibition and adds unnecessary coupling.
+
+### Alternative 2: Query the session venv at scan time
+
+**Description**: After `VenvSessionManager.acquire()`, run `ansible-doc --list` in the session venv to discover available modules and build the mapping dynamically.
+
+**Pros**:
+- Uses the exact collection set available to the project
+- No static mapping to maintain
+- Accurate for the specific scan context
+
+**Cons**:
+- Subprocess call in the scan path (`ansible-doc --list` takes 2-5 seconds)
+- Only knows about collections already installed — cannot suggest collections not yet in the venv (which is R501's primary use case)
+- Tight coupling to Ansible validator lifecycle
+
+**Why not chosen**: R501's purpose is to suggest collections the user *doesn't have* — querying installed collections defeats the purpose. Also, subprocess overhead is too high for the scan path.
+
+### Alternative 3: Embed the mapping in Rego (OPA rule)
+
+**Description**: Implement R501 as an OPA policy rule with the module mapping embedded as Rego data.
+
+**Pros**:
+- OPA rules can consume static data natively
+- No Python code needed
+
+**Cons**:
+- OPA operates on the hierarchy JSON which has already resolved FQCNs — short names may be normalized away
+- Large data blob in Rego is awkward to maintain and test
+- Misaligned with the native validator's role (L037 is a native rule; R501 should complement it)
+
+**Why not chosen**: OPA is the wrong layer — module resolution context lives in the native validator's ContentGraph, not the hierarchy payload.
+
+### Alternative 4: Gateway-mediated enrichment
+
+**Description**: Have the Gateway query Galaxy's REST API for module metadata and attach it to the scan request as context enrichment (consistent with invariant 11's allowance for Gateway-side enrichment).
+
+**Pros**:
+- Architecturally clean (Gateway owns external queries)
+- Always current data
+- No static mapping in the engine
+
+**Cons**:
+- Gateway is not available in CLI daemon mode
+- Adds Gateway as a required dependency for an advisory rule
+- Galaxy's REST API doesn't have a direct "which collection provides module X" endpoint — would need to index all collection metadata
+
+**Why not chosen**: Too heavy for an advisory INFO rule. The static mapping approach covers 95%+ of cases with zero runtime cost.
+
+## Consequences
+
+### Positive
+
+- Users get actionable suggestions when legacy content uses unresolved short module names
+- Zero runtime cost (hash lookup against bundled JSON)
+- No architectural invariant violations
+- Complements L037 (unresolved module) with a constructive suggestion
+- Static mapping can be version-pinned and tested
+
+### Negative
+
+- Static mapping becomes stale as new collections are published — requires periodic regeneration
+- Mapping only covers the curated collection set, not every collection on Galaxy
+- Module name collisions across collections omit ambiguous entries rather than guessing
+
+### Neutral
+
+- The mapping generator script is a build-time tool, not a runtime dependency
+- R501 remains an advisory rule — it suggests, not enforces
+
+## Implementation Notes
+
+1. **Phase 1**: Create `tools/generate_module_map.py` and generate initial mapping from top ~50 collections
+2. **Phase 2**: Implement R501 GraphRule consuming the static mapping
+3. **Phase 3**: Add mapping regeneration to the container build pipeline
+4. **Curated collection list**: Start with collections in the `ansible` meta-package, `community.general`, `community.network`, `ansible.posix`, `ansible.windows`, and major cloud providers (`amazon.aws`, `google.cloud`, `azure.azcollection`)
+5. **L037 dependency**: L037 is currently disabled (`enabled=False` in its GraphRule). R501 should ship enabled but delivers the most value when L037 is also enabled — consider enabling L037 in the same implementation phase or documenting the pairing in release notes.
+6. **Severity catalog alignment**: Update `severity_defaults.py` and `RULE_CATALOG.md` from medium to INFO when R501 is implemented (ADR-043 central table pattern).
+
+## Related Decisions
+
+- [ADR-031](ADR-031-unified-collection-cache.md): Galaxy Proxy as collection boundary — R501's mapping leverages the same collection ecosystem
+- [ADR-032](ADR-032-fqcn-collection-auto-discovery.md): FQCN auto-discovery — R501 covers the inverse case (short names without FQCNs)
+- [ADR-008](ADR-008-rule-id-conventions.md): Rule ID conventions — R501 uses the R (Risk/Reporting) prefix
+- [ADR-009](ADR-009-remediation-engine.md): Validators are read-only — R501 is advisory, no file modification
+- [ADR-043](ADR-043-default-severity-assignment.md): Default severity assignment — R501 severity should be registered as INFO at implementation time
+
+## References
+
+- [Issue #247](https://github.com/ansible/apme/issues/247): Doc-only rules requiring implementation
+- [Rule R501 doc](src/apme_engine/validators/native/rules/R501_dependency_suggestion.md): Current stub documentation
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-23 | AI-assisted | Initial proposal |
+| 2026-07-07 | Review | Renumbered ADR-056 → ADR-058 (ADR-056/057 taken upstream); clarified scope, severity, collisions, and L037 relationship |

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -79,6 +79,7 @@ Decisions under consideration — not yet accepted or implemented.
 | [ADR-052](ADR-052-project-operation-sse-architecture.md) | Project Operation SSE Architecture | 2026-04-14 |
 | [ADR-055](ADR-055-violation-fingerprint-suppression.md) | Content-Based Violation Fingerprinting and Suppression | 2026-05-21 |
 | [ADR-056](ADR-056-apme-owns-scm-commit-push.md) | APME Owns SCM Commit and Push | 2026-07-06 |
+| [ADR-058](ADR-058-collection-dependency-suggestion.md) | Collection Dependency Suggestion for Unresolved Modules (R501) | 2026-06-23 |
 
 ## Superseded
 
@@ -92,7 +93,7 @@ Decisions replaced by newer ADRs.
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-058)
+2. Use the next available number (currently ADR-059)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date


### PR DESCRIPTION
## Summary

- Adds ADR-058 proposing a static module-to-collection mapping bundled with the engine image to power R501 advisory suggestions for unresolved short module names
- Evaluates four alternatives (Galaxy Proxy query, session venv query, OPA rule, Gateway enrichment) and selects the static mapping for zero runtime cost and compliance with engine architectural invariants

Related to #247

> **Note:** Renumbered from ADR-056 → ADR-057 → ADR-058 as upstream merged ADR-056 (APME owns SCM commit/push, #365) and ADR-057 (per-rule version applicability, #371).

## Changes

- Add `.sdlc/adrs/ADR-058-collection-dependency-suggestion.md` — decision record for R501 static mapping approach
- Regenerate `.sdlc/adrs/README.md` index (ADR-058 in Proposed)

## Decision

**We will build a static `module_collection_map.json` at image build time** (via `ansible-doc --list` over a curated collection set) and have R501 consult it when unresolved short module names are detected (same criteria as L037).

Key clarifications in this revision:
- Severity INFO (aligns with R401 reporting pattern; catalog update deferred to implementation)
- PLAYBOOK-level aggregation with per-module file/line detail in violation metadata
- Collision disambiguation policy (prefer ansible meta-package, then community.*, omit ambiguous)
- Independent of L037 firing; complements L037 when both enabled

## Test plan

- [x] `tox -e lint` — `adr-index` hook passes
- [x] `tox -e unit` passes
- [ ] Review ADR-058 options and recommendation
- [ ] Accept ADR before implementing R501 GraphRule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new ADR describing guidance for suggesting a collection when a module name can’t be resolved.
  * Updated the ADR index and next-numbering guidance to reflect the new proposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->