### PR TITLE
docs(sdlc): add productization plan pre-read

### DIFF
--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -220,6 +220,37 @@ for SDK tooling, monitoring, and observant developers.
 | **Sunset** | 2–4 weeks | `410 Gone` returned with `Link` to migration guide |
 | **Removed** | — | Endpoint deleted, docs archived |
 
+#### Consumer obligations
+
+Any team or system integrating with the APME Gateway API accepts these
+responsibilities. These are not suggestions — they are requirements for
+supported integration:
+
+1. **Monitor deprecation headers.** Consumers must check for `Deprecation`
+   and `Sunset` headers in every response. Logging or alerting on their
+   presence should be part of the consumer's standard observability.
+2. **Test for deprecation.** Consumer CI/CD pipelines should include a test
+   that fails if responses from APME contain `Deprecation` or `Sunset`
+   headers, forcing the team to acknowledge and plan migration.
+3. **Migrate within the deprecation window.** Once `Deprecation` headers
+   appear, consumers have the advertised window (1–3 months for internal
+   consumers) to migrate to the successor version. APME will not extend
+   the window for consumers who ignored the headers.
+4. **Handle `410 Gone` gracefully.** After the `Sunset` date, deprecated
+   endpoints return `410 Gone`. Consumer applications must handle this
+   status code — displaying a meaningful error to users, not crashing.
+5. **Validate against the published OpenAPI spec.** Consumers should
+   generate or validate their client code against the published OpenAPI
+   spec for their target API version. Do not rely on undocumented response
+   fields or behaviors.
+6. **No pinning to old versions indefinitely.** APME does not guarantee
+   perpetual support for any API version. Consumers that cannot keep pace
+   with the deprecation lifecycle must raise this as a product requirement
+   — not silently ignore deprecation headers and break at sunset.
+
+These obligations will be documented in the API consumer guide and
+referenced in the OpenAPI spec description.
+
 #### Work items
 
 | Item | Current State | Work Needed |

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -154,15 +154,22 @@ decision. Work includes:
 | Horizontal scaling | ADR-012: scale engine pods as unit | Validate with concurrent scan load |
 | Gateway DB | SQLite (single-writer) | PostgreSQL path (ADR-029) needed for HA / multi-replica |
 
-### 4.5 DevTools Team Onboarding
+### 4.5 DevTools Team Onboarding (Engineering Ownership)
+
+The DevTools team will own the APME engine codebase going forward. This is
+an engineering handoff, not an operational one — they own development,
+maintenance, and bug triage for the engine and validators.
 
 | Item | Work Needed |
 |------|-------------|
-| Bug triage | APME components in Jira/Bugzilla; triage process doc |
-| Support statement | Define supported configurations, response SLAs, escalation path |
-| Runbook | Health checks, log locations, restart procedures, common failures |
-| Monitoring | Prometheus `/metrics` endpoint (not yet implemented); Grafana dashboard |
-| Alerting | Define SLOs and alert thresholds |
+| Codebase walkthrough | Architecture, service boundaries, ADR index, test strategy |
+| Bug triage integration | APME components in team's Jira/Bugzilla; integrate into existing triage cadence |
+| CODEOWNERS | Assign DevTools team as owners for `src/apme_engine/`, validators, proto |
+| CI ownership | Team understands and can modify GitHub Actions workflows, tox environments |
+| Development workflow | Team comfortable with branch strategy, PR process, conventional commits |
+| Contribution ramp | First bugs/features assigned to build familiarity before full ownership |
+| Release process | Team owns version bumps, CHANGELOG, tagging, image publishing |
+| Support boundary | Define what DevTools owns (engine) vs what stays with current team (Gateway, UI, deployment) |
 
 ### 4.6 Dependency Review
 
@@ -244,7 +251,7 @@ Items not in the original list but important for productization:
 | 3 | Base image: stay Debian slim or migrate to UBI | DevTools / Konflux | Downstream build |
 | 4 | PostgreSQL: required for production or SQLite sufficient? | Architect | HA / multi-replica Gateway |
 | 5 | Craig's P0 feature set for Portal launch | Craig | Scope and timeline |
-| 6 | Support model: who triages, SLAs, escalation | DevTools lead | Team onboarding |
+| 6 | Engineering ownership split: what does DevTools own vs current team | DevTools lead + current team | Codebase handoff |
 
 ---
 
@@ -273,13 +280,13 @@ Phase 3 — Portal Integration
 ├── Craig's P0 feature set
 └── API stability contract
 
-Phase 4 — Production Readiness
+Phase 4 — Production Readiness & Handoff
 ├── Load test suite (k6/locust)
 ├── SLA baselines and HPA tuning
 ├── Prometheus metrics + Grafana
-├── Operator runbook
 ├── a11y audit
