### PR TITLE
docs: align .sdlc/context docs with codebase reality

### DIFF
--- a/.sdlc/adrs/ADR-001-grpc-communication.md
+++ b/.sdlc/adrs/ADR-001-grpc-communication.md
@@ -25,8 +25,12 @@ APME is a multi-service system. The Primary orchestrator fans out to multiple va
 **Use gRPC for all inter-service communication** (Primary ↔ Validators, CLI ↔ Primary).
 
 HTTP/REST is used only for:
-- OPA REST API internally (OPA's native interface)
-- Reserved for future presentation layers (web UI)
+- Galaxy Proxy (PEP 503 simple repository API, :8765)
+- Gateway REST API (external consumers, :8080)
+- UI (nginx-served SPA, :8081)
+
+Note: OPA uses `opa eval` subprocess — not REST. The container's vestigial REST
+server on :8181 is unused by application code.
 
 ## Rationale
 

--- a/.sdlc/context/architecture.md
+++ b/.sdlc/context/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-APME is a multi-container gRPC microservice system. The Primary service runs the engine (parse → annotate → hierarchy), then fans validation out in parallel to six independent validator backends over a unified gRPC contract. The CLI is ephemeral — run on-the-fly with the project directory mounted.
+APME is a multi-container gRPC microservice system. The Primary service runs the engine (load definitions → build ContentGraph → apply rules → hierarchy), then fans validation out in parallel to six independent validator backends over a unified gRPC contract. The CLI is ephemeral — run on-the-fly with the project directory mounted.
 
 **Deployment methods** (choose based on target environment):
 
@@ -21,7 +21,9 @@ APME is a multi-container gRPC microservice system. The Primary service runs the
 - Blocking work is dispatched via `asyncio.get_event_loop().run_in_executor()`
 - Each request carries a **request_id** (correlation ID) for end-to-end tracing
 
-## Container Topology
+## Container Topology (Podman — local dev)
+
+This diagram shows the **Podman pod** (local development). All services share one pod and communicate via localhost. On Kubernetes/OpenShift, the system splits into separate Deployments — see the [Scaling](#scaling) section.
 
 ```
 ┌──────────────────────────────────── apme-pod ──────────────────────────────────┐
@@ -30,9 +32,9 @@ APME is a multi-container gRPC microservice system. The Primary service runs the
 │  │ Primary  │  │  Native  │  │   OPA    │  │ Ansible  │  │ Gitleaks │        │
 │  │  :50051  │  │  :50055  │  │  :50054  │  │  :50053  │  │  :50056  │        │
 │  │          │  │          │  │          │  │          │  │          │        │
-│  │ engine + │  │ Python   │  │ OPA bin  │  │ ansible- │  │ gitleaks │        │
+│  │ engine + │  │ GraphRule │  │ OPA bin  │  │ ansible- │  │ gitleaks │        │
 │  │ orchestr │  │ rules on │  │ + gRPC   │  │ core     │  │ + gRPC   │        │
-│  │ session  │  │ scandata │  │ wrapper  │  │ venvs    │  │ wrapper  │        │
+│  │ session  │  │ graph    │  │ wrapper  │  │ venvs    │  │ wrapper  │        │
 │  │  venvs   │  │          │  │          │  │ (ro)     │  │          │        │
 │  └────┬─────┘  └──────────┘  └──────────┘  └──────────┘  └──────────┘        │
 │       │                                                                         │
@@ -63,8 +65,8 @@ APME is a multi-container gRPC microservice system. The Primary service runs the
 
 | Service | Image | Port | Role |
 |---------|-------|------|------|
-| **Primary** | apme-primary | 50051 | Runs the engine (parse → annotate → hierarchy); manages session-scoped venvs (`VenvSessionManager`); fans out `ValidateRequest` to all validators in parallel; merges, deduplicates, and returns violations |
-| **Native** | apme-native | 50055 | Python rules operating on deserialized scandata (the full in-memory model). Rules L026–L060, M005/M010, P001–P004, R101–R501 |
+| **Primary** | apme-primary | 50051 | Runs the engine (load → build_content_graph → apply_rules → hierarchy); manages session-scoped venvs (`VenvSessionManager`); fans out `ValidateRequest` to all validators in parallel; merges, deduplicates, and streams violations via `FixSession` |
+| **Native** | apme-native | 50055 | ~90 GraphRule subclasses operating on deserialized `ContentGraph`. Rules span L027–L110, M005–M030, A001–A002, R101–R501 (see `src/apme_engine/validators/native/rules/`) |
 | **OPA** | apme-opa | 50054 | OPA binary (invoked via subprocess) + Python gRPC wrapper. Rego rules L003–L025, M006/M008/M009/M011, R118 on the hierarchy JSON |
 | **Ansible** | apme-ansible | 50053 | Ansible-runtime checks using session-scoped venvs (shared read-only via `/sessions` volume). Rules L057–L059, M001–M004 |
 | **Gitleaks** | apme-gitleaks | 50056 | Gitleaks binary + Python gRPC wrapper. Scans raw files for hardcoded secrets, API keys, private keys. Filters vault-encrypted content and Jinja2 expressions. Rules SEC:* (800+ patterns) |
@@ -86,18 +88,15 @@ Proto definitions live in `proto/apme/v1/`. Generated Python stubs in `src/apme/
 
 ```protobuf
 service Primary {
-  rpc Scan(ScanRequest) returns (ScanResponse);
   rpc Format(FormatRequest) returns (FormatResponse);
   rpc FormatStream(stream ScanChunk) returns (FormatResponse);
-  rpc FixSession(stream SessionCommand) returns (stream SessionEvent);
   rpc Health(HealthRequest) returns (HealthResponse);
+  rpc FixSession(stream SessionCommand) returns (stream SessionEvent);
   rpc ListAIModels(ListAIModelsRequest) returns (ListAIModelsResponse);
 }
 ```
 
-**`ScanStream` removed (ADR-039).** User-facing **check** and **remediate** both use **`FixSession`**: without `fix_options` on the first chunk the engine runs check (format → convergence in dry-run); with `FixOptions` it runs full remediation (Tier 1 apply, optional AI, approvals). The unary **`Scan`** RPC and **`ScanRequest` / `ScanResponse` / `scan_id`** remain for engine semantics and compatible clients.
-
-For unary `Scan`, the CLI (or another client) sends a `ScanRequest` with project files as `repeated File`, optional `ScanOptions`, and `scan_id`. Primary returns `ScanResponse` with merged violations and `ScanDiagnostics` (engine + validator timing data).
+**`ScanStream` and unary `Scan` removed (ADR-039).** User-facing **check** and **remediate** both use **`FixSession`**: without `fix_options` on the first chunk the engine runs check (format → convergence in dry-run); with `FixOptions` it runs full remediation (Tier 1 apply, optional AI, approvals). `FixSession` is a bidirectional stream — the client sends file chunks then approval commands; the server streams progress, proposals, and results.
 
 ### Validator (`validate.proto`) — Unified Contract
 
@@ -113,9 +112,11 @@ Every validator container implements this service. The `ValidateRequest` carries
 | Field | Type | Used by |
 |-------|------|---------|
 | `project_root` | string | All |
-| `files` | repeated File | Ansible (writes to temp dir), Gitleaks (writes to temp dir) |
+| `files` | repeated File | Ansible (writes to temp dir for syntax check) |
 | `hierarchy_payload` | bytes (JSON) | OPA, Ansible |
-| `scandata` | bytes (jsonpickle) | Native |
+| `content_graph_data` | bytes (JSON) | Native (GraphRules), Gitleaks (node content extraction) |
+| `venv_path` | string | Ansible, Collection Health, Dep Audit |
+| `session_id` | string | Ansible (venv lookup) |
 | `ansible_core_version` | string | Ansible |
 | `collection_specs` | repeated string | Ansible |
 | `request_id` | string | All (correlation ID for logging/tracing) |
@@ -164,15 +165,15 @@ Each validator is discovered by environment variable (`NATIVE_GRPC_ADDRESS`, `OP
 
 All gRPC servers use **grpc.aio** (fully async). This means multiple scan requests can be handled concurrently without thread exhaustion.
 
-| Service | Concurrency strategy | `maximum_concurrent_rpcs` |
-|---------|---------------------|---------------------------|
-| Primary | `asyncio.gather()` fan-out; engine scan via `run_in_executor()` | 16 |
-| Native | CPU-bound rules via `run_in_executor()` | 32 |
-| OPA | Blocking subprocess via `run_in_executor()` | 32 |
-| Ansible | Blocking venv build + subprocess via `run_in_executor()` | 8 |
-| Gitleaks | Blocking subprocess via `run_in_executor()` | 16 |
-
-Each service's `maximum_concurrent_rpcs` is configurable via environment variable (e.g., `APME_PRIMARY_MAX_RPCS`).
+| Service | Concurrency strategy | `maximum_concurrent_rpcs` | Env var |
+|---------|---------------------|---------------------------|---------|
+| Primary | `asyncio.gather()` fan-out; engine scan via `run_in_executor()` | 16 | `APME_PRIMARY_MAX_RPCS` |
+| Native | CPU-bound rules via `run_in_executor()` | 32 | `APME_NATIVE_MAX_RPCS` |
+| OPA | Blocking subprocess via `run_in_executor()` | 32 | `APME_OPA_MAX_RPCS` |
+| Ansible | Blocking venv build + subprocess via `run_in_executor()` | 8 | `APME_ANSIBLE_MAX_RPCS` |
+| Gitleaks | Blocking subprocess via `run_in_executor()` | 16 | `APME_GITLEAKS_MAX_RPCS` |
+| Collection Health | Collection scan via `run_in_executor()` | 4 | `APME_COLLECTION_HEALTH_MAX_RPCS` |
+| Dep Audit | `pip-audit` subprocess via `run_in_executor()` | 8 | `APME_DEP_AUDIT_MAX_RPCS` |
 
 ---
 
@@ -190,7 +191,7 @@ The Primary orchestrator manages session-scoped venvs via `VenvSessionManager`. 
 
 ## Session Tracking (request_id)
 
-Every scan request carries a `request_id` (derived from `ScanRequest.scan_id`) that propagates through the entire system:
+Every scan request carries a `request_id` (derived from the session's scan_id) that propagates through the entire system:
 
 ```
 CLI → Primary (scan_id) → ValidateRequest.request_id → each validator logs [req=xxx]
@@ -206,22 +207,34 @@ All validator logs are prefixed with `[req=xxx]` for end-to-end correlation acro
 | Data | Format | Wire type | Producer | Consumer |
 |------|--------|-----------|----------|----------|
 | Hierarchy payload | JSON (`json.dumps`) | bytes in protobuf | Engine (Primary) | OPA, Ansible |
-| Scandata | jsonpickle (`jsonpickle.encode`) | bytes in protobuf | Engine (Primary) | Native |
+| ContentGraph | `ContentGraph.to_dict(slim=True)` | JSON bytes in protobuf | Engine (Primary) | Native, Gitleaks |
 | Violations | Protobuf `Violation` messages | gRPC | All validators | Primary |
 | Project files | Protobuf `File` messages | gRPC | CLI | Primary, Ansible |
 
-`jsonpickle` is used for scandata because the engine's in-memory model (`SingleScan`) contains complex Python objects (trees, contexts, specs, annotations) that standard JSON cannot represent. `jsonpickle` preserves types for round-trip deserialization.
+The Native validator receives a serialized `ContentGraph` (JSON dict) which it deserializes via `ContentGraph.from_dict()`. This replaced the earlier `jsonpickle`-encoded `SingleScan` (`scandata`) path. The ContentGraph is a lightweight directed graph of nodes (tasks, plays, roles, files) with properties — no complex Python objects requiring `jsonpickle`.
 
 ---
 
-## OPA Container Internals
+## OPA Execution
 
-The OPA container invokes the OPA binary directly via subprocess — no OPA REST server is required:
+OPA policy evaluation always uses `opa eval` as a **subprocess** — the gRPC wrapper never queries OPA via HTTP.
 
-1. **OPA binary** is installed in the container image with the Rego bundle mounted
-2. **apme-opa-validator** (Python gRPC wrapper) starts on port 50054, receives `ValidateRequest`, extracts `hierarchy_payload`, invokes `opa eval` as a subprocess with the hierarchy JSON as input, parses the JSON output, and converts it to `ValidateResponse`
+### In the Podman pod (container)
 
-This avoids the overhead of running a persistent OPA server while presenting a uniform gRPC contract to Primary.
+1. **OPA binary** (`/usr/local/bin/opa`) is copied from the official OPA image at build time
+2. `entrypoint.sh` starts a REST server in the background (vestigial — used only for the readiness-wait loop)
+3. **apme-opa-validator** (Python gRPC wrapper) starts on port 50054, receives `ValidateRequest`, extracts `hierarchy_payload`, invokes `opa eval -I -d /bundle data.apme.rules.violations --format json` as a subprocess with hierarchy JSON on stdin, parses the JSON output, and converts it to `ValidateResponse`
+
+### In CLI daemon mode (no container)
+
+The same `opa_client.run_opa()` code is used, but the binary is accessed differently:
+
+| `OPA_USE_PODMAN` | Mechanism | Performance |
+|------------------|-----------|-------------|
+| `1` (default) | `podman run --rm ... opa eval` — ephemeral container per evaluation | Slower (container startup overhead) |
+| `0` | Local `opa` binary on `$PATH` | Fast (same as in-container) |
+
+If neither Podman nor a local binary is available, OPA validation is skipped (graceful degradation). A circuit breaker disables OPA after 3 consecutive 60s timeouts.
 
 ---
 
@@ -230,7 +243,12 @@ This avoids the overhead of running a persistent OPA server while presenting a u
 The Gitleaks container follows a similar multi-stage pattern:
 
 1. **Gitleaks binary** is copied from the official `zricethezav/gitleaks` image into a Python 3.12 slim image
-2. **apme-gitleaks-validator** (Python gRPC wrapper) starts on port 50056, receives `ValidateRequest`, writes files to a temp directory, runs `gitleaks detect --no-git --report-format json`, parses the JSON report, and converts findings to `ValidateResponse`
+2. **apme-gitleaks-validator** (Python gRPC wrapper) starts on port 50056, receives `ValidateRequest` with `content_graph_data`
+
+The validator supports two scanning strategies:
+
+- **Strategy 1 (directory mode)**: Writes files to a temp directory, runs `gitleaks detect --no-git --report-format json`, parses the JSON report
+- **Strategy 2 (stdin/pipe mode)**: Extracts node content from the `ContentGraph`, concatenates it with delimiter comments, pipes to `gitleaks detect --pipe` via stdin, then maps findings back to graph node IDs by walking backwards from reported line numbers to delimiter boundaries
 
 The wrapper adds **Ansible-aware filtering**:
 - **Vault filtering**: files containing `$ANSIBLE_VAULT;` headers are excluded
@@ -241,10 +259,11 @@ The wrapper adds **Ansible-aware filtering**:
 
 ## Volumes
 
-| Volume | Mount | Services | Access |
-|--------|-------|----------|--------|
-| `sessions` | `/sessions` | Primary (rw), Ansible (ro) | Session-scoped venvs with ansible-core + collections |
-| `workspace` | `/workspace` | CLI (ro) | Project being scanned (mounted from host CWD) |
+| Volume | Mount | Services | Access | Notes |
+|--------|-------|----------|--------|-------|
+| `sessions` | `/sessions` | Primary (rw), Ansible (ro), Collection Health (ro), Dep Audit (ro) | Session-scoped venvs with ansible-core + collections | PVC when replicas=1; emptyDir when replicas>1 (each replica owns its sessions) |
+| `proxy-cache` | `/cache` | Galaxy Proxy | Wheel cache | PVC when replicas=1; emptyDir when replicas>1 |
+| `workspace` | `/workspace` | CLI (ro) | Project being scanned (mounted from host CWD) | Podman only (CLI container joins pod) |
 
 ---
 
@@ -269,11 +288,11 @@ The wrapper adds **Ansible-aware filtering**:
 
 ## Scaling
 
-**Scale pods, not services within a pod.** Each pod is a self-contained stack (Primary + Native + OPA + Ansible + Gitleaks + Collection Health + Dep Audit + Galaxy Proxy) that can process a scan request end-to-end.
+**Scale pods, not services within a pod.** Each engine pod is a self-contained stack (Primary + Native + OPA + Ansible + Gitleaks + Collection Health + Dep Audit + Galaxy Proxy) that can process a scan request end-to-end.
 
 ```
                     ┌─────────────┐
-  ScanRequest ────► │ Load        │
+  FixSession  ────► │ Load        │
                     │ Balancer    │
                     │ (K8s Svc)   │
                     └──┬──┬──┬────┘
@@ -281,11 +300,46 @@ The wrapper adds **Ansible-aware filtering**:
               ┌────────┘  │  └────────┐
               ▼           ▼           ▼
          ┌─────────┐ ┌─────────┐ ┌─────────┐
+         │ Engine  │ │ Engine  │ │ Engine  │
          │ Pod 1   │ │ Pod 2   │ │ Pod 3   │
          │ (full   │ │ (full   │ │ (full   │
          │  stack) │ │  stack) │ │  stack) │
          └─────────┘ └─────────┘ └─────────┘
+              ▲           ▲           ▲
+              └───────────┼───────────┘
+                          │ gRPC (reporting)
+                    ┌─────┴─────┐
+                    │  Gateway  │  (separate Deployment)
+                    │  Abbenay  │  (separate Deployment, optional)
+                    │    UI     │  (separate Deployment)
+                    └───────────┘
 ```
+
+### Kubernetes Topology
+
+On Kubernetes/OpenShift (via the Helm chart), the system is deployed as **separate Deployments**:
+
+| Deployment | Containers (sidecars) | Scaling |
+|-----------|----------------------|---------|
+| **engine** | Primary, Native, OPA, Ansible, Gitleaks*, Coll Health*, Dep Audit*, Galaxy Proxy | HPA (CPU/memory) or fixed replicas |
+| **gateway** | Gateway (REST + gRPC + DB) | Fixed replicas |
+| **ui** | nginx (PatternFly SPA) | Fixed replicas |
+| **abbenay** | Abbenay (AI provider) | Fixed (1 replica) |
+
+*\* = conditionally included via `.Values.gitleaks.enabled`, `.Values.collectionHealth.enabled`, `.Values.depAudit.enabled`*
+
+Key K8s scaling behavior:
+- **HPA**: Optional `HorizontalPodAutoscaler` targets the engine Deployment (default: disabled, maxReplicas=5, CPU target 70%, memory target 80%)
+- **Multi-replica sessions**: When `engine.replicas > 1`, sessions and proxy-cache switch from PVC to `emptyDir` — each replica builds its own session venvs (no shared state)
+- **PodDisruptionBudget**: Protects engine, gateway, and UI during node drains
+- **Abbenay is NOT in the engine pod**: Primary reaches Abbenay via K8s Service DNS (`<release>-abbenay:50057`), not localhost
+- **NetworkPolicy**: Optional default-deny with explicit allow rules for inter-service gRPC/HTTP traffic
+
+### Podman Pod (local dev)
+
+In the local Podman pod, ALL services (including Gateway, UI, and Abbenay) share a single pod and communicate over localhost. This is a development convenience — the scaling invariant still applies (the unit of replication is the full engine stack).
+
+### Scaling Constraints
 
 Within a pod, containers share localhost — no config change needed. If a single validator is the bottleneck for one request, the fix is parallelism inside that validator (e.g., task-level concurrency), not more containers.
 
@@ -321,7 +375,7 @@ message ScanDiagnostics {
   double engine_annotate_ms = 2;
   double engine_total_ms = 3;
   int32  files_scanned = 4;
-  int32  trees_built = 5;
+  int32  graph_nodes_built = 5;
   int32  total_violations = 6;
   repeated ValidatorDiagnostics validators = 7;
   double fan_out_ms = 8;
@@ -333,17 +387,20 @@ message ScanDiagnostics {
 
 | Validator | Timing granularity | Metadata |
 |-----------|-------------------|----------|
-| Native | Per-rule elapsed time from engine's `detect()` timing records | — |
-| OPA | OPA HTTP query time; per-rule violation counts | `opa_query_ms`, `opa_response_size` |
+| Native | Per-rule elapsed time from GraphRule `match()`/`process()` | — |
+| OPA | `opa eval` subprocess wall-clock time; per-rule violation counts | `subprocess_ms` |
 | Ansible | Per-phase: L057 syntax, M001–M004 introspection, L058 argspec-doc, L059 argspec-mock | `ansible_core_version`, `venv_build_ms` |
-| Gitleaks | Total subprocess time | `subprocess_ms`, `files_written` |
+| Gitleaks | Total subprocess time (pipe mode or dir mode) | `subprocess_ms` |
+| Collection Health | Per-collection scan time, per-rule timing | `collections_scanned` |
+| Dep Audit | `pip-audit` subprocess wall-clock time | `subprocess_ms`, `packages_audited` |
 
 ### Engine Timing
 
-The engine (`run_scan()`) reports per-phase timing:
+The engine (`run_scan()`) reports per-phase timing via `EngineDiagnostics`:
 - `parse_ms` — target load + PRM load + metadata load
-- `annotate_ms` — module annotators + variable resolution
-- `tree_build_ms` — call-graph construction
+- `tree_build_ms` — `graph_construction` phase (GraphBuilder → ContentGraph)
+- `graph_nodes_built` — total node count in the constructed ContentGraph
+- `files_scanned` — number of root definitions processed
 - `total_ms` — wall-clock for the full engine run
 
 ### Data Flow
@@ -353,7 +410,7 @@ Validator → ValidateResponse.diagnostics (ValidatorDiagnostics)
                     ↓
 Primary aggregates all ValidatorDiagnostics + engine timing
                     ↓
-ScanResponse.diagnostics (ScanDiagnostics)
+SessionEvent.diagnostics (ScanDiagnostics)
                     ↓
 CLI displays with -v / -vv
 ```

--- a/.sdlc/context/conventions.md
+++ b/.sdlc/context/conventions.md
@@ -86,14 +86,14 @@ except AriNotFoundError:
 ### Logging
 
 ```python
-import structlog
+import logging
 
-logger = structlog.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
-# Use structured logging
-logger.info("scan_started", path=str(path), fix_mode=fix)
-logger.warning("issue_detected", issue_type="FQCN", line=42)
-logger.error("scan_failed", path=str(path), error=str(e))
+# Use standard logging with context
+logger.info("Engine: loader start (%s, type=%s)", path.name, scan_type)
+logger.warning("Validator %s returned empty result", name)
+logger.error("Scan failed for %s: %s", path, e)
 ```
 
 ## File Organization
@@ -101,42 +101,50 @@ logger.error("scan_failed", path=str(path), error=str(e))
 ### Source Structure
 
 ```
-src/apme/
-├── __init__.py          # Version, public API
-├── cli.py               # Typer CLI
-├── scanner/
-│   ├── __init__.py      # Public scanner API
-│   ├── ari_wrapper.py   # ARI integration
-│   ├── issue_types.py   # Issue enums and classes
-│   └── reporter.py      # Output formatting
-├── rewriter/
-│   ├── __init__.py
-│   ├── graph.py         # LangGraph definition
-│   ├── transforms.py    # Transformation functions
-│   └── validators.py    # Validation logic
-└── rules/
-    ├── __init__.py
-    ├── fqcn.py          # FQCN mappings
-    ├── deprecated.py    # Deprecated modules
-    └── syntax.py        # Syntax patterns
+src/
+├── apme/v1/                    # Generated proto stubs (NEVER edit by hand)
+├── apme_engine/                # Core product
+│   ├── cli/                    # argparse-based CLI (check, remediate, format, daemon, health-check)
+│   ├── daemon/                 # gRPC servers: primary, native, opa, ansible, gitleaks, etc.
+│   │   └── sinks/             # Event sinks (grpc_reporting)
+│   ├── engine/                 # Project loader: parser, models, content_graph, scanner
+│   ├── remediation/            # Convergence engine, transform registry
+│   │   └── transforms/        # Per-rule deterministic fix functions
+│   ├── validators/             # Rule implementations
+│   │   ├── native/rules/      # ~90 GraphRule subclasses
+│   │   ├── opa/bundle/        # ~50 Rego rule files
+│   │   ├── ansible/rules/     # L057–L059, M001–M004
+│   │   ├── gitleaks/          # Gitleaks binary wrapper
+│   │   ├── collection_health/ # Installed collection quality checks
+│   │   └── dep_audit/         # pip-audit CVE scanner
+│   ├── venv_manager/          # Session-scoped venvs (VenvSessionManager)
+│   └── runner.py              # run_scan() entry point
+├── apme_gateway/               # FastAPI REST + SQLAlchemy DB + Reporting gRPC server
+│   ├── api/                   # REST routers and schemas
+│   ├── db/                    # SQLAlchemy models and queries
+│   ├── grpc_reporting/        # ReportingServicer (engine event sink)
+│   └── scm/                   # SCM integrations (GitHub)
+└── galaxy_proxy/               # PEP 503 proxy (Galaxy → wheels)
+    └── proxy/                 # ASGI server, cache layer
 ```
 
 ### Test Structure
 
-Mirror source structure:
+Tests mirror the engine structure:
 
 ```
 tests/
-├── conftest.py          # Shared fixtures
-├── test_cli.py
-├── scanner/
-│   ├── test_ari_wrapper.py
-│   └── test_issue_types.py
-├── rewriter/
-│   └── test_transforms.py
+├── conftest.py              # Shared fixtures (tmp projects, mock validators)
+├── unit/                    # Unit tests (run via tox -e unit)
+│   ├── test_runner.py
+│   ├── test_formatter.py
+│   ├── test_remediation/
+│   ├── test_validators/
+│   └── test_cli/
+├── integration/             # Integration tests (marked, may need services)
 └── fixtures/
-    ├── playbooks/       # Test playbook files
-    └── expected/        # Expected outputs
+    ├── projects/            # Sample Ansible projects for scan testing
+    └── golden-collection/   # Collection fixture for validator tests
 ```
 
 ## Naming Conventions
@@ -150,10 +158,11 @@ tests/
 ### Classes
 
 ```python
-class AriWrapper:        # PascalCase
-class FQCNMapper:        # Acronyms as words
-class ScanResult:        # Nouns for data classes
-class PlaybookScanner:   # Noun for service classes
+class ScanContext:            # PascalCase, nouns for data classes
+class ContentGraph:           # PascalCase
+class OpaValidator:           # Noun for service classes
+class TransformRegistry:      # Noun for service classes
+class AnsibleProjectLoader:   # Descriptive noun phrase
 ```
 
 ### Functions
@@ -288,44 +297,51 @@ with open(path, "w") as f:
 
 ## CLI Standards
 
-### Typer Patterns
+### argparse Patterns
+
+The CLI uses standard library `argparse` with subparsers. Each subcommand
+has its own module in `src/apme_engine/cli/`.
 
 ```python
-import typer
+import argparse
 
-app = typer.Typer(help="APME - Ansible Playbook Modernization Engine")
+def build_parser() -> argparse.ArgumentParser:
+    """Build and return the CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        description="APME: Ansible Policy & Modernization Engine",
+    )
+    sub = parser.add_subparsers(dest="command")
 
-@app.command()
-def check(
-    path: Path = typer.Argument(..., help="Path to playbook or directory"),
-    output: Path | None = typer.Option(None, "--output", "-o", help="Output file"),
-):
-    """Check playbooks for AAP compatibility issues (read-only assessment)."""
+    # check subcommand
+    check_p = sub.add_parser("check", help="Assess project (read-only)")
+    check_p.add_argument("target", help="Path to playbook or directory")
+    check_p.add_argument("--json", action="store_true", help="JSON output")
+    check_p.add_argument("--sarif", action="store_true", help="SARIF output")
 
-@app.command()
-def remediate(
-    path: Path = typer.Argument(..., help="Path to playbook or directory"),
-    apply: bool = typer.Option(False, "--apply", help="Write remediations in place"),
-):
-    """Apply format + Tier 1 (and optional AI) remediation via FixSession."""
+    # remediate subcommand
+    rem_p = sub.add_parser("remediate", help="Apply fixes via FixSession")
+    rem_p.add_argument("target", help="Path to playbook or directory")
+    rem_p.add_argument("--ai", action="store_true", help="Enable Tier 2 AI remediation")
+
+    return parser
 ```
 
 ### Output Formatting
 
-```python
-from rich.console import Console
-from rich.table import Table
+The CLI uses a custom ANSI module (`cli/ansi.py`) for colored output,
+respecting `--no-ansi` and `NO_COLOR` environment variable:
 
-console = Console()
+```python
+from apme_engine.cli.ansi import style, Color
 
 # Success
-console.print("[green]Check complete[/green]")
+print(style("Check complete", fg=Color.GREEN))
 
 # Warning
-console.print("[yellow]Warning:[/yellow] 3 issues found")
+print(style("Warning:", fg=Color.YELLOW), "3 issues found")
 
-# Error
-console.print("[red]Error:[/red] File not found")
+# Error  
+print(style("Error:", fg=Color.RED), "File not found")
 ```
 
 ## Visualization Selection

--- a/.sdlc/context/data-flow.md
+++ b/.sdlc/context/data-flow.md
@@ -2,7 +2,7 @@
 
 This document traces a **check** request from CLI to violation output, covering every transformation and serialization boundary. (The engine still **scans** files internally; the user action is **check**, not “run a scan.”)
 
-**ADR-039:** `ScanStream` was removed. The thin CLI and gateway use **`FixSession`** for both **check** and **remediate**; the sequence below shows the engine pipeline and validator fan-out once Primary has the project files (whether they arrived via unary `Scan` or chunked `FixSession` upload).
+**ADR-039:** `ScanStream` and unary `Scan` were removed. The thin CLI and gateway use **`FixSession`** for both **check** and **remediate**. The sequence below shows the engine pipeline and validator fan-out once Primary has the project files via the `FixSession` chunked upload.
 
 ## Request Lifecycle
 
@@ -11,75 +11,70 @@ User runs:  apme check /path/to/project
             │
             ▼
 ┌───────────────────────────────────────────────────────┐
-│  CLI (apme_engine/cli.py)                             │
+│  CLI (apme_engine/cli/)                               │
 │                                                       │
 │  1. Walk project directory                            │
 │  2. Filter: TEXT_EXTENSIONS, skip SKIP_DIRS,          │
 │     exclude >2 MiB and binary files                   │
-│  3. Build ScanRequest:                                │
-│     - scan_id (uuid)                                  │
-│     - project_root (basename)                         │
-│     - files[] = File(path=relative, content=bytes)    │
+│  3. Open FixSession (bidirectional gRPC stream):      │
+│     - Send SessionCommand with ScanChunk messages     │
+│     - Each chunk: File(path=relative, content=bytes)  │
 │     - options (ansible_core_version, collection_specs)│
+│     - No fix_options = check mode (dry-run)           │
 │                                                       │
-│  gRPC: Primary.Scan(ScanRequest) or FixSession (check mode) ─┐
-└───────────────────────────────────────────────────────┘       │
-                                                                ▼
+│  gRPC: Primary.FixSession(stream SessionCommand) ─────────┐
+└───────────────────────────────────────────────────────┘    │
+                                                             ▼
 ┌──────────────────────────────────────────────────────────────────┐
 │  Primary (daemon/primary_server.py)                              │
 │                                                                  │
-│  4. _write_chunked_fs(): write request.files to temp dir         │
+│  4. _write_chunked_fs(): write uploaded files to temp dir        │
 │                                                                  │
-│  5. run_scan(temp_dir, project_root):                            │
+│  5. run_scan(temp_dir, project_root) in executor:                │
 │     ┌────────────────────────────────────────────────────┐       │
-│     │  Engine (engine/scanner.py — ARIScanner.evaluate)  │       │
+│     │  Engine (engine/scanner.py — AnsibleProjectLoader) │       │
 │     │                                                    │       │
 │     │  a. load_definitions_root()                        │       │
-│     │     Parser.run() → playbooks, roles, taskfiles,    │       │
-│     │     tasks, modules, mappings                       │       │
+│     │     Parser dispatches by type (project, collection,│       │
+│     │     role, playbook, taskfile) → raw definitions:   │       │
+│     │     playbooks, roles, taskfiles, tasks, modules    │       │
 │     │                                                    │       │
-│     │  b. construct_trees()                              │       │
-│     │     TreeLoader → PlaybookCall → PlayCall →         │       │
-│     │     RoleCall → TaskFileCall → TaskCall trees       │       │
+│     │  b. build_content_graph()                          │       │
+│     │     GraphBuilder transforms definitions into a     │       │
+│     │     ContentGraph (nodes + edges + properties).     │       │
+│     │     Node types: PLAY, ROLE, TASK, HANDLER, BLOCK,  │       │
+│     │     FILE, etc. Edges encode call relationships.    │       │
 │     │                                                    │       │
-│     │  c. resolve_variables()                            │       │
-│     │     Walk trees, resolve variable references,       │       │
-│     │     track set_fact / register / include_vars       │       │
-│     │                                                    │       │
-│     │  d. annotate()                                     │       │
-│     │     RiskAnnotators (per-module: shell, command,     │       │
-│     │     get_url, file, copy, etc.) add RiskAnnotations │       │
-│     │     to each TaskCall                               │       │
-│     │                                                    │       │
-│     │  e. build_hierarchy_payload()                      │       │
-│     │     Serialize trees → JSON hierarchy:              │       │
-│     │     { scan_id, hierarchy: [{root_key, root_type,   │       │
-│     │       root_path, nodes: [{type, key, file, line,   │       │
-│     │       module, options, module_options,              │       │
-│     │       annotations}]}], metadata }                  │       │
+│     │  c. apply_rules() — internal validation/enrichment │       │
+│     │     Produces hierarchy_payload from the graph:     │       │
+│     │     { hierarchy: [{root_key, root_type, root_path, │       │
+│     │       nodes: [{type, key, file, line, module,      │       │
+│     │       options, module_options, annotations}]}],    │       │
+│     │     metadata }                                     │       │
 │     │                                                    │       │
 │     │  Returns: ScanContext                              │       │
 │     │    .hierarchy_payload = dict (JSON-serializable)   │       │
-│     │    .scandata = SingleScan (full in-memory model)   │       │
+│     │    .scandata = SingleScan (with .content_graph)    │       │
 │     └────────────────────────────────────────────────────┘       │
 │                                                                  │
-│  6. Build ValidateRequest:                                       │
+│  6. Build ValidateRequest for each validator:                    │
 │     - hierarchy_payload = json.dumps(ctx.hierarchy_payload)      │
-│     - scandata = jsonpickle.encode(ctx.scandata)                 │
-│     - files, ansible_core_version, collection_specs              │
+│     - content_graph_data = ContentGraph.to_dict(slim=True)       │
+│     - files, venv_path, session_id, request_id                   │
 │                                                                  │
 │  7. Parallel fan-out (asyncio.gather):                           │
 │     ┌─────────────────────────────────────────────────────┐      │
 │     │                                                     │      │
 │     │  ┌─► Native :50055                                  │      │
-│     │  │   - jsonpickle.decode(scandata) → SingleScan     │      │
-│     │  │   - Build ScanContext, run NativeValidator        │      │
-│     │  │   - Python rules on contexts/trees               │      │
+│     │  │   - Deserialize ContentGraph from                 │      │
+│     │  │     content_graph_data (JSON dict)                │      │
+│     │  │   - Run ~90 GraphRule subclasses on graph nodes   │      │
 │     │  │   → violations[] + ValidatorDiagnostics          │      │
 │     │  │                                                  │      │
 │     │  ├─► OPA :50054                                     │      │
 │     │  │   - json.loads(hierarchy_payload)                 │      │
-│     │  │   - POST to local OPA REST (:8181)               │      │
+│     │  │   - subprocess: opa eval -I -d /bundle           │      │
+│     │  │     (local binary; NOT the REST server)           │      │
 │     │  │   → violations[] + ValidatorDiagnostics          │      │
 │     │  │                                                  │      │
 │     │  ├─► Ansible :50053                                 │      │
@@ -89,11 +84,18 @@ User runs:  apme check /path/to/project
 │     │  │     FQCN, deprecation, redirect, removed)        │      │
 │     │  │   → violations[] + ValidatorDiagnostics          │      │
 │     │  │                                                  │      │
-│     │  └─► Gitleaks :50056                                │      │
-│     │      - Write files to temp dir                      │      │
-│     │      - Run gitleaks detect --no-git                 │      │
-│     │      - Filter vault + Jinja false positives         │      │
-│     │      → violations[] + ValidatorDiagnostics          │      │
+│     │  ├─► Gitleaks :50056                                │      │
+│     │  │   - Pipe node content to gitleaks --pipe stdin    │      │
+│     │  │   - Filter vault + Jinja false positives         │      │
+│     │  │   → violations[] + ValidatorDiagnostics          │      │
+│     │  │                                                  │      │
+│     │  ├─► Collection Health :50058 (optional)            │      │
+│     │  │   - Scan installed collections in session venv   │      │
+│     │  │   → findings[] + ValidatorDiagnostics            │      │
+│     │  │                                                  │      │
+│     │  └─► Dep Audit :50059 (optional)                    │      │
+│     │      - pip-audit against session venv packages      │      │
+│     │      → findings[] + ValidatorDiagnostics            │      │
 │     │                                                     │      │
 │     └─────────────────────────────────────────────────────┘      │
 │                                                                  │
@@ -102,11 +104,11 @@ User runs:  apme check /path/to/project
 │ 10. Sort by (file, line)                                         │
 │ 11. Convert to proto Violation messages                          │
 │ 12. Aggregate diagnostics:                                       │
-│     - Engine timing (parse, annotate, tree build)                │
+│     - Engine timing (parse, graph_construction, total)           │
 │     - Each validator's ValidatorDiagnostics                      │
 │     - Fan-out wall-clock, total wall-clock                       │
 │                                                                  │
-│  Return: ScanResponse(violations, scan_id, diagnostics)          │
+│  Stream back SessionEvent(violations, diagnostics, patches)      │
 └──────────────────────────────────────────────────────────────────┘
                          │
                          ▼
@@ -127,63 +129,38 @@ User runs:  apme check /path/to/project
 
 ## Engine Pipeline Detail
 
-The engine (`ARIScanner.evaluate()`) runs five stages in sequence. All stages operate on the same in-memory model; there is no intermediate serialization between stages.
+The engine (`AnsibleProjectLoader.load()`) runs multiple stages in sequence. All stages operate on the same in-memory model; there is no intermediate serialization between stages.
 
-### Stage 1: Load Definitions
+### Stage 1: Load Definitions (`target_load`)
 
-`Parser.run()` dispatches by load type (PROJECT, COLLECTION, ROLE, PLAYBOOK, TASKFILE). Produces:
+`Parser` dispatches by load type (PROJECT, COLLECTION, ROLE, PLAYBOOK, TASKFILE). Produces:
 
 | Output | Description |
 |--------|-------------|
 | `root_definitions` | playbooks, roles, taskfiles, tasks, modules found in the scan target |
-| `ext_definitions` | external dependencies (collections, roles from cache) |
-| `mappings` | index of module → FQCN, role → path, etc. |
+| `ext_definitions` | external dependencies (collections from `dependency_dir`) |
 
-### Stage 2: Construct Trees
+### Stage 2: Build ContentGraph (`graph_construction`)
 
-`TreeLoader` builds directed graphs of call objects:
+`GraphBuilder` transforms raw definitions into a `ContentGraph` — a directed graph where:
 
-```
-PlaybookCall → PlayCall → RoleCall → TaskFileCall → TaskCall
-                        └──────────► TaskCall (play-level tasks)
-```
+- **Nodes** represent structural elements (PLAY, ROLE, TASK, HANDLER, BLOCK, FILE, etc.)
+- **Edges** encode call relationships (play → role, role → taskfile → task)
+- **Properties** on each node: `file`, `line`, `module`, `options`, `module_options`, `annotations`
 
-Each node has:
-- **spec**: the parsed YAML structure
-- **key**: unique identifier
-- **edges**: connections to children
+The graph preserves execution order, nesting, and variable scope. Node identity is stable across rescans (ADR-044).
 
-The tree preserves execution order and nesting.
+### Stage 3: Apply Rules / Build Hierarchy (`apply_rules`)
 
-### Stage 3: Resolve Variables
+Runs internal enrichment and builds the hierarchy payload from the graph:
 
-Walks the tree and tracks variable definitions (`set_fact`, `register`, `include_vars`, role defaults/vars) and usages. Produces:
+- Resolves module FQCNs, variable provenance, and risk annotations
+- Serializes the graph into a flat JSON hierarchy for OPA/Ansible validators
+- Annotations (e.g., `cmd_exec`, `inbound_transfer`, `file_change`) are attached to task nodes and serialized into the hierarchy payload's `annotations` array
 
-- `variable_use` annotations on tasks (which variables are referenced)
-- Resolution of `{{ var }}` references where statically determinable
+### Hierarchy Payload Shape
 
-### Stage 4: Annotate
-
-Per-module `RiskAnnotator` subclasses inspect each `TaskCall` and attach `RiskAnnotation` objects:
-
-| Annotator | Risk Types |
-|-----------|------------|
-| `ShellAnnotator` | CMD_EXEC |
-| `CommandAnnotator` | CMD_EXEC |
-| `GetUrlAnnotator` | INBOUND_TRANSFER |
-| `UriAnnotator` | INBOUND_TRANSFER, OUTBOUND_TRANSFER |
-| `CopyAnnotator` | FILE_CHANGE |
-| `FileAnnotator` | FILE_CHANGE |
-| `UnarchiveAnnotator` | FILE_CHANGE, INBOUND_TRANSFER |
-| `LineinfileAnnotator` | FILE_CHANGE |
-| `GitAnnotator` | INBOUND_TRANSFER |
-| `PackageAnnotator` | PACKAGE_INSTALL |
-
-Annotations are attached to the `TaskCall` and serialized into the hierarchy payload's `annotations` array, making them available to OPA rules (e.g., R118 checks for `inbound_transfer`).
-
-### Stage 5: Build Hierarchy Payload
-
-Serializes the tree into a flat JSON structure consumable by OPA and other payload-based validators:
+Serializes into a flat JSON structure consumable by OPA and other payload-based validators:
 
 ```json
 {
@@ -223,12 +200,14 @@ Files are sent as protobuf `File` messages (`path` + `content` bytes). This is t
 
 ### Primary → Validators (gRPC)
 
-Two serialization formats in one `ValidateRequest`:
+Multiple serialization formats in one `ValidateRequest`:
 
 | Field | Format | Used By | Description |
 |-------|--------|---------|-------------|
-| `hierarchy_payload` | `json.dumps()` → bytes | OPA, Ansible | Complete hierarchy as JSON. Rego operates on JSON. |
-| `scandata` | `jsonpickle.encode()` → bytes | Native | Full `SingleScan` object including trees, contexts, specs, and annotations. `jsonpickle` preserves Python types for round-trip `decode()`. |
+| `hierarchy_payload` | `json.dumps()` → bytes | OPA, Ansible | Complete hierarchy as JSON. Rego and Ansible runtime operate on JSON. |
+| `content_graph_data` | `ContentGraph.to_dict(slim=True)` → JSON bytes | Native, Gitleaks | Serialized ContentGraph (nodes, edges, properties). Native runs GraphRules on it; Gitleaks extracts node content for pipe-mode scanning. |
+| `files` | protobuf `File` messages | Ansible | Raw file content for writing to temp dirs (syntax check). |
+| `venv_path` | string | Ansible, Collection Health, Dep Audit | Path to session-scoped venv (read-only for validators). |
 
 ### Validators → Primary (gRPC)
 
@@ -236,7 +215,7 @@ Each validator returns `ValidateResponse` containing:
 - Protobuf `Violation` messages
 - `ValidatorDiagnostics` with per-rule timing, violation counts, and validator-specific metadata
 
-Primary converts violations to dicts, merges, deduplicates, and converts back to proto. It also aggregates all `ValidatorDiagnostics` with engine phase timing into a `ScanDiagnostics` message on the `ScanResponse`.
+Primary converts violations to dicts, merges, deduplicates, and converts back to proto. It also aggregates all `ValidatorDiagnostics` with engine phase timing into a `ScanDiagnostics` message streamed via the `SessionEvent`.
 
 ---
 
@@ -245,14 +224,16 @@ Primary converts violations to dicts, merges, deduplicates, and converts back to
 ```
 Engine → EngineDiagnostics (parse_ms, annotate_ms, tree_build_ms, total_ms)
                               ↓
-Native  → ValidatorDiagnostics (per-rule timing from detect() records)
-OPA     → ValidatorDiagnostics (opa_query_ms, per-rule violation counts)
+Native  → ValidatorDiagnostics (per-rule timing from GraphRule match/process)
+OPA     → ValidatorDiagnostics (subprocess_ms, per-rule violation counts)
 Ansible → ValidatorDiagnostics (per-phase: syntax, introspect, argspec; venv_build_ms)
-Gitleaks→ ValidatorDiagnostics (subprocess_ms, files_written)
+Gitleaks→ ValidatorDiagnostics (subprocess_ms)
+Coll Health → ValidatorDiagnostics (per-collection timing, collections_scanned)
+Dep Audit → ValidatorDiagnostics (subprocess_ms, packages_audited)
                               ↓
 Primary aggregates → ScanDiagnostics
                               ↓
-ScanResponse.diagnostics → CLI (-v / -vv) or JSON consumer
+SessionEvent.diagnostics → CLI (-v / -vv) or JSON consumer
 ```
 
 ---
@@ -280,33 +261,58 @@ Every violation, regardless of source validator, has the same structure:
 
 ---
 
-## Local (In-Process) Mode
+## OPA Execution Modes
 
-When running without the daemon (`apme check /path` without `--primary-addr`), the CLI runs everything in-process:
+OPA policy evaluation always uses `opa eval` as a **subprocess** — never an HTTP query.
+The mechanism varies by deployment:
 
-1. Engine runs directly (no temp dir, no gRPC)
-2. `NativeValidator` and `OpaValidator` run in the same process
-3. OPA is invoked via Podman (`podman run ... opa eval`) or local binary
-4. Results are merged locally
+| Deployment | OPA binary location | Mechanism |
+|------------|-------------------|-----------|
+| **Podman pod** (container) | `/usr/local/bin/opa` (copied from OPA image at build time) | Direct subprocess: `opa eval -I -d /bundle <entrypoint>`. Fast — no container startup per eval. |
+| **CLI daemon** (host, default) | Inside an ephemeral Podman container | `podman run --rm ... opa eval` per evaluation. Slower — container startup overhead. |
+| **CLI daemon** (host, `OPA_USE_PODMAN=0`) | Local `opa` binary on `$PATH` | Direct subprocess. Same speed as container path. |
 
-**Note:** This mode is useful for development and testing but does not support the Ansible validator (which requires pre-built venvs in the container).
+**Note:** The OPA container's `entrypoint.sh` starts an OPA REST server on :8181,
+but the gRPC wrapper does **not** query it. The REST server exists only for the
+entrypoint's readiness-wait loop; the actual evaluation always uses `opa eval`
+subprocess. This is a known vestige.
+
+A timeout-based circuit breaker (default: 3 consecutive 60s timeouts) disables
+OPA evaluation for the remainder of the process when evaluations consistently hang.
+
+---
+
+## Daemon Mode
+
+The CLI daemon (`apme daemon start`) runs Primary + validators as localhost gRPC
+servers in a single process without containers:
+
+1. Engine + Primary run directly
+2. Native, OPA, Ansible validators run as in-process gRPC servers
+3. Galaxy Proxy runs as a local uvicorn HTTP server
+4. OPA invoked via Podman container or local binary (see table above)
+5. Results merged via the same gRPC fan-out as the pod
+
+The daemon supports all required validators (Native, OPA, Ansible, Galaxy Proxy).
+Optional validators (Gitleaks, Collection Health, Dep Audit) start when
+`include_optional=True`.
 
 ---
 
 ## Summary
 
 ```
-┌─────────────┐     ┌─────────────┐     ┌─────────────────────────────┐
-│    CLI      │────►│   Primary   │────►│        Validators           │
-│             │     │   Engine    │     │  Native | OPA | Ansible |   │
-│ ScanRequest │     │             │     │  Gitleaks                   │
-│ (files)     │     │ hierarchy   │     │                             │
-└─────────────┘     │ + scandata  │     │ ValidateRequest             │
-                    └──────┬──────┘     │ (hierarchy | scandata |     │
-                           │            │  files)                     │
-                           │            └──────────────┬──────────────┘
-                           │                           │
-                           │◄──────────────────────────┘
+┌─────────────┐     ┌─────────────┐     ┌─────────────────────────────────┐
+│    CLI      │────►│   Primary   │────►│           Validators            │
+│             │     │   Engine    │     │  Native | OPA | Ansible |       │
+│ FixSession  │     │             │     │  Gitleaks | CollHealth | Dep    │
+│ (files)     │     │ hierarchy + │     │                                 │
+└─────────────┘     │ graph +     │     │ ValidateRequest                 │
+                    │ venv_path   │     │ (hierarchy | content_graph |    │
+                    └──────┬──────┘     │  files | venv_path)             │
+                           │            └──────────────────┬──────────────┘
+                           │                               │
+                           │◄──────────────────────────────┘
                            │         violations[]
                            │         + diagnostics
                            ▼

--- a/.sdlc/context/dependencies.md
+++ b/.sdlc/context/dependencies.md
@@ -2,11 +2,16 @@
 
 ## Core Dependencies
 
-### Ansible Risk Insights (ARI)
+These are declared in `pyproject.toml` under `[project.dependencies]` and are required
+for all installations (CLI daemon and Podman pod alike).
 
-**Vendored** in `src/apme_engine/engine/` (not a pip dependency — see [ADR-003](/.sdlc/adrs/ADR-003-vendor-ari-engine.md)).
+### Engine (Integrated)
 
-**Purpose**: The underlying scanning engine that parses Ansible content, builds call trees, resolves variables, annotates risks, and produces a hierarchy payload + scandata for validators.
+The scanning engine lives in `src/apme_engine/engine/` — fully integrated, not a pip
+dependency (see [ADR-003](/.sdlc/adrs/ADR-003-vendor-ari-engine.md)).
+
+**Purpose**: Parses Ansible content, builds a `ContentGraph`, resolves variables,
+annotates risks, and produces a hierarchy payload for validators.
 
 #### Usage Pattern
 
@@ -22,171 +27,83 @@ context = run_scan(
 )
 
 # context.hierarchy_payload — JSON-serializable dict for OPA/Ansible
-# context.scandata — SingleScan object for Native validator
+# context.scandata — legacy SingleScan (native validator now uses ContentGraph)
 ```
 
 #### Key Classes
 
-- `ARIScanner` — Main scanner class (`engine/scanner.py`)
-- `SingleScan` — Per-scan state container (`engine/scan_state.py`)
+- `AnsibleProjectLoader` — Main loader class (`engine/scanner.py`)
+- `ContentGraph` — Graph model for nodes/edges (`engine/content_graph.py`)
 - `ScanContext` — Result container with hierarchy_payload + scandata (`validators/base.py`)
 
 #### Collection Dependencies
 
-ARI no longer downloads collections. The `VenvSessionManager` (owned by Primary) installs collections into session-scoped venvs via the Galaxy Proxy before ARI runs. ARI receives a `dependency_dir` pointing to the venv's `site-packages` for pre-installed collection content.
+The engine never downloads collections. The `VenvSessionManager` (owned by Primary)
+installs collections into session-scoped venvs via the Galaxy Proxy before the engine
+runs. The engine receives a `dependency_dir` pointing to the venv's `site-packages`
+for pre-installed collection content.
 
 ---
 
-### LangGraph
+### gRPC Stack
 
-**Package**: `langgraph`
-**Purpose**: Agent orchestration for the rewriting workflow.
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `grpcio` | `>=1.80.0` | gRPC runtime for all inter-service communication |
+| `grpcio-health-checking` | `>=1.80.0` | Standard health-check protocol |
+| `protobuf` | `>=6.31.1,<7` | Protocol buffer serialization |
 
-#### Installation
-
-```bash
-pip install langgraph
-```
-
-#### Usage Pattern
-
-```python
-from langgraph.graph import StateGraph, END
-from typing import TypedDict
-
-# Define state
-class RewriterState(TypedDict):
-    playbook_path: str
-    issues: list[dict]
-    fixes_applied: list[str]
-    current_step: str
-
-# Create graph
-workflow = StateGraph(RewriterState)
-
-# Add nodes
-workflow.add_node("load", load_playbook)
-workflow.add_node("analyze", analyze_issues)
-workflow.add_node("transform", apply_transforms)
-workflow.add_node("validate", validate_output)
-
-# Add edges
-workflow.set_entry_point("load")
-workflow.add_edge("load", "analyze")
-workflow.add_edge("analyze", "transform")
-workflow.add_edge("transform", "validate")
-workflow.add_edge("validate", END)
-
-# Compile and run
-app = workflow.compile()
-result = app.invoke({"playbook_path": "/path/to/playbook.yml"})
-```
-
-#### Key Concepts
-
-- **StateGraph**: Defines the workflow structure
-- **Nodes**: Functions that process state
-- **Edges**: Connections between nodes
-- **Conditional Edges**: Branching logic based on state
+All gRPC servers use `grpc.aio` (fully async). Proto definitions in `proto/apme/v1/`,
+generated stubs in `src/apme/v1/`.
 
 ---
 
-### Typer
+### Web / HTTP
 
-**Package**: `typer`
-**Purpose**: CLI framework with automatic help generation.
-
-#### Installation
-
-```bash
-pip install typer[all]
-```
-
-#### Usage Pattern
-
-```python
-import typer
-from pathlib import Path
-
-app = typer.Typer()
-
-@app.command()
-def check(
-    path: Path = typer.Argument(..., help="Playbook path"),
-    verbose: bool = typer.Option(False, "--verbose", "-v"),
-):
-    """Check a playbook for AAP compatibility issues."""
-    if verbose:
-        typer.echo(f"Checking {path}...")
-    # ... implementation
-
-@app.command()
-def dashboard(
-    port: int = typer.Option(8501, "--port", "-p"),
-):
-    """Start the APME dashboard."""
-    # ... implementation
-
-if __name__ == "__main__":
-    app()
-```
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `fastapi` | `>=0.100` | REST API framework (Gateway + Galaxy Proxy) |
+| `starlette` | `>=1.3.1` | ASGI framework (underlying FastAPI) |
+| `uvicorn[standard]` | `>=0.20` | ASGI server for Galaxy Proxy and Gateway |
+| `httpx` | latest | HTTP client (Galaxy API calls in proxy) |
 
 ---
 
-### Streamlit
+### Data / Serialization
 
-**Package**: `streamlit`
-**Purpose**: Dashboard UI framework.
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `jsonpickle` | latest | Serializes complex Python objects (scandata) for legacy paths |
+| `PyYAML` | latest | YAML parsing (read-only; writes use ruamel.yaml) |
+| `ruamel.yaml` | latest | Comment-preserving YAML for remediation transforms |
+| `networkx` | `>=3.1` | Graph algorithms for ContentGraph operations |
 
-#### Installation
+---
 
-```bash
-pip install streamlit
-```
+### Ansible / Security
 
-#### Usage Pattern
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `ansible-core` | `>=2.17.14` | Required for Ansible validator (plugin loader, syntax check) |
+| `pip-audit` | `>=2.7` | Python CVE scanning (Dep Audit validator) |
 
-```python
-import streamlit as st
-import pandas as pd
+---
 
-st.title("APME Dashboard")
+### Utilities
 
-# Sidebar filters
-severity = st.sidebar.selectbox("Severity", ["All", "Error", "Warning", "Info"])
-
-# Load and display data
-@st.cache_data
-def load_check_results(path: str) -> pd.DataFrame:
-    return pd.read_json(path)
-
-df = load_check_results("check-results.json")
-
-# Filter
-if severity != "All":
-    df = df[df["severity"] == severity]
-
-# Display
-st.dataframe(df)
-
-# Charts
-st.bar_chart(df["type"].value_counts())
-```
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `filelock` | latest | Venv session locking |
+| `rapidfuzz` | latest | Fuzzy string matching (module name suggestions) |
+| `joblib` | latest | Caching and parallel execution helpers |
+| `packaging` | `>=23` | Version parsing and comparison |
 
 ---
 
 ### ruamel.yaml
 
-**Package**: `ruamel.yaml`
-**Purpose**: YAML parsing that preserves comments and formatting.
-
-#### Installation
-
-```bash
-pip install ruamel.yaml
-```
-
-#### Usage Pattern
+**Purpose**: YAML parsing that preserves comments and formatting. Used by the
+remediation engine's transforms — never PyYAML for writes.
 
 ```python
 from ruamel.yaml import YAML
@@ -204,7 +121,6 @@ with open(path) as f:
 # Modify (in-place)
 for task in data[0]["tasks"]:
     if "copy" in task:
-        # Transform short module to FQCN
         task["ansible.builtin.copy"] = task.pop("copy")
 
 # Save (preserves comments!)
@@ -212,141 +128,83 @@ with open(path, "w") as f:
     yaml.dump(data, f)
 ```
 
-#### Why ruamel.yaml?
+---
 
-- Preserves comments (PyYAML discards them)
-- Maintains formatting and indentation
-- Round-trip editing without data loss
+## Optional Dependencies
+
+### AI (`[project.optional-dependencies.ai]`)
+
+| Package | Purpose |
+|---------|---------|
+| `abbenay-client` | gRPC client for the Abbenay AI provider (Tier 2 remediation) |
+
+### Gateway (`[project.optional-dependencies.gateway]`)
+
+| Package | Purpose |
+|---------|---------|
+| `sqlalchemy>=2.0` | ORM for scan history persistence |
+| `aiosqlite>=0.20` | Async SQLite driver |
+| `python-multipart>=0.0.31` | File upload handling |
 
 ---
 
-## Development Dependencies
+## Development Dependencies (`[project.optional-dependencies.dev]`)
 
-### pytest
+| Package | Purpose |
+|---------|---------|
+| `pytest` | Test framework |
+| `pytest-cov` | Coverage reporting |
+| `pytest-mock` | Mock utilities |
+| `pytest-asyncio>=0.24` | Async test support |
+| `pytest-xdist>=3.5` | Parallel test execution |
+| `pytest-playwright` | Browser/UI tests |
+| `ruff` | Linter and formatter |
+| `mypy` | Static type checker |
+| `pydoclint>=0.8.0` | Docstring linter |
+| `types-protobuf` | Type stubs for protobuf |
+| `types-PyYAML` | Type stubs for PyYAML |
+| `grpc-stubs` | Type stubs for gRPC |
+| `grpcio-tools>=1.80.0` | Proto code generation |
 
-```bash
-pip install pytest pytest-cov pytest-asyncio
-```
-
-```python
-# conftest.py
-import pytest
-from pathlib import Path
-
-@pytest.fixture
-def sample_playbook(tmp_path: Path) -> Path:
-    content = """
-    - hosts: all
-      tasks:
-        - copy:
-            src: /tmp/a
-            dest: /tmp/b
-    """
-    path = tmp_path / "playbook.yml"
-    path.write_text(content)
-    return path
-```
-
-### Ruff
-
-```bash
-pip install ruff
-```
+### Tool Configuration
 
 ```toml
 # pyproject.toml
 [tool.ruff]
-line-length = 88
-target-version = "py311"
+target-version = "py310"
+line-length = 120
 
-[tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B"]
-```
-
-### mypy
-
-```bash
-pip install mypy
-```
-
-```toml
-# pyproject.toml
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.10"
 strict = true
 ```
 
 ---
 
-## Reference: x2a-convertor
+## Frontend Dependencies
 
-**Repository**: https://github.com/ansible/x2a-convertor
+The React SPA (`frontend/`) uses:
 
-APME draws inspiration from x2a-convertor's patterns but is a fresh implementation.
-
-### Key Patterns to Adopt
-
-1. **Module Mapping Structure**
-
-```python
-# From x2a-convertor's approach
-MODULE_MAPPINGS = {
-    "copy": "ansible.builtin.copy",
-    "file": "ansible.builtin.file",
-    "template": "ansible.builtin.template",
-    # ... etc
-}
-```
-
-2. **Collection Detection**
-
-```python
-def detect_collection(module_name: str) -> str | None:
-    """Detect which collection a module belongs to."""
-    # Check ansible.builtin first
-    if module_name in BUILTIN_MODULES:
-        return "ansible.builtin"
-    # Check other collections
-    for collection, modules in COLLECTION_MODULES.items():
-        if module_name in modules:
-            return collection
-    return None
-```
-
-3. **Safe Transformation**
-
-```python
-def safe_transform(playbook_path: Path) -> tuple[bool, str]:
-    """Transform with backup and validation."""
-    # Create backup
-    backup = playbook_path.with_suffix(".yml.bak")
-    shutil.copy(playbook_path, backup)
-
-    try:
-        # Apply transforms
-        transform(playbook_path)
-        # Validate result
-        if not validate_yaml(playbook_path):
-            raise TransformError("Invalid YAML after transform")
-        return True, ""
-    except Exception as e:
-        # Restore backup
-        shutil.copy(backup, playbook_path)
-        return False, str(e)
-```
+| Package | Purpose |
+|---------|---------|
+| React 18 | UI framework |
+| Vite | Build tool |
+| PatternFly 6 | Red Hat design system (components, charts, table, icons) |
+| React Router 6 | Client-side routing |
+| SWR | Data fetching |
+| i18next | Internationalization |
 
 ---
 
 ## Version Compatibility Matrix
 
-| Dependency | Min Version | Max Version | Notes |
-|------------|-------------|-------------|-------|
-| Python | 3.11 | 3.12 | Type syntax requirements |
-| ansible-risk-insight | 0.1.0 | latest | Core scanner |
-| langgraph | 0.1.0 | latest | Agent workflows |
-| typer | 0.9.0 | latest | CLI framework |
-| streamlit | 1.28.0 | latest | Dashboard |
-| ruamel.yaml | 0.18.0 | latest | YAML handling |
-| pytest | 7.0.0 | latest | Testing |
-| ruff | 0.1.0 | latest | Linting |
-| mypy | 1.5.0 | latest | Type checking |
+| Dependency | Min Version | Notes |
+|------------|-------------|-------|
+| Python | 3.10 | `requires-python = ">=3.10"` |
+| ansible-core | 2.17.14 | Multi-version venvs (2.17/2.18/2.19/2.20) |
+| grpcio | 1.80.0 | Required for proto v6 compatibility |
+| protobuf | 6.31.1 | Major version 6 only (not 7) |
+| ruamel.yaml | 0.18.0 | YAML round-trip |
+| pytest | 7.0.0 | Testing |
+| ruff | latest | Linting (120-char, py310 target) |
+| mypy | latest | Type checking (strict) |

--- a/.sdlc/context/deployment.md
+++ b/.sdlc/context/deployment.md
@@ -130,7 +130,7 @@ Reports status of all services (Primary, Native, OPA, Ansible, Gitleaks, Collect
 |----------|---------|-------------|
 | `APME_OPA_VALIDATOR_LISTEN` | `0.0.0.0:50054` | gRPC listen address |
 
-> The OPA binary runs internally on `localhost:8181`; the gRPC wrapper proxies to it.
+> The gRPC wrapper invokes `opa eval` via subprocess (not the REST server on :8181).
 
 #### Ansible
 
@@ -159,14 +159,23 @@ Reports status of all services (Primary, Native, OPA, Ansible, Gitleaks, Collect
 
 The OPA container uses a **multi-stage Dockerfile**:
 
-1. **Stage 1**: Copies the `opa` binary from `docker.io/openpolicyagent/opa:latest`
-2. **Stage 2**: Python slim image with `grpcio`, project code, and the Rego bundle
+1. **Stage 1**: Copies the `opa` binary from `docker.io/openpolicyagent/opa:1.17.1`
+2. **Stage 2**: Base image with project code and the Rego bundle at `/bundle`
 
 At runtime, `entrypoint.sh`:
 
-1. Starts OPA as a REST server: `opa run --server --addr :8181 /bundle`
-2. Waits for OPA to become healthy (polls `/health`)
-3. Starts the Python gRPC wrapper (`apme-opa-validator`)
+1. Starts OPA REST server in background (`opa run --server --addr :8181 /bundle &`)
+2. Waits for readiness (polls `/health` — used only for the entrypoint wait loop)
+3. Starts the Python gRPC wrapper (`apme-opa-validator`) as PID 1
+
+**Important:** The gRPC wrapper does **not** query the REST server. It invokes
+`opa eval -I -d /bundle data.apme.rules.violations --format json` as a **subprocess**
+for each evaluation (the binary is on PATH). The REST server is vestigial — it exists
+only for the entrypoint's readiness check and could be removed.
+
+In **daemon mode** (no container), OPA is invoked via `podman run --rm ... opa eval`
+(one ephemeral container per evaluation), or directly via a local `opa` binary if
+`OPA_USE_PODMAN=0` is set.
 
 The **Rego bundle is baked into the image** at build time (no volume mount needed).
 

--- a/.sdlc/context/design-dashboard.md
+++ b/.sdlc/context/design-dashboard.md
@@ -401,17 +401,17 @@ The standalone UI translates HTTP requests to gRPC calls:
 ```python
 @router.post("/api/v1/activity")
 async def create_operation(body: OperationCreate):
-    request = build_scan_request(body.project_path, body.options)
-
     async with grpc.aio.insecure_channel("127.0.0.1:50051") as channel:
         stub = primary_pb2_grpc.PrimaryStub(channel)
-        response = await stub.Scan(request, timeout=120)
+        async for event in stub.FixSession(build_session_commands(body)):
+            # process SessionEvent (progress, violations, patches)
+            ...
 
-    record = store_scan(response)
+    record = store_operation(events)
     return record
 ```
 
-The UI container **never** runs the engine directly. It always delegates to Primary via gRPC (unary `Scan` for simple flows, or **`FixSession`** for streaming check/remediate per ADR-039). This means:
+The UI/Gateway container **never** runs the engine directly. It always delegates to Primary via the **`FixSession`** bidirectional stream (ADR-039). This means:
 
 - The UI has no dependency on `apme_engine`
 - Primary's contract is the single source of truth

--- a/.sdlc/context/design-remediation.md
+++ b/.sdlc/context/design-remediation.md
@@ -64,8 +64,8 @@ Phase 2: Idempotency Gate
   └─► assert zero diffs (if not: formatter bug, abort)
 
 Phase 3: Engine scan (validators)
-  └─► run engine (parse → annotate → hierarchy)
-  └─► fan out to all validators (Native, OPA, Ansible, Gitleaks)
+  └─► run engine (load → build_content_graph → apply_rules → hierarchy)
+  └─► fan out to all validators (Native, OPA, Ansible, Gitleaks, Coll Health, Dep Audit)
   └─► merge + deduplicate violations
 
 Phase 4: Remediate (Tier 1 — deterministic)
@@ -74,7 +74,7 @@ Phase 4: Remediate (Tier 1 — deterministic)
   └─► re-scan → repeat until converged or oscillation (max --max-passes)
 
 Phase 5: AI Escalation (Tier 2 — AI-proposable)
-  └─► route Tier 2 violations to OpenLLM (if available)
+  └─► route Tier 2 violations to Abbenay AI (if available)
   └─► generate patches with confidence scores
   └─► apply accepted patches (--auto) or present for review
 
@@ -90,9 +90,9 @@ Phase 6: Report
 |-----------|----------|-----|
 | Formatter | CLI (in-process) or Primary (`Format` RPC) | No scan needed; operates on raw files |
 | Scan | Primary service (gRPC) or CLI (in-process) | Already implemented |
-| Remediation Engine | Primary service (`Fix` RPC) | Needs access to scan results and file content; can call OpenLLM |
+| Remediation Engine | Primary service (`FixSession` RPC) | Needs access to scan results and file content; can call Abbenay |
 | Transform Registry | `src/apme_engine/remediation/transforms/` | Pure functions, no container needed |
-| AI Escalation | OpenLLM daemon (gRPC) | Separate container, optional |
+| AI Escalation | Abbenay daemon (gRPC, :50057) | Separate container, optional |
 
 ---
 
@@ -103,7 +103,7 @@ Every violation flows through a three-tier classification that determines how it
 | Tier | Label | Handler | Confidence | User Action |
 |------|-------|---------|------------|-------------|
 | **1 — Deterministic** | `fixable: true` | Transform Registry | 100% — the transform is a known-correct rewrite | None (auto-applied) |
-| **2 — AI-Proposable** | `ai_proposable: true` | OpenLLM gRPC | Variable — LLM generates a patch with a confidence score | Review proposal, accept/reject (or `--auto` in CI) |
+| **2 — AI-Proposable** | `ai_proposable: true` | Abbenay gRPC | Variable — LLM generates a patch with a confidence score | Review proposal, accept/reject (or `--auto` in CI) |
 | **3 — Manual Review** | neither | Human | N/A — requires judgment, policy, or external context | Fix by hand |
 
 ### Tier 1: Deterministic Fixes (Transform Registry)
@@ -117,9 +117,9 @@ These are mechanical rewrites where the correct output is unambiguous given the 
 | M001 | Rewrite short module names to FQCN (`debug` → `ansible.builtin.debug`) |
 | M005 | Rename deprecated parameter (`sudo:` → `become:`) |
 
-The transform function receives the file content and violation, returns the corrected content. No ambiguity, no judgment.
+The transform function receives the node's `CommentedMap` (ruamel round-trip YAML) and the violation, mutates it in-place, and returns `True`. No ambiguity, no judgment.
 
-### Tier 2: AI-Proposable Fixes (OpenLLM)
+### Tier 2: AI-Proposable Fixes (Abbenay)
 
 These violations have a clear "what needs to change" but the "how" requires understanding context that a static transform cannot capture. The AI generates a patch and attaches a confidence score. Examples:
 
@@ -166,7 +166,7 @@ def is_finding_resolvable(violation: dict, registry: TransformRegistry) -> bool:
 
 This is intentionally simple. A violation is resolvable if and only if the transform registry has a function for that rule ID. No heuristics, no guessing.
 
-Violations that fail this check proceed to AI escalation (Tier 2) if OpenLLM is available, otherwise they are reported as manual review (Tier 3).
+Violations that fail this check proceed to AI escalation (Tier 2) if Abbenay is available, otherwise they are reported as manual review (Tier 3).
 
 ### Rule Metadata
 
@@ -192,65 +192,64 @@ class RuleMetadata:
 
 ### Design
 
+Transforms operate on **graph nodes**, not raw file content. Each transform receives a `CommentedMap` (the ruamel.yaml round-trip representation of a single task/play) and a violation dict. It mutates the map in-place and returns `True` if a change was made. The engine handles serialization back to disk.
+
 ```python
-from typing import Callable, NamedTuple
+from collections.abc import Callable
+from ruamel.yaml.comments import CommentedMap
+from apme_engine.engine.models import ViolationDict
 
-class TransformResult(NamedTuple):
-    content: str        # modified file content
-    applied: bool       # True if a change was made
-
-TransformFn = Callable[[str, dict], TransformResult]
-# TransformFn(file_content: str, violation: dict) -> TransformResult
+NodeTransformFn = Callable[[CommentedMap, ViolationDict], bool]
+# NodeTransformFn(task_data: CommentedMap, violation: ViolationDict) -> applied: bool
 
 
 class TransformRegistry:
-    """Maps rule IDs to deterministic fix functions."""
+    """Maps rule IDs to node-level transform functions."""
 
-    def __init__(self):
-        self._transforms: dict[str, TransformFn] = {}
+    def __init__(self) -> None:
+        self._node: dict[str, NodeTransformFn] = {}
 
-    def register(self, rule_id: str, fn: TransformFn) -> None:
-        self._transforms[rule_id] = fn
+    def register(self, rule_id: str, *, node: NodeTransformFn | None = None) -> None:
+        if node is None:
+            raise ValueError(f"register({rule_id!r}): node transform is required")
+        self._node[rule_id] = node
+
+    def get_node_transform(self, rule_id: str) -> NodeTransformFn | None:
+        return self._node.get(rule_id)
 
     def __contains__(self, rule_id: str) -> bool:
-        return rule_id in self._transforms
-
-    def apply(self, rule_id: str, content: str, violation: dict) -> TransformResult:
-        fn = self._transforms.get(rule_id)
-        if fn is None:
-            return TransformResult(content=content, applied=False)
-        return fn(content, violation)
+        return rule_id in self._node
 ```
 
 ### Transform Implementation Rules
 
 | Rule | Description |
 |------|-------------|
-| **Operate on YAML AST** | Use `FormattedYAML` (ruamel round-trip) to preserve comments and formatting |
+| **Operate on CommentedMap** | Transforms receive a ruamel round-trip `CommentedMap` — comments and formatting are preserved automatically |
+| **Mutate in-place** | Modify the map directly and return `True`; do not rebuild or re-serialize |
 | **Single responsibility** | One transform per rule ID; a transform fixes exactly the issue its rule detects |
-| **Idempotent** | Applying a transform to already-fixed content produces no change |
+| **Idempotent** | Applying a transform to already-fixed content returns `False` (no change) |
 | **Independently testable** | Each transform has its own unit test with before/after YAML strings |
-| **No side effects** | Transforms receive content + violation, return content; they do not write files |
+| **No file I/O** | Transforms never read or write files; they operate on the in-memory node representation |
 
 ### Example Transform
 
 ```python
-def fix_missing_mode(content: str, violation: dict) -> TransformResult:
+def fix_missing_mode(task: CommentedMap, violation: ViolationDict) -> bool:
     """L021: add mode: '0644' to file/copy/template tasks missing explicit mode."""
-    yaml = FormattedYAML(typ="rt", pure=True, version=(1, 1))
-    data = yaml.load(content)
-
-    # Navigate to the task identified by the violation
-    task = _find_task_at_line(data, violation.get("line", 0))
-    if task is None:
-        return TransformResult(content=content, applied=False)
-
     module_key = _get_module_key(task)
-    if module_key and "mode" not in task[module_key]:
-        task[module_key]["mode"] = "0644"
-        return TransformResult(content=yaml.dumps(data), applied=True)
+    if module_key is None:
+        return False
 
-    return TransformResult(content=content, applied=False)
+    module_opts = task.get(module_key)
+    if not isinstance(module_opts, dict):
+        return False
+
+    if "mode" in module_opts:
+        return False
+
+    module_opts["mode"] = "0644"
+    return True
 ```
 
 ### File Organization
@@ -258,85 +257,87 @@ def fix_missing_mode(content: str, violation: dict) -> TransformResult:
 ```
 src/apme_engine/remediation/
   ├── __init__.py
-  ├── engine.py              # RemediationEngine class (convergence loop)
+  ├── graph_engine.py        # Graph-based remediation engine (convergence loop)
   ├── partition.py           # is_finding_resolvable()
   ├── registry.py            # TransformRegistry
-  ├── ai_escalation.py       # OpenLLM gRPC client
+  ├── ai_provider.py         # AIProvider protocol
+  ├── ai_context.py          # Context builder for AI requests
+  ├── abbenay_provider.py    # Abbenay gRPC client (implements AIProvider)
   └── transforms/
       ├── __init__.py        # auto-registers all transforms
-      ├── L021_missing_mode.py
+      ├── _helpers.py        # shared transform utilities
       ├── L007_shell_to_command.py
+      ├── L008_local_action.py
+      ├── L009_empty_string.py
       ├── M001_fqcn.py
-      └── ...
+      └── ... (~19 transform modules)
 ```
 
 ---
 
 ## AI Escalation Path
 
-When `is_finding_resolvable()` returns `False` and an OpenLLM service is available, the remediation engine escalates to AI.
+When `is_finding_resolvable()` returns `False` and the Abbenay AI service is available, the remediation engine escalates to AI.
 
 ### Request Packaging
 
-Each violation is packaged with context for the LLM:
+Violations are grouped by graph node and packaged with graph-derived context for the LLM:
 
 ```python
-@dataclass
-class AIRemediationRequest:
-    rule_id: str
-    level: str
-    message: str
-    file_path: str
-    line: int
-    code_window: str        # 10 lines before + after the violation
-    file_content: str       # full file (for broader context)
-    ansible_version: str    # target version (e.g., "2.20")
+@dataclass(frozen=True, slots=True)
+class AINodeContext:
+    node_id: str                     # graph node identifier
+    node_type: str                   # task, block, handler, etc.
+    yaml_lines: str                  # current YAML text for this node
+    violations: list[ViolationDict]  # all violations on this node
+    file_path: str                   # source file (display only)
+    parent_context: str              # summarized ancestor chain (play vars, become, tags)
+    sibling_snippets: list[str]      # YAML of surrounding siblings for awareness
+    feedback: str                    # validation feedback from prior failed AI attempt
 ```
 
-### Structured Prompt
+This is node-scoped, not file-scoped — the AI fixes one graph node at a time with rich structural context from the `ContentGraph`.
 
-```
-You are an Ansible modernization assistant. A static analysis rule has
-flagged an issue in the following YAML file.
+### Structured Prompt (Node-Level)
 
-Rule: {rule_id}
-Message: {message}
-File: {file_path}
-Line: {line}
+The prompt is structured as `NODE_PROMPT_TEMPLATE` and includes:
 
-Code context (lines {start}-{end}):
-```yaml
-{code_window}
-```
+1. **Violations list** — all violations on this node (rule_id, message)
+2. **Rule-specific guidance** — loaded from rule doc frontmatter `ai_prompt` field
+3. **YAML to fix** — the node's current `yaml_lines`
+4. **Parent context** — play vars, become, tags from ancestor nodes
+5. **Sibling context** — surrounding sibling node YAML for awareness
+6. **Best practices** — curated per-rule Ansible best practices
+7. **Feedback** (resubmission only) — why the prior attempt was rejected
 
-Provide a fix for this issue. Respond with ONLY valid YAML for the corrected
-section. Preserve comments and formatting. If you cannot fix it with
-confidence, respond with "SKIP".
-```
+The AI must respond with structured JSON: `fixed_snippet` (complete corrected YAML), `changes[]` (per-violation rule_id + explanation + confidence), and `skipped[]` (violations it couldn't fix). This enables per-violation tracking and confidence scoring.
 
 ### Response Schema
 
 ```python
 @dataclass
-class AIRemediationResponse:
-    suggested_code: str     # corrected YAML (or "SKIP")
-    confidence: float       # 0.0-1.0
-    reasoning: str          # why this fix is correct
-    applicable: bool        # False if LLM says "SKIP"
+class AINodeFix:
+    fixed_snippet: str          # corrected YAML text for the node
+    rule_ids: list[str]         # rule IDs addressed by this fix
+    explanation: str            # human-readable summary of changes
+    confidence: float           # 0.0-1.0 (default 0.85)
+    skipped: list[AISkipped]    # violations the AI could not fix
 ```
+
+The `AIProvider` protocol's sole entry point is `propose_node_fix(context: AINodeContext) -> AINodeFix | None`. Returns `None` when the AI cannot produce a fix.
 
 ### CLI Modes
 
 | Flag | Behavior |
 |------|----------|
-| `--no-ai` | Skip AI entirely; report non-fixable violations as "manual review" |
-| `--auto` | Apply AI patches without prompting (CI mode) |
-| (default) | Show AI-proposed patch + diff, prompt user to accept/reject |
-| `--min-confidence 0.8` | Only apply AI patches with confidence >= threshold |
+| (default) | AI disabled; only Tier 1 deterministic transforms run |
+| `--ai` | Enable Tier 2 AI-assisted remediation |
+| `--auto-approve` | Apply AI patches without prompting (CI mode) |
+| `--model MODEL` | AI model identifier (e.g. `openai/gpt-4o`; falls back to `APME_AI_MODEL` env var) |
 
 ### Graceful Degradation
 
-If `OPENLLM_GRPC_ADDRESS` is unset or the service is unreachable, the remediation engine skips AI escalation silently. Non-fixable violations are reported as "manual review required." The fix pipeline never fails due to missing AI.
+If `APME_ABBENAY_ADDR` is unset or the service is unreachable, the remediation engine skips AI escalation silently. Non-fixable violations are reported as "manual review required." The fix pipeline never fails due to missing AI.
 
 ---
 
@@ -344,175 +345,154 @@ If `OPENLLM_GRPC_ADDRESS` is unset or the service is unreachable, the remediatio
 
 ### Algorithm
 
+The convergence loop operates entirely **in memory on the `ContentGraph`** — no files are read or written during convergence. After convergence, `splice_modifications()` produces file patches.
+
 ```python
-def remediate(files, max_passes=5):
-    prev_count = float("inf")
+class GraphRemediationEngine:
+    def __init__(self, registry, graph, rules, *, max_passes=5, ai_provider=None): ...
 
-    for pass_num in range(1, max_passes + 1):
-        violations = scan(files)
-        fixable = [v for v in violations if is_finding_resolvable(v, registry)]
+    async def remediate(self, initial_violations=None) -> GraphFixReport:
+        """Unified Tier 1 + Tier 2 convergence loop."""
+        if initial_violations is None:
+            violations = scan(graph, rules)  # initial full graph scan
+        else:
+            violations = initial_violations
 
-        if not fixable:
-            break  # nothing left to fix deterministically
+        for pass_num in range(1, max_passes + 1):
+            tier1, tier2, tier3 = partition_violations(violations, registry)
 
-        for v in fixable:
-            content = read_file(v["file"])
-            result = registry.apply(v["rule_id"], content, v)
-            if result.applied:
-                write_file(v["file"], result.content)
+            # Phase A: Tier 1 — deterministic node transforms
+            if tier1:
+                for v in tier1:
+                    node = graph.get_node(v["node_id"])
+                    transform = registry.get_node_transform(v["rule_id"])
+                    if transform and transform(node.commented_map, v):
+                        graph.mark_dirty(node.id)
 
-        # Re-scan to check progress
-        new_violations = scan(files)
-        new_count = len(new_violations)
+            # Rescan only dirty nodes (incremental)
+            violations = rescan_dirty(graph, dirty_node_ids, rules)
 
-        if new_count >= prev_count:
-            # Oscillation or no progress — bail
-            break
+            if not violations or count >= prev_count:
+                break  # converged or oscillation
 
-        prev_count = new_count
+            # Phase B: Tier 2 — AI transforms (when Tier 1 exhausts)
+            if not tier1 and tier2 and ai_provider:
+                proposals = await ai_provider.propose(tier2, graph)
+                # Apply accepted proposals, rescan, loop back to Tier 1
 
-        if new_count == 0:
-            break  # fully converged
-
-    # After deterministic passes (Tier 1), partition remaining into Tier 2 + 3
-    remaining = scan(files)
-    tier2 = [v for v in remaining
-             if not is_finding_resolvable(v, registry) and v.get("ai_proposable", True)]
-    tier3 = [v for v in remaining
-             if not is_finding_resolvable(v, registry) and not v.get("ai_proposable", True)]
-
-    ai_results = escalate_to_ai(tier2)  # no-op if AI unavailable
-
-    return FixReport(
-        passes=pass_num,
-        fixed=prev_initial_count - len(remaining),
-        remaining_ai=tier2,         # Tier 2: AI-proposed patches
-        remaining_manual=tier3,     # Tier 3: manual review only
-        ai_proposed=ai_results,
-    )
+        return GraphFixReport(passes, fixed, remaining, ai_proposals, ...)
 ```
+
+Key differences from a file-based engine:
+- **No file I/O during convergence** — all mutations happen on `ContentNode.yaml_lines` in memory
+- **Incremental rescan** — only dirty (modified) nodes are re-evaluated, not the entire project
+- **Unified Tier 1 + Tier 2 loop** — AI proposals are applied to the same graph; post-AI rescanning catches cross-tier issues and Tier 1 cleanup runs automatically
+- **Transaction safety** — a transform that fails mid-execution leaves the graph unchanged
 
 ### Oscillation Detection
 
-An oscillation occurs when a fix introduces a new violation that triggers another fix that re-introduces the original. Detection is simple: if the violation count does not decrease after a pass, stop. The `max_passes` parameter (default 5) provides a hard ceiling.
+An oscillation occurs when a fix introduces a new violation that triggers another fix that re-introduces the original. Detection: if the violation count does not decrease after a pass, stop. The `max_passes` parameter (default 5) provides a hard ceiling.
 
 ### Convergence Report
 
 ```python
 @dataclass
-class FixReport:
-    passes: int                     # number of convergence passes executed
-    fixed: int                      # violations resolved by Tier 1 transforms
-    remaining_ai: list[dict]        # Tier 2: violations with AI proposals
-    remaining_manual: list[dict]    # Tier 3: violations requiring manual review
-    ai_proposed: list[dict]         # AI-suggested patches (pending review)
-    oscillation_detected: bool      # True if loop bailed due to no progress
+class GraphFixReport:
+    passes: int                                # convergence passes executed
+    fixed: int                                 # violations resolved
+    applied_patches: list[FilePatch]           # populated by splice_modifications()
+    remaining_violations: list[ViolationDict]  # open + ai_abstained
+    fixed_violations: list[ViolationDict]      # resolved during convergence
+    ai_abstained_violations: list[ViolationDict]  # AI attempted but failed
+    oscillation_detected: bool                 # True if loop bailed
+    nodes_modified: int                        # ContentNodes mutated
+    ai_proposals: list[AINodeProposal]         # pending human approval
+
+@dataclass
+class FilePatch:
+    path: str           # file that was patched
+    original: str       # original content
+    patched: str        # content after transforms
+    diff: str           # unified diff
+    rule_ids: list[str] # applied rule IDs
+
+@dataclass
+class AINodeProposal:
+    node_id: str        # graph node modified by AI
+    file_path: str      # source file (for display)
+    before_yaml: str    # YAML before AI transform
+    after_yaml: str     # YAML after AI transform
+    rule_ids: list[str] # addressed rule IDs
+    explanation: str    # human-readable summary
+    confidence: float   # AI confidence score
 ```
 
 ---
 
 ## gRPC Contract
 
-User-facing **check** and **remediate** run through **`FixSession`** (bidirectional stream, ADR-028). **`ScanStream` was removed** (ADR-039) so check and remediate share one engine path. The unary **`Fix` RPC** below remains illustrative for a one-shot shape; the implemented streaming contract is `FixSession`.
+User-facing **check** and **remediate** both run through **`FixSession`** (bidirectional stream, ADR-039). There is no separate unary Fix or Scan RPC — `FixSession` is the sole client path.
 
-### New Fix RPC on Primary
+### Primary Service (Implemented)
 
 ```protobuf
 service Primary {
-  rpc Scan(ScanRequest) returns (ScanResponse);
   rpc Format(FormatRequest) returns (FormatResponse);
-  rpc Fix(FixRequest) returns (FixResponse);            // new
+  rpc FormatStream(stream ScanChunk) returns (FormatResponse);
   rpc Health(HealthRequest) returns (HealthResponse);
-}
-
-message FixRequest {
-  string project_root = 1;
-  repeated File files = 2;
-  FixOptions options = 3;
-}
-
-message FixOptions {
-  int32 max_passes = 1;            // default 5
-  bool no_ai = 2;                  // skip AI escalation
-  bool auto_apply_ai = 3;          // apply AI patches without prompting
-  float min_confidence = 4;        // AI confidence threshold (default 0.0)
-  string ansible_core_version = 5;
-  repeated string collection_specs = 6;
-}
-
-message FixResponse {
-  int32 passes = 1;
-  repeated FileDiff applied_patches = 2;     // deterministic fixes applied
-  repeated AIProposal ai_proposals = 3;      // AI-suggested patches
-  repeated Violation remaining = 4;          // violations not resolved
-  bool oscillation_detected = 5;
-}
-
-message AIProposal {
-  Violation violation = 1;
-  string suggested_code = 2;
-  float confidence = 3;
-  string reasoning = 4;
-  string diff = 5;
+  rpc FixSession(stream SessionCommand) returns (stream SessionEvent);
+  rpc ListAIModels(ListAIModelsRequest) returns (ListAIModelsResponse);
 }
 ```
 
-### OpenLLM Service (Phase 3)
+`FixSession` uses `SessionCommand` messages (containing `ScanChunk` file uploads, `FixOptions`, approval/rejection commands) and streams back `SessionEvent` messages (progress, violations, patches, AI proposals, completion).
+
+### Abbenay AI Service
 
 ```protobuf
-service OpenLLM {
+service Abbenay {
   rpc Remediate(RemediateRequest) returns (RemediateResponse);
   rpc Health(HealthRequest) returns (HealthResponse);
 }
-
-message RemediateRequest {
-  string rule_id = 1;
-  string message = 2;
-  string file_path = 3;
-  int32 line = 4;
-  string code_window = 5;
-  string file_content = 6;
-  string ansible_version = 7;
-}
-
-message RemediateResponse {
-  string suggested_code = 1;
-  float confidence = 2;
-  string reasoning = 3;
-  bool applicable = 4;
-}
 ```
+
+The Abbenay service receives violation context (rule_id, message, node content, surrounding context) and returns suggested YAML + confidence + reasoning.
 
 ---
 
 ## Container Topology (with Remediation)
 
 ```
-┌────────────────────────────── apme-pod ──────────────────────────────────┐
-│                                                                          │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐  │
-│  │ Primary  │  │  Native  │  │   OPA    │  │ Ansible  │  │ Gitleaks │  │
-│  │  :50051  │  │  :50055  │  │  :50054  │  │  :50053  │  │  :50056  │  │
-│  │          │  │          │  │          │  │          │  │          │  │
-│  │ engine + │  │ Python   │  │ OPA bin  │  │ ansible- │  │ gitleaks │  │
-│  │ orchestr │  │ rules on │  │ + gRPC   │  │ core     │  │ + gRPC   │  │
-│  │ remediat │  │ scandata │  │ wrapper  │  │ venvs    │  │ wrapper  │  │
-│  └────┬─────┘  └──────────┘  └──────────┘  └──────────┘  └──────────┘  │
-│       │                                                                  │
-│       │ gRPC (optional)                                                  │
-│       ▼                                                                  │
-│  ┌──────────┐                                                            │
-│  │ OpenLLM  │  Phase 3 — AI escalation                                   │
-│  │  :50057  │  bring-your-own-LLM provider                               │
-│  └──────────┘                                                            │
-│                                                                          │
-│  ┌──────────────────────────────────────────┐                            │
-│  │       Galaxy Proxy :8765 (PEP 503)       │                            │
-│  └──────────────────────────────────────────┘                            │
-└──────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────── apme-pod ────────────────────────────────────┐
+│                                                                              │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐      │
+│  │ Primary  │  │  Native  │  │   OPA    │  │ Ansible  │  │ Gitleaks │      │
+│  │  :50051  │  │  :50055  │  │  :50054  │  │  :50053  │  │  :50056  │      │
+│  │          │  │          │  │          │  │          │  │          │      │
+│  │ engine + │  │ GraphRule │  │ OPA bin  │  │ ansible- │  │ gitleaks │      │
+│  │ orchestr │  │ rules on │  │ + gRPC   │  │ core     │  │ + gRPC   │      │
+│  │ remediat │  │ graph    │  │ wrapper  │  │ venvs    │  │ wrapper  │      │
+│  └────┬─────┘  └──────────┘  └──────────┘  └──────────┘  └──────────┘      │
+│       │                                                                      │
+│       │         ┌──────────────┐  ┌──────────────┐                           │
+│       │         │ Coll Health  │  │  Dep Audit   │                           │
+│       │         │    :50058    │  │    :50059    │                           │
+│       │         └──────────────┘  └──────────────┘                           │
+│       │                                                                      │
+│       │ gRPC (optional)                                                      │
+│       ▼                                                                      │
+│  ┌──────────┐                                                                │
+│  │ Abbenay  │  AI escalation — LLM provider for Tier 2 remediation           │
+│  │  :50057  │                                                                │
+│  └──────────┘                                                                │
+│                                                                              │
+│  ┌──────────────────────────────────────────┐                                │
+│  │       Galaxy Proxy :8765 (PEP 503)       │                                │
+│  └──────────────────────────────────────────┘                                │
+└──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-The remediation engine lives inside **Primary**. It reuses Primary's existing scan pipeline and adds the transform → re-scan convergence loop. AI escalation is a gRPC call to the optional OpenLLM container.
+The remediation engine lives inside **Primary**. It operates on the same `ContentGraph` built by the scan pipeline and runs the transform → rescan convergence loop entirely in memory. AI escalation is a gRPC call to the optional Abbenay container.
 
 ---
 
@@ -524,13 +504,18 @@ The remediation engine lives inside **Primary**. It reuses Primary's existing sc
 apme remediate [target] [options]
 
 Options:
-  --apply              Write fixes in place (without this, show diffs only)
-  --check              Exit 1 if any fixes would be applied (CI mode)
-  --no-ai              Skip AI escalation; deterministic fixes only
-  --auto               Apply AI patches without prompting
-  --min-confidence N   AI confidence threshold (default: 0.0)
-  --max-passes N       Max convergence passes (default: 5)
-  --exclude PATTERN    Glob patterns to skip
+  --max-passes N           Max convergence passes (default: 5)
+  --ansible-version VER    ansible-core version for validation (e.g. 2.18, 2.20)
+  --collections SPEC...    Collection specs (e.g. community.general:9.0.0)
+  --ai                     Enable Tier 2 AI-assisted remediation
+  --auto-approve           Approve all AI proposals without prompting (CI mode)
+  --model MODEL            AI model identifier (e.g. 'openai/gpt-4o')
+  --session ID             Session ID for venv reuse (default: hash of project root)
+  --skip-dep-scan          Disable both dependency validators
+  --skip-collection-scan   Disable collection health scanning only
+  --skip-python-audit      Disable Python CVE audit only
+  --show-suppressed        Include suppressed violations in output (ADR-055)
+  --json                   Output structured data payloads as JSON
 ```
 
 ### Output
@@ -543,7 +528,7 @@ Phase 4: Remediating...
   Pass 1: 28 fixable (Tier 1) → applied 26, 2 failed
   Pass 2: 4 fixable (Tier 1) → applied 4
   Pass 3: 0 fixable → converged
-Phase 5: AI escalation (Tier 2)... 10 candidates → 8 proposals (skipped: --no-ai)
+Phase 5: AI escalation (Tier 2)... 10 candidates → 8 proposals
 Phase 6: Summary
   Tier 1 (deterministic):  30 fixed
   Tier 2 (AI-proposable):  10 remaining → 8 proposals generated
@@ -557,11 +542,11 @@ Phase 6: Summary
 
 1. **Transform Registry + partition** — the data structures and registry pattern
 2. **First transforms** — L021 (missing mode), L007 (shell→command), M001 (FQCN) as proof-of-concept
-3. **Convergence loop** — scan → transform → re-scan loop with oscillation detection
-4. **Fix RPC** — gRPC contract on Primary
-5. **CLI remediate integration** — wire the remediation path to the real engine (`FixSession` per ADR-028/ADR-039)
-6. **AI escalation** — OpenLLM gRPC client + prompt builder (Phase 3)
-7. **Web UI remediation queue** — accept/reject AI proposals (Phase 4)
+3. **Graph-based convergence loop** — ContentGraph → transform → rescan-dirty loop with oscillation detection
+4. **FixSession integration** — wire the remediation path through `FixSession` bidirectional stream (ADR-039)
+5. **CLI remediate integration** — `apme remediate` → daemon → `FixSession` with fix options
+6. **AI escalation** — Abbenay gRPC client + prompt builder
+7. **Web UI remediation queue** — accept/reject AI proposals via Gateway
 
 ---
 

--- a/.sdlc/context/design-validators.md
+++ b/.sdlc/context/design-validators.md
@@ -19,19 +19,21 @@ The engine ingests Ansible content and produces a structured model. Validators c
 ```
 Ansible content (files)
     ↓
-[Engine: parse → trees → variables → annotate → hierarchy]
+[Engine: load_definitions → build_content_graph → apply_rules → hierarchy]
     ↓
-ScanContext { hierarchy_payload (JSON), scandata (SingleScan) }
+ScanContext { hierarchy_payload (JSON), scandata (SingleScan with .content_graph) }
     ↓
-┌─────────────────────────────────────────────────┐
-│              Parallel fan-out                    │
-│                                                  │
-│  ┌─► OPA        (hierarchy_payload → Rego)      │
-│  ├─► Native     (scandata → Python rules)       │
-│  ├─► Ansible    (files + hierarchy → runtime)   │
-│  └─► Gitleaks   (files → secret detection)      │
-│                                                  │
-└─────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────┐
+│              Parallel fan-out                            │
+│                                                          │
+│  ┌─► OPA             (hierarchy_payload → Rego)         │
+│  ├─► Native          (content_graph → GraphRules)       │
+│  ├─► Ansible         (files + hierarchy → runtime)      │
+│  ├─► Gitleaks        (content_graph → stdin pipe)       │
+│  ├─► Collection Hlth (venv → collection scan)           │
+│  └─► Dep Audit       (venv → pip-audit subprocess)      │
+│                                                          │
+└─────────────────────────────────────────────────────────┘
     ↓
 Merged violations (deduplicated, sorted)
 ```
@@ -45,15 +47,20 @@ The engine is the **single source of truth** for "what's in this repo/playbook."
 ```python
 # src/apme_engine/validators/base.py
 
+@runtime_checkable
 class Validator(Protocol):
-    def run(self, context: ScanContext) -> list[dict[str, Any]]:
+    def run(self, context: ScanContext) -> list[ViolationDict]:
         ...
 
+@dataclass
 class ScanContext:
-    hierarchy_payload: dict      # always present (JSON-serializable)
-    scandata: Any = None         # full SingleScan (for native validator)
-    root_dir: str = ""           # filesystem path (for ansible validator)
+    hierarchy_payload: YAMLDict          # always present (JSON-serializable)
+    scandata: object = None              # legacy path (replaced by ContentGraph)
+    root_dir: str = ""                   # filesystem path
+    engine_diagnostics: EngineDiagnostics = field(default_factory=EngineDiagnostics)
 ```
+
+Note: The in-process `Validator` protocol is used by `OpaValidator` and `AnsibleValidator` internally. The production gRPC path uses `ValidatorServicer` adapters that deserialize the `ValidateRequest`, create a `ScanContext`, call the validator's `run()`, and convert the result to a `ValidateResponse`. The Native validator bypasses `ScanContext` — it receives `content_graph_data` directly via gRPC and operates on `ContentGraph`.
 
 Every validator returns the same violation shape:
 
@@ -76,9 +83,9 @@ Every validator returns the same violation shape:
 
 | Aspect | Details |
 |--------|---------|
-| **Input** | `context.hierarchy_payload` (JSON) |
-| **Execution** | Rego bundle evaluated by OPA (`data.apme.rules.violations`) |
-| **Rules** | L002–L025, R118 |
+| **Input** | `hierarchy_payload` (JSON) |
+| **Execution** | `opa eval` subprocess with Rego bundle (`data.apme.rules.violations`). In the container the binary is local; in daemon mode it runs via Podman or local binary. |
+| **Rules** | ~50 Rego files: L002–L025, L061–L072, M006–M028, R118 |
 | **Container** | OPA binary + Python gRPC wrapper (`apme-opa`) |
 
 **Why Rego**: Declarative policy language well-suited for structural checks on JSON; rules are data-driven via `bundle/data.json` (deprecated modules list, package modules, etc.)
@@ -87,12 +94,12 @@ Every validator returns the same violation shape:
 
 | Aspect | Details |
 |--------|---------|
-| **Input** | `context.scandata` (deserialized `SingleScan`) |
-| **Execution** | Python `Rule` subclasses with `match()` / `process()` methods, invoked in-process by `NativeValidator` |
-| **Rules** | L026–L056 (lint), R101–R501 (risk), P001–P004 (legacy) |
+| **Input** | `content_graph_data` (serialized `ContentGraph` JSON dict) |
+| **Execution** | `GraphRule` subclasses with `match()` / `process()` methods, invoked by `graph_scanner.scan()` |
+| **Rules** | ~90 rules: L026–L110 (lint), M005/M010/M014+ (modernize), R101–R501 (risk), A001–A002 (AAP), P001–P004 (legacy) |
 | **Container** | `apme-native` |
 
-**Why Python**: Full access to the in-memory model (trees, contexts, specs, annotations, variable tracking). Rules that need to walk call graphs, inspect variable resolution, or apply complex heuristics that would be awkward in Rego.
+**Why Python**: Full access to the ContentGraph model (nodes, edges, properties, variable tracking). Rules that need to walk call graphs, inspect variable resolution, or apply complex heuristics that would be awkward in Rego.
 
 ### Ansible (Runtime)
 
@@ -109,12 +116,34 @@ Every validator returns the same violation shape:
 
 | Aspect | Details |
 |--------|---------|
-| **Input** | `request.files` (raw file content) |
-| **Execution** | Writes files to temp dir, runs `gitleaks detect --no-git --report-format json`, parses JSON report |
+| **Input** | `content_graph_data` (node content extracted from ContentGraph) + uncovered raw files |
+| **Execution** | Pipes concatenated node content to `gitleaks detect --pipe` via stdin; maps findings back to node IDs via delimiter lines |
 | **Rules** | SEC:* (800+ patterns for credentials, API keys, private keys, tokens) |
 | **Container** | `apme-gitleaks` (gitleaks binary + Python gRPC wrapper) |
 
 **Why separate container**: Requires Go binary; wraps external tool output into the unified violation format. Adds Ansible-aware filtering: vault-encrypted files and Jinja2 expressions are automatically excluded.
+
+### Collection Health (optional)
+
+| Aspect | Details |
+|--------|---------|
+| **Input** | `venv_path` (session venv with installed collections) |
+| **Execution** | Scans installed collections in venv with a curated subset of Native GraphRules. Findings cached by `(fqcn, version)`. |
+| **Rules** | M005, M010, R101, R103–R115, R117, R401 (18 curated rules) |
+| **Container** | `apme-collection-health` |
+
+**Why separate**: Decouples collection quality from project scan; results are cached and reused across scans with same collections.
+
+### Dep Audit (optional)
+
+| Aspect | Details |
+|--------|---------|
+| **Input** | `venv_path` (session venv with Python packages) |
+| **Execution** | Runs `pip-audit -f json --strict --path <site-packages>` against OSV.dev |
+| **Rules** | R200 (Python CVE findings) |
+| **Container** | `apme-dep-audit` |
+
+**Why separate**: Isolates dependency auditing from scan logic; uses pip-audit binary.
 
 ---
 
@@ -126,16 +155,16 @@ The engine was originally derived from ARI (Ansible Risk Insights). It is now fu
 
 **Rationale**:
 
-- Full control over the hierarchy payload shape, annotator behavior, and parser logic
-- Single parse, single model — validators reuse the same `SingleScan` and `hierarchy_payload`
+- Full control over the hierarchy payload shape, ContentGraph structure, and parser logic
+- Single parse, single model — validators reuse the same `ContentGraph` and `hierarchy_payload`
 - No version drift between engine and validators
-- Annotators (risk annotations) are engine concerns that feed into both OPA rules (via hierarchy JSON) and native rules (via scandata)
+- Annotators (risk annotations) are engine concerns that feed into both OPA rules (via hierarchy JSON) and native rules (via ContentGraph)
 
 The engine exposes one public function:
 
 ```python
 # src/apme_engine/runner.py
-def run_scan(target_path, project_root, include_scandata=True) -> ScanContext:
+def run_scan(target_path, project_root, include_scandata=True, dependency_dir="") -> ScanContext:
 ```
 
 Everything downstream (validators, daemon, CLI) calls `run_scan()` and works with `ScanContext`.
@@ -144,11 +173,11 @@ Everything downstream (validators, daemon, CLI) calls `run_scan()` and works wit
 
 ## Parallel Execution
 
-Primary calls all four validators concurrently using `asyncio.gather()` with async gRPC stubs (`grpc.aio`). Each validator is a gRPC call to an independent container. The `ValidateRequest` is immutable and shared across all calls.
+Primary calls all configured validators concurrently using `asyncio.gather()` with async gRPC stubs (`grpc.aio`). Each validator is a gRPC call to an independent container. The `ValidateRequest` is immutable and shared across all calls.
 
-**Total latency = max(native, opa, ansible, gitleaks)** instead of sum.
+**Total latency = max(validators)** instead of sum.
 
-Each validator is discovered by environment variable (`NATIVE_GRPC_ADDRESS`, `OPA_GRPC_ADDRESS`, `ANSIBLE_GRPC_ADDRESS`, `GITLEAKS_GRPC_ADDRESS`). If a variable is unset, that validator is skipped — no error, just fewer results. This makes it possible to run a subset of validators during development or testing.
+Each validator is discovered by environment variable (`NATIVE_GRPC_ADDRESS`, `OPA_GRPC_ADDRESS`, `ANSIBLE_GRPC_ADDRESS`, `GITLEAKS_GRPC_ADDRESS`, `COLLECTION_HEALTH_GRPC_ADDRESS`, `DEP_AUDIT_GRPC_ADDRESS`). If a variable is unset, that validator is skipped — no error, just fewer results. This makes it possible to run a subset of validators during development or testing.
 
 ---
 
@@ -200,7 +229,7 @@ ValidatorDiagnostics(
 )
 ```
 
-Primary aggregates all `ValidatorDiagnostics` plus engine phase timing into `ScanDiagnostics` on the `ScanResponse`. `apme check` (and related clients) show diagnostics with `-v` (summary + top 10 slowest rules) or `-vv` (full per-rule breakdown).
+Primary aggregates all `ValidatorDiagnostics` plus engine phase timing into `ScanDiagnostics` on the `SessionEvent` stream. `apme check` (and related clients) show diagnostics with `-v` (summary + top 10 slowest rules) or `-vv` (full per-rule breakdown).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,10 @@ one needs to change, write an ADR first.
    invokes `opa eval` via subprocess — there is no OPA REST server on 8181.
    Do not introduce httpx or HTTP client dependencies for OPA.
 
-10. **`FixSession` is the unified client path** (ADR-039). Both `check` and
-    `remediate` use the bidirectional `FixSession` RPC. The unary `Scan` RPC
-    exists for backward-compatible engine-aligned clients only. New features
-    target `FixSession`.
+10. **`FixSession` is the sole client path** (ADR-039). Both `check` and
+    `remediate` use the bidirectional `FixSession` RPC. The unary `Scan` and
+    `ScanStream` RPCs have been removed from `primary.proto`. All client
+    operations go through `FixSession`.
 
 11. **The engine never queries out; it only emits** (ADR-020, ADR-029). The
     engine does not fetch data from external sources, third-party APIs, or any
@@ -76,10 +76,11 @@ one needs to change, write an ADR first.
     required for both the CLI daemon and the Podman pod — their dependencies
     belong in core `dependencies` (not optional extras), and they live in
     `_DEFAULT_PORTS`. Galaxy Proxy is the sole collection installation path
-    for session venvs; the daemon cannot scan without it. Only Gitleaks is
-    truly optional (`_OPTIONAL_SERVICES`) because it requires an external
-    binary. Gateway, UI, and Abbenay are pod-level / enterprise services
-    that the CLI daemon does not start.
+    for session venvs; the daemon cannot scan without it. Gitleaks,
+    Collection Health, and Dep Audit are optional (`_OPTIONAL_SERVICES`)
+    because they require external binaries or venv-dependent scanning;
+    they start when `include_optional=True`. Gateway, UI, and Abbenay are
+    pod-level / enterprise services that the CLI daemon does not start.
 
 13. **Transforms are semantically trusted; the engine owns state and syntax**
     (ADR-044). Transforms operate on an **ephemeral copy** of the graph and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Full workflow: [workflow.md](/.sdlc/context/workflow.md) | Getting started: [get
 - **Use gRPC** — all inter-service communication
 - **Async servers** — grpc.aio, not synchronous
 - **Rule IDs** — L/M/R/P/SEC convention per ADR-008
-- **Engine-core services are required** — Primary, Native, OPA, Ansible, and Galaxy Proxy are all required for both the CLI daemon and pod. Their deps are core, not optional extras. Only Gitleaks is optional (external binary). Gateway, UI, and Abbenay are pod-level/enterprise services the CLI daemon does not start.
+- **Engine-core services are required** — Primary, Native, OPA, Ansible, and Galaxy Proxy are all required for both the CLI daemon and pod. Their deps are core, not optional extras. Gitleaks, Collection Health, and Dep Audit are optional (`_OPTIONAL_SERVICES`; start with `include_optional=True`). Gateway, UI, and Abbenay are pod-level/enterprise services the CLI daemon does not start.
 - Do NOT modify files outside task scope
 - Do NOT add features not in requirements
 - Ask for clarification if specs are ambiguous


### PR DESCRIPTION
## Summary
- Comprehensive audit and correction of all `.sdlc/context/` documentation against the actual codebase implementation
- Fixes critical inaccuracies accumulated as the architecture evolved from file-based scanning to the graph-based `ContentGraph` model

## Changes

### Engine Pipeline (`data-flow.md`, `architecture.md`)
- Replace removed `Scan`/`ScanStream` RPCs with `FixSession` bidirectional stream throughout
- Rewrite engine pipeline from `ARIScanner`/`TreeLoader`/`RiskAnnotators` to `AnsibleProjectLoader` with `load_definitions → build_content_graph → apply_rules` stages
- Fix `ValidateRequest` table: remove `scandata (jsonpickle)`, add `content_graph_data`, `venv_path`, `session_id`
- Fix `ScanDiagnostics` proto: `trees_built` → `graph_nodes_built`

### Validators (`design-validators.md`, `architecture.md`)
- Update Native validator: `SingleScan`/`Rule` → `ContentGraph`/`GraphRule`
- Document OPA subprocess execution model (`opa eval`), not REST
- Update Gitleaks: document stdin/pipe mode from ContentGraph nodes
- Add Collection Health and Dep Audit validators to all relevant sections (fan-out, diagnostics, volumes, concurrency)

### Remediation (`design-remediation.md`)
- Rewrite Transform Registry API from `TransformFn(str, dict) → TransformResult` to `NodeTransformFn(CommentedMap, ViolationDict) → bool`
- Rewrite convergence loop from file-based read/write to in-memory `GraphRemediationEngine` on `ContentGraph`
- Replace `FixReport` with actual `GraphFixReport`, `FilePatch`, `AINodeProposal` dataclasses
- Fix AI contract: `AIRemediationRequest` → `AINodeContext` (node-scoped); `AIRemediationResponse` → `AINodeFix`
- Update CLI flags to match actual argparse (`--ai`, `--auto-approve`, `--model`, `--skip-dep-scan`)
- Remove stale proto sketches (unary `Fix` RPC, `Scan` RPC)

### Scaling & Deployment (`architecture.md`)
- Add Kubernetes topology section: separate Deployments for engine, gateway, UI, abbenay
- Document HPA (CPU/memory targets), PDB, NetworkPolicy
- Document multi-replica behavior: PVC → emptyDir for sessions/proxy-cache
- Clarify Abbenay reaches engine pods via K8s Service DNS, not localhost
- Add `proxy-cache` volume to table

### Conventions & Dependencies (`conventions.md`, `dependencies.md`)
- Replace Typer with argparse patterns and examples
- Replace structlog with standard Python logging
- Rewrite source structure to match actual `src/` layout
- Remove phantom dependencies (LangGraph, Streamlit, Typer)
- Add actual dependencies (grpcio, fastapi, uvicorn, ansible-core, pip-audit, etc.)

### Project Constitution (`AGENTS.md`, `CLAUDE.md`)
- Correct invariant 12: Gitleaks, Collection Health, AND Dep Audit are optional (not just Gitleaks)
- Fix invariant 10: clarify `Scan`/`ScanStream` fully removed

### ADR-001
- Remove erroneous claim that OPA uses HTTP/REST internally

## Test plan
- [x] `tox -e lint` passes
- [ ] `tox -e unit` — not required (docs-only changes, no `.py` files modified)
- [x] All referenced code paths verified against actual source files

Made with [Cursor](https://cursor.com)