-└── DevTools team onboarding
+├── DevTools codebase walkthrough and first contributions
+└── CODEOWNERS + triage integration for DevTools ownership
 ```
 
 ---

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -166,17 +166,50 @@ decision. Work includes:
 ### 4.4 API Versioning & Contract
 
 The Gateway REST API is URL-versioned (`/api/v1`) today, which is the right
-foundation. What's missing is the contract and tooling around it — all UI
+foundation. What's missing is the contract and tooling around it — all
 consumers (Portal, standalone web UI, CLI, third-party integrations) need a
 stable interface they can code against without tight coupling to APME's
 release cycle.
+
+**Principle: the engine drives the pace; consumers must stay current.** APME
+should not carry indefinite backward compatibility burden. The contract
+gives consumers a clear deprecation window and migration path, but the
+obligation is on consumers to upgrade — not on APME to maintain old API
+versions forever.
+
+#### Deprecation lifecycle (RFC-based)
+
+Follow the standards-based pattern using RFC 9745 (`Deprecation` header)
+and RFC 8594 (`Sunset` header):
+
+```
+HTTP/1.1 200 OK
+Deprecation: Sat, 01 Nov 2026 00:00:00 GMT
+Sunset: Sun, 01 May 2027 00:00:00 GMT
+Link: </api/v2/projects>; rel="successor-version",
+      </docs/migrate/v1-to-v2>; rel="deprecation"
+```
+
+Implement as FastAPI middleware — checks request path version and injects
+headers automatically. No per-endpoint logic needed. Responses continue
+to work normally during the deprecation window; the headers are metadata
+for SDK tooling, monitoring, and observant developers.
+
+| Phase | Duration | Behavior |
+|-------|----------|----------|
+| **Active** | Indefinite | Normal support, bug fixes, improvements |
+| **Deprecated** | 1–3 months (internal consumers) | `Deprecation` + `Sunset` headers on every response; migration docs published; consumers must begin migration |
+| **Sunset** | 2–4 weeks | `410 Gone` returned with `Link` to migration guide |
+| **Removed** | — | Endpoint deleted, docs archived |
+
+#### Work items
 
 | Item | Current State | Work Needed |
 |------|---------------|-------------|
 | URL versioning | All routes under `/api/v1` | Foundation exists; no changes needed |
 | OpenAPI spec | FastAPI auto-generates from code; not published as artifact | Publish versioned OpenAPI spec (JSON/YAML) as release artifact; all consumers validate against it |
 | Stability guarantee | None — any commit can change the API shape | ADR defining API stability policy: what constitutes a breaking change, deprecation timeline, v1 support window |
-| Deprecation policy | No mechanism | Add `Deprecation` / `Sunset` headers; document migration path before removing endpoints |
+| Deprecation middleware | No mechanism | FastAPI middleware: inject `Deprecation` / `Sunset` / `Link` headers for deprecated API versions |
 | Changelog | No API-specific changelog | Track breaking vs non-breaking changes per release; include in release notes |
 | Contract testing | No consumer-driven contract tests | Pact or similar to verify consumer integrations (Portal, standalone UI, CLI) don't break on APME upgrades |
 | SDK / client library | Consumers code directly against REST | Consider a thin Python/TypeScript client generated from OpenAPI spec for Portal, CLI, and third-party use |

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -1,12 +1,12 @@
 # APME Productization Plan — Pre-Read
 
 **Prepared:** 2026-06-24  
-**Updated:** 2026-06-25 (Portal integration architecture aligned with [PR #352](https://github.com/ansible/apme/pull/352) v2)  
+**Updated:** 2026-06-25 (Portal integration architecture aligned with [PR #352](https://github.com/ansible/apme/pull/352) v2; auth decision resolved)  
 **Status:** Draft for review
 
 This document captures the productization strategy for APME across two deployment tracks: **Portal-integrated product** (Track A) and **upstream standalone** (Track B). It consolidates architecture, authentication, work streams, open decisions, PostgreSQL-only persistence (SQLite removed), and Portal integration requirements.
 
-Companion research: [PR #352](https://github.com/ansible/apme/pull/352) (`.sdlc/research/portal-integration/00-integration-requirements.md`), [ansible-rhdh-plugins PR #676](https://github.com/ansible/ansible-rhdh-plugins/pull/676), [ANSTRAT-2222](https://issues.redhat.com/browse/ANSTRAT-2222).
+Companion research: [PR #352](https://github.com/ansible/apme/pull/352) (`.sdlc/research/portal-integration/00-integration-requirements.md`), [ansible-rhdh-plugins PR #676](https://github.com/ansible/ansible-rhdh-plugins/pull/676) (9-document integration architecture design from Portal team), [ANSTRAT-2222](https://issues.redhat.com/browse/ANSTRAT-2222).
 
 ---
 
@@ -95,9 +95,26 @@ APME ships on two parallel tracks with different packaging, persistence, and UX 
 | **Database** | **Shared PostgreSQL instance** with Portal — APME owns `apme_*` tables (Alembic); Portal owns `backstage_*`; Portal manages the instance, APME manages its schema |
 | **UI** | Portal UX only; APME standalone UI container **not deployed** |
 | **Portal role** | **Thin proxy client** — RBAC, optional credential injection, forward to APME API; no APME data layer in Portal |
-| **Auth** | Portal Auth/RBAC (user-facing) + Bearer service token (Portal backend → Gateway) |
+| **Auth** | Portal Auth/RBAC (user-facing) + **service-to-service Bearer token** (Portal backend → Gateway); decided DC-05 |
 | **Credentials** | **Optional per-request** — Portal injects SCM/Galaxy tokens when available; APME falls back to its own configured settings (A3) |
 | **Target users** | AAP customers consuming APME via Ansible Automation Portal |
+
+#### Track A Downstream Differentiators
+
+Features available **only in Portal (Track A)** — not in upstream standalone (Track B). These leverage Portal's knowledge of AAP release versions and multi-repo fleet context.
+
+| Feature | Description | Engine Support |
+|---------|-------------|----------------|
+| **Version migration readiness** | Scan repos against current AAP version AND next AAP version; show delta — what breaks on upgrade, new violations, resolved violations | Engine already supports `ansible_version` per-scan; Portal orchestrates two scans and presents comparison |
+| **AAP version ↔ ansible-core mapping** | Portal maps AAP releases (2.5, 2.6, 2.7) to ansible-core versions (2.16, 2.17, 2.18); users select AAP version, not raw core version | Portal owns the mapping table; passes resolved `ansible_version` to APME |
+| **Fleet-wide migration dashboard** | "X% of repos ready for AAP 2.7" across all registered repositories | Portal aggregates per-repo scan results across both versions |
+| **Upgrade readiness gate** | Block/warn AAP upgrade if repos have critical violations on next version | Portal integrates with AAP Operator upgrade lifecycle |
+
+**Implementation notes:**
+- APME engine requires **zero changes** — `ansible_version` in `ScanOptions` already supports arbitrary versions
+- Portal backend plugin orchestrates dual scans (current + next) per repo during scheduled scan cycles
+- Portal stores both result sets; frontend renders diff/comparison view
+- AAP version → ansible-core mapping is a Portal-maintained lookup (not in APME)
 
 ### Track B — Upstream / Dev
 
@@ -134,9 +151,11 @@ Authentication differs by deployment track. **Podman, bootc, and CLI daemon path
 | Layer | Mechanism |
 |-------|-----------|
 | **User → Portal** | Portal Auth (OIDC/SSO) + Portal RBAC |
-| **Portal → Gateway** | Bearer service token (`APME_SERVICE_TOKENS`); Portal backend injects from K8s Secret |
+| **Portal → Gateway** | **Service-to-service Bearer token** (`APME_SERVICE_TOKENS`); Portal backend injects from K8s Secret — **decided** |
 | **Gateway → Engine** | Pod-local gRPC; no end-user identity in engine |
 | **Galaxy credentials** | Optional per-request on operations (A3); APME falls back to own Galaxy config |
+
+**Auth decision (resolved):** Portal → APME Gateway uses **service-to-service authentication** — Portal backend plugin includes a shared Bearer token in every request; APME Gateway validates against `APME_SERVICE_TOKENS`. No mTLS, no OAuth client credentials grant. User identity and RBAC are handled entirely Portal-side before the request reaches APME. See [ansible-rhdh-plugins PR #676 §06-security-and-rbac](https://github.com/ansible/ansible-rhdh-plugins/pull/676) for the full security design.
 
 **A1 (PR #352):** Gateway auth middleware with `APME_AUTH_DISABLED` escape hatch for backward-compatible CLI daemon dev only.
 
@@ -153,10 +172,10 @@ Authentication differs by deployment track. **Podman, bootc, and CLI daemon path
 
 | Gap | Impact | Resolution |
 |-----|--------|------------|
-| ADR-038 not fully implemented | No stable machine-auth contract | Phase 1 auth ADR + middleware |
+| ~~ADR-038 not fully implemented~~ | ~~No stable machine-auth contract~~ | **Resolved for Track A** — service-to-service token (DC-05); Track B still needs ADR-038 |
 | Podman/bootc Helm values lack auth secrets | Open deployments | Document required `APME_SERVICE_TOKENS` |
 | CLI daemon has no Gateway auth today | `apme sbom` etc. need Gateway (ADR-049) | Separate from Portal track — see ADR-049 |
-| Portal proxy service-token rotation | Ops burden | ADR for token lifecycle (D-01) |
+| ~~Portal proxy service-token rotation~~ | ~~Ops burden~~ | Standard K8s Secret rotation; no ADR needed |
 
 ---
 
@@ -215,9 +234,9 @@ Authentication differs by deployment track. **Podman, bootc, and CLI daemon path
 
 ### 4.3 — Authentication
 
-- **Track A:** Implement A1 service-token middleware; Helm secret injection; disable auth only via explicit `APME_AUTH_DISABLED` for dev.
+- **Track A (decided):** Service-to-service Bearer token — Portal backend injects token from K8s Secret; Gateway validates via `APME_SERVICE_TOKENS`. No mTLS or OAuth client credentials. User identity stays in Portal (RBAC, audit). Ref: [PR #676 §06-security-and-rbac](https://github.com/ansible/ansible-rhdh-plugins/pull/676).
 - **Track B:** Implement ADR-038 bearer validation for `/api/v1/*` machine consumers.
-- **Deliverables:** ADR for Portal service-token model (D-01); ADR-038 implementation tasks.
+- **Deliverables:** Implement A1 Gateway middleware (simple); ADR-038 implementation tasks for Track B.
 
 ### 4.4 — API Versioning
 
@@ -328,6 +347,7 @@ ADR-049 status: **Accepted** (2026-04-01). **Implementation: not done** — `lau
 
 | Setting | Purpose | Values |
 |---------|---------|--------|
+| `APME_DEPLOYMENT_MODE` | Deployment context — controls credential resolution behavior | `standalone` (default), `portal` |
 | `APME_DATABASE_URL` | PostgreSQL DSN (**required**) | `postgresql+asyncpg://...` |
 | `APME_DATABASE_MODE` | DB topology | `bundled`, `external`, `shared` (Track A Portal instance) |
 | `gateway.database.poolSize` | Connection pool | e.g. `10` (important when sharing Portal PG) |
@@ -337,7 +357,14 @@ ADR-049 status: **Accepted** (2026-04-01). **Implementation: not done** — `lau
 | `APME_AIR_GAPPED` | Air-gapped deployments | `true` / `false` (A6, proposed) |
 | `APME_RATE_LIMIT` | Gateway throttling | e.g. `100/minute` (A11, proposed) |
 
-No `APME_GATEWAY_MODE` — same full Gateway on both tracks.
+**`APME_DEPLOYMENT_MODE` behavior:**
+
+| Mode | SCM credentials | Galaxy credentials | Per-project stored tokens |
+|------|----------------|-------------------|--------------------------|
+| `portal` | **Must** come per-request from Portal; project-stored SCM tokens ignored; error if missing on SCM ops | Per-request from Portal preferred; fallback to APME Galaxy config | Project SCM token field disabled/hidden |
+| `standalone` | Per-request if provided; **fallback to project-stored token** if configured | Per-request if provided; fallback to APME Galaxy config | Fully supported (existing behavior) |
+
+Same full Gateway on both modes — no code path divergence for API logic, persistence, or engine interaction. The mode only affects credential resolution priority.
 
 ---
 
@@ -347,7 +374,6 @@ No `APME_GATEWAY_MODE` — same full Gateway on both tracks.
 
 | ID | Topic | Options | Blocker for |
 |----|-------|---------|-------------|
-| D-01 | **Auth model (Portal)** | Service token list vs mTLS vs OAuth client credentials | Track A GA |
 | D-02 | **Packaging** | See Section 2 table | Release pipeline |
 | D-03 | **Shared PG pooling** | Pool size / max connections when APME shares Portal instance | Track A stability |
 | D-04 | **PostgreSQL topology** | Bundled subchart vs external RDS vs customer-managed | All Gateway persistence deployments |
@@ -366,6 +392,7 @@ No `APME_GATEWAY_MODE` — same full Gateway on both tracks.
 | DC-02 | **Gateway persistence:** PostgreSQL only (upstream, downstream/production, dev); SQLite removed entirely | 2026-06-25 | §9, ADR-029 amendment |
 | DC-03 | **Dual tracks:** Portal product (Track A) vs upstream standalone (Track B) | 2026-06-24 | §2 |
 | DC-04 | **Portal integration:** Shared PostgreSQL instance; APME owns `apme_*`; thin Portal proxy | 2026-06-25 | §8, PR #352 v2 |
+| DC-05 | **Portal auth model:** Service-to-service Bearer token (Portal → Gateway); no mTLS/OAuth CC | 2026-06-25 | §3, [PR #676 §06](https://github.com/ansible/ansible-rhdh-plugins/pull/676) |
 
 ---
 
@@ -375,7 +402,7 @@ No `APME_GATEWAY_MODE` — same full Gateway on both tracks.
 
 1. Validator scope alignment (4.10) — launcher, Helm, Podman, health-check
 2. SQLite removal + Alembic + PostgreSQL (upstream, downstream/production, dev — bundled or external PG) (4.5, §9)
-3. Auth ADR — bearer for Track B (ADR-038); draft Portal service-token ADR (4.3, D-01)
+3. Gateway auth middleware — A1 service-to-service token validation (decided DC-05); ADR-038 bearer for Track B (4.3)
 
 ### Phase 2 — Hardening (weeks 5–8)
 
@@ -469,6 +496,7 @@ Source: [PR #352](https://github.com/ansible/apme/pull/352) (updated 2026-06-25 
 | **A10** | Observability (Prometheus + structured logging) | High | Limited | `/metrics`, JSON logs | Medium |
 | **A11** | Rate limiting | Medium | Not implemented | `APME_RATE_LIMIT` | Small |
 | **A12** | Non-root containers | High | Documented only | `USER` in all Dockerfiles | Small |
+| **A13** | GitLab SCM provider | High | GitHub only | `GitLabProvider` implementation; Portal supports both GitHub and GitLab repos | Medium |
 
 ### A2 — PostgreSQL + Alembic
 
@@ -492,17 +520,53 @@ gateway:
 
 ### A3 — Optional Credential Acceptance
 
-All scan/operation endpoints accept optional credentials. If Portal provides them, use them; otherwise fall back to APME's configured project/Galaxy settings.
+All scan/operation endpoints accept credentials for SCM and Galaxy interactions. Behavior depends on `APME_DEPLOYMENT_MODE`:
+
+**Portal mode (`APME_DEPLOYMENT_MODE=portal`):**
+- Portal is the credential owner for SCM. Portal passes `scm_token` per-request on any call that triggers SCM interaction (clone, PR, push). APME uses it directly — ephemeral, never stored.
+- Per-project stored SCM tokens are **not used** in this mode (project SCM config is ignored at runtime even if present in DB).
+- If no `scm_token` is provided and the operation requires SCM access, APME returns an error.
+
+**Standalone mode (`APME_DEPLOYMENT_MODE=standalone`, default):**
+- Per-request `scm_token` takes precedence if provided.
+- If not provided, APME falls back to the **per-project stored SCM token** (existing project configuration).
+- This preserves the existing Track B / CI / CLI experience where users configure SCM credentials per project.
+
+**Galaxy credentials** behave the same in both modes: per-request `galaxy_servers` takes precedence; fallback to APME's configured Galaxy settings.
+
+| Credential | Portal mode | Standalone mode |
+|------------|-------------|-----------------|
+| `scm_token` (per-request) | Required for SCM ops; no fallback | Preferred if provided |
+| Project-stored SCM token | Ignored | Fallback if no per-request token |
+| `galaxy_servers` (per-request) | Preferred; fallback to APME config | Preferred; fallback to APME config |
 
 ```python
 class OperateRequest(BaseModel):
     action: Literal["check", "remediate"]
-    scm_token: Optional[str] = None
-    galaxy_servers: Optional[list] = None
+    scm_token: Optional[str] = None       # Per-request SCM credential
+    galaxy_servers: Optional[list] = None  # Per-request Galaxy credentials
     options: Optional[dict] = None
 ```
 
-Works for Portal-integrated (Portal injects tokens), standalone (APME settings), and CI/CD (caller passes tokens).
+Works for Portal-integrated (Portal always provides SCM token), standalone (per-project stored tokens or caller-provided), and CI/CD (token in request).
+
+### A13 — GitLab SCM Provider
+
+**Current state:** APME's SCM abstraction (`src/apme_gateway/scm/`) defines a `ScmProvider` protocol (ADR-050) with methods for `create_branch`, `push_files`, and `create_pull_request`. Only `GitHubProvider` is implemented. `detect_provider()` already recognizes `gitlab.com` URLs but `get_provider("gitlab")` raises `ValueError`.
+
+**Required:** Portal supports both GitHub and GitLab repositories. APME must support PR creation (merge requests) on both platforms.
+
+| Item | Status |
+|------|--------|
+| `ScmProvider` protocol | Ready — provider-agnostic; token passed per-method |
+| `detect_provider("gitlab.com")` | Ready — returns `"gitlab"` |
+| `GitLabProvider` implementation | **Missing** — needs `create_branch`, `push_files`, `create_pull_request` via GitLab REST API |
+| Registry entry | **Missing** — add `"gitlab": GitLabProvider` to `_PROVIDERS` |
+| GitLab API differences | MR (not PR); project ID from URL; different branch/commit API | 
+
+**Implementation:** `src/apme_gateway/scm/gitlab.py` implementing `ScmProvider` using GitLab REST v4 API (`/api/v4/projects/:id/repository/branches`, `/api/v4/projects/:id/merge_requests`). Token passed as `PRIVATE-TOKEN` header.
+
+**Effort:** Medium (1 sprint) — protocol already exists; straightforward REST implementation.
 
 ### A4 — Day 0 / Day 2 Management APIs
 
@@ -525,10 +589,10 @@ Portal Helm post-install/post-upgrade hook calls `POST /admin/db/migrate`. Insta
 | Endpoint Group | Portal Need | Status |
 | --- | --- | --- |
 | Projects CRUD | Manage scanned repos | Ready |
-| Operations (scan trigger) | Trigger scans with optional credentials | Needs A3 |
+| Operations (scan trigger) | Trigger scans with `scm_token` + optional `galaxy_servers` | Needs A3 |
 | Operations (SSE progress) | Real-time progress | Ready |
 | Operations (approve) | HITL proposal approval | Ready |
-| Operations (create PR) | Open PR with fixes | Ready (optional `scm_token`) |
+| Operations (create PR) | Open PR with fixes — Portal provides `scm_token` (required) | Ready (wire `scm_token` through) |
 | Violations / trend / dashboard | Metrics and history | Ready |
 | Rule catalog | List/configure rules | Ready |
 | Galaxy server config | Manage Galaxy credentials | Ready |
@@ -540,15 +604,37 @@ No new tarball `POST /scan` endpoint required — existing `operation_router` + 
 ### Galaxy / Automation Hub Credential Flow
 
 ```
-Portal (optional per-request)              APME (own settings)
+Portal mode (APME_DEPLOYMENT_MODE=portal)
+─────────────────────────────────────────
+Portal (credential owner)                  APME Gateway
 ┌─────────────────────────┐                ┌─────────────────────────┐
-│ ansible.rhaap.baseUrl   │                │ Gateway Galaxy config   │
-│ ansible.rhaap.token     │  operations  │ (apme_galaxy_servers)   │
-│ Injected as optional    │  ──────────► │ If request has tokens   │
-│ galaxy_servers          │              │ → use them              │
-└─────────────────────────┘              │ Else → own config     │
+│ SCM token (admin or     │  per-request │ scm_token provided?     │
+│ user OAuth per context) │  ──────────► │ → use it (no fallback)  │
+│                         │              │ Not provided?           │
+│ galaxy_servers (from    │              │ → error if SCM needed   │
+│ ansible.rhaap.*)        │              │                         │
+│                         │              │ galaxy_servers provided? │
+└─────────────────────────┘              │ → use them              │
+                                         │ Else → own Galaxy config│
+                                         └─────────────────────────┘
+
+Standalone mode (APME_DEPLOYMENT_MODE=standalone)
+─────────────────────────────────────────────────
+Caller (CLI / CI / UI)                     APME Gateway
+┌─────────────────────────┐                ┌─────────────────────────┐
+│ scm_token (optional)    │  per-request │ scm_token provided?     │
+│ galaxy_servers (opt)    │  ──────────► │ → use it                │
+│                         │              │ Not provided?           │
+└─────────────────────────┘              │ → project stored token  │
+                                         │ Neither? → error        │
+                                         │                         │
+                                         │ galaxy_servers provided? │
+                                         │ → use them              │
+                                         │ Else → own Galaxy config│
                                          └─────────────────────────┘
 ```
+
+**Key principle:** Per-project SCM tokens remain a first-class feature in APME — they are not removed. `APME_DEPLOYMENT_MODE` controls whether the Gateway resolves credentials from stored project config (`standalone`) or requires them per-request (`portal`).
 
 In AAP 2.5+, Hub is behind AAP Gateway: `ansible.rhaap.baseUrl` + `ansible.rhaap.token` (AAP admin token, org-scoped).
 
@@ -590,13 +676,14 @@ APME ships as Portal Helm subchart. `helm upgrade` updates Portal + APME togethe
 1. **A1** — Gateway auth
 2. **A2** — PostgreSQL + Alembic (enables shared-instance architecture)
 3. **A3** — Optional credentials
-4. **A4** — Day 0/Day 2 management APIs
-5. **A12** — Non-root containers
-6. **A9** — API versioning contract
-7. **A10** — Observability
-8. **A5** — PVC sizing
-9. **A6** — Air-gapped mode
-10. **A11** — Rate limiting
+4. **A13** — GitLab SCM provider (Portal supports GitHub + GitLab)
+5. **A4** — Day 0/Day 2 management APIs
+6. **A12** — Non-root containers
+7. **A9** — API versioning contract
+8. **A10** — Observability
+9. **A5** — PVC sizing
+10. **A6** — Air-gapped mode
+11. **A11** — Rate limiting
 
 ### What Stays Unchanged
 
@@ -676,7 +763,7 @@ When `APME_DATABASE_MODE=shared`, Gateway connects to Portal's PostgreSQL. Use c
 | Artifact | Type | Title | Trigger | Phase |
 |----------|------|-------|---------|-------|
 | ADR-055 (proposed) | ADR | Shared PostgreSQL instance integration (Track A) | §8 architecture | 3 |
-| ADR-056 (proposed) | ADR | Portal service-token authentication | D-01 resolution | 1 |
+| ADR-056 (proposed) | ADR | Portal service-to-service token implementation | DC-05 (decided) | 1 |
 | ADR-029-amend | ADR | PostgreSQL only — SQLite removal | §9 checklist | 1 |
 | ADR-057 (proposed) | ADR | Required validator set (Collection Health + Dep Audit) | 4.10 completion | 1 |
 | ADR-058 (proposed) | ADR | API versioning — RFC 9745 / RFC 8594 | 4.4 / A9 | 3 |
@@ -688,6 +775,7 @@ When `APME_DATABASE_MODE=shared`, Gateway connects to Portal's PostgreSQL. Use c
 | TASK-005-03 | TASK | CI publish collection-health + dep-audit images | 4.1 | 2 |
 | TASK-005-04 | TASK | Gateway auth middleware (A1) | §8 | 3 |
 | TASK-005-05 | TASK | Optional credential acceptance on operations (A3) | §8 | 3 |
+| TASK-005-09 | TASK | GitLab SCM provider — `GitLabProvider` implementing `ScmProvider` (A13) | §8 | 3 |
 | TASK-005-08 | TASK | Day 0/Day 2 admin/db APIs (A4) | §8 | 3 |
 | TASK-005-06 | TASK | `USER` directive all Dockerfiles (A12) | 4.2 | 2 |
 | TASK-005-07 | TASK | Prometheus `/metrics` on Gateway (A10) | §8 | 4 |

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -1,0 +1,297 @@
+# APME Productization Plan — Pre-Read
+
+**Prepared:** 2026-06-24  
+**Target discussion:** Friday architecture review  
+**Status:** Draft for review
+
+---
+
+## 1. Architecture Overview
+
+APME is a multi-service system that automates policy enforcement and
+modernization of Ansible content for AAP 2.5+. The architecture separates
+concerns into three tiers:
+
+```
+┌──────────────────────────────── apme-pod ─────────────────────────────┐
+│ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ │
+│ │ Primary  │ │ Native   │ │   OPA    │ │ Ansible  │ │ Gitleaks │ │
+│ │  :50051  │ │  :50055  │ │  :50054  │ │  :50053  │ │  :50056  │ │
+│ └────┬─────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘ │
+│      ┌────┴─────────────────────────────────────┐  ┌──────────┐     │
+│      │    Galaxy Proxy :8765 (PEP 503)          │  │ Abbenay  │     │
+│      └──────────────────────────────────────────┘  │  :50057  │     │
+│        ┌──────────────────────┐  ┌──────────┐      └──────────┘     │
+│        │ Gateway :50060/:8080 │  │ UI :8081 │                       │
+│        │  REST + gRPC + DB   │  │ (nginx)  │                       │
+│        └──────────────────────┘  └──────────┘                       │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+- **Engine tier:** Primary orchestrator + validators (Native, OPA, Ansible,
+  Gitleaks, Collection Health, Dep Audit) + Galaxy Proxy. Scales as a unit
+  (ADR-012). Stateless — no database code.
+- **Gateway tier:** FastAPI REST + gRPC Reporting server + SQLAlchemy/SQLite
+  persistence. Bridges HTTP/WebSocket clients to the engine's gRPC interface.
+  Owns all persistence and context enrichment (ADR-020, ADR-029).
+- **UI tier:** React SPA served by nginx. Talks exclusively to the Gateway
+  REST API.
+
+All inter-service communication uses gRPC (ADR-001). The only HTTP endpoints
+are Gateway REST (:8080), Galaxy Proxy PEP 503 (:8765), and the UI (:8081).
+
+---
+
+## 2. Deployment: Portal-First, Then Expand
+
+The same services run in every deployment target — only the orchestration
+and networking differ.
+
+| Target | Method | Status |
+|--------|--------|--------|
+| **Portal / OpenShift** (primary) | Helm chart (`deploy/helm/apme/`) | Structurally ready (ADR-054); needs auth, ingress/route, network policy |
+| Podman pod (dev, standalone, GitHub) | `tox -e up` | Working today |
+| bootc VM (air-gapped / edge) | Systemd quadlets (`deploy/bootc/`) | Prototype exists |
+| CLI daemon (quick eval / CI) | `apme daemon start` | Working; embedded Gateway (ADR-049) |
+
+### Helm on OpenShift (Portal path)
+
+The Helm chart produces separate Deployments:
+
+| Deployment | Contents | Scaling |
+|------------|----------|---------|
+| `engine` | Primary + all validators + Galaxy Proxy (sidecars) | HPA optional (1–5 replicas) |
+| `gateway` | REST + gRPC Reporting + SQLite | Fixed replicas |
+| `ui` | nginx + React SPA | Fixed replicas |
+| `abbenay` | AI provider | Optional, 1 replica |
+
+Templates for Ingress, OpenShift Route, NetworkPolicy, and PodDisruptionBudget
+exist but are disabled by default — enable for production.
+
+### Why one architecture serves all use cases
+
+A Podman pod is the same services on localhost. It satisfies the standalone
+web UI and GitHub-integrated use cases without a separate product SKU or
+different code path. The CLI daemon embeds the Gateway for zero-dependency
+local evaluation.
+
+---
+
+## 3. Authentication — Open Decision Required
+
+**There is no ADR that implements inbound API authentication.** This is the
+single largest productization gap.
+
+### What exists today
+
+| ADR | Auth relevance | Status |
+|-----|----------------|--------|
+| ADR-029 | Standalone V1: no auth. Enterprise: trust identity headers (`X-User`, `X-Org`) from AAP Gateway proxy | Implemented (no auth code) |
+| ADR-038 | Three modes: no auth, Bearer token (machine), enterprise via AAP headers | Proposed only |
+| ADR-048 | Pod-internal admin endpoints rely on network isolation | Accepted |
+| ADR-054 | K8s Secrets for SCM/AI tokens (outbound creds, not user auth) | Accepted |
+
+### Open question: AAP Gateway proxy vs self-contained auth
+
+**Option A — AAP Gateway proxy (ADR-029 sketch):**
+APME sits behind the AAP Gateway, which handles OAuth2/OIDC/RBAC. APME
+trusts `X-User` / `X-Org` headers. Minimal APME code change; depends on
+AAP Gateway being in the request path.
+
+**Option B — OAuth2/OIDC middleware in APME Gateway:**
+APME validates JWTs directly (e.g., from platform Keycloak). Self-contained
+but duplicates auth infrastructure.
+
+**Option C — Platform auth token validation:**
+Portal provides a signed JWT; APME validates it against a shared JWKS
+endpoint. Middle ground — APME verifies tokens but doesn't own the IdP.
+
+**Recommendation:** Write an ADR committing to one approach before any
+multi-user deployment. Option A aligns with existing ADR-029 direction and
+avoids APME owning identity management.
+
+---
+
+## 4. Productization Work Streams
+
+### 4.1 Downstream Build & Release
+
+| Item | Current State | Work Needed |
+|------|---------------|-------------|
+| Container images | 13 images on `ghcr.io`; git-SHA tags | Konflux pipelines; `registry.redhat.io` target; evaluate UBI base |
+| Versioning | `0.1.0` in pyproject; chart `0.1.0`; no unified semver | Align pyproject, Helm `appVersion`, and image tags to single semver |
+| Release SBOM | Per-project CycloneDX via Gateway API (runtime) | Release-artifact SBOM via syft/cyclonedx-bom in pipeline |
+| Image signing | Not implemented | cosign in Konflux pipeline |
+| Base image | `astral-sh/uv:python3.12-bookworm-slim` | Evaluate UBI 9 for downstream; uv still usable on UBI |
+
+### 4.2 Security & Compliance
+
+| Item | Current State | Work Needed |
+|------|---------------|-------------|
+| SAST | Manual bandit; no CodeQL | CodeQL or Snyk in CI; gitleaks + pip-audit in pipeline |
+| Container scanning | Manual Trivy/Grype (documented, not automated) | Konflux Clair/Trivy gate on image build |
+| Non-root containers | Documented in SECURITY.md; `USER` directive missing from Dockerfiles | Add non-root USER to all Containerfiles |
+| Dependency governance | ADR-019 checklist; Dependabot weekly | Formal dep review for legal (license audit) |
+| TLS | Insecure channels in dev; TLS noted for prod | mTLS or cert-manager for K8s |
+| Network policy | Helm template exists, disabled by default | Enable by default for production values |
+
+### 4.3 Authentication & Authorization
+
+See [Section 3](#3-authentication--open-decision-required). Requires ADR
+decision. Work includes:
+
+- Middleware implementation in Gateway (`FastAPI Depends()`)
+- RBAC model if multi-tenant (or defer to AAP Gateway)
+- API key management for machine consumers (ADR-038)
+
+### 4.4 Scaling & Performance
+
+| Item | Current State | Work Needed |
+|------|---------------|-------------|
+| Load testing | No infrastructure | k6 or locust suite against Gateway REST + FixSession gRPC |
+| Baseline metrics | Per-scan diagnostics (`engine_total_ms`, per-rule timing) | Establish SLA baselines (e.g., 1000-task project < 30s) |
+| HPA | Helm template exists (disabled) | Enable and tune with load test data |
+| Horizontal scaling | ADR-012: scale engine pods as unit | Validate with concurrent scan load |
+| Gateway DB | SQLite (single-writer) | PostgreSQL path (ADR-029) needed for HA / multi-replica |
+
+### 4.5 DevTools Team Onboarding
+
+| Item | Work Needed |
+|------|-------------|
+| Bug triage | APME components in Jira/Bugzilla; triage process doc |
+| Support statement | Define supported configurations, response SLAs, escalation path |
+| Runbook | Health checks, log locations, restart procedures, common failures |
+| Monitoring | Prometheus `/metrics` endpoint (not yet implemented); Grafana dashboard |
+| Alerting | Define SLOs and alert thresholds |
+
+### 4.6 Dependency Review
+
+| Category | Current Dependencies | Review Action |
+|----------|---------------------|---------------|
+| Python runtime | grpcio, protobuf, fastapi, uvicorn, ruamel.yaml, httpx, ansible-core | License audit; legal review |
+| External binaries | OPA 1.17.1, Gitleaks 8.30.1 | License compatibility; upstream support lifecycle |
+| AI provider | Abbenay (`ghcr.io/redhat-developer/abbenay`) | Internal dependency; version pinning strategy |
+| Frontend | React, PatternFly, Vite, Node 22 | Standard UI stack; confirm PatternFly version |
+| Container base | Debian bookworm-slim | UBI migration path for downstream |
+
+### 4.7 Repo & Process Hardening
+
+| Item | Current State | Work Needed |
+|------|---------------|-------------|
+| CI security gates | Unit + integration + lint; no SAST/container scan | Add CodeQL, pip-audit, container scan to CI |
+| Pre-commit hooks | ruff, mypy, pydoclint, uv-lock | Add gitleaks to pre-commit (currently manual) |
+| Branch protection | Single-branch `main` (ADR-016) | Verify CODEOWNERS, required reviews, status checks |
+| Vulnerability disclosure | SECURITY.md with private reporting | Confirm GitHub Security Advisories enabled |
+| Industry gap analysis | `.sdlc/research/industry-gap-analysis.md` exists | Use as checklist; close gaps systematically |
+
+### 4.8 Product Requirements from Craig
+
+Craig should author a formal requirement covering:
+
+- What "APME in Portal" means from a product owner perspective
+- User personas and workflows in Portal context
+- Which APME capabilities are P0 vs P1 for Portal launch
+- Integration points with existing Portal services
+- Success metrics and acceptance criteria
+- Use `/req-new` or `/prd-import` to formalize as SDLC artifact
+
+---
+
+## 5. Additional Considerations
+
+Items not in the original list but important for productization:
+
+1. **Observability** — No Prometheus metrics endpoint, no OpenTelemetry
+   traces, no structured log aggregation. Production needs `/metrics` on
+   Gateway and engine.
+
+2. **Rate limiting** — Gateway has no request throttling. If exposed through
+   Portal, needs abuse protection.
+
+3. **Multi-tenancy / data isolation** — SQLite is single-tenant. Portal
+   implies multiple users/orgs. Decision needed: one APME instance per
+   tenant, or shared instance with row-level isolation (requires
+   PostgreSQL).
+
+4. **Database migrations** — No Alembic or migration tooling. Schema changes
+   will break existing databases without a migration path.
+
+5. **Operator documentation** — Admin guide, configuration reference,
+   troubleshooting guide. Current docs are developer-focused.
+
+6. **Feature flags** — No feature flag system. Portal rollout likely needs
+   staged enablement.
+
+7. **Graceful degradation** — What happens when APME engine is down? Portal
+   needs a degraded UX, not a 500.
+
+8. **API versioning contract** — REST API is `/api/v1` but no formal
+   stability guarantee or deprecation policy. Portal consumers need this.
+
+9. **Accessibility (a11y)** — PatternFly helps, but no a11y audit has been
+   performed.
+
+10. **Telemetry** — No opt-in usage analytics for understanding adoption.
+
+---
+
+## 6. Open Decisions
+
+| # | Decision | Owner | Blocker for |
+|---|----------|-------|-------------|
+| 1 | Auth model: AAP proxy vs self-contained vs platform JWT | Architect + Craig | Any multi-user deployment |
+| 2 | Multi-tenancy: per-tenant instance vs shared + row isolation | Architect | Portal deployment |
+| 3 | Base image: stay Debian slim or migrate to UBI | DevTools / Konflux | Downstream build |
+| 4 | PostgreSQL: required for production or SQLite sufficient? | Architect | HA / multi-replica Gateway |
+| 5 | Craig's P0 feature set for Portal launch | Craig | Scope and timeline |
+| 6 | Support model: who triages, SLAs, escalation | DevTools lead | Team onboarding |
+
+---
+
+## 7. Suggested Priority Sequence
+
+```
+Phase 1 — Security & Auth Foundation
+├── Auth ADR decision
+├── Non-root containers
+├── CI security gates (CodeQL, pip-audit, container scan)
+├── Dependency / license audit
+└── TLS for production
+
+Phase 2 — Downstream Build
+├── UBI base image evaluation
+├── Konflux pipeline setup
+├── Unified semver strategy
+├── Release SBOM + cosign
+└── Image publish to registry.redhat.io
+
+Phase 3 — Portal Integration
+├── Auth middleware implementation
+├── Ingress / Route configuration
+├── Network policy defaults
+├── PostgreSQL support (if multi-tenant)
+├── Craig's P0 feature set
+└── API stability contract
+
+Phase 4 — Production Readiness
+├── Load test suite (k6/locust)
+├── SLA baselines and HPA tuning
+├── Prometheus metrics + Grafana
+├── Operator runbook
+├── a11y audit
+└── DevTools team onboarding
+```
+
+---
+
+## References
+
+| Document | Path |
+|----------|------|
+| Architecture | `.sdlc/context/architecture.md` |
+| Deployment | `.sdlc/context/deployment.md` |
+| Helm chart | `deploy/helm/apme/` |
+| ADR index | `.sdlc/adrs/README.md` |
+| Security policy | `SECURITY.md` |
+| Operating procedures | `SOP.md` |
+| Industry gap analysis | `.sdlc/research/industry-gap-analysis.md` |

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -81,11 +81,18 @@ runs a reduced stack (engine + embedded Gateway, no UI) for zero-dependency
 local evaluation. The Helm chart deploys the same services as separate
 Kubernetes Deployments.
 
-**Portal caveat:** The Helm chart in this repo is structured for standalone
-APME deployment on OpenShift. Portal integration may require a different
-deployment model — APME services deployed as part of the Portal's existing
-Helm chart or operator, rather than as a standalone Helm release. This is
-an open question (see Section 6).
+**Portal deployment model:** APME deploys as a standalone Helm release — not
+embedded in the AAP installer or Portal operator. Portal configures its UI
+to point at the APME Gateway endpoint. This is the right approach because:
+
+- **Multiple entry points:** The same APME deployment serves Portal, GitHub
+  integrations, standalone web UI, and API consumers. Coupling to the AAP
+  installer would lock APME into a single entry point.
+- **Reduced complexity:** A standalone Helm chart is straightforward for any
+  Kubernetes shop to deploy and operate. Embedding in the AAP installer adds
+  coupling, release coordination overhead, and upgrade complexity.
+- **Independent lifecycle:** APME can version, release, and scale independently
+  of the broader AAP platform.
 
 ---
 
@@ -165,6 +172,7 @@ decision. Work includes:
 | HPA | Helm template exists (disabled) | Enable and tune with load test data |
 | Horizontal scaling | ADR-012: scale engine pods as unit | Validate with concurrent scan load |
 | Gateway DB | SQLite (single-writer) | **Decision needed:** move to PostgreSQL now, or keep SQLite for standalone and add PostgreSQL as a production option? See Section 6. |
+| DB migrations | No migration tooling exists (no Alembic, no versioned schema) | **Gap:** schema changes today silently break existing databases. Need Alembic (or equivalent) with versioned migrations before any production release. |
 
 ### 4.5 Ownership Model
 
@@ -254,25 +262,22 @@ Items not in the original list but important for productization:
    tenant, or shared instance with row-level isolation (requires
    PostgreSQL).
 
-4. **Database migrations** — No Alembic or migration tooling. Schema changes
-   will break existing databases without a migration path.
-
-5. **Operator documentation** — Admin guide, configuration reference,
+4. **Operator documentation** — Admin guide, configuration reference,
    troubleshooting guide. Current docs are developer-focused.
 
-6. **Feature flags** — No feature flag system. Portal rollout likely needs
+5. **Feature flags** — No feature flag system. Portal rollout likely needs
    staged enablement.
 
-7. **Graceful degradation** — What happens when APME engine is down? Portal
+6. **Graceful degradation** — What happens when APME engine is down? Portal
    needs a degraded UX, not a 500.
 
-8. **API versioning contract** — REST API is `/api/v1` but no formal
+7. **API versioning contract** — REST API is `/api/v1` but no formal
    stability guarantee or deprecation policy. Portal consumers need this.
 
-9. **Accessibility (a11y)** — PatternFly helps, but no a11y audit has been
+8. **Accessibility (a11y)** — PatternFly helps, but no a11y audit has been
    performed.
 
-10. **Telemetry** — No opt-in usage analytics for understanding adoption.
+9. **Telemetry** — No opt-in usage analytics for understanding adoption.
 
 ---
 
@@ -287,7 +292,7 @@ Items not in the original list but important for productization:
 | 5 | Craig's P0 feature set for Portal launch | Craig | Scope and timeline |
 | 6 | Rule governance: who proposes, reviews, approves prescriptive rules | Community of practice + BU + Ansible eng | Rule quality and relevance |
 | 7 | DevTools ownership scope: engine + gateway + deploy + CI + release | DevTools lead + current team | Codebase handoff |
-| 8 | Portal deployment model: standalone APME Helm chart, or integrated into Portal's operator/chart? | Architect + Portal team | Deployment architecture |
+| 8 | DB migration tooling: adopt Alembic, define schema versioning strategy, test upgrade path | DevTools | Any schema change post-release |
 
 ---
 
@@ -313,6 +318,7 @@ Phase 3 — Portal Integration
 ├── Ingress / Route configuration
 ├── Network policy defaults
 ├── PostgreSQL support (if multi-tenant)
+├── Alembic DB migrations (schema versioning + upgrade path)
 ├── Craig's P0 feature set
 └── API stability contract
 

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -1,446 +1,771 @@
 # APME Productization Plan — Pre-Read
 
 **Prepared:** 2026-06-24  
-**Target discussion:** Friday architecture review  
+**Updated:** 2026-06-25  
 **Status:** Draft for review
 
----
+This document captures the productization strategy for APME across two deployment tracks: **Portal-integrated product** (Track A) and **upstream standalone** (Track B). It consolidates architecture, authentication, work streams, open decisions, PostgreSQL migration, and Portal integration requirements.
 
-## 1. Architecture Overview
-
-APME is a multi-service system that automates policy enforcement and
-modernization of Ansible content for AAP 2.5+. The architecture separates
-concerns into three tiers:
-
-```
-┌──────────────────────────────── apme-pod ─────────────────────────────┐
-│ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ │
-│ │ Primary  │ │ Native   │ │   OPA    │ │ Ansible  │ │ Gitleaks │ │
-│ │  :50051  │ │  :50055  │ │  :50054  │ │  :50053  │ │  :50056  │ │
-│ └────┬─────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘ │
-│      ┌────┴─────────────────────────────────────┐  ┌──────────┐     │
-│      │    Galaxy Proxy :8765 (PEP 503)          │  │ Abbenay  │     │
-│      └──────────────────────────────────────────┘  │  :50057  │     │
-│        ┌──────────────────────┐  ┌──────────┐      └──────────┘     │
-│        │ Gateway :50060/:8080 │  │ UI :8081 │                       │
-│        │  REST + gRPC + DB   │  │ (nginx)  │                       │
-│        └──────────────────────┘  └──────────┘                       │
-└──────────────────────────────────────────────────────────────────────┘
-```
-
-- **Engine tier:** Primary orchestrator + validators (Native, OPA, Ansible,
-  Gitleaks, Collection Health, Dep Audit) + Galaxy Proxy. Scales as a unit
-  (ADR-012). Stateless — no database code.
-- **Gateway tier:** FastAPI REST + gRPC Reporting server + SQLAlchemy/SQLite
-  persistence. Bridges HTTP/WebSocket clients to the engine's gRPC interface.
-  Owns all persistence and context enrichment (ADR-020, ADR-029).
-- **UI tier:** React SPA served by nginx. Talks exclusively to the Gateway
-  REST API.
-
-Inter-service communication uses gRPC (ADR-001), with one exception: Galaxy
-Proxy exposes an internal PEP 503 HTTP endpoint (:8765) used by Primary for
-collection resolution. External-facing HTTP endpoints are Gateway REST
-(:8080) and the UI (:8081).
+Companion research: [PR #352](https://github.com/ansible/apme/pull/352) (`.sdlc/research/portal-integration/00-integration-requirements.md`), [ansible-rhdh-plugins PR #676](https://github.com/ansible/ansible-rhdh-plugins/pull/676), [ANSTRAT-2222](https://issues.redhat.com/browse/ANSTRAT-2222).
 
 ---
 
-## 2. Deployment: Portal-First, Then Expand
+## Section 1 — Architecture Overview
 
-The core engine stack (Primary + validators + Galaxy Proxy) runs in every
-deployment target. Gateway, UI, and Abbenay are included in pod and Helm
-deployments but not in the CLI daemon (which embeds a lightweight Gateway
-instead — ADR-049). Optional validators (Gitleaks, Collection Health, Dep
-Audit) start only when `include_optional=True`.
+APME is a multi-service system that automates policy enforcement and modernization of Ansible content for AAP 2.5+. Services communicate via gRPC (ADR-001); the engine is stateless; persistence lives at the Gateway edge (ADR-020, ADR-029).
 
-| Target | Method | Status |
-|--------|--------|--------|
-| **Portal / OpenShift** (primary) | Helm chart (`deploy/helm/apme/`) | Structurally ready (ADR-054); needs auth, ingress/route, network policy |
-| Podman pod (dev, standalone, GitHub) | `tox -e up` | Working today |
-| bootc VM (air-gapped / edge) | Systemd quadlets (`deploy/bootc/`) | Prototype exists |
-| CLI daemon (quick eval / CI) | `apme daemon start` | Working; embedded Gateway (ADR-049) |
+### Three-Tier Topology
 
-### Helm on OpenShift (Portal path)
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                           APME Engine Tier                                    │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐           │
+│  │ Primary  │ │ Native   │ │ OPA      │ │ Ansible  │ │ Gitleaks │ (optional)│
+│  │ :50051   │ │ :50055   │ │ :50054   │ │ :50053   │ │ :50056   │           │
+│  └────┬─────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘           │
+│       │  ┌──────────────────┐ ┌──────────────────┐ ┌──────────┐               │
+│       │  │ Collection Health│ │ Dep Audit        │ │ Abbenay  │               │
+│       │  │ :50058 (required)│ │ :50059 (required)│ │ :50057   │               │
+│       │  └──────────────────┘ └──────────────────┘ └──────────┘               │
+│  ┌────┴─────────────────────────────────────┐                                │
+│  │ Galaxy Proxy :8765 (PEP 503)             │                                │
+│  └──────────────────────────────────────────┘                                │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                     │ gRPC
+                                     ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                           Gateway Tier                                        │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │ Gateway :8080 (REST) / :50060 (gRPC Reporting — Track B full mode only) │  │
+│  │ Track B: PostgreSQL persistence │ Track A proxy: no APME database      │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                     │ REST + WebSocket
+                                     ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                           UI Tier (Track B only)                              │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │ UI :8081 (nginx SPA) — REST + WebSocket /api/v1/ws/session             │  │
+│  └────────────────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
 
-The Helm chart produces separate Deployments:
+### Tier Summary
 
-| Deployment | Contents | Scaling |
-|------------|----------|---------|
-| `engine` | Primary + all validators + Galaxy Proxy (sidecars) | HPA optional (1–5 replicas) |
-| `gateway` | REST + gRPC Reporting + SQLite | Configurable replicas (SQLite limits practical concurrency) |
-| `ui` | nginx + React SPA | Configurable replicas |
-| `abbenay` | AI provider | Optional, 1 replica |
+| Tier | Components | Notes |
+|------|------------|-------|
+| **Engine** | Primary, Native, OPA, Ansible, Galaxy Proxy, **Collection Health**, **Dep Audit**, Abbenay; Gitleaks optional | Collection Health and Dep Audit are **required** for productized engine runtime. Gitleaks is **optional** (external binary). |
+| **Gateway** | REST API, Reporting gRPC (full mode), persistence (full mode) | **Upstream/dev (Track B):** PostgreSQL. **Portal proxy mode (Track A):** no APME-owned database — Portal owns persistence. |
+| **UI** | React SPA (PatternFly) | **Track B:** standalone UI via REST and WebSocket `/api/v1/ws/session`. **Track A:** no APME UI — Portal provides UX. |
 
-Templates for Ingress, OpenShift Route, NetworkPolicy, and PodDisruptionBudget
-exist but are disabled by default — enable for production.
+### Engine-Core vs Product Validator Scope
 
-### Why one architecture serves multiple use cases
+| Service | Product / Podman | CLI daemon today | CI publish today |
+|---------|------------------|------------------|------------------|
+| Primary, Native, OPA, Ansible, Galaxy Proxy | Required | Required | ✓ |
+| Collection Health | Required | Optional (`include_optional`) | Local build only |
+| Dep Audit | Required | Optional (`include_optional`) | Local build only |
+| Gitleaks | Optional | Optional | ✓ |
+| Abbenay | Pod-level (AI) | Not in daemon | External image |
 
-The Podman pod runs the full stack (engine + gateway + UI) on localhost,
-satisfying standalone web UI and GitHub-integrated use cases. The CLI daemon
-runs a reduced stack (engine + embedded Gateway, no UI) for zero-dependency
-local evaluation. The Helm chart deploys the same services as separate
-Kubernetes Deployments.
+### Implementation Gap
 
-**Portal deployment model:** APME deploys as a standalone Helm release — not
-embedded in the AAP installer or Portal operator. Portal configures its UI
-to point at the APME Gateway endpoint. This is the right approach because:
+`launcher.py` still lists `collection_health` and `dep_audit` in `_OPTIONAL_SERVICES` alongside `gitleaks`. They start only when `include_optional=True`. **Productization work stream 4.10** must align launcher defaults, Helm values, Podman pod spec, bootc image, and CI with the required-validator scope.
 
-- **Multiple entry points:** The same APME deployment serves Portal, GitHub
-  integrations, standalone web UI, and API consumers. Coupling to the AAP
-  installer would lock APME into a single entry point.
-- **Reduced complexity:** A standalone Helm chart is straightforward for any
-  Kubernetes shop to deploy and operate. Embedding in the AAP installer adds
-  coupling, release coordination overhead, and upgrade complexity.
-- **Independent lifecycle:** APME can version, release, and scale independently
-  of the broader AAP platform.
+```33:37:src/apme_engine/daemon/launcher.py
+_OPTIONAL_SERVICES = {
+    "gitleaks": 50056,
+    "collection_health": 50058,
+    "dep_audit": 50059,
+}
+```
 
 ---
 
-## 3. Authentication — Open Decision Required
+## Section 2 — Dual Deployment Tracks
 
-**There is no ADR that implements inbound API authentication.** This is the
-single largest productization gap.
+APME ships on two parallel tracks with different packaging, persistence, and UX surfaces.
 
-### What exists today
+### Track A — Product (Portal)
 
-| ADR | Auth relevance | Status |
-|-----|----------------|--------|
-| ADR-029 | Standalone V1: no auth. Enterprise: trust identity headers (`X-User`, `X-Org`) from AAP Gateway proxy | Implemented (no auth code) |
-| ADR-038 | Three modes: no auth, Bearer token (machine), enterprise via AAP headers | Proposed only |
-| ADR-048 | Pod-internal admin endpoints rely on network isolation | Accepted |
-| ADR-054 | K8s Secrets for SCM/AI tokens (outbound creds, not user auth) | Accepted |
+| Attribute | Value |
+|-----------|-------|
+| **Distribution** | Bundled with Portal Operator / bootc product image |
+| **Gateway mode** | Proxy mode (`APME_GATEWAY_MODE=proxy`) — stateless REST↔gRPC proxy |
+| **Database** | Portal PostgreSQL (`apme_*` tables); **no** APME Gateway DB or PVC |
+| **UI** | Portal UX only; **no** standalone APME UI container |
+| **Auth** | Portal Auth/RBAC + service token for Portal→Gateway |
+| **Content ingress** | Portal clones SCM, sends tarballs — APME never holds SCM credentials |
+| **Target users** | AAP customers consuming APME via Ansible Automation Portal |
 
-### Open question: AAP Gateway proxy vs self-contained auth
+### Track B — Upstream / Dev
 
-**Option A — AAP Gateway proxy (ADR-029 sketch):**
-APME sits behind the AAP Gateway, which handles OAuth2/OIDC/RBAC. APME
-trusts `X-User` / `X-Org` headers. Minimal APME code change; depends on
-AAP Gateway being in the request path.
+| Attribute | Value |
+|-----------|-------|
+| **Distribution** | Standalone Helm chart (`deploy/helm/apme/`), Podman pod (`tox -e up`), bootc VM, CLI daemon |
+| **Gateway mode** | Full mode (`APME_GATEWAY_MODE=full`) — owns REST, reporting, persistence |
+| **Database** | PostgreSQL for production; SQLite acceptable for local dev only |
+| **UI** | Standalone APME UI (:8081) — **not removed** for upstream |
+| **Auth** | Bearer tokens per ADR-038 (Proposed) |
+| **Target users** | Open-source consumers, integrators, developers |
 
-**Option B — OAuth2/OIDC middleware in APME Gateway:**
-APME validates JWTs directly (e.g., from platform Keycloak). Self-contained
-but duplicates auth infrastructure.
+### Open Packaging Decision Table
 
-**Option C — Platform auth token validation:**
-Portal provides a signed JWT; APME validates it against a shared JWKS
-endpoint. Middle ground — APME verifies tokens but doesn't own the IdP.
-
-**Recommendation:** Write an ADR committing to one approach before any
-multi-user deployment. Option A aligns with existing ADR-029 direction and
-avoids APME owning identity management.
+| Decision | Option A | Option B | Option C | Status |
+|----------|----------|----------|----------|--------|
+| **Image registry** | `ghcr.io` (current CI) | Red Hat catalog | Customer mirror | **Open** |
+| **Chart packaging** | OCI artifact standalone | Subchart of Portal Operator | Helm only, no Operator | **Open** |
+| **Version coupling** | Lockstep with Portal release | Independent semver | LTS branches | **Open** |
+| **CLI distribution** | PyPI + `apme-cli` container | RPM in bootc only | Bundled in Portal image | **Open** (CLI packaging gap — see 4.1) |
+| **Engine image layout** | Per-service images (current) | Single fat engine image | Hybrid | **Open** |
+| **Abbenay sourcing** | External `ghcr.io/redhat-developer/abbenay` | Vendor in product chart | Optional feature flag | **Open** |
 
 ---
 
-## 4. Productization Work Streams
+## Section 3 — Authentication
 
-### 4.1 Downstream Build & Release
+Authentication differs by deployment track. **Podman, bootc, and CLI daemon paths need token-based auth**, not AAP-header-only or auth-disabled defaults suitable only for local dev.
 
-| Item | Current State | Work Needed |
-|------|---------------|-------------|
-| Container images | 13 images on `ghcr.io`; git-SHA tags | Konflux pipelines; `registry.redhat.io` target; evaluate UBI base |
-| Versioning | `0.1.0` in pyproject; chart `0.1.0`; no unified semver | Align pyproject, Helm `appVersion`, and image tags to single semver |
-| Release SBOM | Per-project CycloneDX via Gateway API (runtime) | Release-artifact SBOM via syft/cyclonedx-bom in pipeline |
-| Image signing | Not implemented | cosign in Konflux pipeline |
-| Base image | `astral-sh/uv:python3.12-bookworm-slim` | Evaluate UBI 9 for downstream; uv still usable on UBI |
+### Track A — Portal Product
 
-### 4.2 Security & Compliance
+| Layer | Mechanism |
+|-------|-----------|
+| **User → Portal** | Portal Auth (OIDC/SSO) + Portal RBAC |
+| **Portal → Gateway** | Bearer service token (`APME_SERVICE_TOKENS`); Portal backend injects from K8s Secret |
+| **Gateway → Engine** | Pod-local gRPC; no end-user identity in engine |
+| **Galaxy credentials** | Per-request in `POST /scan` body — never persisted by APME |
 
-| Item | Current State | Work Needed |
-|------|---------------|-------------|
-| SAST | Manual bandit; no CodeQL | CodeQL or Snyk in CI; gitleaks + pip-audit in pipeline |
-| Container scanning | Manual Trivy/Grype (documented, not automated) | Konflux Clair/Trivy gate on image build |
-| Non-root containers | Documented in SECURITY.md; `USER` directive missing from Dockerfiles | Add non-root USER to all Containerfiles |
-| Dependency governance | ADR-019 checklist; Dependabot weekly | Formal dep review for legal (license audit) |
-| TLS | Insecure channels in dev; TLS noted for prod | mTLS or cert-manager for K8s |
-| Network policy | Helm template exists, disabled by default | Enable by default for production values |
+**A1 (PR #352):** Gateway auth middleware with `APME_AUTH_DISABLED` escape hatch for backward-compatible CLI daemon dev only.
 
-### 4.3 Authentication & Authorization
+### Track B — Upstream / Dev
 
-See [Section 3](#3-authentication--open-decision-required). Requires ADR
-decision. Work includes:
+| Layer | Mechanism |
+|-------|-----------|
+| **User → Gateway/UI** | Bearer token (ADR-038 — status: Proposed) |
+| **CLI → Primary** | Local daemon trust boundary today; production needs bearer or mTLS |
+| **Machine consumers** | ADR-038 pull model: `Authorization: Bearer` on `/api/v1/*` |
+| **Gateway → Engine** | Pod-local gRPC inside engine pod |
 
-- Middleware implementation in Gateway (`FastAPI Depends()`)
-- RBAC model if multi-tenant (or defer to AAP Gateway)
-- API key management for machine consumers (ADR-038)
+### Gaps
 
-### 4.4 API Versioning & Contract
+| Gap | Impact | Resolution |
+|-----|--------|------------|
+| ADR-038 not fully implemented | No stable machine-auth contract | Phase 1 auth ADR + middleware |
+| Podman/bootc Helm values lack auth secrets | Open deployments | Document required `APME_SERVICE_TOKENS` |
+| CLI daemon has no Gateway auth today | `apme sbom` etc. need Gateway (ADR-049) | Separate from Portal track — see ADR-049 |
+| Portal proxy service-token rotation | Ops burden | ADR for token lifecycle (D-01) |
 
-The Gateway REST API is URL-versioned (`/api/v1`) today, which is the right
-foundation. What's missing is the contract and tooling around it — all
-consumers (Portal, standalone web UI, CLI, third-party integrations) need a
-stable interface they can code against without tight coupling to APME's
-release cycle.
+---
 
-**Principle: the engine drives the pace; consumers must stay current.** APME
-should not carry indefinite backward compatibility burden. The contract
-gives consumers a clear deprecation window and migration path, but the
-obligation is on consumers to upgrade — not on APME to maintain old API
-versions forever.
+## Section 4 — Productization Work Streams
 
-**Why standards-based:** APME will have an unknown number of consumers —
-Portal, standalone web UI, CLI, GitHub integrations, and potentially
-third-party tooling we don't control. We cannot rely on direct
-communication channels (emails, Slack messages) to reach all of them.
-Standards-based HTTP headers are the only mechanism that reaches every
-consumer automatically, in-band, on every request. Existing HTTP client
-libraries, API gateways, and monitoring tools already understand these
-headers — consumers don't need custom parsing logic to detect deprecation.
+### 4.1 — Container Images & CI
 
-#### Deprecation lifecycle
+**Current state — CI (`container-images.yml`):** publishes **10 images** to GHCR:
 
-The approach **must** use the IETF standards:
+1. `apme-base`
+2. `apme-primary`
+3. `apme-native`
+4. `apme-opa`
+5. `apme-ansible`
+6. `apme-galaxy-proxy`
+7. `apme-gitleaks`
+8. `apme-gateway`
+9. `apme-cli`
+10. `apme-ui`
 
-- **[RFC 9745](https://www.rfc-editor.org/rfc/rfc9745.html)** —
-  `Deprecation` response header: signals a resource is deprecated, with
-  a timestamp of when deprecation took/takes effect.
-- **[RFC 8594](https://www.rfc-editor.org/rfc/rfc8594.html)** — `Sunset`
-  response header: signals when the resource will become unresponsive
-  (the hard cutoff date).
-- **`Link` header** with `rel="successor-version"` and
-  `rel="deprecation"` — points consumers to the replacement endpoint and
-  migration documentation.
+**Local Podman build (`tox -e build`):** additionally builds `apme-collection-health` and `apme-dep-audit` (11 application images + base). Abbenay is pulled from `ghcr.io/redhat-developer/abbenay`.
 
-```
-HTTP/1.1 200 OK
-Deprecation: Sat, 01 Nov 2026 00:00:00 GMT
-Sunset: Sun, 01 May 2027 00:00:00 GMT
-Link: </api/v2/projects>; rel="successor-version",
-      </docs/migrate/v1-to-v2>; rel="deprecation"
-```
+**Target state — CI:** **12 service images** in the publish matrix by adding:
 
-Implement as FastAPI middleware — checks request path version and injects
-headers automatically. No per-endpoint logic needed. Responses continue
-to work normally during the deprecation window; the headers are metadata
-for SDK tooling, monitoring, and observant developers.
+- `apme-collection-health` (`containers/collection-health/Dockerfile`)
+- `apme-dep-audit` (`containers/dep-audit/Dockerfile`)
 
-| Phase | Duration | Behavior |
-|-------|----------|----------|
-| **Active** | Indefinite | Normal support, bug fixes, improvements |
-| **Deprecated** | 1–3 months (internal consumers) | `Deprecation` + `Sunset` headers on every response; migration docs published; consumers must begin migration |
-| **Sunset** | 2–4 weeks | `410 Gone` returned with `Link` to migration guide |
-| **Removed** | — | Endpoint deleted, docs archived |
+| Image | Track A | Track B | CI today | CI target |
+|-------|---------|---------|----------|-----------|
+| primary | ✓ | ✓ | ✓ | ✓ |
+| native | ✓ | ✓ | ✓ | ✓ |
+| opa | ✓ | ✓ | ✓ | ✓ |
+| ansible | ✓ | ✓ | ✓ | ✓ |
+| galaxy-proxy | ✓ | ✓ | ✓ | ✓ |
+| collection-health | ✓ | ✓ | ✗ | ✓ |
+| dep-audit | ✓ | ✓ | ✗ | ✓ |
+| gitleaks | opt | opt | ✓ | opt |
+| gateway | proxy | full | ✓ | ✓ |
+| ui | ✗ | ✓ | ✓ | ✓ (Track B only) |
+| cli | ✓ | ✓ | ✓ | ✓ |
+| abbenay | ✓ | ✓ | external | external |
 
-#### Consumer obligations
+**CLI packaging gap:** PyPI package `apme-engine` and `apme-cli` container exist, but there is no productized RPM/bootc artifact path aligned with Portal Operator delivery. Track A needs a defined CLI artifact policy (packaging table, Section 2).
 
-Any team or system integrating with the APME Gateway API accepts these
-responsibilities. These are not suggestions — they are requirements for
-supported integration:
+### 4.2 — Security Hardening
 
-1. **Monitor deprecation headers.** Consumers must check for `Deprecation`
-   and `Sunset` headers in every response. Logging or alerting on their
-   presence should be part of the consumer's standard observability.
-2. **Test for deprecation.** Consumer CI/CD pipelines should include a test
-   that fails if responses from APME contain `Deprecation` or `Sunset`
-   headers, forcing the team to acknowledge and plan migration.
-3. **Migrate within the deprecation window.** Once `Deprecation` headers
-   appear, consumers have the advertised window (1–3 months for internal
-   consumers) to migrate to the successor version. APME will not extend
-   the window for consumers who ignored the headers.
-4. **Handle `410 Gone` gracefully.** After the `Sunset` date, deprecated
-   endpoints return `410 Gone`. Consumer applications must handle this
-   status code — displaying a meaningful error to users, not crashing.
-5. **Validate against the published OpenAPI spec.** Consumers should
-   generate or validate their client code against the published OpenAPI
-   spec for their target API version. Do not rely on undocumented response
-   fields or behaviors.
-6. **No pinning to old versions indefinitely.** APME does not guarantee
-   perpetual support for any API version. Consumers that cannot keep pace
-   with the deprecation lifecycle must raise this as a product requirement
-   — not silently ignore deprecation headers and break at sunset.
+| Item | Status | Action |
+|------|--------|--------|
+| Non-root containers (`USER` in Dockerfiles) | **Missing** — no `USER` directive in any `containers/*/Dockerfile` | A12 / Phase 2 — add non-root user to all images |
+| Secret redaction in logs | Partial | Audit all services for `[REDACTED]` compliance |
+| SBOM generation | CI | Extend to collection-health and dep-audit images |
+| Image signing | Open | Cosign/sigstore on release tags |
+| Dependency scanning | CI | `tox -e security` / lean-ci gates |
+| Network policies (K8s) | Helm | Document NetworkPolicy for Track B |
+| Rate limiting | Not implemented | A11 — `APME_RATE_LIMIT` on Gateway |
 
-These obligations will be documented in the API consumer guide and
-referenced in the OpenAPI spec description.
+### 4.3 — Authentication
 
-#### Work items
+- **Track A:** Implement A1 service-token middleware; Helm secret injection; disable auth only via explicit `APME_AUTH_DISABLED` for dev.
+- **Track B:** Implement ADR-038 bearer validation for `/api/v1/*` machine consumers.
+- **Deliverables:** ADR for Portal service-token model (D-01); ADR-038 implementation tasks.
 
-| Item | Current State | Work Needed |
-|------|---------------|-------------|
-| URL versioning | All routes under `/api/v1` | Foundation exists; no changes needed |
-| OpenAPI spec | FastAPI auto-generates from code; not published as artifact | Publish versioned OpenAPI spec (JSON/YAML) as release artifact; all consumers validate against it |
-| Stability guarantee | None — any commit can change the API shape | ADR defining API stability policy: what constitutes a breaking change, deprecation timeline, v1 support window |
-| Deprecation middleware | No mechanism | FastAPI middleware: inject `Deprecation` / `Sunset` / `Link` headers for deprecated API versions |
-| Changelog | No API-specific changelog | Track breaking vs non-breaking changes per release; include in release notes |
-| Contract testing | No consumer-driven contract tests | Pact or similar to verify consumer integrations (Portal, standalone UI, CLI) don't break on APME upgrades |
-| SDK / client library | Consumers code directly against REST | Consider a thin Python/TypeScript client generated from OpenAPI spec for Portal, CLI, and third-party use |
+### 4.4 — API Versioning
 
-### 4.5 Scaling & Performance
+- Adopt [RFC 9745](https://www.rfc-editor.org/rfc/rfc9745.html) (Deprecation header) and [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594.html) (Sunset header) as FastAPI middleware on Gateway REST.
+- Version prefix: `/api/v1/` (current); sunset headers on breaking changes.
+- WebSocket session endpoint `/api/v1/ws/session` versioned with REST (Track B).
+- Portal proxy mode exposes a reduced surface (`POST /scan`, `GET /scan/{id}/events`, etc.) — versioning applies to both modes.
+- **Deliverable:** API contract document; cross-ref PR #351 / this plan §4.4.
 
-| Item | Current State | Work Needed |
-|------|---------------|-------------|
-| Load testing | No infrastructure | k6 or locust suite against Gateway REST + FixSession gRPC |
-| Baseline metrics | Per-scan diagnostics (`engine_total_ms`, per-rule timing) | Establish SLA baselines (e.g., 1000-task project < 30s) |
-| HPA | Helm template exists (disabled) | Enable and tune with load test data |
-| Horizontal scaling | ADR-012: scale engine pods as unit | Validate with concurrent scan load |
-| Gateway DB | SQLite (single-writer) | **Decision needed:** move to PostgreSQL now, or keep SQLite for standalone and add PostgreSQL as a production option? See Section 6. |
-| DB migrations | No migration tooling exists (no Alembic, no versioned schema) | **Gap:** schema changes today silently break existing databases. Need Alembic (or equivalent) with versioned migrations before any production release. |
+### 4.5 — PostgreSQL Migration
 
-### 4.6 Ownership Model
+**Decision:** Upstream Track B uses PostgreSQL for production (see Section 9). SQLite remains dev-only.
 
-#### DevTools team — platform engineering
-
-The DevTools team will own the APME platform codebase: engine, gateway,
-validators (framework and execution), deployment artifacts, CI/CD, and
-release process. They own the **how** — the machinery that loads projects,
-runs validators, serves results, and deploys.
-
-| Item | Work Needed |
+| Item | Requirement |
 |------|-------------|
-| Codebase walkthrough | Architecture, service boundaries, ADR index, test strategy |
-| Bug triage integration | APME components in team's Jira/Bugzilla; integrate into existing triage cadence |
-| CODEOWNERS | Assign DevTools as owners for `src/apme_engine/`, `src/apme_gateway/`, validators (framework), proto, `deploy/`, CI |
-| CI ownership | Team understands and can modify GitHub Actions workflows, tox environments |
-| Development workflow | Team comfortable with branch strategy, PR process, conventional commits |
-| Contribution ramp | First bugs/features assigned to build familiarity before full ownership |
-| Release process | Team owns version bumps, CHANGELOG, tagging, image publishing |
+| **Alembic** | Required — schema migrations versioned in repo |
+| **Multi-replica Gateway** | Enabled only after PostgreSQL — SQLite blocks HA |
+| **Connection pooling** | SQLAlchemy async + pool config in Helm |
+| **Portal proxy mode** | No APME database — Gateway is stateless for persistence |
+| **Current code** | `GatewayConfig.db_path` / `APME_DB_PATH` only — no `APME_DATABASE_URL` yet |
 
-#### Rules & policy — community of practice
+### 4.6 — Ownership Model
 
-The prescriptive ruleset (what APME checks and why) must be owned
-collectively by people closer to the users — the community of practice,
-the business unit, and the broader Ansible engineering team. DevTools
-maintains the validator framework and rule execution machinery, but does
-not unilaterally author policy rules.
+**Status: PROPOSED — not decided**
 
-This is a pattern we've used before and it needs a formal governance model:
+| Role | Proposed owner | Notes |
+|------|----------------|-------|
+| Engine validators | APME platform engineering | |
+| Gateway/API | APME platform engineering | |
+| Portal integration | Portal team (ansible-rhdh-plugins) | ANSTRAT-2222 |
+| UI (Track B) | APME community / platform | Retained for upstream |
+| Helm chart / Operator subchart | Integration / release engineering | |
+| Security response | Shared on-call | |
+| Custom rules (Phase 2) | Joint — Portal git policy + APME OPA merge | ADR required |
 
-| Item | Work Needed |
-|------|-------------|
-| Rule governance model | Define who can propose, review, approve, and merge new rules |
-| Rule ownership by category | Map L/M/R/P/SEC categories to responsible groups (e.g., Risk/Policy rules owned by platform team, Lint/Modernize by community) |
-| Contribution workflow | External rule contributors follow a defined process: proposal → review by domain experts → implementation by contributor or DevTools → merge |
-| Rule review board | Standing group (community of practice + BU + Ansible engineering) that reviews rule proposals, severity assignments, and deprecations |
-| Plugin boundary (ADR-042) | Third-party/org-specific rules go through the Plugin service — not into the built-in ruleset — giving teams autonomy without gating on DevTools |
-| Rule catalog maintenance | Published catalog with rationale, references, and ownership metadata per rule |
-| Feedback loop | Portal/CLI users can flag false positives or request new rules; routed to rule owners, not DevTools backlog |
+Requires governance ADR or RACI in `.sdlc/context/`.
 
-### 4.7 Dependency Review
+### 4.7 — Dependency Management
 
-| Category | Current Dependencies | Review Action |
-|----------|---------------------|---------------|
-| Python runtime | grpcio, protobuf, fastapi, uvicorn, ruamel.yaml, httpx, ansible-core | License audit; legal review |
-| External binaries | OPA 1.17.1, Gitleaks 8.30.1 | License compatibility; upstream support lifecycle |
-| AI provider | Abbenay (`ghcr.io/redhat-developer/abbenay`) | Internal dependency; version pinning strategy |
-| Frontend | React, PatternFly, Vite, Node 22 | Standard UI stack; confirm PatternFly version |
-| Container base | Debian bookworm-slim | UBI migration path for downstream |
+- Pin production dependencies in `pyproject.toml` / lockfile.
+- Vendored ARI engine (ADR-003) — no pip drift.
+- Galaxy Proxy collection versions pinned per release.
+- Document upgrade policy for Ansible-core compatibility.
+- Air-gapped mode (A5): disable PyPI fallback, optional dep-audit skip — **proposed**, requires ADR.
 
-### 4.8 Repo & Process Hardening
+### 4.8 — Repository Hardening
 
-| Item | Current State | Work Needed |
-|------|---------------|-------------|
-| CI security gates | Unit + integration + lint; no SAST/container scan | Add CodeQL, pip-audit, container scan to CI |
-| Pre-commit hooks | ruff, mypy, pydoclint, uv-lock | Add gitleaks to pre-commit (currently manual) |
-| Branch protection | Single-branch `main` (ADR-016) | Verify CODEOWNERS, required reviews, status checks |
-| Vulnerability disclosure | SECURITY.md with private reporting | Confirm GitHub Security Advisories enabled |
-| Industry gap analysis | `.sdlc/research/industry-gap-analysis.md` exists | Use as checklist; close gaps systematically |
+- Branch protection; required `tox -e lint` + `tox -e unit` on PRs.
+- Signed commits encouraged; provenance attestations on container images.
+- `.github/workflows/` review per lean-ci skill.
+- Secret scanning (Gitleaks in CI meta).
+- prek hooks: ruff, mypy, pydoclint on commit.
 
-### 4.9 Product Requirements from Craig
+### 4.9 — Craig Requirements (P0 Alignment)
 
-Craig should author a formal requirement covering:
+Portal stakeholder requirements traced to PR #352 / ANSTRAT-2222:
 
-- What "APME in Portal" means from a product owner perspective
-- User personas and workflows in Portal context
-- Which APME capabilities are P0 vs P1 for Portal launch
-- Integration points with existing Portal services
-- Success metrics and acceptance criteria
-- Use `/req-new` or `/prd-import` to formalize as SDLC artifact
+| ID | Requirement | Priority | Status |
+|----|-------------|----------|--------|
+| CR-1 | Gateway proxy mode without APME DB | P0 | Spec §8 A2 |
+| CR-2 | Tarball scan — no SCM credentials in APME | P0 | Spec §8 A3 |
+| CR-3 | Galaxy credentials per-request from Portal | P0 | Spec §8 Galaxy flow |
+| CR-4 | Git-backed collections (phase 1: Hub only) | P0 | Spec §8 |
+| CR-5 | Service-token auth on Gateway | P0 | Spec §8 A1 |
+| CR-6 | Validator scope (CH + DA required) | P0 | **Decided** §4.10 |
+| CR-7 | Non-root containers | P0 | Spec §8 A12 |
+| CR-8 | Observability `/metrics` | P1 | Spec §8 A10 |
 
----
+Full Craig P0 scope sign-off remains **open** (D-06).
 
-## 5. Additional Considerations
+### 4.10 — Validator Scope Alignment Checklist
 
-Items not in the original list but important for productization:
+Align code, deployment manifests, and docs with **Collection Health + Dep Audit required; Gitleaks optional**.
 
-1. **Observability** — No Prometheus metrics endpoint, no OpenTelemetry
-   traces, no structured log aggregation. Production needs `/metrics` on
-   Gateway and engine.
-
-2. **Rate limiting** — Gateway has no request throttling. If exposed through
-   Portal, needs abuse protection.
-
-3. **Multi-tenancy / data isolation** — SQLite is single-tenant. Portal
-   implies multiple users/orgs. Decision needed: one APME instance per
-   tenant, or shared instance with row-level isolation (requires
-   PostgreSQL).
-
-4. **Operator documentation** — Admin guide, configuration reference,
-   troubleshooting guide. Current docs are developer-focused.
-
-5. **Feature flags** — No feature flag system. Portal rollout likely needs
-   staged enablement.
-
-6. **Graceful degradation** — What happens when APME engine is down? Portal
-   needs a degraded UX, not a 500.
-
-7. **Accessibility (a11y)** — PatternFly helps, but no a11y audit has been
-   performed.
-
-8. **Telemetry** — No opt-in usage analytics for understanding adoption.
+- [ ] Remove `collection_health` and `dep_audit` from `_OPTIONAL_SERVICES` in `launcher.py` (or promote to `_DEFAULT_PORTS` / required set)
+- [ ] Update CLI daemon default: start CH + DA without `include_optional`
+- [ ] Helm chart: CH + DA enabled by default; Gitleaks behind `optional.enabled`
+- [ ] Podman `pod.yaml`: CH + DA already present — verify Primary env vars always set
+- [ ] bootc image: include CH + DA units
+- [ ] CI: add `collection-health` and `dep-audit` to `container-images.yml` matrix
+- [ ] Health-check aggregation in Primary includes CH + DA endpoints
+- [ ] `apme health-check` reports CH + DA as required services
+- [ ] Documentation: `architecture.md`, `deployment.md`, `CLAUDE.md` invariant 12
+- [ ] ADR-012 note: engine pod replicates as unit including CH + DA
 
 ---
 
-## 6. Open Decisions
+## Section 5 — Additional Considerations
 
-| # | Decision | Owner | Blocker for |
-|---|----------|-------|-------------|
-| 1 | Auth model: AAP proxy vs self-contained vs platform JWT | Architect + Craig | Any multi-user deployment |
-| 2 | Multi-tenancy: per-tenant instance vs shared + row isolation | Architect | Portal deployment |
-| 3 | Base image: stay Debian slim or migrate to UBI | DevTools / Konflux | Downstream build |
-| 4 | Database: move to PostgreSQL now, or dual-mode (SQLite standalone / PostgreSQL production)? SQLite is single-writer — blocks multi-replica Gateway and concurrent Portal use. ADR-029 documents a PostgreSQL path via `APME_DATABASE_URL` but it's unvalidated. Alembic migrations don't exist yet. | Architect | HA Gateway, multi-tenancy, Portal scale |
-| 5 | Craig's P0 feature set for Portal launch | Craig | Scope and timeline |
-| 6 | Rule governance: who proposes, reviews, approves prescriptive rules | Community of practice + BU + Ansible eng | Rule quality and relevance |
-| 7 | DevTools ownership scope: engine + gateway + deploy + CI + release | DevTools lead + current team | Codebase handoff |
-| 8 | DB migration tooling: adopt Alembic, define schema versioning strategy, test upgrade path | DevTools | Any schema change post-release |
-| 9 | API stability contract: define v1 support window, breaking change policy, deprecation timeline for all consumers | Architect + DevTools | Portal, standalone UI, CLI, third-party integrations |
+### ADR-042 — Third-Party Plugin Services
+
+Custom/organization-specific rules ship via the **Plugin service** container (ADR-042), not volume-mounted rules into built-in validators (invariant 14).
+
+- Portal Phase 2 custom rules (PR #352) may use **ephemeral Rego merge** at scan time — **proposed**; requires ADR distinct from ADR-042 plugin sidecar.
+- Built-in validator bundles remain closed; Plugin sidecar is optional enterprise path.
+- Plan Plugin image in CI when Portal custom-rules phase 2 lands.
+
+### ADR-049 — Gateway Embedded in Local Daemon
+
+ADR-049 status: **Accepted** (2026-04-01). **Implementation: not done** — `launcher.py` has no Gateway HTTP/gRPC startup; Gateway remains pod-level only.
+
+- `apme sbom` and future REST-backed CLI commands require Gateway reachability.
+- **Separate work stream from Portal Track A** — does not block proxy mode.
+- Deliverable: embed FastAPI + ReportingServicer + SQLite in daemon per ADR-049.
+
+### Feature Flags
+
+| Flag | Purpose | Values |
+|------|---------|--------|
+| `APME_GATEWAY_MODE` | Gateway operating mode | `full` (Track B default), `proxy` (Track A) |
+| `APME_DATABASE_MODE` | Persistence backend | `bundled`, `external`, `none` (proxy) |
+| `APME_DATABASE_URL` | PostgreSQL DSN | `postgresql+asyncpg://...` |
+| `APME_DB_PATH` | SQLite file path | **Deprecated** for production — dev/local only (`GatewayConfig` default `/data/apme.db`) |
+| `APME_AUTH_DISABLED` | Skip Gateway auth | `true` dev only — not for production |
+| `APME_AIR_GAPPED` | Air-gapped deployments | `true` / `false` (A5, proposed) |
+| `APME_RATE_LIMIT` | Gateway throttling | e.g. `100/minute` (A11, proposed) |
+
+Gateway reads `APME_GATEWAY_MODE` at startup to enable/disable local SQLAlchemy init, Reporting gRPC server, full REST surface, and Portal proxy routes.
 
 ---
 
-## 7. Suggested Priority Sequence
+## Section 6 — Decision Matrix
+
+### Open Decisions
+
+| ID | Topic | Options | Blocker for |
+|----|-------|---------|-------------|
+| D-01 | **Auth model (Portal)** | Service token list vs mTLS vs OAuth client credentials | Track A GA |
+| D-02 | **Packaging** | See Section 2 table | Release pipeline |
+| D-03 | **Gateway modes** | Runtime flag only vs separate proxy image build | Helm/CI complexity |
+| D-04 | **PostgreSQL topology** | Bundled subchart vs external RDS vs customer-managed | Track B HA |
+| D-05 | **SQLite migration strategy** | Big-bang Alembic init vs export/import tool vs dual-run period | Existing dev adopters |
+| D-06 | **Craig P0 scope** | Full A1–A12 vs phased MVP (A1,A3,A12,A2) | Portal milestone |
+| D-07 | **Governance / ownership** | Section 4.6 RACI | Support model |
+| D-08 | **DevTools** | In-cluster vs local-only CLI | Developer UX |
+| D-09 | **Alembic ownership** | Gateway team vs shared platform | Schema change velocity |
+| D-10 | **API contract** | OpenAPI publish location, deprecation policy, consumer SLA | Integrators |
+
+### Decided
+
+| ID | Decision | Date | Reference |
+|----|----------|------|-----------|
+| DC-01 | **Validator scope:** Collection Health + Dep Audit required; Gitleaks optional | 2026-06-24 | §4.10 |
+| DC-02 | **Upstream persistence:** PostgreSQL for production Track B | 2026-06-24 | §9, ADR-029 extension |
+| DC-03 | **Dual tracks:** Portal product (Track A) vs upstream standalone (Track B) | 2026-06-24 | §2 |
+| DC-04 | **Portal persistence:** No APME DB in proxy mode — Portal PostgreSQL | 2026-06-24 | §8 A2, PR #352 |
+
+---
+
+## Section 7 — Priority Sequence
+
+### Phase 1 — Foundation (weeks 1–4)
+
+1. Validator scope alignment (4.10) — launcher, Helm, Podman, health-check
+2. Alembic + PostgreSQL migration scaffolding (4.5, §9)
+3. Auth ADR — bearer for Track B (ADR-038); draft Portal service-token ADR (4.3, D-01)
+
+### Phase 2 — Hardening (weeks 5–8)
+
+4. Security — `USER` in all Dockerfiles (4.2, A12)
+5. CI images — collection-health + dep-audit in `container-images.yml` (4.1)
+6. Dependency and repo hardening (4.7, 4.8)
+
+### Phase 3 — Product Integration (weeks 9–12)
+
+7. Portal A1–A3 — auth middleware, tarball `POST /scan`, Galaxy per-request credentials
+8. Portal A2 — Gateway proxy mode behind `APME_GATEWAY_MODE=proxy`
+9. Packaging decisions (D-02) — Operator subchart, image pins, CLI artifact
+10. API contract + RFC 9745/8594 middleware (4.4, A9)
+
+### Phase 4 — Scale & Handoff (weeks 13+)
+
+11. HA Gateway — multi-replica after PostgreSQL (4.5)
+12. Load testing — engine pod at Portal scale (100+ repos, A4 PVC sizing)
+13. Observability — Prometheus `/metrics`, structured logging (A10)
+14. Rate limiting (A11), air-gapped mode (A5), rule catalog API (A6)
+15. Ownership/governance sign-off (4.6) and operator handoff documentation
+16. ADR-049 daemon Gateway embedding (CLI track — parallel, not Portal-blocking)
+
+---
+
+## Section 8 — Portal Integration Requirements (A1–A12)
+
+Source: [PR #352](https://github.com/ansible/apme/pull/352) — `.sdlc/research/portal-integration/00-integration-requirements.md`, [ansible-rhdh-plugins PR #676](https://github.com/ansible/ansible-rhdh-plugins/pull/676), [ANSTRAT-2222](https://issues.redhat.com/browse/ANSTRAT-2222).
+
+### Corrections (this plan vs PR #352 draft)
+
+| PR #352 statement | Correction |
+|-------------------|------------|
+| "APME standalone UI is removed" | **UI is removed only for Track A (Portal).** Track B upstream retains standalone UI (:8081). |
+| CLI daemon unchanged | **ADR-049 Gateway-in-daemon is separate work** — not implemented; not required for Portal proxy mode. |
+| Custom rules / air-gapped / rate limit | Marked **proposed** — each requires ADR before implementation. |
+
+### Core Architectural Decisions (Portal)
+
+1. **Portal owns all scan data** — stored in Portal PostgreSQL (`apme_*` tables).
+2. **APME Gateway becomes stateless in proxy mode** — no database, no PVC, thin REST↔gRPC proxy.
+3. **Portal clones repos** — tars content, sends to APME via REST; APME never holds SCM credentials.
+4. **PR creation is Portal-side** — using user's OAuth token, not APME.
+5. **Feature flag:** `APME_GATEWAY_MODE=proxy` (Portal) vs `full` (standalone upstream).
+
+### C4 Context — APME in the Portal Ecosystem
 
 ```
-Phase 1 — Security & Auth Foundation
-├── Auth ADR decision
-├── Non-root containers
-├── CI security gates (CodeQL, pip-audit, container scan)
-├── Dependency / license audit
-└── TLS for production
-
-Phase 2 — Downstream Build
-├── UBI base image evaluation
-├── Konflux pipeline setup
-├── Unified semver strategy
-├── Release SBOM + cosign
-└── Image publish to registry.redhat.io
-
-Phase 3 — Portal Integration
-├── Auth middleware implementation
-├── Ingress / Route configuration
-├── Network policy defaults
-├── PostgreSQL support (if multi-tenant)
-├── Alembic DB migrations (schema versioning + upgrade path)
-├── API stability contract + published OpenAPI spec
-├── Craig's P0 feature set
-└── Consumer contract testing (Portal, standalone UI, CLI)
-
-Phase 4 — Production Readiness & Handoff
-├── Load test suite (k6/locust)
-├── SLA baselines and HPA tuning
-├── Prometheus metrics + Grafana
-├── a11y audit
-├── DevTools codebase walkthrough and first contributions
-├── CODEOWNERS + triage integration for DevTools ownership
-└── Rule governance model: community of practice + BU + Ansible eng
+                     ┌───────────────────────┐
+                     │  Ansible Automation   │
+                     │       Portal          │
+                     │  (owns all data)      │
+                     │  (clones repos)       │
+                     └───────────┬───────────┘
+                                 │
+                    REST: POST /scan (tarball upload)
+                    REST: GET /scan/{id}/events (SSE)
+                    REST: GET /rules
+                    REST: GET /health
+                                 │
+                     ┌───────────▼───────────┐
+                     │   APME Gateway        │
+                     │   (STATELESS proxy)   │
+                     │   No DB, no PVC       │
+                     │   REST :8080          │
+                     └───────────┬───────────┘
+                                 │
+                          gRPC (internal)
+                                 │
+                     ┌───────────▼───────────┐
+                     │   APME Engine Pod     │
+                     │  Primary + Validators │
+                     │  + Galaxy Proxy       │
+                     └───────────────────────┘
 ```
+
+### Gap Table (A1–A12)
+
+| ID | Requirement | Priority | Current | Gap | Effort |
+|----|-------------|----------|---------|-----|--------|
+| **A1** | Gateway auth middleware (Bearer service token) | Critical | No auth middleware | Implement `verify_service_token`; Helm secret | Small |
+| **A2** | Gateway stateless proxy mode | High | Full Gateway with SQLite + UI | `APME_GATEWAY_MODE=proxy`; remove persistence paths | Medium (1–2 sprints) |
+| **A3** | Tarball scan endpoint `POST /scan` | High | WS upload / project CRUD model | New scan router + tarball service + FixSession proxy | Medium (1 sprint) |
+| **A4** | PVC sizing for scale | Medium | 10Gi defaults | sessions 50Gi, proxy-cache 20Gi; no gateway PVC in proxy | Small |
+| **A5** | Air-gapped mode flag | Medium | Not implemented | `APME_AIR_GAPPED=true` behavior | Small (proposed ADR) |
+| **A6** | Rule catalog API (stateless) | Medium | Partial via Primary | `GET /rules` from in-memory catalog | Small |
+| **A7** | *(reserved / Portal-side)* | — | — | Portal backend plugin owns CRUD | — |
+| **A8** | *(reserved / Portal-side)* | — | — | Portal SQL for trends, dashboard | — |
+| **A9** | API versioning (RFC 9745/8594) | High | Not implemented | Deprecation + Sunset middleware | Medium |
+| **A10** | Observability (Prometheus + structured logging) | High | Limited | `/metrics` endpoint, JSON logs | Medium |
+| **A11** | Rate limiting | Medium | Not implemented | `APME_RATE_LIMIT` | Small (proposed ADR) |
+| **A12** | Non-root containers | High | Documented only | `USER` in all Dockerfiles | Small |
+
+### A2 — Proxy Mode Details
+
+When `APME_GATEWAY_MODE=proxy`:
+
+**Remove / skip:**
+
+- SQLite database initialization, SQLAlchemy models, Alembic migrations
+- gRPC Reporting servicer (:50060) — Portal stores results directly
+- Persistence-dependent REST: projects CRUD, dashboard, activity, trends, settings, notifications, suppressions
+- UI deployment (:8081) — **Track A only**
+
+**Keep (stateless):**
+
+- `GET /health` — probes Primary + validators via gRPC
+- `GET /rules` — from Primary in-memory catalog (A6)
+- SSE: `GET /scan/{id}/events` — proxies gRPC SessionEvents
+- `POST /scan/{id}/approve`, `POST /scan/{id}/cancel`
+- Bearer auth middleware (A1)
+
+**Add:**
+
+- `POST /scan` — tarball upload (A3)
+
+**Files (from PR #352):**
+
+- `src/apme_gateway/app.py` — conditional startup
+- `src/apme_gateway/api/router.py` — proxy route registration
+- `deploy/helm/apme/values.yaml` — `gateway.mode: proxy`
+- Remove in proxy chart overlay: `gateway-pvc.yaml`, reporting service, `ui-deployment.yaml`
+
+### A3 — Tarball Scan Endpoint
+
+**Endpoint:** `POST /scan`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `content` | `UploadFile` | tar.gz of Ansible project |
+| `options` | JSON form string | `ansible_core_version`, `collection_specs`, `rule_configs` |
+| `galaxy_servers` | JSON form string | `[{name, url, token, auth_url}]` per-scan |
+| `action` | form string | `check` or `remediate` |
+
+**Flow:**
+
+1. Extract tarball to temp directory
+2. Discover Ansible files
+3. Configure Galaxy Proxy with per-request credentials
+4. Run `FixSession` via Primary gRPC
+5. Cleanup temp dir
+6. Return violations, proposals, patches, diagnostics, summary
+
+**SSE progress:** `GET /scan/{scan_id}/events`  
+**Approvals:** `POST /scan/{scan_id}/approve`
+
+**New modules (proposed):**
+
+- `src/apme_gateway/api/scan_router.py`
+- `src/apme_gateway/services/tarball_service.py`
+- `src/apme_gateway/services/scan_proxy.py`
+
+### API Surface — Before vs After (Proxy Mode)
+
+**Removed (Portal backend plugin owns):**
+
+| Endpoint | Previous purpose | New owner |
+|----------|------------------|-----------|
+| CRUD `/projects` | Project management | Portal `apme_projects` |
+| `GET /dashboard/*` | Aggregate metrics | Portal SQL |
+| `GET /activity/*` | Scan history | Portal `apme_scans` |
+| `GET /violations/top` | Top rules | Portal SQL |
+| `GET /stats/*` | Remediation rates | Portal SQL |
+| CRUD `/settings/galaxy-servers` | Galaxy config | Portal `apme_galaxy_servers` |
+| `POST /suppressions` | Rule suppressions | Portal `apme_rule_overrides` |
+| `GET /notifications/*` | Notifications | Portal notification service |
+| `GET /projects/{id}/trend` | Trends | Portal SQL |
+| `GET /projects/{id}/dependencies` | SBOM | Portal (post-scan store) |
+
+**Kept (stateless proxy):**
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /scan` | **NEW** — tarball upload, trigger scan |
+| `GET /scan/{id}/events` | SSE — proxy SessionEvents |
+| `POST /scan/{id}/approve` | Forward proposal approvals |
+| `POST /scan/{id}/cancel` | Cancel running scan |
+| `GET /rules` | Rule catalog (A6) |
+| `GET /health` | Health check |
+
+**Track B full mode retains** `/api/v1/ws/session`, project CRUD, dashboard, and full persistence API.
+
+### A4 — PVC Sizing (Portal Scale)
+
+```yaml
+persistence:
+  sessions:
+    size: 50Gi        # up from 10Gi — 100+ repos
+  proxyCache:
+    size: 20Gi        # up from 10Gi
+  # gateway PVC REMOVED in proxy mode
+```
+
+### Galaxy / Automation Hub Credential Flow
+
+```
+Portal (owns credentials)                    APME (stateless)
+┌─────────────────────────┐                 ┌─────────────────────────┐
+│ apme_galaxy_servers     │                 │ Gateway (no DB)         │
+│ + K8s Secrets for tokens│  POST /scan     │                         │
+│                         │  galaxy_servers │  → Galaxy Proxy admin   │
+│ ansible.rhaap.baseUrl   │  ────────────►  │  temp ansible.cfg       │
+│ ansible.rhaap.token     │                 │  ephemeral per-scan     │
+└─────────────────────────┘                 └─────────────────────────┘
+```
+
+**Sources in Portal:**
+
+1. Existing Portal config: `ansible.rhaap.baseUrl` + `ansible.rhaap.token` (AAP admin token, org-scoped)
+2. Optional additional servers → `apme_galaxy_servers` table
+3. Default community Galaxy fallback (no token)
+
+**Key points:**
+
+- Tokens in K8s Secrets, not DB plaintext
+- Portal injects tokens per scan request
+- APME never persists Galaxy credentials
+- Galaxy Proxy writes temp `ansible.cfg`, downloads collections, deletes temp file
+
+### Git-Based Collection Dependencies
+
+| Phase | Scope |
+|-------|-------|
+| **Phase 1** | Collections must be on Galaxy or Automation Hub. `type: git` in `requirements.yml` **not supported** in Portal scans. Aligns with AAP 2.5+ Hub model. |
+| **Phase 2** | Portal passes admin SCM token in scan request (`GH_TOKEN` for `ansible-galaxy`), **or** Portal pre-builds git collections and includes tarball in upload. APME stays credential-free in preferred path. |
+
+### Custom Rules — Phase 2 (Proposed — Requires ADR)
+
+- Policy-as-code in git; Portal clones policy repo, passes `custom_policies: [{name, rule_id, rego_source}]` in `POST /scan`
+- Gateway writes temp Rego alongside built-in OPA bundle; OPA loads merged bundle
+- Custom rule IDs: `P100+` prefix (distinct from built-in `P001–P004`)
+- **Phase 1:** per-project `.apme/rules.yml` and `rule_configs` in `ScanOptions` already supported — no git policy merge yet
+
+### Helm Chart — Proxy Mode Overlay
+
+```yaml
+gateway:
+  mode: proxy
+  replicas: 2                      # stateless — scale freely
+  resources:
+    requests: { cpu: 250m, memory: 256Mi }
+    limits: { cpu: 500m, memory: 512Mi }
+  auth:
+    enabled: true
+    serviceTokenSecret: apme-service-token
+
+# Remove in proxy overlay:
+# - gateway-pvc.yaml
+# - gateway-reporting-service.yaml (:50060)
+# - ui-deployment.yaml / ui-service.yaml
+```
+
+### bootc (Proxy / Product)
+
+APME container volumes:
+
+- `/sessions` — venv session storage
+- `/cache` — Galaxy Proxy wheel cache
+- **No Gateway DB volume**
+
+### Implementation Order (Portal — from PR #352)
+
+1. **A1** — Gateway auth (security prerequisite)
+2. **A3** — Tarball scan endpoint
+3. **A12** — Non-root containers
+4. **A2** — Gateway stateless refactor (`APME_GATEWAY_MODE=proxy`)
+5. **A9** — API versioning contract
+6. **A10** — Observability
+7. **A4** — PVC sizing
+8. **A5** — Air-gapped mode
+9. **A6** — Rule catalog API
+10. **A11** — Rate limiting
+
+### What Stays Unchanged
+
+- Primary gRPC / `FixSession` protocol
+- All validators (read-only)
+- Galaxy Proxy PEP 503 caching
+- Engine pod architecture (ADR-012 — scale pods, not services)
+- Remediation engine (3-tier model)
+- Rule ID conventions (ADR-008)
+- **Track B** standalone UI, full Gateway, PostgreSQL path
+
+---
+
+## Section 9 — PostgreSQL Migration Plan
+
+### Decision
+
+Upstream Track B production deployments use **PostgreSQL**. SQLite (`APME_DB_PATH`, default `/data/apme.db` in `GatewayConfig`) is **dev/local only** and deprecated for production documentation.
+
+Portal Track A proxy mode: **no APME database** — skip all items below except engine/session volumes.
+
+### Configuration Example
+
+```yaml
+# apme-gateway-config.yaml (Track B full mode)
+gateway:
+  mode: full
+
+database:
+  mode: bundled          # bundled | external | none
+  # bundled: deploy PostgreSQL subchart, auto-wire URL
+  # external: customer supplies APME_DATABASE_URL
+  # none: proxy mode only (Track A)
+  url: ""                # required when mode=external
+  pool_size: 10
+  echo: false
+```
+
+### Environment Variables
+
+| Variable | Description | Status |
+|----------|-------------|--------|
+| `APME_DATABASE_URL` | PostgreSQL DSN (`postgresql+asyncpg://user:pass@host:5432/apme`) | **New — required** (Track B prod) |
+| `APME_DATABASE_MODE` | `bundled`, `external`, or `none` | **New** |
+| `APME_GATEWAY_MODE` | `full` or `proxy` | **New** |
+| `APME_DB_PATH` | SQLite file path | **Deprecated** — maps to `GatewayConfig.db_path` today |
+
+### Portal Proxy Mode Note
+
+When `APME_GATEWAY_MODE=proxy`, set `APME_DATABASE_MODE=none`. Gateway must not create, migrate, or connect to any APME schema. Portal owns `apme_projects`, `apme_scans`, `apme_galaxy_servers`, etc.
+
+### Implementation Checklist
+
+- [ ] `src/apme_gateway/db/` — async engine factory supporting PostgreSQL via `APME_DATABASE_URL`
+- [ ] `src/apme_gateway/config.py` — add `database_url`, `database_mode`, `gateway_mode`; deprecate `db_path` for prod
+- [ ] `pyproject.toml` — add `asyncpg`, `alembic` dependencies
+- [ ] `alembic/` — initial revision from current SQLite models; forward-only migrations
+- [ ] `alembic.ini` + env.py wired to `GatewayConfig`
+- [ ] Helm — PostgreSQL subchart **or** `externalDatabase.*` values; Secret for `APME_DATABASE_URL`
+- [ ] Helm — Gate multi-replica Gateway on `database.mode != none`
+- [ ] Podman — document external PostgreSQL or optional compose sidecar for integration tests
+- [ ] bootc — external PostgreSQL connection or bundled PG unit
+- [ ] **ADR-029 amendment** — PostgreSQL production store; SQLite dev-only
+- [ ] Migration guide — SQLite export → PostgreSQL import (addresses D-05)
+- [ ] Gateway `/health` — DB ping when `database.mode != none`
+- [ ] Remove `APME_DB_PATH` from production Helm values and user-facing docs
+- [ ] CI integration test job with PostgreSQL service container
+
+---
+
+## Section 10 — Follow-Up ADRs and Tasks
+
+| Artifact | Type | Title | Trigger | Phase |
+|----------|------|-------|---------|-------|
+| ADR-055 (proposed) | ADR | Portal Gateway proxy mode (`APME_GATEWAY_MODE`) | A2 implementation | 3 |
+| ADR-056 (proposed) | ADR | Portal service-token authentication | D-01 resolution | 1 |
+| ADR-029-amend | ADR | PostgreSQL production persistence | §9 checklist | 1 |
+| ADR-057 (proposed) | ADR | Required validator set (Collection Health + Dep Audit) | 4.10 completion | 1 |
+| ADR-058 (proposed) | ADR | API versioning — RFC 9745 / RFC 8594 | 4.4 / A9 | 3 |
+| ADR-059 (proposed) | ADR | Portal ephemeral custom Rego policies (Phase 2) | Custom rules scope | 4+ |
+| ADR-049-impl | TASK | Embed Gateway in CLI daemon | ADR-049 accepted, not coded | 4 (parallel) |
+| REQ-005 (proposed) | REQ | Portal product integration (ANSTRAT-2222) | §8 | 3 |
+| TASK-005-01 | TASK | Alembic initial migration + PG engine factory | §9 | 1 |
+| TASK-005-02 | TASK | Promote CH/DA to required in launcher + Helm | 4.10 | 1 |
+| TASK-005-03 | TASK | CI publish collection-health + dep-audit images | 4.1 | 2 |
+| TASK-005-04 | TASK | Gateway auth middleware (A1) | §8 | 3 |
+| TASK-005-05 | TASK | Tarball `POST /scan` endpoint (A3) | §8 | 3 |
+| TASK-005-06 | TASK | `USER` directive all Dockerfiles (A12) | 4.2 | 2 |
+| TASK-005-07 | TASK | Prometheus `/metrics` on Gateway (A10) | §8 | 4 |
+| DR-xxx | DR | Packaging registry / Operator ownership | D-02 | 3 |
+| DR-xxx | DR | SQLite → PostgreSQL migration strategy | D-05 | 1 |
 
 ---
 
 ## References
 
-| Document | Path |
-|----------|------|
-| Architecture | `.sdlc/context/architecture.md` |
-| Deployment | `.sdlc/context/deployment.md` |
-| Helm chart | `deploy/helm/apme/` |
-| ADR index | `.sdlc/adrs/README.md` |
-| Security policy | `SECURITY.md` |
-| Operating procedures | `SOP.md` |
-| Industry gap analysis | `.sdlc/research/industry-gap-analysis.md` |
+| Reference | Location / Link |
+|-----------|-----------------|
+| Architecture | [`.sdlc/context/architecture.md`](architecture.md) |
+| Deployment | [`.sdlc/context/deployment.md`](deployment.md) |
+| ADR-001 gRPC | [`.sdlc/adrs/ADR-001-grpc-communication.md`](../adrs/ADR-001-grpc-communication.md) |
+| ADR-012 Scale pods | [`.sdlc/adrs/ADR-012-scale-pods-not-services.md`](../adrs/ADR-012-scale-pods-not-services.md) |
+| ADR-020 Stateless engine | [`.sdlc/adrs/ADR-020-stateless-engine.md`](../adrs/ADR-020-stateless-engine.md) |
+| ADR-029 Web Gateway | [`.sdlc/adrs/ADR-029-web-gateway-architecture.md`](../adrs/ADR-029-web-gateway-architecture.md) |
+| ADR-037 Project-centric UI | [`.sdlc/adrs/ADR-037-project-centric-ui-model.md`](../adrs/ADR-037-project-centric-ui-model.md) |
+| ADR-038 Public data API | [`.sdlc/adrs/ADR-038-public-data-api.md`](../adrs/ADR-038-public-data-api.md) |
+| ADR-042 Plugin services | [`.sdlc/adrs/ADR-042-third-party-plugin-services.md`](../adrs/ADR-042-third-party-plugin-services.md) |
+| ADR-049 Gateway in daemon | [`.sdlc/adrs/ADR-049-gateway-in-daemon.md`](../adrs/ADR-049-gateway-in-daemon.md) |
+| ADR-054 Production deploy | [`.sdlc/adrs/ADR-054-production-deployment.md`](../adrs/ADR-054-production-deployment.md) |
+| DR-008 Data persistence | [`.sdlc/decisions/closed/decided/DR-008-data-persistence.md`](../decisions/closed/decided/DR-008-data-persistence.md) |
+| Portal integration research | [PR #352](https://github.com/ansible/apme/pull/352) |
+| Portal plugins PR 676 | https://github.com/ansible/ansible-rhdh-plugins/pull/676 |
+| ANSTRAT-2222 | https://issues.redhat.com/browse/ANSTRAT-2222 |
+| CI container workflow | [`.github/workflows/container-images.yml`](../../.github/workflows/container-images.yml) |
+| Helm chart | [`deploy/helm/apme/`](../../deploy/helm/apme/) |
+| Launcher | [`src/apme_engine/daemon/launcher.py`](../../src/apme_engine/daemon/launcher.py) |
+| Gateway config | [`src/apme_gateway/config.py`](../../src/apme_gateway/config.py) |
+| RFC 9745 API Versioning | https://www.rfc-editor.org/rfc/rfc9745.html |
+| RFC 8594 Deprecation | https://www.rfc-editor.org/rfc/rfc8594.html |
+| Project constitution | [`CLAUDE.md`](../../CLAUDE.md) |
+| Agent invariants | [`AGENTS.md`](../../AGENTS.md) |
+| User deployment guide | [`docs/guides/DEPLOYMENT.md`](../../docs/guides/DEPLOYMENT.md) |
+
+---
+
+*End of productization plan — draft for review.*

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -163,7 +163,25 @@ decision. Work includes:
 - RBAC model if multi-tenant (or defer to AAP Gateway)
 - API key management for machine consumers (ADR-038)
 
-### 4.4 Scaling & Performance
+### 4.4 API Versioning & Contract
+
+The Gateway REST API is URL-versioned (`/api/v1`) today, which is the right
+foundation. What's missing is the contract and tooling around it — all UI
+consumers (Portal, standalone web UI, CLI, third-party integrations) need a
+stable interface they can code against without tight coupling to APME's
+release cycle.
+
+| Item | Current State | Work Needed |
+|------|---------------|-------------|
+| URL versioning | All routes under `/api/v1` | Foundation exists; no changes needed |
+| OpenAPI spec | FastAPI auto-generates from code; not published as artifact | Publish versioned OpenAPI spec (JSON/YAML) as release artifact; all consumers validate against it |
+| Stability guarantee | None — any commit can change the API shape | ADR defining API stability policy: what constitutes a breaking change, deprecation timeline, v1 support window |
+| Deprecation policy | No mechanism | Add `Deprecation` / `Sunset` headers; document migration path before removing endpoints |
+| Changelog | No API-specific changelog | Track breaking vs non-breaking changes per release; include in release notes |
+| Contract testing | No consumer-driven contract tests | Pact or similar to verify consumer integrations (Portal, standalone UI, CLI) don't break on APME upgrades |
+| SDK / client library | Consumers code directly against REST | Consider a thin Python/TypeScript client generated from OpenAPI spec for Portal, CLI, and third-party use |
+
+### 4.5 Scaling & Performance
 
 | Item | Current State | Work Needed |
 |------|---------------|-------------|
@@ -174,7 +192,7 @@ decision. Work includes:
 | Gateway DB | SQLite (single-writer) | **Decision needed:** move to PostgreSQL now, or keep SQLite for standalone and add PostgreSQL as a production option? See Section 6. |
 | DB migrations | No migration tooling exists (no Alembic, no versioned schema) | **Gap:** schema changes today silently break existing databases. Need Alembic (or equivalent) with versioned migrations before any production release. |
 
-### 4.5 Ownership Model
+### 4.6 Ownership Model
 
 #### DevTools team — platform engineering
 
@@ -213,7 +231,7 @@ This is a pattern we've used before and it needs a formal governance model:
 | Rule catalog maintenance | Published catalog with rationale, references, and ownership metadata per rule |
 | Feedback loop | Portal/CLI users can flag false positives or request new rules; routed to rule owners, not DevTools backlog |
 
-### 4.6 Dependency Review
+### 4.7 Dependency Review
 
 | Category | Current Dependencies | Review Action |
 |----------|---------------------|---------------|
@@ -223,7 +241,7 @@ This is a pattern we've used before and it needs a formal governance model:
 | Frontend | React, PatternFly, Vite, Node 22 | Standard UI stack; confirm PatternFly version |
 | Container base | Debian bookworm-slim | UBI migration path for downstream |
 
-### 4.7 Repo & Process Hardening
+### 4.8 Repo & Process Hardening
 
 | Item | Current State | Work Needed |
 |------|---------------|-------------|
@@ -233,7 +251,7 @@ This is a pattern we've used before and it needs a formal governance model:
 | Vulnerability disclosure | SECURITY.md with private reporting | Confirm GitHub Security Advisories enabled |
 | Industry gap analysis | `.sdlc/research/industry-gap-analysis.md` exists | Use as checklist; close gaps systematically |
 
-### 4.8 Product Requirements from Craig
+### 4.9 Product Requirements from Craig
 
 Craig should author a formal requirement covering:
 
@@ -271,13 +289,10 @@ Items not in the original list but important for productization:
 6. **Graceful degradation** — What happens when APME engine is down? Portal
    needs a degraded UX, not a 500.
 
-7. **API versioning contract** — REST API is `/api/v1` but no formal
-   stability guarantee or deprecation policy. Portal consumers need this.
-
-8. **Accessibility (a11y)** — PatternFly helps, but no a11y audit has been
+7. **Accessibility (a11y)** — PatternFly helps, but no a11y audit has been
    performed.
 
-9. **Telemetry** — No opt-in usage analytics for understanding adoption.
+8. **Telemetry** — No opt-in usage analytics for understanding adoption.
 
 ---
 
@@ -293,6 +308,7 @@ Items not in the original list but important for productization:
 | 6 | Rule governance: who proposes, reviews, approves prescriptive rules | Community of practice + BU + Ansible eng | Rule quality and relevance |
 | 7 | DevTools ownership scope: engine + gateway + deploy + CI + release | DevTools lead + current team | Codebase handoff |
 | 8 | DB migration tooling: adopt Alembic, define schema versioning strategy, test upgrade path | DevTools | Any schema change post-release |
+| 9 | API stability contract: define v1 support window, breaking change policy, deprecation timeline for all consumers | Architect + DevTools | Portal, standalone UI, CLI, third-party integrations |
 
 ---
 
@@ -319,8 +335,9 @@ Phase 3 — Portal Integration
 ├── Network policy defaults
 ├── PostgreSQL support (if multi-tenant)
 ├── Alembic DB migrations (schema versioning + upgrade path)
+├── API stability contract + published OpenAPI spec
 ├── Craig's P0 feature set
-└── API stability contract
+└── Consumer contract testing (Portal, standalone UI, CLI)
 
 Phase 4 — Production Readiness & Handoff
 ├── Load test suite (k6/locust)

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -154,22 +154,44 @@ decision. Work includes:
 | Horizontal scaling | ADR-012: scale engine pods as unit | Validate with concurrent scan load |
 | Gateway DB | SQLite (single-writer) | PostgreSQL path (ADR-029) needed for HA / multi-replica |
 
-### 4.5 DevTools Team Onboarding (Engineering Ownership)
+### 4.5 Ownership Model
 
-The DevTools team will own the APME engine codebase going forward. This is
-an engineering handoff, not an operational one — they own development,
-maintenance, and bug triage for the engine and validators.
+#### DevTools team — platform engineering
+
+The DevTools team will own the APME platform codebase: engine, gateway,
+validators (framework and execution), deployment artifacts, CI/CD, and
+release process. They own the **how** — the machinery that loads projects,
+runs validators, serves results, and deploys.
 
 | Item | Work Needed |
 |------|-------------|
 | Codebase walkthrough | Architecture, service boundaries, ADR index, test strategy |
 | Bug triage integration | APME components in team's Jira/Bugzilla; integrate into existing triage cadence |
-| CODEOWNERS | Assign DevTools team as owners for `src/apme_engine/`, validators, proto |
+| CODEOWNERS | Assign DevTools as owners for `src/apme_engine/`, `src/apme_gateway/`, validators (framework), proto, `deploy/`, CI |
 | CI ownership | Team understands and can modify GitHub Actions workflows, tox environments |
 | Development workflow | Team comfortable with branch strategy, PR process, conventional commits |
 | Contribution ramp | First bugs/features assigned to build familiarity before full ownership |
 | Release process | Team owns version bumps, CHANGELOG, tagging, image publishing |
-| Support boundary | Define what DevTools owns (engine) vs what stays with current team (Gateway, UI, deployment) |
+
+#### Rules & policy — community of practice
+
+The prescriptive ruleset (what APME checks and why) must be owned
+collectively by people closer to the users — the community of practice,
+the business unit, and the broader Ansible engineering team. DevTools
+maintains the validator framework and rule execution machinery, but does
+not unilaterally author policy rules.
+
+This is a pattern we've used before and it needs a formal governance model:
+
+| Item | Work Needed |
+|------|-------------|
+| Rule governance model | Define who can propose, review, approve, and merge new rules |
+| Rule ownership by category | Map L/M/R/P/SEC categories to responsible groups (e.g., Risk/Policy rules owned by platform team, Lint/Modernize by community) |
+| Contribution workflow | External rule contributors follow a defined process: proposal → review by domain experts → implementation by contributor or DevTools → merge |
+| Rule review board | Standing group (community of practice + BU + Ansible engineering) that reviews rule proposals, severity assignments, and deprecations |
+| Plugin boundary (ADR-042) | Third-party/org-specific rules go through the Plugin service — not into the built-in ruleset — giving teams autonomy without gating on DevTools |
+| Rule catalog maintenance | Published catalog with rationale, references, and ownership metadata per rule |
+| Feedback loop | Portal/CLI users can flag false positives or request new rules; routed to rule owners, not DevTools backlog |
 
 ### 4.6 Dependency Review
 
@@ -251,7 +273,8 @@ Items not in the original list but important for productization:
 | 3 | Base image: stay Debian slim or migrate to UBI | DevTools / Konflux | Downstream build |
 | 4 | PostgreSQL: required for production or SQLite sufficient? | Architect | HA / multi-replica Gateway |
 | 5 | Craig's P0 feature set for Portal launch | Craig | Scope and timeline |
-| 6 | Engineering ownership split: what does DevTools own vs current team | DevTools lead + current team | Codebase handoff |
+| 6 | Rule governance: who proposes, reviews, approves prescriptive rules | Community of practice + BU + Ansible eng | Rule quality and relevance |
+| 7 | DevTools ownership scope: engine + gateway + deploy + CI + release | DevTools lead + current team | Codebase handoff |
 
 ---
 
@@ -286,7 +309,8 @@ Phase 4 — Production Readiness & Handoff
 ├── Prometheus metrics + Grafana
 ├── a11y audit
 ├── DevTools codebase walkthrough and first contributions
-└── CODEOWNERS + triage integration for DevTools ownership
+├── CODEOWNERS + triage integration for DevTools ownership
+└── Rule governance model: community of practice + BU + Ansible eng
 ```
 
 ---

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -4,7 +4,7 @@
 **Updated:** 2026-06-25  
 **Status:** Draft for review
 
-This document captures the productization strategy for APME across two deployment tracks: **Portal-integrated product** (Track A) and **upstream standalone** (Track B). It consolidates architecture, authentication, work streams, open decisions, PostgreSQL migration, and Portal integration requirements.
+This document captures the productization strategy for APME across two deployment tracks: **Portal-integrated product** (Track A) and **upstream standalone** (Track B). It consolidates architecture, authentication, work streams, open decisions, PostgreSQL-only persistence (SQLite removed), and Portal integration requirements.
 
 Companion research: [PR #352](https://github.com/ansible/apme/pull/352) (`.sdlc/research/portal-integration/00-integration-requirements.md`), [ansible-rhdh-plugins PR #676](https://github.com/ansible/ansible-rhdh-plugins/pull/676), [ANSTRAT-2222](https://issues.redhat.com/browse/ANSTRAT-2222).
 
@@ -37,7 +37,7 @@ APME is a multi-service system that automates policy enforcement and modernizati
 │                           Gateway Tier                                        │
 │  ┌────────────────────────────────────────────────────────────────────────┐  │
 │  │ Gateway :8080 (REST) / :50060 (gRPC Reporting — Track B full mode only) │  │
-│  │ Track B: PostgreSQL persistence │ Track A proxy: no APME database      │  │
+│  │ PostgreSQL only (bundled/external) │ Track A proxy: no APME database │  │
 │  └────────────────────────────────────────────────────────────────────────┘  │
 └──────────────────────────────────────────────────────────────────────────────┘
                                      │ REST + WebSocket
@@ -55,7 +55,7 @@ APME is a multi-service system that automates policy enforcement and modernizati
 | Tier | Components | Notes |
 |------|------------|-------|
 | **Engine** | Primary, Native, OPA, Ansible, Galaxy Proxy, **Collection Health**, **Dep Audit**, Abbenay; Gitleaks optional | Collection Health and Dep Audit are **required** for productized engine runtime. Gitleaks is **optional** (external binary). |
-| **Gateway** | REST API, Reporting gRPC (full mode), persistence (full mode) | **Upstream/dev (Track B):** PostgreSQL. **Portal proxy mode (Track A):** no APME-owned database — Portal owns persistence. |
+| **Gateway** | REST API, Reporting gRPC (full mode), persistence (full mode) | **PostgreSQL only** (bundled or external) wherever Gateway persists data. **Portal proxy mode (Track A):** no APME database — Portal owns persistence. |
 | **UI** | React SPA (PatternFly) | **Track B:** standalone UI via REST and WebSocket `/api/v1/ws/session`. **Track A:** no APME UI — Portal provides UX. |
 
 ### Engine-Core vs Product Validator Scope
@@ -102,9 +102,9 @@ APME ships on two parallel tracks with different packaging, persistence, and UX 
 
 | Attribute | Value |
 |-----------|-------|
-| **Distribution** | Standalone Helm chart (`deploy/helm/apme/`), Podman pod (`tox -e up`), bootc VM, CLI daemon |
+| **Distribution** | Standalone Helm (`deploy/helm/apme/`), Podman pod (`tox -e up`), bootc VM, CLI daemon; same PostgreSQL requirement applies to downstream/production (Konflux, Red Hat catalog) |
 | **Gateway mode** | Full mode (`APME_GATEWAY_MODE=full`) — owns REST, reporting, persistence |
-| **Database** | PostgreSQL for production; SQLite acceptable for local dev only |
+| **Database** | **PostgreSQL only** — bundled container or external URL; SQLite removed entirely |
 | **UI** | Standalone APME UI (:8081) — **not removed** for upstream |
 | **Auth** | Bearer tokens per ADR-038 (Proposed) |
 | **Target users** | Open-source consumers, integrators, developers |
@@ -224,17 +224,18 @@ Authentication differs by deployment track. **Podman, bootc, and CLI daemon path
 - Portal proxy mode exposes a reduced surface (`POST /scan`, `GET /scan/{id}/events`, etc.) — versioning applies to both modes.
 - **Deliverable:** API contract document; cross-ref PR #351 / this plan §4.4.
 
-### 4.5 — PostgreSQL Migration
+### 4.5 — PostgreSQL (SQLite Removal)
 
-**Decision:** Upstream Track B uses PostgreSQL for production (see Section 9). SQLite remains dev-only.
+**Decision:** All deployments where the APME Gateway persists data use **PostgreSQL only** — upstream/dev (Track B), downstream/production (Konflux, customer Helm, bootc), and future CLI daemon Gateway (ADR-049). **SQLite is removed entirely** — no dev exception, no dual-mode fallback. See Section 9.
 
 | Item | Requirement |
 |------|-------------|
 | **Alembic** | Required — schema migrations versioned in repo |
-| **Multi-replica Gateway** | Enabled only after PostgreSQL — SQLite blocks HA |
+| **Multi-replica Gateway** | Enabled with PostgreSQL (remove SQLite single-replica guard) |
 | **Connection pooling** | SQLAlchemy async + pool config in Helm |
-| **Portal proxy mode** | No APME database — Gateway is stateless for persistence |
-| **Current code** | `GatewayConfig.db_path` / `APME_DB_PATH` only — no `APME_DATABASE_URL` yet |
+| **Bundled vs external PG** | Config file / Helm values: bundled PostgreSQL container **or** external `APME_DATABASE_URL` |
+| **Portal proxy mode (Track A)** | No APME database — Gateway is stateless; Portal PostgreSQL owns persistence |
+| **Current code gap** | `GatewayConfig.db_path` / `APME_DB_PATH` / `aiosqlite` must be removed — `APME_DATABASE_URL` + `asyncpg` required |
 
 ### 4.6 — Ownership Model
 
@@ -318,7 +319,7 @@ ADR-049 status: **Accepted** (2026-04-01). **Implementation: not done** — `lau
 
 - `apme sbom` and future REST-backed CLI commands require Gateway reachability.
 - **Separate work stream from Portal Track A** — does not block proxy mode.
-- Deliverable: embed FastAPI + ReportingServicer + SQLite in daemon per ADR-049.
+- Deliverable: embed FastAPI + ReportingServicer + PostgreSQL in daemon per ADR-049 (bundled or external PG — no SQLite).
 
 ### Feature Flags
 
@@ -326,8 +327,8 @@ ADR-049 status: **Accepted** (2026-04-01). **Implementation: not done** — `lau
 |------|---------|--------|
 | `APME_GATEWAY_MODE` | Gateway operating mode | `full` (Track B default), `proxy` (Track A) |
 | `APME_DATABASE_MODE` | Persistence backend | `bundled`, `external`, `none` (proxy) |
-| `APME_DATABASE_URL` | PostgreSQL DSN | `postgresql+asyncpg://...` |
-| `APME_DB_PATH` | SQLite file path | **Deprecated** for production — dev/local only (`GatewayConfig` default `/data/apme.db`) |
+| `APME_DATABASE_URL` | PostgreSQL DSN (required when Gateway persists data) | `postgresql+asyncpg://...` |
+| `APME_DB_PATH` | *(removed)* | **Dropped** — SQLite no longer supported; remove from code and docs |
 | `APME_AUTH_DISABLED` | Skip Gateway auth | `true` dev only — not for production |
 | `APME_AIR_GAPPED` | Air-gapped deployments | `true` / `false` (A5, proposed) |
 | `APME_RATE_LIMIT` | Gateway throttling | e.g. `100/minute` (A11, proposed) |
@@ -345,8 +346,8 @@ Gateway reads `APME_GATEWAY_MODE` at startup to enable/disable local SQLAlchemy 
 | D-01 | **Auth model (Portal)** | Service token list vs mTLS vs OAuth client credentials | Track A GA |
 | D-02 | **Packaging** | See Section 2 table | Release pipeline |
 | D-03 | **Gateway modes** | Runtime flag only vs separate proxy image build | Helm/CI complexity |
-| D-04 | **PostgreSQL topology** | Bundled subchart vs external RDS vs customer-managed | Track B HA |
-| D-05 | **SQLite migration strategy** | Big-bang Alembic init vs export/import tool vs dual-run period | Existing dev adopters |
+| D-04 | **PostgreSQL topology** | Bundled subchart vs external RDS vs customer-managed | All Gateway persistence deployments |
+| D-05 | **One-time SQLite data migration** | Export/import tool for early adopters with existing `apme.db` files vs fresh-install only | Pre-release adopters only |
 | D-06 | **Craig P0 scope** | Full A1–A12 vs phased MVP (A1,A3,A12,A2) | Portal milestone |
 | D-07 | **Governance / ownership** | Section 4.6 RACI | Support model |
 | D-08 | **DevTools** | In-cluster vs local-only CLI | Developer UX |
@@ -358,7 +359,7 @@ Gateway reads `APME_GATEWAY_MODE` at startup to enable/disable local SQLAlchemy 
 | ID | Decision | Date | Reference |
 |----|----------|------|-----------|
 | DC-01 | **Validator scope:** Collection Health + Dep Audit required; Gitleaks optional | 2026-06-24 | §4.10 |
-| DC-02 | **Upstream persistence:** PostgreSQL for production Track B | 2026-06-24 | §9, ADR-029 extension |
+| DC-02 | **Gateway persistence:** PostgreSQL only (upstream, downstream/production, dev); SQLite removed entirely | 2026-06-25 | §9, ADR-029 amendment |
 | DC-03 | **Dual tracks:** Portal product (Track A) vs upstream standalone (Track B) | 2026-06-24 | §2 |
 | DC-04 | **Portal persistence:** No APME DB in proxy mode — Portal PostgreSQL | 2026-06-24 | §8 A2, PR #352 |
 
@@ -369,7 +370,7 @@ Gateway reads `APME_GATEWAY_MODE` at startup to enable/disable local SQLAlchemy 
 ### Phase 1 — Foundation (weeks 1–4)
 
 1. Validator scope alignment (4.10) — launcher, Helm, Podman, health-check
-2. Alembic + PostgreSQL migration scaffolding (4.5, §9)
+2. SQLite removal + Alembic + PostgreSQL (upstream, downstream/production, dev — bundled or external PG) (4.5, §9)
 3. Auth ADR — bearer for Track B (ADR-038); draft Portal service-token ADR (4.3, D-01)
 
 ### Phase 2 — Hardening (weeks 5–8)
@@ -452,7 +453,7 @@ Source: [PR #352](https://github.com/ansible/apme/pull/352) — `.sdlc/research/
 | ID | Requirement | Priority | Current | Gap | Effort |
 |----|-------------|----------|---------|-----|--------|
 | **A1** | Gateway auth middleware (Bearer service token) | Critical | No auth middleware | Implement `verify_service_token`; Helm secret | Small |
-| **A2** | Gateway stateless proxy mode | High | Full Gateway with SQLite + UI | `APME_GATEWAY_MODE=proxy`; remove persistence paths | Medium (1–2 sprints) |
+| **A2** | Gateway stateless proxy mode | High | Full Gateway with PostgreSQL + UI | `APME_GATEWAY_MODE=proxy`; remove persistence paths | Medium (1–2 sprints) |
 | **A3** | Tarball scan endpoint `POST /scan` | High | WS upload / project CRUD model | New scan router + tarball service + FixSession proxy | Medium (1 sprint) |
 | **A4** | PVC sizing for scale | Medium | 10Gi defaults | sessions 50Gi, proxy-cache 20Gi; no gateway PVC in proxy | Small |
 | **A5** | Air-gapped mode flag | Medium | Not implemented | `APME_AIR_GAPPED=true` behavior | Small (proposed ADR) |
@@ -470,7 +471,7 @@ When `APME_GATEWAY_MODE=proxy`:
 
 **Remove / skip:**
 
-- SQLite database initialization, SQLAlchemy models, Alembic migrations
+- PostgreSQL database initialization, SQLAlchemy models, Alembic migrations (Track B full mode only)
 - gRPC Reporting servicer (:50060) — Portal stores results directly
 - Persistence-dependent REST: projects CRUD, dashboard, activity, trends, settings, notifications, suppressions
 - UI deployment (:8081) — **Track A only**
@@ -652,17 +653,23 @@ APME container volumes:
 - Engine pod architecture (ADR-012 — scale pods, not services)
 - Remediation engine (3-tier model)
 - Rule ID conventions (ADR-008)
-- **Track B** standalone UI, full Gateway, PostgreSQL path
+- **Track B** standalone UI, full Gateway, PostgreSQL-only path (upstream + downstream/production)
 
 ---
 
-## Section 9 — PostgreSQL Migration Plan
+## Section 9 — PostgreSQL Only (SQLite Removal)
 
 ### Decision
 
-Upstream Track B production deployments use **PostgreSQL**. SQLite (`APME_DB_PATH`, default `/data/apme.db` in `GatewayConfig`) is **dev/local only** and deprecated for production documentation.
+**PostgreSQL is the sole APME Gateway database** wherever the Gateway persists data:
 
-Portal Track A proxy mode: **no APME database** — skip all items below except engine/session volumes.
+- **Upstream/dev (Track B):** Helm, Podman pod, bootc, CLI daemon (ADR-049) — bundled PostgreSQL container **or** external `APME_DATABASE_URL`
+- **Downstream/production:** Konflux-built images, customer OpenShift/K8s, Red Hat catalog deployments — same PostgreSQL requirement; no SQLite fallback
+- **Local development:** bundled PostgreSQL sidecar/container (e.g. Podman compose, Helm subchart) — **not** SQLite files
+
+**SQLite is removed entirely** from APME: delete `APME_DB_PATH`, `aiosqlite`, SQLite-specific pragmas/migrations, and Gateway SQLite PVCs. Early adopters with existing `apme.db` files get a one-time export/import path (open decision D-05).
+
+**Portal Track A (proxy mode):** no APME database — skip all Gateway DB items below; Portal PostgreSQL owns persistence.
 
 ### Configuration Example
 
@@ -685,10 +692,10 @@ database:
 
 | Variable | Description | Status |
 |----------|-------------|--------|
-| `APME_DATABASE_URL` | PostgreSQL DSN (`postgresql+asyncpg://user:pass@host:5432/apme`) | **New — required** (Track B prod) |
-| `APME_DATABASE_MODE` | `bundled`, `external`, or `none` | **New** |
-| `APME_GATEWAY_MODE` | `full` or `proxy` | **New** |
-| `APME_DB_PATH` | SQLite file path | **Deprecated** — maps to `GatewayConfig.db_path` today |
+| `APME_DATABASE_URL` | PostgreSQL DSN (`postgresql+asyncpg://user:pass@host:5432/apme`) | **Required** when Gateway persists data |
+| `APME_DATABASE_MODE` | `bundled`, `external`, or `none` | **Required** — `none` only in proxy mode |
+| `APME_GATEWAY_MODE` | `full` or `proxy` | **Required** |
+| `APME_DB_PATH` | *(removed)* | **Dropped** — SQLite no longer supported |
 
 ### Portal Proxy Mode Note
 
@@ -697,18 +704,19 @@ When `APME_GATEWAY_MODE=proxy`, set `APME_DATABASE_MODE=none`. Gateway must not 
 ### Implementation Checklist
 
 - [ ] `src/apme_gateway/db/` — async engine factory supporting PostgreSQL via `APME_DATABASE_URL`
-- [ ] `src/apme_gateway/config.py` — add `database_url`, `database_mode`, `gateway_mode`; deprecate `db_path` for prod
-- [ ] `pyproject.toml` — add `asyncpg`, `alembic` dependencies
-- [ ] `alembic/` — initial revision from current SQLite models; forward-only migrations
+- [ ] `src/apme_gateway/config.py` — add `database_url`, `database_mode`, `gateway_mode`; **remove** `db_path`
+- [ ] `pyproject.toml` — add `asyncpg`, `alembic`; **remove** `aiosqlite` from gateway deps
+- [ ] `src/apme_gateway/db/` — **delete** SQLite engine factory, pragmas, ad-hoc column migrations
+- [ ] `alembic/` — initial revision from current ORM models; forward-only migrations
 - [ ] `alembic.ini` + env.py wired to `GatewayConfig`
 - [ ] Helm — PostgreSQL subchart **or** `externalDatabase.*` values; Secret for `APME_DATABASE_URL`
 - [ ] Helm — Gate multi-replica Gateway on `database.mode != none`
 - [ ] Podman — document external PostgreSQL or optional compose sidecar for integration tests
 - [ ] bootc — external PostgreSQL connection or bundled PG unit
-- [ ] **ADR-029 amendment** — PostgreSQL production store; SQLite dev-only
-- [ ] Migration guide — SQLite export → PostgreSQL import (addresses D-05)
+- [ ] **ADR-029 amendment** — PostgreSQL only; SQLite removed (supersedes SQLite-as-V1)
+- [ ] One-time migration guide — export existing `apme.db` → PostgreSQL import (addresses D-05; pre-release adopters only)
 - [ ] Gateway `/health` — DB ping when `database.mode != none`
-- [ ] Remove `APME_DB_PATH` from production Helm values and user-facing docs
+- [ ] Remove `APME_DB_PATH`, Gateway SQLite PVC, and all SQLite references from Helm, Podman, bootc, and docs
 - [ ] CI integration test job with PostgreSQL service container
 
 ---
@@ -719,7 +727,7 @@ When `APME_GATEWAY_MODE=proxy`, set `APME_DATABASE_MODE=none`. Gateway must not 
 |----------|------|-------|---------|-------|
 | ADR-055 (proposed) | ADR | Portal Gateway proxy mode (`APME_GATEWAY_MODE`) | A2 implementation | 3 |
 | ADR-056 (proposed) | ADR | Portal service-token authentication | D-01 resolution | 1 |
-| ADR-029-amend | ADR | PostgreSQL production persistence | §9 checklist | 1 |
+| ADR-029-amend | ADR | PostgreSQL only — SQLite removal | §9 checklist | 1 |
 | ADR-057 (proposed) | ADR | Required validator set (Collection Health + Dep Audit) | 4.10 completion | 1 |
 | ADR-058 (proposed) | ADR | API versioning — RFC 9745 / RFC 8594 | 4.4 / A9 | 3 |
 | ADR-059 (proposed) | ADR | Portal ephemeral custom Rego policies (Phase 2) | Custom rules scope | 4+ |
@@ -733,7 +741,7 @@ When `APME_GATEWAY_MODE=proxy`, set `APME_DATABASE_MODE=none`. Gateway must not 
 | TASK-005-06 | TASK | `USER` directive all Dockerfiles (A12) | 4.2 | 2 |
 | TASK-005-07 | TASK | Prometheus `/metrics` on Gateway (A10) | §8 | 4 |
 | DR-xxx | DR | Packaging registry / Operator ownership | D-02 | 3 |
-| DR-xxx | DR | SQLite → PostgreSQL migration strategy | D-05 | 1 |
+| DR-xxx | DR | One-time SQLite data export for pre-release adopters | D-05 | 1 |
 
 ---
 

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -177,10 +177,28 @@ gives consumers a clear deprecation window and migration path, but the
 obligation is on consumers to upgrade — not on APME to maintain old API
 versions forever.
 
-#### Deprecation lifecycle (RFC-based)
+**Why standards-based:** APME will have an unknown number of consumers —
+Portal, standalone web UI, CLI, GitHub integrations, and potentially
+third-party tooling we don't control. We cannot rely on direct
+communication channels (emails, Slack messages) to reach all of them.
+Standards-based HTTP headers are the only mechanism that reaches every
+consumer automatically, in-band, on every request. Existing HTTP client
+libraries, API gateways, and monitoring tools already understand these
+headers — consumers don't need custom parsing logic to detect deprecation.
 
-Follow the standards-based pattern using RFC 9745 (`Deprecation` header)
-and RFC 8594 (`Sunset` header):
+#### Deprecation lifecycle
+
+The approach **must** use the IETF standards:
+
+- **[RFC 9745](https://www.rfc-editor.org/rfc/rfc9745.html)** —
+  `Deprecation` response header: signals a resource is deprecated, with
+  a timestamp of when deprecation took/takes effect.
+- **[RFC 8594](https://www.rfc-editor.org/rfc/rfc8594.html)** — `Sunset`
+  response header: signals when the resource will become unresponsive
+  (the hard cutoff date).
+- **`Link` header** with `rel="successor-version"` and
+  `rel="deprecation"` — points consumers to the replacement endpoint and
+  migration documentation.
 
 ```
 HTTP/1.1 200 OK

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -37,15 +37,20 @@ concerns into three tiers:
 - **UI tier:** React SPA served by nginx. Talks exclusively to the Gateway
   REST API.
 
-All inter-service communication uses gRPC (ADR-001). The only HTTP endpoints
-are Gateway REST (:8080), Galaxy Proxy PEP 503 (:8765), and the UI (:8081).
+Inter-service communication uses gRPC (ADR-001), with one exception: Galaxy
+Proxy exposes an internal PEP 503 HTTP endpoint (:8765) used by Primary for
+collection resolution. External-facing HTTP endpoints are Gateway REST
+(:8080) and the UI (:8081).
 
 ---
 
 ## 2. Deployment: Portal-First, Then Expand
 
-The same services run in every deployment target — only the orchestration
-and networking differ.
+The core engine stack (Primary + validators + Galaxy Proxy) runs in every
+deployment target. Gateway, UI, and Abbenay are included in pod and Helm
+deployments but not in the CLI daemon (which embeds a lightweight Gateway
+instead — ADR-049). Optional validators (Gitleaks, Collection Health, Dep
+Audit) start only when `include_optional=True`.
 
 | Target | Method | Status |
 |--------|--------|--------|
@@ -61,19 +66,26 @@ The Helm chart produces separate Deployments:
 | Deployment | Contents | Scaling |
 |------------|----------|---------|
 | `engine` | Primary + all validators + Galaxy Proxy (sidecars) | HPA optional (1–5 replicas) |
-| `gateway` | REST + gRPC Reporting + SQLite | Fixed replicas |
-| `ui` | nginx + React SPA | Fixed replicas |
+| `gateway` | REST + gRPC Reporting + SQLite | Configurable replicas (SQLite limits practical concurrency) |
+| `ui` | nginx + React SPA | Configurable replicas |
 | `abbenay` | AI provider | Optional, 1 replica |
 
 Templates for Ingress, OpenShift Route, NetworkPolicy, and PodDisruptionBudget
 exist but are disabled by default — enable for production.
 
-### Why one architecture serves all use cases
+### Why one architecture serves multiple use cases
 
-A Podman pod is the same services on localhost. It satisfies the standalone
-web UI and GitHub-integrated use cases without a separate product SKU or
-different code path. The CLI daemon embeds the Gateway for zero-dependency
-local evaluation.
+The Podman pod runs the full stack (engine + gateway + UI) on localhost,
+satisfying standalone web UI and GitHub-integrated use cases. The CLI daemon
+runs a reduced stack (engine + embedded Gateway, no UI) for zero-dependency
+local evaluation. The Helm chart deploys the same services as separate
+Kubernetes Deployments.
+
+**Portal caveat:** The Helm chart in this repo is structured for standalone
+APME deployment on OpenShift. Portal integration may require a different
+deployment model — APME services deployed as part of the Portal's existing
+Helm chart or operator, rather than as a standalone Helm release. This is
+an open question (see Section 6).
 
 ---
 
@@ -152,7 +164,7 @@ decision. Work includes:
 | Baseline metrics | Per-scan diagnostics (`engine_total_ms`, per-rule timing) | Establish SLA baselines (e.g., 1000-task project < 30s) |
 | HPA | Helm template exists (disabled) | Enable and tune with load test data |
 | Horizontal scaling | ADR-012: scale engine pods as unit | Validate with concurrent scan load |
-| Gateway DB | SQLite (single-writer) | PostgreSQL path (ADR-029) needed for HA / multi-replica |
+| Gateway DB | SQLite (single-writer) | **Decision needed:** move to PostgreSQL now, or keep SQLite for standalone and add PostgreSQL as a production option? See Section 6. |
 
 ### 4.5 Ownership Model
 
@@ -271,10 +283,11 @@ Items not in the original list but important for productization:
 | 1 | Auth model: AAP proxy vs self-contained vs platform JWT | Architect + Craig | Any multi-user deployment |
 | 2 | Multi-tenancy: per-tenant instance vs shared + row isolation | Architect | Portal deployment |
 | 3 | Base image: stay Debian slim or migrate to UBI | DevTools / Konflux | Downstream build |
-| 4 | PostgreSQL: required for production or SQLite sufficient? | Architect | HA / multi-replica Gateway |
+| 4 | Database: move to PostgreSQL now, or dual-mode (SQLite standalone / PostgreSQL production)? SQLite is single-writer — blocks multi-replica Gateway and concurrent Portal use. ADR-029 documents a PostgreSQL path via `APME_DATABASE_URL` but it's unvalidated. Alembic migrations don't exist yet. | Architect | HA Gateway, multi-tenancy, Portal scale |
 | 5 | Craig's P0 feature set for Portal launch | Craig | Scope and timeline |
 | 6 | Rule governance: who proposes, reviews, approves prescriptive rules | Community of practice + BU + Ansible eng | Rule quality and relevance |
 | 7 | DevTools ownership scope: engine + gateway + deploy + CI + release | DevTools lead + current team | Codebase handoff |
+| 8 | Portal deployment model: standalone APME Helm chart, or integrated into Portal's operator/chart? | Architect + Portal team | Deployment architecture |
 
 ---
 

--- a/.sdlc/context/productization-plan.md
+++ b/.sdlc/context/productization-plan.md
@@ -1,7 +1,7 @@
 # APME Productization Plan — Pre-Read
 
 **Prepared:** 2026-06-24  
-**Updated:** 2026-06-25  
+**Updated:** 2026-06-25 (Portal integration architecture aligned with [PR #352](https://github.com/ansible/apme/pull/352) v2)  
 **Status:** Draft for review
 
 This document captures the productization strategy for APME across two deployment tracks: **Portal-integrated product** (Track A) and **upstream standalone** (Track B). It consolidates architecture, authentication, work streams, open decisions, PostgreSQL-only persistence (SQLite removed), and Portal integration requirements.
@@ -36,8 +36,8 @@ APME is a multi-service system that automates policy enforcement and modernizati
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │                           Gateway Tier                                        │
 │  ┌────────────────────────────────────────────────────────────────────────┐  │
-│  │ Gateway :8080 (REST) / :50060 (gRPC Reporting — Track B full mode only) │  │
-│  │ PostgreSQL only (bundled/external) │ Track A proxy: no APME database │  │
+│  │ Gateway :8080 (REST) / :50060 (gRPC Reporting)                         │  │
+│  │ PostgreSQL only — bundled or external (shared instance in Track A)   │  │
 │  └────────────────────────────────────────────────────────────────────────┘  │
 └──────────────────────────────────────────────────────────────────────────────┘
                                      │ REST + WebSocket
@@ -55,7 +55,7 @@ APME is a multi-service system that automates policy enforcement and modernizati
 | Tier | Components | Notes |
 |------|------------|-------|
 | **Engine** | Primary, Native, OPA, Ansible, Galaxy Proxy, **Collection Health**, **Dep Audit**, Abbenay; Gitleaks optional | Collection Health and Dep Audit are **required** for productized engine runtime. Gitleaks is **optional** (external binary). |
-| **Gateway** | REST API, Reporting gRPC (full mode), persistence (full mode) | **PostgreSQL only** (bundled or external) wherever Gateway persists data. **Portal proxy mode (Track A):** no APME database — Portal owns persistence. |
+| **Gateway** | REST API, Reporting gRPC, PostgreSQL persistence | **Same full Gateway** on both tracks. **PostgreSQL only** (bundled or external). Track A connects to **Portal's shared PostgreSQL instance**; APME owns `apme_*` tables, Portal owns `backstage_*`. |
 | **UI** | React SPA (PatternFly) | **Track B:** standalone UI via REST and WebSocket `/api/v1/ws/session`. **Track A:** no APME UI — Portal provides UX. |
 
 ### Engine-Core vs Product Validator Scope
@@ -90,24 +90,27 @@ APME ships on two parallel tracks with different packaging, persistence, and UX 
 
 | Attribute | Value |
 |-----------|-------|
-| **Distribution** | Bundled with Portal Operator / bootc product image |
-| **Gateway mode** | Proxy mode (`APME_GATEWAY_MODE=proxy`) — stateless REST↔gRPC proxy |
-| **Database** | Portal PostgreSQL (`apme_*` tables); **no** APME Gateway DB or PVC |
-| **UI** | Portal UX only; **no** standalone APME UI container |
-| **Auth** | Portal Auth/RBAC + service token for Portal→Gateway |
-| **Content ingress** | Portal clones SCM, sends tarballs — APME never holds SCM credentials |
+| **Distribution** | APME as **Portal Helm subchart** or bundled in Portal bootc image (single install/upgrade with Portal) |
+| **Gateway** | **Full Gateway service** — same codebase and REST API as Track B; not a stateless proxy |
+| **Database** | **Shared PostgreSQL instance** with Portal — APME owns `apme_*` tables (Alembic); Portal owns `backstage_*`; Portal manages the instance, APME manages its schema |
+| **UI** | Portal UX only; APME standalone UI container **not deployed** |
+| **Portal role** | **Thin proxy client** — RBAC, optional credential injection, forward to APME API; no APME data layer in Portal |
+| **Auth** | Portal Auth/RBAC (user-facing) + Bearer service token (Portal backend → Gateway) |
+| **Credentials** | **Optional per-request** — Portal injects SCM/Galaxy tokens when available; APME falls back to its own configured settings (A3) |
 | **Target users** | AAP customers consuming APME via Ansible Automation Portal |
 
 ### Track B — Upstream / Dev
 
 | Attribute | Value |
 |-----------|-------|
-| **Distribution** | Standalone Helm (`deploy/helm/apme/`), Podman pod (`tox -e up`), bootc VM, CLI daemon; same PostgreSQL requirement applies to downstream/production (Konflux, Red Hat catalog) |
-| **Gateway mode** | Full mode (`APME_GATEWAY_MODE=full`) — owns REST, reporting, persistence |
+| **Distribution** | Standalone Helm (`deploy/helm/apme/`), Podman pod (`tox -e up`), bootc VM, CLI daemon; same PostgreSQL requirement for downstream/production (Konflux, Red Hat catalog) |
+| **Gateway** | **Full Gateway service** — REST, WebSocket, Reporting gRPC, persistence |
 | **Database** | **PostgreSQL only** — bundled container or external URL; SQLite removed entirely |
-| **UI** | Standalone APME UI (:8081) — **not removed** for upstream |
+| **UI** | Standalone APME UI (:8081) |
 | **Auth** | Bearer tokens per ADR-038 (Proposed) |
 | **Target users** | Open-source consumers, integrators, developers |
+
+**One codebase, one API:** Track A and Track B use the same Gateway — no `full` vs `proxy` mode split. Difference is packaging, DB connection target (shared Portal instance vs bundled/external), and which UI is deployed.
 
 ### Open Packaging Decision Table
 
@@ -133,7 +136,7 @@ Authentication differs by deployment track. **Podman, bootc, and CLI daemon path
 | **User → Portal** | Portal Auth (OIDC/SSO) + Portal RBAC |
 | **Portal → Gateway** | Bearer service token (`APME_SERVICE_TOKENS`); Portal backend injects from K8s Secret |
 | **Gateway → Engine** | Pod-local gRPC; no end-user identity in engine |
-| **Galaxy credentials** | Per-request in `POST /scan` body — never persisted by APME |
+| **Galaxy credentials** | Optional per-request on operations (A3); APME falls back to own Galaxy config |
 
 **A1 (PR #352):** Gateway auth middleware with `APME_AUTH_DISABLED` escape hatch for backward-compatible CLI daemon dev only.
 
@@ -191,7 +194,7 @@ Authentication differs by deployment track. **Podman, bootc, and CLI daemon path
 | collection-health | ✓ | ✓ | ✗ | ✓ |
 | dep-audit | ✓ | ✓ | ✗ | ✓ |
 | gitleaks | opt | opt | ✓ | opt |
-| gateway | proxy | full | ✓ | ✓ |
+| gateway | ✓ | ✓ | ✓ | ✓ |
 | ui | ✗ | ✓ | ✓ | ✓ (Track B only) |
 | cli | ✓ | ✓ | ✓ | ✓ |
 | abbenay | ✓ | ✓ | external | external |
@@ -221,7 +224,7 @@ Authentication differs by deployment track. **Podman, bootc, and CLI daemon path
 - Adopt [RFC 9745](https://www.rfc-editor.org/rfc/rfc9745.html) (Deprecation header) and [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594.html) (Sunset header) as FastAPI middleware on Gateway REST.
 - Version prefix: `/api/v1/` (current); sunset headers on breaking changes.
 - WebSocket session endpoint `/api/v1/ws/session` versioned with REST (Track B).
-- Portal proxy mode exposes a reduced surface (`POST /scan`, `GET /scan/{id}/events`, etc.) — versioning applies to both modes.
+- Versioning applies to full Gateway REST + WebSocket surface used by Portal and Track B.
 - **Deliverable:** API contract document; cross-ref PR #351 / this plan §4.4.
 
 ### 4.5 — PostgreSQL (SQLite Removal)
@@ -234,7 +237,7 @@ Authentication differs by deployment track. **Podman, bootc, and CLI daemon path
 | **Multi-replica Gateway** | Enabled with PostgreSQL (remove SQLite single-replica guard) |
 | **Connection pooling** | SQLAlchemy async + pool config in Helm |
 | **Bundled vs external PG** | Config file / Helm values: bundled PostgreSQL container **or** external `APME_DATABASE_URL` |
-| **Portal proxy mode (Track A)** | No APME database — Gateway is stateless; Portal PostgreSQL owns persistence |
+| **Track A shared instance** | APME connects to Portal PostgreSQL; owns `apme_*` only; connection pooling required |
 | **Current code gap** | `GatewayConfig.db_path` / `APME_DB_PATH` / `aiosqlite` must be removed — `APME_DATABASE_URL` + `asyncpg` required |
 
 ### 4.6 — Ownership Model
@@ -259,7 +262,7 @@ Requires governance ADR or RACI in `.sdlc/context/`.
 - Vendored ARI engine (ADR-003) — no pip drift.
 - Galaxy Proxy collection versions pinned per release.
 - Document upgrade policy for Ansible-core compatibility.
-- Air-gapped mode (A5): disable PyPI fallback, optional dep-audit skip — **proposed**, requires ADR.
+- Air-gapped mode (A6): disable PyPI fallback, optional dep-audit skip — **proposed**, requires ADR.
 
 ### 4.8 — Repository Hardening
 
@@ -275,9 +278,9 @@ Portal stakeholder requirements traced to PR #352 / ANSTRAT-2222:
 
 | ID | Requirement | Priority | Status |
 |----|-------------|----------|--------|
-| CR-1 | Gateway proxy mode without APME DB | P0 | Spec §8 A2 |
-| CR-2 | Tarball scan — no SCM credentials in APME | P0 | Spec §8 A3 |
-| CR-3 | Galaxy credentials per-request from Portal | P0 | Spec §8 Galaxy flow |
+| CR-1 | Shared PostgreSQL instance; APME owns `apme_*` schema | P0 | Spec §8 A2 |
+| CR-2 | Optional credentials with APME settings fallback | P0 | Spec §8 A3 |
+| CR-3 | Optional Galaxy credentials per-request (A3) | P0 | Spec §8 |
 | CR-4 | Git-backed collections (phase 1: Hub only) | P0 | Spec §8 |
 | CR-5 | Service-token auth on Gateway | P0 | Spec §8 A1 |
 | CR-6 | Validator scope (CH + DA required) | P0 | **Decided** §4.10 |
@@ -318,22 +321,23 @@ Custom/organization-specific rules ship via the **Plugin service** container (AD
 ADR-049 status: **Accepted** (2026-04-01). **Implementation: not done** — `launcher.py` has no Gateway HTTP/gRPC startup; Gateway remains pod-level only.
 
 - `apme sbom` and future REST-backed CLI commands require Gateway reachability.
-- **Separate work stream from Portal Track A** — does not block proxy mode.
+- **Separate work stream from Portal Track A** — uses PostgreSQL when implemented.
 - Deliverable: embed FastAPI + ReportingServicer + PostgreSQL in daemon per ADR-049 (bundled or external PG — no SQLite).
 
-### Feature Flags
+### Configuration (Environment / Helm Values)
 
-| Flag | Purpose | Values |
-|------|---------|--------|
-| `APME_GATEWAY_MODE` | Gateway operating mode | `full` (Track B default), `proxy` (Track A) |
-| `APME_DATABASE_MODE` | Persistence backend | `bundled`, `external`, `none` (proxy) |
-| `APME_DATABASE_URL` | PostgreSQL DSN (required when Gateway persists data) | `postgresql+asyncpg://...` |
-| `APME_DB_PATH` | *(removed)* | **Dropped** — SQLite no longer supported; remove from code and docs |
+| Setting | Purpose | Values |
+|---------|---------|--------|
+| `APME_DATABASE_URL` | PostgreSQL DSN (**required**) | `postgresql+asyncpg://...` |
+| `APME_DATABASE_MODE` | DB topology | `bundled`, `external`, `shared` (Track A Portal instance) |
+| `gateway.database.poolSize` | Connection pool | e.g. `10` (important when sharing Portal PG) |
+| `APME_DB_PATH` | *(removed)* | **Dropped** — SQLite no longer supported |
 | `APME_AUTH_DISABLED` | Skip Gateway auth | `true` dev only — not for production |
-| `APME_AIR_GAPPED` | Air-gapped deployments | `true` / `false` (A5, proposed) |
+| `APME_SERVICE_TOKENS` | Portal→Gateway auth | Comma-separated bearer tokens (A1) |
+| `APME_AIR_GAPPED` | Air-gapped deployments | `true` / `false` (A6, proposed) |
 | `APME_RATE_LIMIT` | Gateway throttling | e.g. `100/minute` (A11, proposed) |
 
-Gateway reads `APME_GATEWAY_MODE` at startup to enable/disable local SQLAlchemy init, Reporting gRPC server, full REST surface, and Portal proxy routes.
+No `APME_GATEWAY_MODE` — same full Gateway on both tracks.
 
 ---
 
@@ -345,7 +349,7 @@ Gateway reads `APME_GATEWAY_MODE` at startup to enable/disable local SQLAlchemy 
 |----|-------|---------|-------------|
 | D-01 | **Auth model (Portal)** | Service token list vs mTLS vs OAuth client credentials | Track A GA |
 | D-02 | **Packaging** | See Section 2 table | Release pipeline |
-| D-03 | **Gateway modes** | Runtime flag only vs separate proxy image build | Helm/CI complexity |
+| D-03 | **Shared PG pooling** | Pool size / max connections when APME shares Portal instance | Track A stability |
 | D-04 | **PostgreSQL topology** | Bundled subchart vs external RDS vs customer-managed | All Gateway persistence deployments |
 | D-05 | **One-time SQLite data migration** | Export/import tool for early adopters with existing `apme.db` files vs fresh-install only | Pre-release adopters only |
 | D-06 | **Craig P0 scope** | Full A1–A12 vs phased MVP (A1,A3,A12,A2) | Portal milestone |
@@ -361,7 +365,7 @@ Gateway reads `APME_GATEWAY_MODE` at startup to enable/disable local SQLAlchemy 
 | DC-01 | **Validator scope:** Collection Health + Dep Audit required; Gitleaks optional | 2026-06-24 | §4.10 |
 | DC-02 | **Gateway persistence:** PostgreSQL only (upstream, downstream/production, dev); SQLite removed entirely | 2026-06-25 | §9, ADR-029 amendment |
 | DC-03 | **Dual tracks:** Portal product (Track A) vs upstream standalone (Track B) | 2026-06-24 | §2 |
-| DC-04 | **Portal persistence:** No APME DB in proxy mode — Portal PostgreSQL | 2026-06-24 | §8 A2, PR #352 |
+| DC-04 | **Portal integration:** Shared PostgreSQL instance; APME owns `apme_*`; thin Portal proxy | 2026-06-25 | §8, PR #352 v2 |
 
 ---
 
@@ -381,17 +385,16 @@ Gateway reads `APME_GATEWAY_MODE` at startup to enable/disable local SQLAlchemy 
 
 ### Phase 3 — Product Integration (weeks 9–12)
 
-7. Portal A1–A3 — auth middleware, tarball `POST /scan`, Galaxy per-request credentials
-8. Portal A2 — Gateway proxy mode behind `APME_GATEWAY_MODE=proxy`
-9. Packaging decisions (D-02) — Operator subchart, image pins, CLI artifact
-10. API contract + RFC 9745/8594 middleware (4.4, A9)
+7. Portal A1–A4 — auth, PostgreSQL+Alembic, optional credentials, admin/db APIs
+8. Portal Helm subchart packaging, upgrade hooks, image pins (D-02)
+9. API contract + RFC 9745/8594 middleware (4.4, A9)
 
 ### Phase 4 — Scale & Handoff (weeks 13+)
 
 11. HA Gateway — multi-replica after PostgreSQL (4.5)
-12. Load testing — engine pod at Portal scale (100+ repos, A4 PVC sizing)
+12. Load testing — engine pod at Portal scale (100+ repos, A5 PVC sizing)
 13. Observability — Prometheus `/metrics`, structured logging (A10)
-14. Rate limiting (A11), air-gapped mode (A5), rule catalog API (A6)
+14. Rate limiting (A11), air-gapped mode (A6)
 15. Ownership/governance sign-off (4.6) and operator handoff documentation
 16. ADR-049 daemon Gateway embedding (CLI track — parallel, not Portal-blocking)
 
@@ -399,23 +402,25 @@ Gateway reads `APME_GATEWAY_MODE` at startup to enable/disable local SQLAlchemy 
 
 ## Section 8 — Portal Integration Requirements (A1–A12)
 
-Source: [PR #352](https://github.com/ansible/apme/pull/352) — `.sdlc/research/portal-integration/00-integration-requirements.md`, [ansible-rhdh-plugins PR #676](https://github.com/ansible/ansible-rhdh-plugins/pull/676), [ANSTRAT-2222](https://issues.redhat.com/browse/ANSTRAT-2222).
+Source: [PR #352](https://github.com/ansible/apme/pull/352) (updated 2026-06-25 — shared-DB-instance architecture), [ansible-rhdh-plugins PR #676](https://github.com/ansible/ansible-rhdh-plugins/pull/676), [ANSTRAT-2222](https://issues.redhat.com/browse/ANSTRAT-2222).
 
-### Corrections (this plan vs PR #352 draft)
+### Core Architecture: Shared DB Instance, Separate Ownership
 
-| PR #352 statement | Correction |
-|-------------------|------------|
-| "APME standalone UI is removed" | **UI is removed only for Track A (Portal).** Track B upstream retains standalone UI (:8081). |
-| CLI daemon unchanged | **ADR-049 Gateway-in-daemon is separate work** — not implemented; not required for Portal proxy mode. |
-| Custom rules / air-gapped / rate limit | Marked **proposed** — each requires ADR before implementation. |
+1. **APME keeps its database** — Gateway maintains `apme_*` tables via Alembic; stores scan results, rules, projects
+2. **Shared PostgreSQL instance** — Track A: APME connects to Portal's PostgreSQL; each service manages its own tables
+3. **Portal is a thin proxy client** — RBAC + optional credential injection + forward to APME API; no APME data layer in Portal
+4. **Optional credentials per-request** — Portal injects tokens when available; APME falls back to own settings (A3)
+5. **Same API for standalone and integrated** — no Gateway mode split; ~90% of REST surface already exists
+6. **Day 0/Day 2 management APIs** — APME exposes DB migrate/status/backup/restore; Portal orchestrates (A4)
 
-### Core Architectural Decisions (Portal)
+### Why This Design Over Alternatives
 
-1. **Portal owns all scan data** — stored in Portal PostgreSQL (`apme_*` tables).
-2. **APME Gateway becomes stateless in proxy mode** — no database, no PVC, thin REST↔gRPC proxy.
-3. **Portal clones repos** — tars content, sends to APME via REST; APME never holds SCM credentials.
-4. **PR creation is Portal-side** — using user's OAuth token, not APME.
-5. **Feature flag:** `APME_GATEWAY_MODE=proxy` (Portal) vs `full` (standalone upstream).
+| Alternative | Problem | This Design |
+| --- | --- | --- |
+| **Separate APME DB** | Two databases for operators — double provisioning, backup, HA | Single PostgreSQL instance; Portal manages instance, APME manages `apme_*` tables |
+| **Portal owns data (stateless Gateway)** | Portal must understand APME schema; breaks standalone; requires gutting Gateway | APME owns schema; Portal is thin proxy; works standalone and integrated |
+
+> **Supersedes:** Earlier PR #352 draft (stateless Gateway, tarball `POST /scan`, Portal-owned `apme_*` tables). That model is **rejected**.
 
 ### C4 Context — APME in the Portal Ecosystem
 
@@ -423,28 +428,28 @@ Source: [PR #352](https://github.com/ansible/apme/pull/352) — `.sdlc/research/
                      ┌───────────────────────┐
                      │  Ansible Automation   │
                      │       Portal          │
-                     │  (owns all data)      │
-                     │  (clones repos)       │
+                     │  (thin proxy client)  │
                      └───────────┬───────────┘
                                  │
-                    REST: POST /scan (tarball upload)
-                    REST: GET /scan/{id}/events (SSE)
-                    REST: GET /rules
-                    REST: GET /health
+                    REST API (optional credentials)
                                  │
                      ┌───────────▼───────────┐
                      │   APME Gateway        │
-                     │   (STATELESS proxy)   │
-                     │   No DB, no PVC       │
+                     │   Full service        │
+                     │   Owns apme_* tables  │
                      │   REST :8080          │
                      └───────────┬───────────┘
-                                 │
-                          gRPC (internal)
-                                 │
+                                 │ gRPC
                      ┌───────────▼───────────┐
                      │   APME Engine Pod     │
                      │  Primary + Validators │
                      │  + Galaxy Proxy       │
+                     └───────────┬───────────┘
+                                 │
+                     ┌───────────▼───────────┐
+                     │  Shared PostgreSQL    │
+                     │  backstage_* (Portal) │
+                     │  apme_* (APME)        │
                      └───────────────────────┘
 ```
 
@@ -452,197 +457,145 @@ Source: [PR #352](https://github.com/ansible/apme/pull/352) — `.sdlc/research/
 
 | ID | Requirement | Priority | Current | Gap | Effort |
 |----|-------------|----------|---------|-----|--------|
-| **A1** | Gateway auth middleware (Bearer service token) | Critical | No auth middleware | Implement `verify_service_token`; Helm secret | Small |
-| **A2** | Gateway stateless proxy mode | High | Full Gateway with PostgreSQL + UI | `APME_GATEWAY_MODE=proxy`; remove persistence paths | Medium (1–2 sprints) |
-| **A3** | Tarball scan endpoint `POST /scan` | High | WS upload / project CRUD model | New scan router + tarball service + FixSession proxy | Medium (1 sprint) |
-| **A4** | PVC sizing for scale | Medium | 10Gi defaults | sessions 50Gi, proxy-cache 20Gi; no gateway PVC in proxy | Small |
-| **A5** | Air-gapped mode flag | Medium | Not implemented | `APME_AIR_GAPPED=true` behavior | Small (proposed ADR) |
-| **A6** | Rule catalog API (stateless) | Medium | Partial via Primary | `GET /rules` from in-memory catalog | Small |
-| **A7** | *(reserved / Portal-side)* | — | — | Portal backend plugin owns CRUD | — |
-| **A8** | *(reserved / Portal-side)* | — | — | Portal SQL for trends, dashboard | — |
-| **A9** | API versioning (RFC 9745/8594) | High | Not implemented | Deprecation + Sunset middleware | Medium |
-| **A10** | Observability (Prometheus + structured logging) | High | Limited | `/metrics` endpoint, JSON logs | Medium |
-| **A11** | Rate limiting | Medium | Not implemented | `APME_RATE_LIMIT` | Small (proposed ADR) |
+| **A1** | Gateway auth middleware (Bearer service token) | Critical | No auth middleware | `verify_service_token`; Helm secret | Small |
+| **A2** | PostgreSQL + Alembic | Critical | SQLite only (`APME_DB_PATH`) | `APME_DATABASE_URL`, `asyncpg`, Alembic migrations | Medium (1–2 sprints) |
+| **A3** | Optional credential acceptance | High | Partial | `scm_token`, `galaxy_servers` optional on operations; fallback to APME settings | Small–Medium |
+| **A4** | Day 0/Day 2 management APIs | High | Not implemented | `/admin/db/migrate`, status, health, vacuum, backup/restore | Medium (1 sprint) |
+| **A5** | PVC sizing for scale | Medium | 10Gi defaults | sessions 50Gi, proxy-cache 20Gi; no Gateway DB PVC (shared PG) | Small |
+| **A6** | Air-gapped mode flag | Medium | Not implemented | `APME_AIR_GAPPED=true` | Small (proposed ADR) |
+| **A7** | *(reserved / Portal-side)* | — | — | Portal backend plugin | — |
+| **A8** | *(reserved / Portal-side)* | — | — | Portal plugin UX | — |
+| **A9** | API versioning (RFC 9745/8594) | High | Not implemented | Deprecation + Sunset middleware; published OpenAPI | Medium |
+| **A10** | Observability (Prometheus + structured logging) | High | Limited | `/metrics`, JSON logs | Medium |
+| **A11** | Rate limiting | Medium | Not implemented | `APME_RATE_LIMIT` | Small |
 | **A12** | Non-root containers | High | Documented only | `USER` in all Dockerfiles | Small |
 
-### A2 — Proxy Mode Details
+### A2 — PostgreSQL + Alembic
 
-When `APME_GATEWAY_MODE=proxy`:
+APME is not yet released — clean PostgreSQL implementation, no SQLite dual-mode.
 
-**Remove / skip:**
+**Required:**
 
-- PostgreSQL database initialization, SQLAlchemy models, Alembic migrations (Track B full mode only)
-- gRPC Reporting servicer (:50060) — Portal stores results directly
-- Persistence-dependent REST: projects CRUD, dashboard, activity, trends, settings, notifications, suppressions
-- UI deployment (:8081) — **Track A only**
-
-**Keep (stateless):**
-
-- `GET /health` — probes Primary + validators via gRPC
-- `GET /rules` — from Primary in-memory catalog (A6)
-- SSE: `GET /scan/{id}/events` — proxies gRPC SessionEvents
-- `POST /scan/{id}/approve`, `POST /scan/{id}/cancel`
-- Bearer auth middleware (A1)
-
-**Add:**
-
-- `POST /scan` — tarball upload (A3)
-
-**Files (from PR #352):**
-
-- `src/apme_gateway/app.py` — conditional startup
-- `src/apme_gateway/api/router.py` — proxy route registration
-- `deploy/helm/apme/values.yaml` — `gateway.mode: proxy`
-- Remove in proxy chart overlay: `gateway-pvc.yaml`, reporting service, `ui-deployment.yaml`
-
-### A3 — Tarball Scan Endpoint
-
-**Endpoint:** `POST /scan`
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `content` | `UploadFile` | tar.gz of Ansible project |
-| `options` | JSON form string | `ansible_core_version`, `collection_specs`, `rule_configs` |
-| `galaxy_servers` | JSON form string | `[{name, url, token, auth_url}]` per-scan |
-| `action` | form string | `check` or `remediate` |
-
-**Flow:**
-
-1. Extract tarball to temp directory
-2. Discover Ansible files
-3. Configure Galaxy Proxy with per-request credentials
-4. Run `FixSession` via Primary gRPC
-5. Cleanup temp dir
-6. Return violations, proposals, patches, diagnostics, summary
-
-**SSE progress:** `GET /scan/{scan_id}/events`  
-**Approvals:** `POST /scan/{scan_id}/approve`
-
-**New modules (proposed):**
-
-- `src/apme_gateway/api/scan_router.py`
-- `src/apme_gateway/services/tarball_service.py`
-- `src/apme_gateway/services/scan_proxy.py`
-
-### API Surface — Before vs After (Proxy Mode)
-
-**Removed (Portal backend plugin owns):**
-
-| Endpoint | Previous purpose | New owner |
-|----------|------------------|-----------|
-| CRUD `/projects` | Project management | Portal `apme_projects` |
-| `GET /dashboard/*` | Aggregate metrics | Portal SQL |
-| `GET /activity/*` | Scan history | Portal `apme_scans` |
-| `GET /violations/top` | Top rules | Portal SQL |
-| `GET /stats/*` | Remediation rates | Portal SQL |
-| CRUD `/settings/galaxy-servers` | Galaxy config | Portal `apme_galaxy_servers` |
-| `POST /suppressions` | Rule suppressions | Portal `apme_rule_overrides` |
-| `GET /notifications/*` | Notifications | Portal notification service |
-| `GET /projects/{id}/trend` | Trends | Portal SQL |
-| `GET /projects/{id}/dependencies` | SBOM | Portal (post-scan store) |
-
-**Kept (stateless proxy):**
-
-| Endpoint | Purpose |
-|----------|---------|
-| `POST /scan` | **NEW** — tarball upload, trigger scan |
-| `GET /scan/{id}/events` | SSE — proxy SessionEvents |
-| `POST /scan/{id}/approve` | Forward proposal approvals |
-| `POST /scan/{id}/cancel` | Cancel running scan |
-| `GET /rules` | Rule catalog (A6) |
-| `GET /health` | Health check |
-
-**Track B full mode retains** `/api/v1/ws/session`, project CRUD, dashboard, and full persistence API.
-
-### A4 — PVC Sizing (Portal Scale)
+- `asyncpg` dependency; configure via `APME_DATABASE_URL`
+- Track A: `postgresql+asyncpg://user:pass@portal-db:5432/apme` (shared instance)
+- Track B: bundled PostgreSQL subchart or external URL
+- Alembic migrations for all `apme_*` tables
+- Connection pooling (pool size limits when sharing Portal's PostgreSQL)
 
 ```yaml
-persistence:
-  sessions:
-    size: 50Gi        # up from 10Gi — 100+ repos
-  proxyCache:
-    size: 20Gi        # up from 10Gi
-  # gateway PVC REMOVED in proxy mode
+gateway:
+  database:
+    url: ""           # PostgreSQL URI; empty = error (SQLite removed)
+    poolSize: 10
+    maxOverflow: 5
 ```
+
+### A3 — Optional Credential Acceptance
+
+All scan/operation endpoints accept optional credentials. If Portal provides them, use them; otherwise fall back to APME's configured project/Galaxy settings.
+
+```python
+class OperateRequest(BaseModel):
+    action: Literal["check", "remediate"]
+    scm_token: Optional[str] = None
+    galaxy_servers: Optional[list] = None
+    options: Optional[dict] = None
+```
+
+Works for Portal-integrated (Portal injects tokens), standalone (APME settings), and CI/CD (caller passes tokens).
+
+### A4 — Day 0 / Day 2 Management APIs
+
+Portal manages the PostgreSQL **instance** but not APME's schema. APME exposes admin endpoints (service-token protected):
+
+```
+POST /api/v1/admin/db/migrate     → Alembic migrations on apme_* tables
+GET  /api/v1/admin/db/status      → schema version, table count, needs_migration
+GET  /api/v1/admin/db/health      → connection + pool stats
+POST /api/v1/admin/db/vacuum      → retention cleanup
+POST /api/v1/admin/db/backup      → pg_dump apme_* tables only
+POST /api/v1/admin/db/restore     → restore apme_* from backup
+GET  /api/v1/admin/db/backups     → list backups
+```
+
+Portal Helm post-install/post-upgrade hook calls `POST /admin/db/migrate`. Instance-level full backup (Portal + APME) remains Portal's responsibility.
+
+### API Surface — Existing Endpoints (~90% Ready)
+
+| Endpoint Group | Portal Need | Status |
+| --- | --- | --- |
+| Projects CRUD | Manage scanned repos | Ready |
+| Operations (scan trigger) | Trigger scans with optional credentials | Needs A3 |
+| Operations (SSE progress) | Real-time progress | Ready |
+| Operations (approve) | HITL proposal approval | Ready |
+| Operations (create PR) | Open PR with fixes | Ready (optional `scm_token`) |
+| Violations / trend / dashboard | Metrics and history | Ready |
+| Rule catalog | List/configure rules | Ready |
+| Galaxy server config | Manage Galaxy credentials | Ready |
+| Health / dependencies / SBOM | Monitoring and deps | Ready |
+| **Admin/DB management** | Day 0/Day 2 ops | **Needs A4** |
+
+No new tarball `POST /scan` endpoint required — existing `operation_router` + project model cover Portal needs.
 
 ### Galaxy / Automation Hub Credential Flow
 
 ```
-Portal (owns credentials)                    APME (stateless)
-┌─────────────────────────┐                 ┌─────────────────────────┐
-│ apme_galaxy_servers     │                 │ Gateway (no DB)         │
-│ + K8s Secrets for tokens│  POST /scan     │                         │
-│                         │  galaxy_servers │  → Galaxy Proxy admin   │
-│ ansible.rhaap.baseUrl   │  ────────────►  │  temp ansible.cfg       │
-│ ansible.rhaap.token     │                 │  ephemeral per-scan     │
-└─────────────────────────┘                 └─────────────────────────┘
+Portal (optional per-request)              APME (own settings)
+┌─────────────────────────┐                ┌─────────────────────────┐
+│ ansible.rhaap.baseUrl   │                │ Gateway Galaxy config   │
+│ ansible.rhaap.token     │  operations  │ (apme_galaxy_servers)   │
+│ Injected as optional    │  ──────────► │ If request has tokens   │
+│ galaxy_servers          │              │ → use them              │
+└─────────────────────────┘              │ Else → own config     │
+                                         └─────────────────────────┘
 ```
 
-**Sources in Portal:**
-
-1. Existing Portal config: `ansible.rhaap.baseUrl` + `ansible.rhaap.token` (AAP admin token, org-scoped)
-2. Optional additional servers → `apme_galaxy_servers` table
-3. Default community Galaxy fallback (no token)
-
-**Key points:**
-
-- Tokens in K8s Secrets, not DB plaintext
-- Portal injects tokens per scan request
-- APME never persists Galaxy credentials
-- Galaxy Proxy writes temp `ansible.cfg`, downloads collections, deletes temp file
+In AAP 2.5+, Hub is behind AAP Gateway: `ansible.rhaap.baseUrl` + `ansible.rhaap.token` (AAP admin token, org-scoped).
 
 ### Git-Based Collection Dependencies
 
 | Phase | Scope |
 |-------|-------|
-| **Phase 1** | Collections must be on Galaxy or Automation Hub. `type: git` in `requirements.yml` **not supported** in Portal scans. Aligns with AAP 2.5+ Hub model. |
-| **Phase 2** | Portal passes admin SCM token in scan request (`GH_TOKEN` for `ansible-galaxy`), **or** Portal pre-builds git collections and includes tarball in upload. APME stays credential-free in preferred path. |
+| **Phase 1** | Collections on Galaxy or Automation Hub only; `type: git` in `requirements.yml` not supported in Portal scans |
+| **Phase 2** | Optional admin SCM token per-request, or Portal pre-builds git collections |
 
 ### Custom Rules — Phase 2 (Proposed — Requires ADR)
 
-- Policy-as-code in git; Portal clones policy repo, passes `custom_policies: [{name, rule_id, rego_source}]` in `POST /scan`
-- Gateway writes temp Rego alongside built-in OPA bundle; OPA loads merged bundle
-- Custom rule IDs: `P100+` prefix (distinct from built-in `P001–P004`)
-- **Phase 1:** per-project `.apme/rules.yml` and `rule_configs` in `ScanOptions` already supported — no git policy merge yet
+Policy-as-code from git; Portal passes optional `custom_policies` at scan time. Phase 1 uses existing `rule_configs` in `ScanOptions`.
 
-### Helm Chart — Proxy Mode Overlay
+### A5 — PVC Sizing (Portal Scale)
 
 ```yaml
-gateway:
-  mode: proxy
-  replicas: 2                      # stateless — scale freely
-  resources:
-    requests: { cpu: 250m, memory: 256Mi }
-    limits: { cpu: 500m, memory: 512Mi }
-  auth:
-    enabled: true
-    serviceTokenSecret: apme-service-token
-
-# Remove in proxy overlay:
-# - gateway-pvc.yaml
-# - gateway-reporting-service.yaml (:50060)
-# - ui-deployment.yaml / ui-service.yaml
+persistence:
+  sessions:
+    size: 50Gi
+  proxyCache:
+    size: 20Gi
+  # No Gateway DB PVC — shared PostgreSQL instance
 ```
 
-### bootc (Proxy / Product)
+### Upgrade Strategy (Track A)
 
-APME container volumes:
+APME ships as Portal Helm subchart. `helm upgrade` updates Portal + APME together:
 
-- `/sessions` — venv session storage
-- `/cache` — Galaxy Proxy wheel cache
-- **No Gateway DB volume**
+1. Engine pods RollingUpdate (sessions/cache PVCs preserved)
+2. Gateway pods RollingUpdate; post-upgrade hook: `POST /admin/db/migrate`
+3. Portal pods updated with new APME plugin
+4. Rollback: `helm rollback`; Alembic supports downgrade to target version
 
-### Implementation Order (Portal — from PR #352)
+**bootc:** `portal-post-upgrade.service` calls `POST /admin/db/migrate` after reboot.
 
-1. **A1** — Gateway auth (security prerequisite)
-2. **A3** — Tarball scan endpoint
-3. **A12** — Non-root containers
-4. **A2** — Gateway stateless refactor (`APME_GATEWAY_MODE=proxy`)
-5. **A9** — API versioning contract
-6. **A10** — Observability
-7. **A4** — PVC sizing
-8. **A5** — Air-gapped mode
-9. **A6** — Rule catalog API
+### Implementation Order (Portal)
+
+1. **A1** — Gateway auth
+2. **A2** — PostgreSQL + Alembic (enables shared-instance architecture)
+3. **A3** — Optional credentials
+4. **A4** — Day 0/Day 2 management APIs
+5. **A12** — Non-root containers
+6. **A9** — API versioning contract
+7. **A10** — Observability
+8. **A5** — PVC sizing
+9. **A6** — Air-gapped mode
 10. **A11** — Rate limiting
 
 ### What Stays Unchanged
@@ -650,12 +603,11 @@ APME container volumes:
 - Primary gRPC / `FixSession` protocol
 - All validators (read-only)
 - Galaxy Proxy PEP 503 caching
-- Engine pod architecture (ADR-012 — scale pods, not services)
+- Engine pod architecture (ADR-012)
 - Remediation engine (3-tier model)
 - Rule ID conventions (ADR-008)
-- **Track B** standalone UI, full Gateway, PostgreSQL-only path (upstream + downstream/production)
-
----
+- **Gateway REST API** — existing endpoints preserved; admin/db and optional credentials added
+- **Track B** standalone UI and full Gateway path
 
 ## Section 9 — PostgreSQL Only (SQLite Removal)
 
@@ -669,23 +621,22 @@ APME container volumes:
 
 **SQLite is removed entirely** from APME: delete `APME_DB_PATH`, `aiosqlite`, SQLite-specific pragmas/migrations, and Gateway SQLite PVCs. Early adopters with existing `apme.db` files get a one-time export/import path (open decision D-05).
 
-**Portal Track A (proxy mode):** no APME database — skip all Gateway DB items below; Portal PostgreSQL owns persistence.
+**Portal Track A:** connect to shared Portal PostgreSQL instance via `APME_DATABASE_URL`; APME runs Alembic on `apme_*` tables only (A4). Same implementation as Track B — different connection target.
 
 ### Configuration Example
 
 ```yaml
-# apme-gateway-config.yaml (Track B full mode)
+# apme-gateway-config.yaml
 gateway:
-  mode: full
-
-database:
-  mode: bundled          # bundled | external | none
-  # bundled: deploy PostgreSQL subchart, auto-wire URL
-  # external: customer supplies APME_DATABASE_URL
-  # none: proxy mode only (Track A)
-  url: ""                # required when mode=external
-  pool_size: 10
-  echo: false
+  database:
+    mode: bundled          # bundled | external | shared
+    # bundled: deploy PostgreSQL subchart (Track B standalone)
+    # external: customer-managed PostgreSQL
+    # shared: Portal PostgreSQL instance (Track A)
+    url: ""                # required — postgresql+asyncpg://...
+    pool_size: 10
+    max_overflow: 5
+    echo: false
 ```
 
 ### Environment Variables
@@ -693,13 +644,12 @@ database:
 | Variable | Description | Status |
 |----------|-------------|--------|
 | `APME_DATABASE_URL` | PostgreSQL DSN (`postgresql+asyncpg://user:pass@host:5432/apme`) | **Required** when Gateway persists data |
-| `APME_DATABASE_MODE` | `bundled`, `external`, or `none` | **Required** — `none` only in proxy mode |
-| `APME_GATEWAY_MODE` | `full` or `proxy` | **Required** |
+| `APME_DATABASE_MODE` | `bundled`, `external`, or `shared` | **Required** |
 | `APME_DB_PATH` | *(removed)* | **Dropped** — SQLite no longer supported |
 
-### Portal Proxy Mode Note
+### Track A Shared Instance Note
 
-When `APME_GATEWAY_MODE=proxy`, set `APME_DATABASE_MODE=none`. Gateway must not create, migrate, or connect to any APME schema. Portal owns `apme_projects`, `apme_scans`, `apme_galaxy_servers`, etc.
+When `APME_DATABASE_MODE=shared`, Gateway connects to Portal's PostgreSQL. Use conservative pool sizing. Portal post-upgrade hooks call `POST /api/v1/admin/db/migrate` (A4).
 
 ### Implementation Checklist
 
@@ -725,7 +675,7 @@ When `APME_GATEWAY_MODE=proxy`, set `APME_DATABASE_MODE=none`. Gateway must not 
 
 | Artifact | Type | Title | Trigger | Phase |
 |----------|------|-------|---------|-------|
-| ADR-055 (proposed) | ADR | Portal Gateway proxy mode (`APME_GATEWAY_MODE`) | A2 implementation | 3 |
+| ADR-055 (proposed) | ADR | Shared PostgreSQL instance integration (Track A) | §8 architecture | 3 |
 | ADR-056 (proposed) | ADR | Portal service-token authentication | D-01 resolution | 1 |
 | ADR-029-amend | ADR | PostgreSQL only — SQLite removal | §9 checklist | 1 |
 | ADR-057 (proposed) | ADR | Required validator set (Collection Health + Dep Audit) | 4.10 completion | 1 |
@@ -737,7 +687,8 @@ When `APME_GATEWAY_MODE=proxy`, set `APME_DATABASE_MODE=none`. Gateway must not 
 | TASK-005-02 | TASK | Promote CH/DA to required in launcher + Helm | 4.10 | 1 |
 | TASK-005-03 | TASK | CI publish collection-health + dep-audit images | 4.1 | 2 |
 | TASK-005-04 | TASK | Gateway auth middleware (A1) | §8 | 3 |
-| TASK-005-05 | TASK | Tarball `POST /scan` endpoint (A3) | §8 | 3 |
+| TASK-005-05 | TASK | Optional credential acceptance on operations (A3) | §8 | 3 |
+| TASK-005-08 | TASK | Day 0/Day 2 admin/db APIs (A4) | §8 | 3 |
 | TASK-005-06 | TASK | `USER` directive all Dockerfiles (A12) | 4.2 | 2 |
 | TASK-005-07 | TASK | Prometheus `/metrics` on Gateway (A10) | §8 | 4 |
 | DR-xxx | DR | Packaging registry / Operator ownership | D-02 | 3 |


### PR DESCRIPTION
## Summary
- Adds a comprehensive productization plan document covering all work streams
  needed to take APME from internal tooling to a supported product deployment
  (Portal-first, with Podman/bootc as secondary targets).

## Changes
- New `.sdlc/context/productization-plan.md` covering:
  - Architecture overview (engine/gateway/UI tiers, Galaxy Proxy as internal HTTP exception)
  - Deployment strategy: Portal (Helm) primary, Podman/bootc secondary, with Portal Helm caveat
  - Authentication gap analysis (no inbound auth ADR exists; three options outlined)
  - 8 productization work streams: downstream build, security, auth, scaling,
    ownership model, dependency review, repo hardening, Craig's product requirements
  - Ownership model: DevTools owns platform (engine, gateway, deploy, CI, release);
    community of practice + BU + Ansible eng owns prescriptive rules
  - Database decision: SQLite vs PostgreSQL for production/Portal scale
  - 10 additional considerations (observability, multi-tenancy, DB migrations,
    rate limiting, API stability, a11y, feature flags, etc.)
  - 8 open decisions matrix with owners and blockers
  - Phased priority sequence (security → downstream build → Portal integration → production readiness)

## Test plan
- [x] `tox -e lint` passes
- [x] Docs-only change — no code modified