### PR TITLE
feat(native): shared audit infra and doc-only rule resolutions (#247)

### DIFF
--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -2532,7 +2532,7 @@
         "type": "object"
       },
       "ViolationDetail": {
-        "description": "Violation row.\n\nAttributes:\n    id: Auto-increment ID.\n    rule_id: Rule identifier (e.g. L001).\n    level: Severity level string.\n    message: Human-readable description.\n    file: Relative file path.\n    line: Line number or None.\n    path: YAML path within the file.\n    remediation_class: Numeric remediation tier.\n    remediation_resolution: Numeric remediation resolution status.\n    scope: Numeric rule scope.\n    validator_source: Validator that produced this (native, opa, ansible, gitleaks).\n    original_yaml: Full node YAML as originally written.\n    fixed_yaml: Node YAML after transforms (fixed violations only).\n    co_fixes: Other rule IDs whose fixes are included in this node's diff.\n    node_line_start: File line where the node starts.\n    node_type: ContentGraph NodeType value (task, block, play, \u2026).\n    ai_reason: Why the AI could not fix this violation (ai_abstained only).\n    ai_suggestion: Manual remediation guidance from the AI (ai_abstained only).\n    suppressed: True if this violation matches an active suppression (ADR-055).\n    review_status: Human/gate decision (ADR-062); null if never reviewed.",
+        "description": "Violation row.\n\nAttributes:\n    id: Auto-increment ID.\n    rule_id: Rule identifier (e.g. L001).\n    level: Severity level string.\n    message: Human-readable description.\n    file: Relative file path.\n    line: Line number or None.\n    path: YAML path within the file.\n    remediation_class: Numeric remediation tier.\n    remediation_resolution: Numeric remediation resolution status.\n    scope: Numeric rule scope.\n    validator_source: Validator that produced this (native, opa, ansible, gitleaks).\n    original_yaml: Full node YAML as originally written.\n    fixed_yaml: Node YAML after transforms (fixed violations only).\n    co_fixes: Other rule IDs whose fixes are included in this node's diff.\n    node_line_start: File line where the node starts.\n    node_type: ContentGraph NodeType value (task, block, play, \u2026).\n    ai_reason: Why the AI could not fix this violation (ai_abstained only).\n    ai_suggestion: Manual remediation guidance from the AI (ai_abstained only).\n    audit_metadata: Parsed audit rule payloads when present.\n    suppressed: True if this violation matches an active suppression (ADR-055).\n    review_status: Human/gate decision (ADR-062); null if never reviewed.",
         "properties": {
           "ai_reason": {
             "default": "",
@@ -2543,6 +2543,18 @@
             "default": "",
             "title": "Ai Suggestion",
             "type": "string"
+          },
+          "audit_metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Audit Metadata"
           },
           "co_fixes": {
             "items": {

--- a/docs/rules/REMEDIATION_TIER_REPORT.md
+++ b/docs/rules/REMEDIATION_TIER_REPORT.md
@@ -10,14 +10,14 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | Tier | Count | % of 157 |
 |------|-------|--------|
 | Tier 1 — auto (has transform) | 25 | 16% |
-| Tier 2 — AI (task/block, no fixer) | 67 | 43% |
-| Tier 3 — manual | 65 | 41% |
+| Tier 2 — AI (task/block, no fixer) | 68 | 43% |
+| Tier 3 — manual | 64 | 41% |
 
 ### Promotion potential
 
 - **26** Tier 2 rules could likely move to Tier 1 (mechanical transforms)
 - **9** Tier 3 rules have mechanical fixes blocked by scope
-- **67 - 26 = 41** Tier 2 rules should stay AI (judgment/security)
+- **68 - 26 = 42** Tier 2 rules should stay AI (judgment/security)
 
 ### Tier 3 breakdown
 
@@ -29,7 +29,7 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | collection scope | 10 |
 | role scope | 10 |
 | play scope | 7 |
-| inventory scope | 4 |
+| inventory scope | 3 |
 
 ## Tier 1 — Auto (25 rules)
 
@@ -61,7 +61,7 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | M008 | OPA | high | task | Bare include is removed in 2.19+; use include_tasks or import_tasks. |
 | M009 | OPA | high | task | with_* loops are deprecated; use loop instead. |
 
-## Tier 2 — AI (67 rules)
+## Tier 2 — AI (68 rules)
 
 ### Could move to Tier 1 auto
 
@@ -128,6 +128,7 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | P001 | error | task | Task/block scope — AI can propose fix (Tier 2) |
 | P002 | error | task | Task/block scope — AI can propose fix (Tier 2) |
 | P003 | error | task | Task/block scope — AI can propose fix (Tier 2) |
+| P004 | error | task | Task/block scope — AI can propose fix (Tier 2) |
 | R101 | medium | task | Task/block scope — AI can propose fix (Tier 2) |
 | R103 | medium | task | Task/block scope — AI can propose fix (Tier 2) |
 | R104 | medium | task | Task/block scope — AI can propose fix (Tier 2) |
@@ -140,7 +141,7 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | R115 | medium | task | Task/block scope — AI can propose fix (Tier 2) |
 | SEC:* | critical | task | Task/block scope — AI can propose fix (Tier 2) |
 
-## Tier 3 — Manual (65 rules)
+## Tier 3 — Manual (64 rules)
 
 | Rule ID | Validator | Severity | Scope | Auto candidate? | Reason |
 |---------|-----------|----------|-------|-----------------|--------|
@@ -199,7 +200,6 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | M011 | OPA | high | collection | — | Scope 'collection' — play/role/collection not AI-proposable |
 | M025 | OPA | high | play | — | Scope 'play' — play/role/collection not AI-proposable |
 | M029 | Native | medium | playbook | — | Scope 'playbook' — play/role/collection not AI-proposable |
-| P004 | Native | error | inventory | — | Scope 'inventory' — play/role/collection not AI-proposable |
 | R108 | Native | medium | play | — | Scope 'play' — play/role/collection not AI-proposable |
 | R111 | Native | medium | task | — | Project-level context required (cross-file or data-flow consumers) |
 | R112 | Native | medium | task | — | Project-level context required (cross-file or data-flow consumers) |

--- a/docs/rules/RULE_CATALOG.md
+++ b/docs/rules/RULE_CATALOG.md
@@ -7,7 +7,7 @@
 | Metric | Count |
 |--------|-------|
 | Implemented | 150/157 |
-| Tested | 118/157 |
+| Tested | 154/157 |
 | Documented | 156/157 |
 | Deterministic fixer (Tier 1) | 25/157 |
 | Severity resolved (ADR-043 table or SEC: prefix) | 157/157 |
@@ -51,8 +51,8 @@ Routing follows `src/apme_engine/remediation/partition.py` (ADR-026 scope metada
 | Tier | Label | Count | Routing |
 |------|-------|-------|---------|
 | 1 | auto | 25 | Deterministic transform in registry — applied by `apme remediate` |
-| 2 | ai | 67 | Task/block scope, no fixer — AI proposes patch (Abbenay) |
-| 3 | manual | 65 | Play/role/collection scope, cross-file, or info severity |
+| 2 | ai | 68 | Task/block scope, no fixer — AI proposes patch (Abbenay) |
+| 3 | manual | 64 | Play/role/collection scope, cross-file, or info severity |
 
 Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION_TIER_REPORT.md).
 
@@ -89,14 +89,14 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L027 | L | Native | low | role | manual | Roles should have meta/main.yml with metadata. | Yes | Yes | Yes | — |
 | L030 | L | Native | low | task | ai | Non-builtin module used when a builtin equivalent exists. | Yes | Yes | Yes | — |
 | L031 | L | Native | high | task | ai | File permission may be insecure. | Yes | Yes | Yes | — |
-| L032 | L | Native | low | task | ai | Variable redefinition may cause confusion. | Yes | — | Yes | — |
-| L033 | L | Native | low | task | ai | Overriding vars without conditions. | Yes | — | Yes | — |
-| L034 | L | Native | low | inventory | manual | Lower-precedence override may be unused. | Yes | — | Yes | — |
+| L032 | L | Native | low | task | ai | Variable redefinition may cause confusion. | Yes | Yes | Yes | — |
+| L033 | L | Native | low | task | ai | Overriding vars without conditions. | Yes | Yes | Yes | — |
+| L034 | L | Native | low | inventory | manual | Lower-precedence override may be unused. | Yes | Yes | Yes | — |
 | L035 | L | Native | low | task | ai | set_fact with random in args. | Yes | Yes | Yes | — |
 | L036 | L | Native | low | task | ai | include_vars without when/tags. | Yes | Yes | Yes | — |
 | L037 | L | Native | medium | collection | manual | Module name could not be resolved. | Yes | Yes | Yes | — |
-| L038 | L | Native | medium | role | manual | Role could not be resolved. | Yes | — | Yes | — |
-| L039 | L | Native | medium | inventory | manual | Variable use may be undefined. | Yes | — | Yes | — |
+| L038 | L | Native | medium | role | manual | Role could not be resolved. | Yes | Yes | Yes | — |
+| L039 | L | Native | medium | inventory | manual | Variable use may be undefined. | Yes | Yes | Yes | — |
 | L040 | L | Native | info | playbook | manual | YAML should not contain tabs; use spaces. | Yes | Yes | Yes | — |
 | L041 | L | Native | low | task | ai | Task keys should follow canonical order (e.g. name before module). | Yes | Yes | Yes | — |
 | L042 | L | Native | info | play | manual | Play/block has high task count. | Yes | Yes | Yes | — |
@@ -111,9 +111,9 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L051 | L | Native | low | task | ai | Jinja spacing: {{ var }} not {{var}}. | Yes | Yes | Yes | — |
 | L052 | L | Native | low | role | manual | Galaxy version in meta should be semantic. | Yes | Yes | Yes | — |
 | L053 | L | Native | low | role | manual | Role meta should have valid structure. | Yes | Yes | Yes | — |
-| L054 | L | Native | low | role | manual | Role meta galaxy_info should include galaxy_tags. | Yes | — | Yes | — |
-| L055 | L | Native | low | role | manual | Role meta video_links should be valid URLs. | Yes | — | Yes | — |
-| L056 | L | Native | info | playbook | manual | Path may match ignore pattern. | Yes | — | Yes | — |
+| L054 | L | Native | low | role | manual | Role meta galaxy_info should include galaxy_tags. | Yes | Yes | Yes | — |
+| L055 | L | Native | low | role | manual | Role meta video_links should be valid URLs. | Yes | Yes | Yes | — |
+| L056 | L | Native | info | playbook | manual | Path may match ignore pattern. | Yes | Yes | Yes | — |
 | L057 | L | Ansible | error | playbook | manual | Syntax check via ansible-playbook --syntax-check. | Yes | Yes | Yes | — |
 | L058 | L | Ansible | error | task | ai | Argspec validation (docstring-based). | Yes | Yes | Yes | — |
 | L059 | L | Ansible | error | task | ai | Argspec validation (mock/patch-based). | Yes | Yes | Yes | — |
@@ -130,36 +130,36 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L070 | L | OPA | info | task | manual | Jinja in task names should only appear at the end of the name string. | Yes | Yes | Yes | — |
 | L071 | L | OPA | info | task | manual | Consider using template instead of copy with Jinja content. | Yes | Yes | Yes | — |
 | L072 | L | OPA | info | task | manual | Consider setting backup true on template/copy tasks. | Yes | Yes | Yes | — |
-| L073 | L | Native | low | playbook | manual | YAML should use 2-space indentation. | Yes | — | Yes | — |
+| L073 | L | Native | low | playbook | manual | YAML should use 2-space indentation. | Yes | Yes | Yes | — |
 | L074 | L | Native | low | role | manual | Role names should not contain dashes. | Yes | Yes | Yes | — |
-| L075 | L | Native | low | role | manual | Template source files should use .j2 extension (ansible_managed best practice). | Yes | — | Yes | — |
-| L076 | L | Native | low | task | ai | Use ansible_facts bracket notation instead of injected fact variables. | Yes | — | Yes | — |
+| L075 | L | Native | low | role | manual | Template source files should use .j2 extension (ansible_managed best practice). | Yes | Yes | Yes | — |
+| L076 | L | Native | low | task | ai | Use ansible_facts bracket notation instead of injected fact variables. | Yes | Yes | Yes | — |
 | L077 | L | Native | low | role | manual | Roles should have meta/argument_specs.yml for fail-fast parameter validation. | Yes | Yes | Yes | — |
 | L078 | L | Native | low | task | ai | Use bracket notation for dict key access in Jinja. | Yes | Yes | Yes | — |
 | L079 | L | Native | low | role | manual | Role defaults/vars should be prefixed with the role name. | Yes | Yes | Yes | — |
 | L080 | L | Native | low | task | manual | Internal role variables should be prefixed with _ (underscore). | Yes | Yes | Yes | — |
 | L081 | L | Native | low | playbook | manual | Do not number roles or playbooks. | Yes | Yes | Yes | — |
-| L082 | L | Native | low | task | ai | Template source files should use .j2 extension. | Yes | — | Yes | — |
+| L082 | L | Native | low | task | ai | Template source files should use .j2 extension. | Yes | Yes | Yes | — |
 | L083 | L | Native | low | task | ai | Do not hardcode host group names in roles. | Yes | Yes | Yes | — |
 | L084 | L | Native | low | task | auto | Task names in included sub-task files should use a prefix. | Yes | Yes | Yes | Yes |
 | L085 | L | Native | low | task | ai | Use explicit role_path prefix in include paths within roles. | Yes | Yes | Yes | — |
-| L086 | L | Native | low | play | manual | Avoid playbook/play vars for routine config; use inventory vars. | Yes | — | Yes | — |
+| L086 | L | Native | low | play | manual | Avoid playbook/play vars for routine config; use inventory vars. | Yes | Yes | Yes | — |
 | L087 | L | Native | low | collection | manual | Collection root should have a LICENSE or COPYING file. | Yes | Yes | Yes | — |
 | L088 | L | Native | low | collection | manual | Collection README should document supported ansible-core versions. | Yes | Yes | Yes | — |
 | L089 | L | Native | low | collection | manual | Plugin Python files should include type hints. | Yes | Yes | Yes | — |
 | L090 | L | Native | low | collection | manual | Plugin entry files should be small; move helpers to module_utils. | Yes | Yes | Yes | — |
-| L091 | L | Native | low | task | ai | Use \| bool for bare variables in when conditions. | Yes | — | Yes | — |
-| L092 | L | Native | low | task | ai | Avoid loop variable references in task names. | Yes | — | Yes | — |
-| L093 | L | Native | low | task | ai | Do not override role defaults/vars with set_fact. | Yes | — | Yes | — |
-| L094 | L | Native | low | task | ai | Do not put dynamic dates in templates; breaks change detection. | Yes | — | Yes | — |
+| L091 | L | Native | low | task | ai | Use \| bool for bare variables in when conditions. | Yes | Yes | Yes | — |
+| L092 | L | Native | low | task | ai | Avoid loop variable references in task names. | Yes | Yes | Yes | — |
+| L093 | L | Native | low | task | ai | Do not override role defaults/vars with set_fact. | Yes | Yes | Yes | — |
+| L094 | L | Native | low | task | ai | Do not put dynamic dates in templates; breaks change detection. | Yes | Yes | Yes | — |
 | L095 | L | Native | error | playbook | manual | YAML file does not match expected schema structure. | Yes | Yes | Yes | — |
 | L096 | L | Native | high | collection | manual | meta/runtime.yml should declare requires_ansible. | Yes | Yes | Yes | — |
-| L097 | L | Native | low | playbook | manual | Task names should be unique within a play. | Yes | — | Yes | — |
+| L097 | L | Native | low | playbook | manual | Task names should be unique within a play. | Yes | Yes | Yes | — |
 | L098 | L | Native | error | playbook | manual | YAML files should not have duplicate mapping keys. | Yes | Yes | Yes | — |
 | L099 | L | Native | info | playbook | manual | Prefer double quotes for YAML string values. | Yes | Yes | Yes | — |
 | L100 | L | Native | medium | playbook | manual | Variable names must not be Python or Ansible keywords. | Yes | Yes | Yes | — |
-| L101 | L | Native | medium | playbook | manual | Variable names must not collide with Ansible reserved names. | Yes | — | Yes | — |
-| L102 | L | Native | medium | playbook | manual | Do not set read-only Ansible variables. | Yes | — | Yes | — |
+| L101 | L | Native | medium | playbook | manual | Variable names must not collide with Ansible reserved names. | Yes | Yes | Yes | — |
+| L102 | L | Native | medium | playbook | manual | Do not set read-only Ansible variables. | Yes | Yes | Yes | — |
 | L103 | L | Native | low | collection | manual | Collection should have a CHANGELOG file. | Yes | Yes | Yes | — |
 | L104 | L | Native | low | collection | manual | Collection should have meta/runtime.yml. | Yes | Yes | Yes | — |
 | L105 | L | Native | low | collection | manual | galaxy.yml should have a repository key. | Yes | Yes | Yes | — |
@@ -169,7 +169,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | M001 | M | Ansible | high | task | auto | FQCN resolution — module resolved to a different canonical name. | Yes | Yes | Yes | Yes |
 | M002 | M | Ansible | high | task | auto | Deprecated module — module has deprecation metadata. | Yes | Yes | Yes | Yes |
 | M003 | M | Ansible | high | task | auto | Module redirect — module name was redirected to a new FQCN. | Yes | Yes | Yes | Yes |
-| M004 | M | Ansible | error | task | auto | Removed module — tombstoned module that raises AnsiblePluginRemovedError. | Yes | — | Yes | Yes |
+| M004 | M | Ansible | error | task | auto | Removed module — tombstoned module that raises AnsiblePluginRemovedError. | Yes | Yes | Yes | Yes |
 | M005 | M | Native | high | task | ai | Registered variable used in Jinja template may be untrusted in 2.19+. | Yes | Yes | Yes | — |
 | M006 | M | OPA | high | task | auto | become with ignore_errors will not catch timeout in 2.19+. | Yes | Yes | Yes | Yes |
 | M008 | M | OPA | high | task | auto | Bare include is removed in 2.19+; use include_tasks or import_tasks. | Yes | Yes | Yes | Yes |
@@ -177,44 +177,44 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | M010 | M | Native | high | play | manual | ansible_python_interpreter set to Python 2; dropped in 2.18+. | Yes | Yes | Yes | — |
 | M011 | M | OPA | high | collection | manual | Network module may require collection upgrade for 2.19+ compatibility. | Yes | Yes | Yes | — |
 | M014 | M | Native | medium | task | ai | Use ansible_facts["name"] instead of injected ansible_* fact variables (removed in 2.24) | Yes | Yes | Yes | — |
-| M015 | M | Native | medium | task | ai | Use ansible_play_batch instead of deprecated play_hosts variable (removed in 2.23) | Yes | — | Yes | — |
+| M015 | M | Native | medium | task | ai | Use ansible_play_batch instead of deprecated play_hosts variable (removed in 2.23) | Yes | Yes | Yes | — |
 | M016 | M | OPA | high | task | ai | Empty when: conditional is deprecated; remove it or add an explicit condition (2.23) | Yes | Yes | Yes | — |
 | M017 | M | OPA | high | task | ai | action: with a mapping value is deprecated; use string form or module key directly (2.23) | Yes | Yes | Yes | — |
 | M018 | M | OPA | high | task | ai | paramiko_ssh connection plugin is deprecated; use ssh connection instead (removed in 2.21) | Yes | Yes | Yes | — |
-| M019 | M | Native | low | task | ai | !!omap and !!pairs YAML tags are deprecated; standard YAML mappings preserve order in Python 3.7+ (2.23) | Yes | — | Yes | — |
-| M020 | M | Native | low | task | ai | Use !vault instead of deprecated !vault-encrypted tag (2.23) | Yes | — | Yes | — |
+| M019 | M | Native | low | task | ai | !!omap and !!pairs YAML tags are deprecated; standard YAML mappings preserve order in Python 3.7+ (2.23) | Yes | Yes | Yes | — |
+| M020 | M | Native | low | task | ai | Use !vault instead of deprecated !vault-encrypted tag (2.23) | Yes | Yes | Yes | — |
 | M021 | M | OPA | high | task | ai | Empty args: keyword on a task is deprecated; remove it (2.23) | Yes | Yes | Yes | — |
 | M022 | M | Native | medium | task | ai | tree and oneline callback plugins are removed in 2.23; choose an alternative | Yes | Yes | Yes | — |
 | M023 | M | OPA | high | task | ai | follow_redirects: yes/no (string) is deprecated in url lookup; use true/false boolean (2.22) | Yes | Yes | Yes | — |
 | M024 | M | OPA | high | task | ai | include_vars ignore_files must be a list, not a string (2.24) | Yes | Yes | Yes | — |
 | M025 | M | OPA | high | play | manual | Third-party strategy plugins are deprecated; only ansible.builtin strategies are supported (2.23) | Yes | Yes | Yes | — |
-| M026 | M | Native | medium | task | ai | Inventory variable names must be valid Python identifiers (enforced in 2.23) | Yes | — | Yes | — |
-| M027 | M | Native | low | task | ai | Mixing inline k=v arguments with args: mapping is deprecated (2.23) | Yes | — | Yes | — |
+| M026 | M | Native | medium | task | ai | Inventory variable names must be valid Python identifiers (enforced in 2.23) | Yes | Yes | Yes | — |
+| M027 | M | Native | low | task | ai | Mixing inline k=v arguments with args: mapping is deprecated (2.23) | Yes | Yes | Yes | — |
 | M028 | M | OPA | high | task | ai | first_found lookup auto-splitting paths on delimiters is deprecated (2.23) | Yes | Yes | Yes | — |
 | M029 | M | Native | medium | playbook | manual | Inventory scripts must include _meta.hostvars in JSON output (enforced in 2.23) | Yes | Yes | Yes | — |
-| M030 | M | Native | medium | task | ai | Conditional expressions that fail Jinja2 parsing will error in 2.23 instead of being silently ignored | Yes | — | Yes | — |
-| P001 | P | Native | error | task | ai | Validate module name (Ansible required). | — | Yes | Yes | — |
-| P002 | P | Native | error | task | ai | Validate module argument keys (Ansible required). | — | Yes | Yes | — |
-| P003 | P | Native | error | task | ai | Validate module argument values (Ansible required). | — | — | Yes | — |
-| P004 | P | Native | error | inventory | manual | Validate variables (Ansible required). | — | — | Yes | — |
+| M030 | M | Native | medium | task | ai | Conditional expressions that fail Jinja2 parsing will error in 2.23 instead of being silently ignored | Yes | Yes | Yes | — |
+| P001 | P | Ansible | error | task | ai | Validate module name (Ansible required). | — | Yes | Yes | — |
+| P002 | P | Ansible | error | task | ai | Validate module argument keys (Ansible required). | — | Yes | Yes | — |
+| P003 | P | Ansible | error | task | ai | Validate module argument values (Ansible required). | — | — | Yes | — |
+| P004 | P | Ansible | error | task | ai | Validate variables (Ansible required). | — | — | Yes | — |
 | R101 | R | Native | medium | task | ai | Task executes parameterized command (annotation-based) | Yes | Yes | Yes | — |
 | R103 | R | Native | medium | task | ai | Task downloads and executes (annotation-based). | Yes | Yes | Yes | — |
 | R104 | R | Native | medium | task | ai | Download from unauthorized source (annotation-based). | Yes | Yes | Yes | — |
-| R105 | R | Native | medium | task | ai | Outbound transfer (annotation-based). | Yes | — | Yes | — |
-| R106 | R | Native | medium | task | ai | Inbound transfer (annotation-based). | Yes | — | Yes | — |
-| R107 | R | Native | medium | task | ai | Package install with insecure option (annotation-based). | Yes | — | Yes | — |
+| R105 | R | Native | medium | task | ai | Outbound transfer (annotation-based). | Yes | Yes | Yes | — |
+| R106 | R | Native | medium | task | ai | Inbound transfer (annotation-based). | Yes | Yes | Yes | — |
+| R107 | R | Native | medium | task | ai | Package install with insecure option (annotation-based). | Yes | Yes | Yes | — |
 | R108 | R | Native | medium | play | manual | Privilege escalation (annotation-based). | Yes | Yes | Yes | — |
-| R109 | R | Native | medium | task | ai | Key/config change (annotation-based). | Yes | — | Yes | — |
+| R109 | R | Native | medium | task | ai | Key/config change (annotation-based). | Yes | Yes | Yes | — |
 | R111 | R | Native | medium | task | manual | Parameterized role import (annotation-based). | Yes | Yes | Yes | — |
 | R112 | R | Native | medium | task | manual | Parameterized taskfile import (annotation-based). | Yes | Yes | Yes | — |
 | R113 | R | Native | medium | task | ai | Parameterized package install (annotation-based). | Yes | Yes | Yes | — |
 | R114 | R | Native | medium | task | ai | File change (annotation-based). | Yes | Yes | Yes | — |
-| R115 | R | Native | medium | task | ai | File deletion (annotation-based). | Yes | — | Yes | — |
-| R117 | R | Native | info | role | manual | Role is from Galaxy/external source. | Yes | — | Yes | — |
+| R115 | R | Native | medium | task | ai | File deletion (annotation-based). | Yes | Yes | Yes | — |
+| R117 | R | Native | info | role | manual | Role is from Galaxy/external source. | Yes | Yes | Yes | — |
 | R118 | R | OPA | info | task | manual | Task downloads from an external source (inbound transfer). | Yes | Yes | Yes | — |
-| R401 | R | Native | info | playbook | manual | Report inbound transfer sources. | Yes | — | Yes | — |
-| R402 | R | Native | info | task | manual | Report variables used at end of sequence. | — | — | Yes | — |
-| R404 | R | Native | info | task | manual | Expose variable_set for the task. | — | — | Yes | — |
+| R401 | R | Native | info | playbook | manual | Report inbound transfer sources. | Yes | Yes | Yes | — |
+| R402 | R | Native | info | task | manual | Report variables used at end of sequence. | — | Yes | Yes | — |
+| R404 | R | Native | info | task | manual | Expose variable_set for the task. | — | Yes | Yes | — |
 | R501 | R | Native | info | collection | manual | Suggest collection/role dependency. | — | — | Yes | — |
 | SEC:* | SEC | Gitleaks | critical | task | ai | Secret/credential detection (delegated to Gitleaks binary). | Yes | Yes | — | — |
 
@@ -274,7 +274,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | M028 | high | task | ai | first_found lookup auto-splitting paths on delimiters is deprecated (2.23) | Yes | Yes | Yes | — |
 | R118 | info | task | manual | Task downloads from an external source (inbound transfer). | Yes | Yes | Yes | — |
 
-### Native (100 rules, 93 impl, 62 tested, 4 fixers)
+### Native (96 rules, 93 impl, 95 tested, 4 fixers)
 
 | Rule ID | Severity | Scope | Tier | Description | Impl | Test | Doc | Fix |
 |---------|----------|-------|------|-------------|------|------|-----|-----|
@@ -284,14 +284,14 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L027 | low | role | manual | Roles should have meta/main.yml with metadata. | Yes | Yes | Yes | — |
 | L030 | low | task | ai | Non-builtin module used when a builtin equivalent exists. | Yes | Yes | Yes | — |
 | L031 | high | task | ai | File permission may be insecure. | Yes | Yes | Yes | — |
-| L032 | low | task | ai | Variable redefinition may cause confusion. | Yes | — | Yes | — |
-| L033 | low | task | ai | Overriding vars without conditions. | Yes | — | Yes | — |
-| L034 | low | inventory | manual | Lower-precedence override may be unused. | Yes | — | Yes | — |
+| L032 | low | task | ai | Variable redefinition may cause confusion. | Yes | Yes | Yes | — |
+| L033 | low | task | ai | Overriding vars without conditions. | Yes | Yes | Yes | — |
+| L034 | low | inventory | manual | Lower-precedence override may be unused. | Yes | Yes | Yes | — |
 | L035 | low | task | ai | set_fact with random in args. | Yes | Yes | Yes | — |
 | L036 | low | task | ai | include_vars without when/tags. | Yes | Yes | Yes | — |
 | L037 | medium | collection | manual | Module name could not be resolved. | Yes | Yes | Yes | — |
-| L038 | medium | role | manual | Role could not be resolved. | Yes | — | Yes | — |
-| L039 | medium | inventory | manual | Variable use may be undefined. | Yes | — | Yes | — |
+| L038 | medium | role | manual | Role could not be resolved. | Yes | Yes | Yes | — |
+| L039 | medium | inventory | manual | Variable use may be undefined. | Yes | Yes | Yes | — |
 | L040 | info | playbook | manual | YAML should not contain tabs; use spaces. | Yes | Yes | Yes | — |
 | L041 | low | task | ai | Task keys should follow canonical order (e.g. name before module). | Yes | Yes | Yes | — |
 | L042 | info | play | manual | Play/block has high task count. | Yes | Yes | Yes | — |
@@ -306,40 +306,40 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L051 | low | task | ai | Jinja spacing: {{ var }} not {{var}}. | Yes | Yes | Yes | — |
 | L052 | low | role | manual | Galaxy version in meta should be semantic. | Yes | Yes | Yes | — |
 | L053 | low | role | manual | Role meta should have valid structure. | Yes | Yes | Yes | — |
-| L054 | low | role | manual | Role meta galaxy_info should include galaxy_tags. | Yes | — | Yes | — |
-| L055 | low | role | manual | Role meta video_links should be valid URLs. | Yes | — | Yes | — |
-| L056 | info | playbook | manual | Path may match ignore pattern. | Yes | — | Yes | — |
+| L054 | low | role | manual | Role meta galaxy_info should include galaxy_tags. | Yes | Yes | Yes | — |
+| L055 | low | role | manual | Role meta video_links should be valid URLs. | Yes | Yes | Yes | — |
+| L056 | info | playbook | manual | Path may match ignore pattern. | Yes | Yes | Yes | — |
 | L060 | info | playbook | manual | Line too long (exceeds 160 characters). | Yes | Yes | Yes | — |
-| L073 | low | playbook | manual | YAML should use 2-space indentation. | Yes | — | Yes | — |
+| L073 | low | playbook | manual | YAML should use 2-space indentation. | Yes | Yes | Yes | — |
 | L074 | low | role | manual | Role names should not contain dashes. | Yes | Yes | Yes | — |
-| L075 | low | role | manual | Template source files should use .j2 extension (ansible_managed best practice). | Yes | — | Yes | — |
-| L076 | low | task | ai | Use ansible_facts bracket notation instead of injected fact variables. | Yes | — | Yes | — |
+| L075 | low | role | manual | Template source files should use .j2 extension (ansible_managed best practice). | Yes | Yes | Yes | — |
+| L076 | low | task | ai | Use ansible_facts bracket notation instead of injected fact variables. | Yes | Yes | Yes | — |
 | L077 | low | role | manual | Roles should have meta/argument_specs.yml for fail-fast parameter validation. | Yes | Yes | Yes | — |
 | L078 | low | task | ai | Use bracket notation for dict key access in Jinja. | Yes | Yes | Yes | — |
 | L079 | low | role | manual | Role defaults/vars should be prefixed with the role name. | Yes | Yes | Yes | — |
 | L080 | low | task | manual | Internal role variables should be prefixed with _ (underscore). | Yes | Yes | Yes | — |
 | L081 | low | playbook | manual | Do not number roles or playbooks. | Yes | Yes | Yes | — |
-| L082 | low | task | ai | Template source files should use .j2 extension. | Yes | — | Yes | — |
+| L082 | low | task | ai | Template source files should use .j2 extension. | Yes | Yes | Yes | — |
 | L083 | low | task | ai | Do not hardcode host group names in roles. | Yes | Yes | Yes | — |
 | L084 | low | task | auto | Task names in included sub-task files should use a prefix. | Yes | Yes | Yes | Yes |
 | L085 | low | task | ai | Use explicit role_path prefix in include paths within roles. | Yes | Yes | Yes | — |
-| L086 | low | play | manual | Avoid playbook/play vars for routine config; use inventory vars. | Yes | — | Yes | — |
+| L086 | low | play | manual | Avoid playbook/play vars for routine config; use inventory vars. | Yes | Yes | Yes | — |
 | L087 | low | collection | manual | Collection root should have a LICENSE or COPYING file. | Yes | Yes | Yes | — |
 | L088 | low | collection | manual | Collection README should document supported ansible-core versions. | Yes | Yes | Yes | — |
 | L089 | low | collection | manual | Plugin Python files should include type hints. | Yes | Yes | Yes | — |
 | L090 | low | collection | manual | Plugin entry files should be small; move helpers to module_utils. | Yes | Yes | Yes | — |
-| L091 | low | task | ai | Use \| bool for bare variables in when conditions. | Yes | — | Yes | — |
-| L092 | low | task | ai | Avoid loop variable references in task names. | Yes | — | Yes | — |
-| L093 | low | task | ai | Do not override role defaults/vars with set_fact. | Yes | — | Yes | — |
-| L094 | low | task | ai | Do not put dynamic dates in templates; breaks change detection. | Yes | — | Yes | — |
+| L091 | low | task | ai | Use \| bool for bare variables in when conditions. | Yes | Yes | Yes | — |
+| L092 | low | task | ai | Avoid loop variable references in task names. | Yes | Yes | Yes | — |
+| L093 | low | task | ai | Do not override role defaults/vars with set_fact. | Yes | Yes | Yes | — |
+| L094 | low | task | ai | Do not put dynamic dates in templates; breaks change detection. | Yes | Yes | Yes | — |
 | L095 | error | playbook | manual | YAML file does not match expected schema structure. | Yes | Yes | Yes | — |
 | L096 | high | collection | manual | meta/runtime.yml should declare requires_ansible. | Yes | Yes | Yes | — |
-| L097 | low | playbook | manual | Task names should be unique within a play. | Yes | — | Yes | — |
+| L097 | low | playbook | manual | Task names should be unique within a play. | Yes | Yes | Yes | — |
 | L098 | error | playbook | manual | YAML files should not have duplicate mapping keys. | Yes | Yes | Yes | — |
 | L099 | info | playbook | manual | Prefer double quotes for YAML string values. | Yes | Yes | Yes | — |
 | L100 | medium | playbook | manual | Variable names must not be Python or Ansible keywords. | Yes | Yes | Yes | — |
-| L101 | medium | playbook | manual | Variable names must not collide with Ansible reserved names. | Yes | — | Yes | — |
-| L102 | medium | playbook | manual | Do not set read-only Ansible variables. | Yes | — | Yes | — |
+| L101 | medium | playbook | manual | Variable names must not collide with Ansible reserved names. | Yes | Yes | Yes | — |
+| L102 | medium | playbook | manual | Do not set read-only Ansible variables. | Yes | Yes | Yes | — |
 | L103 | low | collection | manual | Collection should have a CHANGELOG file. | Yes | Yes | Yes | — |
 | L104 | low | collection | manual | Collection should have meta/runtime.yml. | Yes | Yes | Yes | — |
 | L105 | low | collection | manual | galaxy.yml should have a repository key. | Yes | Yes | Yes | — |
@@ -348,38 +348,34 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | M005 | high | task | ai | Registered variable used in Jinja template may be untrusted in 2.19+. | Yes | Yes | Yes | — |
 | M010 | high | play | manual | ansible_python_interpreter set to Python 2; dropped in 2.18+. | Yes | Yes | Yes | — |
 | M014 | medium | task | ai | Use ansible_facts["name"] instead of injected ansible_* fact variables (removed in 2.24) | Yes | Yes | Yes | — |
-| M015 | medium | task | ai | Use ansible_play_batch instead of deprecated play_hosts variable (removed in 2.23) | Yes | — | Yes | — |
-| M019 | low | task | ai | !!omap and !!pairs YAML tags are deprecated; standard YAML mappings preserve order in Python 3.7+ (2.23) | Yes | — | Yes | — |
-| M020 | low | task | ai | Use !vault instead of deprecated !vault-encrypted tag (2.23) | Yes | — | Yes | — |
+| M015 | medium | task | ai | Use ansible_play_batch instead of deprecated play_hosts variable (removed in 2.23) | Yes | Yes | Yes | — |
+| M019 | low | task | ai | !!omap and !!pairs YAML tags are deprecated; standard YAML mappings preserve order in Python 3.7+ (2.23) | Yes | Yes | Yes | — |
+| M020 | low | task | ai | Use !vault instead of deprecated !vault-encrypted tag (2.23) | Yes | Yes | Yes | — |
 | M022 | medium | task | ai | tree and oneline callback plugins are removed in 2.23; choose an alternative | Yes | Yes | Yes | — |
-| M026 | medium | task | ai | Inventory variable names must be valid Python identifiers (enforced in 2.23) | Yes | — | Yes | — |
-| M027 | low | task | ai | Mixing inline k=v arguments with args: mapping is deprecated (2.23) | Yes | — | Yes | — |
+| M026 | medium | task | ai | Inventory variable names must be valid Python identifiers (enforced in 2.23) | Yes | Yes | Yes | — |
+| M027 | low | task | ai | Mixing inline k=v arguments with args: mapping is deprecated (2.23) | Yes | Yes | Yes | — |
 | M029 | medium | playbook | manual | Inventory scripts must include _meta.hostvars in JSON output (enforced in 2.23) | Yes | Yes | Yes | — |
-| M030 | medium | task | ai | Conditional expressions that fail Jinja2 parsing will error in 2.23 instead of being silently ignored | Yes | — | Yes | — |
-| P001 | error | task | ai | Validate module name (Ansible required). | — | Yes | Yes | — |
-| P002 | error | task | ai | Validate module argument keys (Ansible required). | — | Yes | Yes | — |
-| P003 | error | task | ai | Validate module argument values (Ansible required). | — | — | Yes | — |
-| P004 | error | inventory | manual | Validate variables (Ansible required). | — | — | Yes | — |
+| M030 | medium | task | ai | Conditional expressions that fail Jinja2 parsing will error in 2.23 instead of being silently ignored | Yes | Yes | Yes | — |
 | R101 | medium | task | ai | Task executes parameterized command (annotation-based) | Yes | Yes | Yes | — |
 | R103 | medium | task | ai | Task downloads and executes (annotation-based). | Yes | Yes | Yes | — |
 | R104 | medium | task | ai | Download from unauthorized source (annotation-based). | Yes | Yes | Yes | — |
-| R105 | medium | task | ai | Outbound transfer (annotation-based). | Yes | — | Yes | — |
-| R106 | medium | task | ai | Inbound transfer (annotation-based). | Yes | — | Yes | — |
-| R107 | medium | task | ai | Package install with insecure option (annotation-based). | Yes | — | Yes | — |
+| R105 | medium | task | ai | Outbound transfer (annotation-based). | Yes | Yes | Yes | — |
+| R106 | medium | task | ai | Inbound transfer (annotation-based). | Yes | Yes | Yes | — |
+| R107 | medium | task | ai | Package install with insecure option (annotation-based). | Yes | Yes | Yes | — |
 | R108 | medium | play | manual | Privilege escalation (annotation-based). | Yes | Yes | Yes | — |
-| R109 | medium | task | ai | Key/config change (annotation-based). | Yes | — | Yes | — |
+| R109 | medium | task | ai | Key/config change (annotation-based). | Yes | Yes | Yes | — |
 | R111 | medium | task | manual | Parameterized role import (annotation-based). | Yes | Yes | Yes | — |
 | R112 | medium | task | manual | Parameterized taskfile import (annotation-based). | Yes | Yes | Yes | — |
 | R113 | medium | task | ai | Parameterized package install (annotation-based). | Yes | Yes | Yes | — |
 | R114 | medium | task | ai | File change (annotation-based). | Yes | Yes | Yes | — |
-| R115 | medium | task | ai | File deletion (annotation-based). | Yes | — | Yes | — |
-| R117 | info | role | manual | Role is from Galaxy/external source. | Yes | — | Yes | — |
-| R401 | info | playbook | manual | Report inbound transfer sources. | Yes | — | Yes | — |
-| R402 | info | task | manual | Report variables used at end of sequence. | — | — | Yes | — |
-| R404 | info | task | manual | Expose variable_set for the task. | — | — | Yes | — |
+| R115 | medium | task | ai | File deletion (annotation-based). | Yes | Yes | Yes | — |
+| R117 | info | role | manual | Role is from Galaxy/external source. | Yes | Yes | Yes | — |
+| R401 | info | playbook | manual | Report inbound transfer sources. | Yes | Yes | Yes | — |
+| R402 | info | task | manual | Report variables used at end of sequence. | — | Yes | Yes | — |
+| R404 | info | task | manual | Expose variable_set for the task. | — | Yes | Yes | — |
 | R501 | info | collection | manual | Suggest collection/role dependency. | — | — | Yes | — |
 
-### Ansible (7 rules, 7 impl, 6 tested, 4 fixers)
+### Ansible (11 rules, 7 impl, 9 tested, 4 fixers)
 
 | Rule ID | Severity | Scope | Tier | Description | Impl | Test | Doc | Fix |
 |---------|----------|-------|------|-------------|------|------|-----|-----|
@@ -389,7 +385,11 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | M001 | high | task | auto | FQCN resolution — module resolved to a different canonical name. | Yes | Yes | Yes | Yes |
 | M002 | high | task | auto | Deprecated module — module has deprecation metadata. | Yes | Yes | Yes | Yes |
 | M003 | high | task | auto | Module redirect — module name was redirected to a new FQCN. | Yes | Yes | Yes | Yes |
-| M004 | error | task | auto | Removed module — tombstoned module that raises AnsiblePluginRemovedError. | Yes | — | Yes | Yes |
+| M004 | error | task | auto | Removed module — tombstoned module that raises AnsiblePluginRemovedError. | Yes | Yes | Yes | Yes |
+| P001 | error | task | ai | Validate module name (Ansible required). | — | Yes | Yes | — |
+| P002 | error | task | ai | Validate module argument keys (Ansible required). | — | Yes | Yes | — |
+| P003 | error | task | ai | Validate module argument values (Ansible required). | — | — | Yes | — |
+| P004 | error | task | ai | Validate variables (Ansible required). | — | — | Yes | — |
 
 ### Gitleaks (1 rules, 1 impl, 1 tested, 0 fixers)
 
@@ -399,52 +399,18 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 
 ## Coverage Gaps
 
-### Doc-only rules (no implementation) — 7
+### Planned rules (implementation pending) — 3
 
-- **P001** (Native): Validate module name (Ansible required).
-- **P002** (Native): Validate module argument keys (Ansible required).
-- **P003** (Native): Validate module argument values (Ansible required).
-- **P004** (Native): Validate variables (Ansible required).
-- **R402** (Native): Report variables used at end of sequence.
-- **R404** (Native): Expose variable_set for the task.
-- **R501** (Native): Suggest collection/role dependency.
+- **R402** (Native): Report variables used at end of sequence. — Informational/reporting rule requiring deeper graph analysis to enumerate all variables referenced across a task sequence. Planned for future implementation using VariableProvenanceResolver.
+- **R404** (Native): Expose variable_set for the task. — Informational/debug rule that would expose the resolved variable_set for each task. Disabled by default. Planned for future implementation using VariableProvenanceResolver.
+- **R501** (Native): Suggest collection/role dependency. — Advisory rule requiring collection dependency resolution context. The rule needs access to the Galaxy/collection index to suggest which collection provides an unresolved module. Planned for future implementation.
 
-### Implemented but untested — 34
+### Resolved without implementation — 4
 
-- **L032** (Native): Variable redefinition may cause confusion.
-- **L033** (Native): Overriding vars without conditions.
-- **L034** (Native): Lower-precedence override may be unused.
-- **L038** (Native): Role could not be resolved.
-- **L039** (Native): Variable use may be undefined.
-- **L054** (Native): Role meta galaxy_info should include galaxy_tags.
-- **L055** (Native): Role meta video_links should be valid URLs.
-- **L056** (Native): Path may match ignore pattern.
-- **L073** (Native): YAML should use 2-space indentation.
-- **L075** (Native): Template source files should use .j2 extension (ansible_managed best practice).
-- **L076** (Native): Use ansible_facts bracket notation instead of injected fact variables.
-- **L082** (Native): Template source files should use .j2 extension.
-- **L086** (Native): Avoid playbook/play vars for routine config; use inventory vars.
-- **L091** (Native): Use | bool for bare variables in when conditions.
-- **L092** (Native): Avoid loop variable references in task names.
-- **L093** (Native): Do not override role defaults/vars with set_fact.
-- **L094** (Native): Do not put dynamic dates in templates; breaks change detection.
-- **L097** (Native): Task names should be unique within a play.
-- **L101** (Native): Variable names must not collide with Ansible reserved names.
-- **L102** (Native): Do not set read-only Ansible variables.
-- **M004** (Ansible): Removed module — tombstoned module that raises AnsiblePluginRemovedError.
-- **M015** (Native): Use ansible_play_batch instead of deprecated play_hosts variable (removed in 2.23)
-- **M019** (Native): !!omap and !!pairs YAML tags are deprecated; standard YAML mappings preserve order in Python 3.7+ (2.23)
-- **M020** (Native): Use !vault instead of deprecated !vault-encrypted tag (2.23)
-- **M026** (Native): Inventory variable names must be valid Python identifiers (enforced in 2.23)
-- **M027** (Native): Mixing inline k=v arguments with args: mapping is deprecated (2.23)
-- **M030** (Native): Conditional expressions that fail Jinja2 parsing will error in 2.23 instead of being silently ignored
-- **R105** (Native): Outbound transfer (annotation-based).
-- **R106** (Native): Inbound transfer (annotation-based).
-- **R107** (Native): Package install with insecure option (annotation-based).
-- **R109** (Native): Key/config change (annotation-based).
-- **R115** (Native): File deletion (annotation-based).
-- **R117** (Native): Role is from Galaxy/external source.
-- **R401** (Native): Report inbound transfer sources.
+- **P001** (Ansible): [Delegated] Validate module name (Ansible required). — Emitted by the Ansible validator via find_plugin_with_context() argspec validation (L058/L059). Not a native GraphRule — the Ansible validator owns module name resolution.
+- **P002** (Ansible): [Delegated] Validate module argument keys (Ansible required). — Emitted by the Ansible validator via argspec validation (L058/L059). Not a native GraphRule — the Ansible validator owns module argument key validation using real module argspecs.
+- **P003** (Ansible): [Delegated] Validate module argument values (Ansible required). — Emitted by the Ansible validator via argspec validation (L058/L059). Not a native GraphRule — the Ansible validator owns module argument value validation using real module argspecs.
+- **P004** (Ansible): [Delegated] Validate variables (Ansible required). — Emitted by the Ansible validator via argspec validation (L058/L059). Not a native GraphRule — the Ansible validator owns variable validation in the context of module argument resolution.
 
 ### Implemented but undocumented — 1
 

--- a/proto/apme/v1/validate.proto
+++ b/proto/apme/v1/validate.proto
@@ -23,6 +23,7 @@ message ValidateRequest {
   string venv_path = 9;           // resolved venv path (set by Engine; validators use read-only)
   bytes content_graph_data = 10;  // JSON-serialized ContentGraph (ADR-044)
   repeated string dirty_node_ids = 11;  // hint for native validator: rescan only these nodes
+  repeated string graph_rule_opt_in = 12;  // disabled-by-default GraphRule IDs to enable (ADR-041)
 }
 
 message ValidateResponse {

--- a/src/apme/v1/validate_pb2.py
+++ b/src/apme/v1/validate_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from apme.v1 import common_pb2 as apme_dot_v1_dot_common__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16\x61pme/v1/validate.proto\x12\x07\x61pme.v1\x1a\x14\x61pme/v1/common.proto\"\x99\x02\n\x0fValidateRequest\x12\x14\n\x0cproject_root\x18\x01 \x01(\t\x12\x1c\n\x05\x66iles\x18\x02 \x03(\x0b\x32\r.apme.v1.File\x12\x19\n\x11hierarchy_payload\x18\x03 \x01(\x0c\x12\x10\n\x08scandata\x18\x04 \x01(\x0c\x12\x1c\n\x14\x61nsible_core_version\x18\x05 \x01(\t\x12\x18\n\x10\x63ollection_specs\x18\x06 \x03(\t\x12\x12\n\nrequest_id\x18\x07 \x01(\t\x12\x12\n\nsession_id\x18\x08 \x01(\t\x12\x11\n\tvenv_path\x18\t \x01(\t\x12\x1a\n\x12\x63ontent_graph_data\x18\n \x01(\x0c\x12\x16\n\x0e\x64irty_node_ids\x18\x0b \x03(\t\"\xa9\x01\n\x10ValidateResponse\x12&\n\nviolations\x18\x01 \x03(\x0b\x32\x12.apme.v1.Violation\x12\x12\n\nrequest_id\x18\x02 \x01(\t\x12\x32\n\x0b\x64iagnostics\x18\x03 \x01(\x0b\x32\x1d.apme.v1.ValidatorDiagnostics\x12%\n\x04logs\x18\x04 \x03(\x0b\x32\x17.apme.v1.ProgressUpdate2\x87\x01\n\tValidator\x12?\n\x08Validate\x12\x18.apme.v1.ValidateRequest\x1a\x19.apme.v1.ValidateResponse\x12\x39\n\x06Health\x12\x16.apme.v1.HealthRequest\x1a\x17.apme.v1.HealthResponseb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16\x61pme/v1/validate.proto\x12\x07\x61pme.v1\x1a\x14\x61pme/v1/common.proto\"\xb4\x02\n\x0fValidateRequest\x12\x14\n\x0cproject_root\x18\x01 \x01(\t\x12\x1c\n\x05\x66iles\x18\x02 \x03(\x0b\x32\r.apme.v1.File\x12\x19\n\x11hierarchy_payload\x18\x03 \x01(\x0c\x12\x10\n\x08scandata\x18\x04 \x01(\x0c\x12\x1c\n\x14\x61nsible_core_version\x18\x05 \x01(\t\x12\x18\n\x10\x63ollection_specs\x18\x06 \x03(\t\x12\x12\n\nrequest_id\x18\x07 \x01(\t\x12\x12\n\nsession_id\x18\x08 \x01(\t\x12\x11\n\tvenv_path\x18\t \x01(\t\x12\x1a\n\x12\x63ontent_graph_data\x18\n \x01(\x0c\x12\x16\n\x0e\x64irty_node_ids\x18\x0b \x03(\t\x12\x19\n\x11graph_rule_opt_in\x18\x0c \x03(\t\"\xa9\x01\n\x10ValidateResponse\x12&\n\nviolations\x18\x01 \x03(\x0b\x32\x12.apme.v1.Violation\x12\x12\n\nrequest_id\x18\x02 \x01(\t\x12\x32\n\x0b\x64iagnostics\x18\x03 \x01(\x0b\x32\x1d.apme.v1.ValidatorDiagnostics\x12%\n\x04logs\x18\x04 \x03(\x0b\x32\x17.apme.v1.ProgressUpdate2\x87\x01\n\tValidator\x12?\n\x08Validate\x12\x18.apme.v1.ValidateRequest\x1a\x19.apme.v1.ValidateResponse\x12\x39\n\x06Health\x12\x16.apme.v1.HealthRequest\x1a\x17.apme.v1.HealthResponseb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,9 +33,9 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'apme.v1.validate_pb2', _glo
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
   _globals['_VALIDATEREQUEST']._serialized_start=58
-  _globals['_VALIDATEREQUEST']._serialized_end=339
-  _globals['_VALIDATERESPONSE']._serialized_start=342
-  _globals['_VALIDATERESPONSE']._serialized_end=511
-  _globals['_VALIDATOR']._serialized_start=514
-  _globals['_VALIDATOR']._serialized_end=649
+  _globals['_VALIDATEREQUEST']._serialized_end=366
+  _globals['_VALIDATERESPONSE']._serialized_start=369
+  _globals['_VALIDATERESPONSE']._serialized_end=538
+  _globals['_VALIDATOR']._serialized_start=541
+  _globals['_VALIDATOR']._serialized_end=676
 # @@protoc_insertion_point(module_scope)

--- a/src/apme/v1/validate_pb2.pyi
+++ b/src/apme/v1/validate_pb2.pyi
@@ -16,6 +16,7 @@ class ValidateRequest:
     venv_path: str
     content_graph_data: bytes
     dirty_node_ids: list[str]
+    graph_rule_opt_in: list[str]
     def __init__(
         self,
         *,
@@ -23,6 +24,7 @@ class ValidateRequest:
         venv_path: str = "",
         content_graph_data: bytes = b"",
         dirty_node_ids: Iterable[str] | None = ...,
+        graph_rule_opt_in: Iterable[str] | None = ...,
         **kwargs: object,
     ) -> None: ...
     def HasField(self, field_name: str) -> bool: ...

--- a/src/apme_engine/cli/check.py
+++ b/src/apme_engine/cli/check.py
@@ -20,7 +20,6 @@ from apme.v1.engine_pb2 import (
     FixReport,
     SessionCommand,
 )
-from apme_engine.cli._convert import violation_proto_to_dict
 from apme_engine.cli._exit_codes import EXIT_ERROR, EXIT_VIOLATIONS
 from apme_engine.cli._galaxy_config import discover_galaxy_servers
 from apme_engine.cli._models import ViolationDict
@@ -36,6 +35,7 @@ from apme_engine.cli.output import (
 )
 from apme_engine.cli.sarif import violations_to_sarif
 from apme_engine.daemon.chunked_fs import yield_scan_chunks
+from apme_engine.daemon.violation_convert import violation_proto_to_dict
 from apme_engine.remediation.partition import count_by_remediation_class, count_by_resolution
 
 _SAFE_SESSION_RE = __import__("re").compile(r"^[A-Za-z0-9_\-]+$")

--- a/src/apme_engine/daemon/engine_server.py
+++ b/src/apme_engine/daemon/engine_server.py
@@ -89,6 +89,7 @@ from apme_engine.daemon.fs_utils import write_chunked_fs as _write_chunked_fs
 from apme_engine.daemon.session import ResourceExhaustedError, SessionState, SessionStore
 from apme_engine.daemon.violation_convert import violation_dict_to_proto, violation_proto_to_dict
 from apme_engine.engine.models import RemediationClass, ViolationDict
+from apme_engine.graph.scanner import graph_rule_opt_in_from_rule_configs
 from apme_engine.log_bridge import attach_collector
 from apme_engine.remediation.graph_engine import FilePatch as SplicedFilePatch
 from apme_engine.runner import run_scan
@@ -1083,6 +1084,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
             session_id=sid,
             venv_path=venv_path,
             content_graph_data=content_graph_data,
+            graph_rule_opt_in=graph_rule_opt_in_from_rule_configs(rule_configs),
         )
 
         _pcb = progress_callback
@@ -1824,6 +1826,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
             _heartbeat=_heartbeat,
             format_content=format_content,
             format_diffs=format_diffs,
+            rule_configs=scan_rule_configs or None,
         ):
             yield event
 
@@ -2063,6 +2066,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         _heartbeat: Callable[[], Awaitable[None]],
         format_content: Callable[..., object],
         format_diffs: Sequence[object],
+        rule_configs: list[object] | None = None,
     ) -> AsyncIterator[SessionEvent]:
         """Graph-engine remediation — in-memory convergence, graph-authoritative.
 
@@ -2088,6 +2092,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
             _heartbeat: Coroutine factory for periodic heartbeats.
             format_content: Formatter function for post-remediation pass.
             format_diffs: Accumulated format diffs from earlier step.
+            rule_configs: Per-rule overrides for opt-in audit GraphRules.
 
         Yields:
             SessionEvent: Progress, Tier1Summary, and result events.
@@ -2095,6 +2100,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         from apme_engine.engine.graph_opa_payload import content_node_to_opa_dict
         from apme_engine.graph.content_graph import ContentGraph, EdgeType, NodeType
         from apme_engine.graph.scanner import (
+            graph_rule_opt_in_from_rule_configs,
             load_graph_rules,
             native_rules_dir,
         )
@@ -2126,7 +2132,15 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         originals = await loop.run_in_executor(None, _load_yaml_originals, yaml_paths, temp_dir)
 
         # 2. Convergence: all validators on dirty nodes via gRPC
-        rules = load_graph_rules(rules_dir=native_rules_dir())
+        rules, missing_opt_in = load_graph_rules(
+            rules_dir=native_rules_dir(),
+            opt_in_rule_ids=graph_rule_opt_in_from_rule_configs(rule_configs),
+        )
+        if missing_opt_in:
+            logger.warning(
+                "Remediation: requested opt-in graph rules failed to load: %s",
+                ", ".join(missing_opt_in),
+            )
 
         async def _rescan_bridge(
             g: ContentGraph,

--- a/src/apme_engine/daemon/native_validator_server.py
+++ b/src/apme_engine/daemon/native_validator_server.py
@@ -63,6 +63,7 @@ def _default_rules_dir() -> str:
 def _run_graph(
     raw_graph_data: bytes,
     dirty_node_ids: frozenset[str] | None = None,
+    opt_in_rule_ids: list[str] | None = None,
 ) -> _GraphRunResult:
     """Blocking function: deserialize ContentGraph, load GraphRules, and scan.
 
@@ -77,6 +78,7 @@ def _run_graph(
     Args:
         raw_graph_data: Raw JSON bytes from ``ValidateRequest.content_graph_data``.
         dirty_node_ids: Optional set of node IDs to rescan.
+        opt_in_rule_ids: Disabled-by-default GraphRule IDs to enable for this scan.
 
     Returns:
         _GraphRunResult with violations and the raw report.
@@ -84,10 +86,11 @@ def _run_graph(
     graph_dict = json.loads(raw_graph_data)
     content_graph = ContentGraph.from_dict(graph_dict)
     rules_dir = _default_rules_dir()
-    rules = load_graph_rules(rules_dir=rules_dir)
-
-    report = rescan_dirty(content_graph, rules, dirty_node_ids) if dirty_node_ids else graph_scan(content_graph, rules)
-
+    rules, missing = load_graph_rules(rules_dir=rules_dir, opt_in_rule_ids=opt_in_rule_ids or [])
+    if dirty_node_ids:
+        report = rescan_dirty(content_graph, rules, dirty_node_ids)
+    else:
+        report = graph_scan(content_graph, rules, missing_requested_rule_ids=missing)
     violations = graph_report_to_violations(report)
     return _GraphRunResult(violations=violations, report=report)
 
@@ -127,6 +130,7 @@ class NativeValidatorServicer(validate_pb2_grpc.ValidatorServicer):
                         req_id,
                     )
 
+                opt_in = list(request.graph_rule_opt_in)
                 ctx = contextvars.copy_context()
                 result = await asyncio.get_event_loop().run_in_executor(
                     None,
@@ -134,6 +138,7 @@ class NativeValidatorServicer(validate_pb2_grpc.ValidatorServicer):
                     _run_graph,
                     request.content_graph_data,
                     dirty,
+                    opt_in,
                 )
 
                 total_ms = (time.monotonic() - t0) * 1000
@@ -144,12 +149,19 @@ class NativeValidatorServicer(validate_pb2_grpc.ValidatorServicer):
                     req_id,
                 )
 
+                diag_metadata: dict[str, str] = {}
+                if result.report and result.report.missing_requested_rule_ids:
+                    diag_metadata["missing_requested_rules"] = ",".join(result.report.missing_requested_rule_ids)
+                if result.report and result.report.audit_serialization_failures:
+                    diag_metadata["audit_serialization_failures"] = str(result.report.audit_serialization_failures)
+
                 diag = ValidatorDiagnostics(
                     validator_name="native",
                     request_id=req_id,
                     total_ms=total_ms,
                     files_received=len(request.files),
                     violations_found=len(result.violations),
+                    metadata=diag_metadata,
                 )
 
                 return validate_pb2.ValidateResponse(

--- a/src/apme_engine/daemon/violation_convert.py
+++ b/src/apme_engine/daemon/violation_convert.py
@@ -1,10 +1,16 @@
 """Convert between dict violations (validator output) and proto Violation."""
 
+import json
 from collections.abc import Mapping
 
 from apme.v1 import common_pb2
 from apme.v1.common_pb2 import LineRange, Violation
 from apme_engine.engine.models import RemediationClass, RemediationResolution, RuleScope, ViolationDict
+from apme_engine.graph.audit_metadata import (
+    AUDIT_JSON_METADATA_KEYS,
+    sanitize_audit_metadata_value,
+    serialize_audit_metadata_value,
+)
 from apme_engine.graph.severity import (
     Severity,
     get_severity,
@@ -54,8 +60,13 @@ _METADATA_KEYS = frozenset(
         "ai_reason",
         "ai_suggestion",
         "ansible_core_version",
+        "variables_used",
+        "variable_set",
+        "inbound_src",
     }
 )
+
+_JSON_METADATA_KEYS = AUDIT_JSON_METADATA_KEYS
 
 _REMEDIATION_CLASS_TO_PROTO: dict[str, int] = {
     RemediationClass.AUTO_FIXABLE.value: common_pb2.REMEDIATION_CLASS_AUTO_FIXABLE,  # type: ignore[attr-defined]
@@ -219,7 +230,30 @@ def violation_dict_to_proto(v: ViolationDict | Mapping[str, str | int | list[int
     for key in _METADATA_KEYS:
         val = v.get(key)
         if val is not None:
-            if isinstance(val, list):
+            if key in _JSON_METADATA_KEYS:
+                if isinstance(val, str):
+                    try:
+                        parsed = json.loads(val)
+                    except json.JSONDecodeError:
+                        out.metadata[key] = val
+                    else:
+                        sanitized = sanitize_audit_metadata_value(key, parsed)
+                        serialized = serialize_audit_metadata_value(
+                            sanitized,
+                            rule_id=str(v.get("rule_id") or ""),
+                            key=key,
+                        )
+                        if serialized is not None:
+                            out.metadata[key] = serialized
+                else:
+                    serialized = serialize_audit_metadata_value(
+                        val,
+                        rule_id=str(v.get("rule_id") or ""),
+                        key=key,
+                    )
+                    if serialized is not None:
+                        out.metadata[key] = serialized
+            elif isinstance(val, list):
                 out.metadata[key] = ",".join(str(x) for x in val)
             else:
                 out.metadata[key] = str(val)
@@ -279,10 +313,19 @@ def violation_proto_to_dict(v: Violation) -> ViolationDict:
     if v.affected_children > 0:
         result["affected_children"] = v.affected_children
 
+    module_fqcn = v.metadata.get("resolved_fqcn") or v.metadata.get("original_module") or v.metadata.get("fqcn") or ""
+    if module_fqcn:
+        result["module_fqcn"] = module_fqcn
+
     for key, val in v.metadata.items():
         if key in _METADATA_KEYS and val:
             if key == "redirect_chain":
                 result[key] = val.split(",")  # type: ignore[assignment]
+            elif key in _JSON_METADATA_KEYS:
+                try:
+                    result[key] = json.loads(val)
+                except json.JSONDecodeError:
+                    result[key] = val
             else:
                 result[key] = val
 

--- a/src/apme_engine/graph/audit_metadata.py
+++ b/src/apme_engine/graph/audit_metadata.py
@@ -1,0 +1,171 @@
+"""Shared audit-metadata keys and JSON serialization for violation payloads."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from apme_engine.graph.sensitivity import (
+    REDACTED,
+    redact_sensitive_structure,
+    redact_url_userinfo,
+    value_looks_sensitive,
+    var_looks_sensitive,
+)
+
+logger = logging.getLogger(__name__)
+
+AUDIT_JSON_METADATA_KEYS: frozenset[str] = frozenset({"variables_used", "variable_set", "inbound_src"})
+
+
+def _sanitize_scalar(key: str, value: object) -> object:
+    if key == "inbound_src" and isinstance(value, str):
+        return redact_url_userinfo(value)
+    if isinstance(value, str) and value_looks_sensitive(value):
+        return REDACTED
+    return value
+
+
+def _sanitize_audit_structure(key: str, value: object) -> object:
+    """Recursively redact sensitive audit payload values before JSON encoding.
+
+    Args:
+        key: Metadata key name.
+        value: Native Python structure from a GraphRule detail dict.
+
+    Returns:
+        Redacted structure safe for persistence.
+    """
+    if key == "inbound_src":
+        if isinstance(value, list):
+            return [_sanitize_scalar(key, item) for item in value]
+        return _sanitize_scalar(key, value)
+
+    if key == "variables_used" and isinstance(value, list):
+        sanitized: list[object] = []
+        for entry in value:
+            if not isinstance(entry, dict):
+                sanitized.append(entry)
+                continue
+            name = entry.get("name")
+            if isinstance(name, str) and var_looks_sensitive(name):
+                sanitized.append({**entry, "name": REDACTED})
+            else:
+                sanitized.append(entry)
+        return sanitized
+
+    if key == "variable_set" and isinstance(value, list):
+        sanitized_vars: list[object] = []
+        for entry in value:
+            if not isinstance(entry, dict):
+                sanitized_vars.append(entry)
+                continue
+            patched = dict(entry)
+            name = patched.get("name")
+            if isinstance(name, str) and var_looks_sensitive(name):
+                patched["name"] = REDACTED
+            val = patched.get("value")
+            if isinstance(val, (dict, list)):
+                patched["value"] = redact_sensitive_structure(val)
+            elif val is not None and (
+                (var_looks_sensitive(str(name)) if name is not None else False) or value_looks_sensitive(val)
+            ):
+                patched["value"] = REDACTED
+            sanitized_vars.append(patched)
+        return sanitized_vars
+
+    if isinstance(value, dict):
+        return redact_sensitive_structure(value)
+    if isinstance(value, list):
+        return redact_sensitive_structure(value)
+    return _sanitize_scalar(key, value)
+
+
+def sanitize_audit_metadata_value(key: str, val: object) -> object:
+    """Apply key-aware redaction to an audit metadata structure.
+
+    Args:
+        key: Metadata key name (``variables_used``, ``variable_set``, ``inbound_src``).
+        val: Native Python structure from a GraphRule detail dict.
+
+    Returns:
+        Redacted structure safe for persistence.
+    """
+    return _sanitize_audit_structure(key, val)
+
+
+def parse_audit_metadata_value(raw: str) -> object:
+    """Decode a proto-stored audit metadata JSON string.
+
+    Args:
+        raw: JSON string from violation proto metadata.
+
+    Returns:
+        Parsed Python object, or the original string when not valid JSON.
+    """
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def serialize_audit_metadata_value(val: object, *, rule_id: str = "", key: str = "") -> str | None:
+    """Serialize an audit metadata value to a JSON string for proto storage.
+
+    Args:
+        val: Structure to serialize (list, dict, etc.).
+        rule_id: Rule ID for error logging (optional).
+        key: Metadata key name for error logging (optional).
+
+    Returns:
+        JSON string, or None if serialization fails.
+    """
+    sanitized = sanitize_audit_metadata_value(key, val) if key in AUDIT_JSON_METADATA_KEYS else val
+    try:
+        return json.dumps(sanitized, default=str, sort_keys=True)
+    except (TypeError, ValueError) as err:
+        logger.warning(
+            "Failed to serialize audit metadata %s for rule %s: %s",
+            key or "?",
+            rule_id or "?",
+            err,
+        )
+        return None
+
+
+def decode_audit_payload_entry(raw: object) -> object:
+    """Decode one audit metadata entry that may already be JSON-encoded.
+
+    Args:
+        raw: Value from proto metadata or a nested audit payload dict.
+
+    Returns:
+        Parsed structure when ``raw`` is a JSON string; otherwise ``raw``.
+    """
+    if isinstance(raw, str):
+        return parse_audit_metadata_value(raw)
+    return raw
+
+
+def build_audit_metadata_blob(metadata: dict[str, str]) -> str:
+    """Build a single JSON blob for Gateway persistence from proto metadata.
+
+    Args:
+        metadata: Violation proto metadata map.
+
+    Returns:
+        JSON object string with decoded audit keys, or empty string when absent.
+    """
+    audit_payload: dict[str, object] = {}
+    for key in AUDIT_JSON_METADATA_KEYS:
+        if key not in metadata:
+            continue
+        decoded = decode_audit_payload_entry(metadata[key])
+        audit_payload[key] = sanitize_audit_metadata_value(key, decoded)
+    if not audit_payload:
+        return ""
+    try:
+        return json.dumps(audit_payload, default=str, sort_keys=True)
+    except (TypeError, ValueError) as err:
+        logger.warning("Failed to build Gateway audit blob: %s", err)
+        return ""

--- a/src/apme_engine/graph/scanner.py
+++ b/src/apme_engine/graph/scanner.py
@@ -18,13 +18,15 @@ import os
 import re
 import time
 import traceback
-from dataclasses import dataclass, field
+from collections.abc import Sequence
+from dataclasses import dataclass, field, replace
 
 from apme_engine.graph._loader import load_classes_in_dir
+from apme_engine.graph.audit_metadata import AUDIT_JSON_METADATA_KEYS, serialize_audit_metadata_value
 from apme_engine.graph.content_graph import ContentGraph, ContentNode, NodeScope, NodeType
 from apme_engine.graph.rule_base import GraphRule, GraphRuleResult
 from apme_engine.graph.severity import get_severity, severity_to_label
-from apme_engine.graph.types import ViolationDict
+from apme_engine.graph.types import RuleScope, ViolationDict
 
 logger = logging.getLogger(__name__)
 
@@ -58,12 +60,16 @@ class GraphScanReport:
         rules_evaluated: Number of enabled rules in the scan.
         nodes_scanned: Number of nodes visited.
         elapsed_ms: Total wall-clock time in milliseconds.
+        missing_requested_rule_ids: Rule IDs explicitly requested but not loaded.
+        audit_serialization_failures: Count of audit metadata fields dropped on encode failure.
     """
 
     node_results: list[GraphNodeResult] = field(default_factory=list)
     rules_evaluated: int = 0
     nodes_scanned: int = 0
     elapsed_ms: float = 0.0
+    missing_requested_rule_ids: list[str] = field(default_factory=list)
+    audit_serialization_failures: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -83,11 +89,35 @@ def native_rules_dir() -> str:
     return os.path.join(os.path.dirname(__file__), "rules")
 
 
+DISABLED_BY_DEFAULT_GRAPH_RULE_IDS: frozenset[str] = frozenset({"R402", "R404"})
+
+
+def graph_rule_opt_in_from_rule_configs(rule_configs: Sequence[object] | None) -> list[str]:
+    """Return disabled-by-default GraphRule IDs enabled via ``RuleConfig``.
+
+    Args:
+        rule_configs: Proto ``RuleConfig`` messages from ``ScanOptions``.
+
+    Returns:
+        Sorted rule IDs to opt in when loading native graph rules.
+    """
+    if not rule_configs:
+        return []
+    return sorted(
+        rc.rule_id  # type: ignore[attr-defined]
+        for rc in rule_configs
+        if rc.enabled and rc.rule_id in DISABLED_BY_DEFAULT_GRAPH_RULE_IDS  # type: ignore[attr-defined]
+    )
+
+
 def load_graph_rules(
     rules_dir: str = "",
     rule_id_list: list[str] | None = None,
+    opt_in_rule_ids: list[str] | None = None,
     exclude_rule_ids: list[str] | None = None,
-) -> list[GraphRule]:
+    *,
+    preserve_disabled_defaults: bool = False,
+) -> tuple[list[GraphRule], list[str]]:
     """Discover and instantiate GraphRule subclasses from directories.
 
     Uses the same directory-scanning approach as ``risk_detector.load_rules``
@@ -95,16 +125,26 @@ def load_graph_rules(
 
     Args:
         rules_dir: Colon-separated directories containing rule modules.
-        rule_id_list: If provided, only include these rule IDs.
+        rule_id_list: If non-empty, only include these rule IDs (restrictive
+            whitelist).  IDs listed here are loaded even when the rule class
+            sets ``enabled=False``.
+        opt_in_rule_ids: In normal (non-whitelist) mode, additionally load
+            these disabled-by-default rule IDs.
         exclude_rule_ids: Rule IDs to skip.
+        preserve_disabled_defaults: When True, do not flip ``enabled=False`` rules
+            to enabled even when explicitly requested via ``rule_id_list`` or
+            ``opt_in_rule_ids``.  Used by the ADR-041 catalog collector.
 
     Returns:
-        Sorted list of enabled GraphRule instances.
+        Tuple of sorted GraphRule instances and any requested rule IDs that
+        failed to load.
     """
     if not rules_dir:
-        return []
+        return [], []
     if rule_id_list is None:
         rule_id_list = []
+    if opt_in_rule_ids is None:
+        opt_in_rule_ids = []
     if exclude_rule_ids is None:
         exclude_rule_ids = []
 
@@ -120,18 +160,33 @@ def load_graph_rules(
                 rule = cls()
                 if not isinstance(rule, GraphRule):
                     continue
-                if rule_id_list and rule.rule_id not in rule_id_list:
-                    continue
                 if rule.rule_id in exclude_rule_ids:
                     continue
-                if not rule.enabled:
-                    continue
+                if rule_id_list:
+                    if rule.rule_id not in rule_id_list:
+                        continue
+                    explicitly_requested = True
+                else:
+                    explicitly_requested = rule.rule_id in opt_in_rule_ids
+                    if not rule.enabled and not explicitly_requested:
+                        continue
+                if explicitly_requested and not rule.enabled and not preserve_disabled_defaults:
+                    rule = replace(rule, enabled=True)
                 rules.append(rule)
             except Exception:
                 logger.warning("Failed to instantiate graph rule %s: %s", cls, traceback.format_exc())
 
+    missing_requested: list[str] = []
+    requested = (set(rule_id_list) | set(opt_in_rule_ids)) - set(exclude_rule_ids)
+    if requested:
+        loaded = {r.rule_id for r in rules}
+        missing = sorted(requested - loaded)
+        if missing:
+            logger.warning("Requested graph rules not loaded: %s", missing)
+            missing_requested = missing
+
     rules.sort(key=lambda r: r.precedence)
-    return rules
+    return rules, missing_requested
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +211,13 @@ _SCANNABLE_TYPES = frozenset(
 
 _NOQA_RE = re.compile(r"(?:^|\s)#\s*noqa:\s*([A-Za-z0-9_,\t ]+)")
 _QUOTED_RE = re.compile(r""""[^"\\]*(?:\\.[^"\\]*)*"|'[^']*'""")
+_AGGREGATE_SCOPE_NODE_TYPES: dict[str, frozenset[NodeType]] = {
+    RuleScope.BLOCK.value: frozenset({NodeType.BLOCK}),
+    RuleScope.PLAY.value: frozenset({NodeType.PLAY}),
+    RuleScope.PLAYBOOK.value: frozenset({NodeType.PLAYBOOK}),
+    RuleScope.ROLE.value: frozenset({NodeType.ROLE}),
+    RuleScope.COLLECTION.value: frozenset({NodeType.COLLECTION}),
+}
 
 
 def parse_noqa(yaml_lines: str) -> frozenset[str]:
@@ -256,6 +318,7 @@ def scan(
     rules: list[GraphRule],
     *,
     owned_only: bool = True,
+    missing_requested_rule_ids: list[str] | None = None,
 ) -> GraphScanReport:
     """Evaluate all rules against every eligible node in a ContentGraph.
 
@@ -267,13 +330,18 @@ def scan(
         graph: ContentGraph to scan.
         rules: Pre-loaded GraphRule instances.
         owned_only: If True (default), skip ``REFERENCED`` nodes.
+        missing_requested_rule_ids: Rule IDs that were requested at load time
+            but could not be instantiated (surfaced on the report).
 
     Returns:
         GraphScanReport with per-node results and timing.
     """
     start = time.monotonic()
     enabled_rules = [r for r in rules if r.enabled]
-    report = GraphScanReport(rules_evaluated=len(enabled_rules))
+    report = GraphScanReport(
+        rules_evaluated=len(enabled_rules),
+        missing_requested_rule_ids=list(missing_requested_rule_ids or ()),
+    )
     _reset_rule_scan_state(enabled_rules)
 
     all_nodes = sorted(graph.nodes(), key=lambda n: n.node_id)
@@ -318,7 +386,8 @@ def rescan_dirty(
     report = GraphScanReport(rules_evaluated=len(enabled_rules))
     _reset_rule_scan_state(enabled_rules)
 
-    for node_id in sorted(dirty_node_ids):
+    effective_dirty_ids = expand_dirty_node_ids(graph, enabled_rules, dirty_node_ids)
+    for node_id in sorted(effective_dirty_ids):
         node = graph.get_node(node_id)
         if node is None:
             continue
@@ -330,6 +399,55 @@ def rescan_dirty(
 
     report.elapsed_ms = round((time.monotonic() - start) * 1000, 3)
     return report
+
+
+def expand_dirty_node_ids(
+    graph: ContentGraph,
+    rules: Sequence[GraphRule],
+    dirty_node_ids: frozenset[str],
+) -> frozenset[str]:
+    """Expand dirty nodes to include ancestors needed by aggregate-scope rules.
+
+    Task-local rescans are sufficient for task-scoped rules, but play-, role-,
+    playbook-, block-, and collection-scoped rules may derive findings from
+    descendant content. When one of those descendant nodes changes, the enclosing
+    aggregate node must also be re-evaluated so remediation convergence and
+    audit/reporting rules observe the updated graph state.
+
+    Args:
+        graph: ContentGraph containing the dirty nodes.
+        rules: Enabled graph rules participating in the rescan.
+        dirty_node_ids: Node IDs directly modified since the last pass.
+
+    Returns:
+        Dirty node IDs plus any structural ancestors required by enabled
+        aggregate-scope rules.
+    """
+    if not dirty_node_ids:
+        return frozenset()
+
+    aggregate_node_types = {
+        node_type
+        for rule in rules
+        for node_type in _AGGREGATE_SCOPE_NODE_TYPES.get(
+            rule.scope.value if isinstance(rule.scope, RuleScope) else str(rule.scope),
+            frozenset(),
+        )
+    }
+    if not aggregate_node_types:
+        return dirty_node_ids
+
+    expanded = set(dirty_node_ids)
+    for node_id in dirty_node_ids:
+        node = graph.get_node(node_id)
+        if node is None:
+            continue
+        if node.node_type in aggregate_node_types:
+            expanded.add(node_id)
+        for ancestor in graph.ancestors(node_id):
+            if ancestor.node_type in aggregate_node_types:
+                expanded.add(ancestor.node_id)
+    return frozenset(expanded)
 
 
 # ---------------------------------------------------------------------------
@@ -422,6 +540,15 @@ def graph_report_to_violations(report: GraphScanReport) -> list[ViolationDict]:
                 val = detail.get(key)
                 if val is not None:
                     v[key] = str(val)
+
+            for key in AUDIT_JSON_METADATA_KEYS:
+                val = detail.get(key)
+                if val is not None:
+                    serialized = serialize_audit_metadata_value(val, rule_id=rid, key=key)
+                    if serialized is not None:
+                        v[key] = serialized
+                    else:
+                        report.audit_serialization_failures += 1
 
             affected = detail.get("affected_children")
             if isinstance(affected, int) and affected > 0:

--- a/src/apme_engine/graph/sensitivity.py
+++ b/src/apme_engine/graph/sensitivity.py
@@ -1,0 +1,151 @@
+"""Shared sensitivity and redaction helpers used across engine components."""
+
+from __future__ import annotations
+
+import re
+
+REDACTED = "[REDACTED]"
+
+_SENSITIVE_WORDS: frozenset[str] = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "secrets",
+        "token",
+        "api_key",
+        "apikey",
+        "credential",
+        "credentials",
+        "cred",
+        "authorization",
+        "private_key",
+        "ssh_key",
+        "access_key",
+        "client_key",
+    }
+)
+
+_PASS_SUFFIX_RE = re.compile(r"(?:^|[_.])pass$")
+_SCALAR_SECRET_RE = re.compile(
+    r"(?i)("
+    r"password\s*[=:]|"
+    r"passwd\s*[=:]|"
+    r"api[_-]?key\s*[=:]|"
+    r"bearer\s+\S+|"
+    r"BEGIN\s+(?:RSA\s+)?PRIVATE\s+KEY|"
+    r"://[^:]+:[^@]+@|"
+    r"\$ANSIBLE_VAULT;|"
+    r"!vault\b"
+    r")"
+)
+_OPAQUE_TOKEN_RE = re.compile(
+    r"(?i)(?:"
+    r"AKIA[0-9A-Z]{16}|"
+    r"sk[_-](?:live|test)[_-]|"
+    r"ghp_[A-Za-z0-9]{20,}|"
+    r"xox[baprs]-[A-Za-z0-9-]+|"
+    r"eyJ[A-Za-z0-9_-]+\.eyJ"
+    r")"
+)
+_WORD_BOUNDARY_RE = re.compile(r"(?:^|[_.'\"\[])({})(?:[_.'\"\[\]]|$)".format("|".join(_SENSITIVE_WORDS)))
+_URL_USERINFO_RE = re.compile(r"^([^:]+)://([^/@]+):([^/@]+)@")
+
+
+def redact_url_userinfo(url: str) -> str:
+    """Strip credential userinfo from a URL string.
+
+    Args:
+        url: URL that may contain ``user:pass@`` before the host.
+
+    Returns:
+        URL with userinfo replaced by ``[REDACTED]``.
+    """
+    match = _URL_USERINFO_RE.match(url)
+    if not match:
+        return url
+    scheme = match.group(1)
+    rest = url[match.end() :]
+    return f"{scheme}://{REDACTED}@{rest}"
+
+
+def var_looks_sensitive(var_name: str) -> bool:
+    """Check if a variable name matches sensitive patterns.
+
+    Args:
+        var_name: Variable name or dotted path to check.
+
+    Returns:
+        True if the variable name contains a sensitive word as a segment.
+    """
+    lower = var_name.lower()
+    if _PASS_SUFFIX_RE.search(lower):
+        return True
+    return bool(_WORD_BOUNDARY_RE.search(lower))
+
+
+def value_looks_sensitive(value: object) -> bool:
+    """Check if a scalar value contains credential-like content.
+
+    Args:
+        value: Variable value to inspect.
+
+    Returns:
+        True when a string value matches common secret patterns.
+    """
+    if not isinstance(value, str):
+        return False
+    return bool(_SCALAR_SECRET_RE.search(value) or _OPAQUE_TOKEN_RE.search(value))
+
+
+def redact_sensitive_structure(
+    value: object,
+    *,
+    redact_all_scalars: bool = False,
+    depth: int = 0,
+    max_depth: int = 32,
+) -> object:
+    """Recursively redact nested structures while preserving overall shape.
+
+    Args:
+        value: Arbitrary nested structure.
+        redact_all_scalars: When True, replace all scalar leaves with
+            ``[REDACTED]``. When False, only redact credential-like values.
+        depth: Current recursion depth.
+        max_depth: Maximum depth before replacing the subtree wholesale.
+
+    Returns:
+        A redacted structure safe for persistence or display.
+    """
+    if depth > max_depth:
+        return REDACTED
+    if isinstance(value, dict):
+        return {
+            k: REDACTED
+            if var_looks_sensitive(str(k))
+            else redact_sensitive_structure(
+                v,
+                redact_all_scalars=redact_all_scalars,
+                depth=depth + 1,
+                max_depth=max_depth,
+            )
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            redact_sensitive_structure(
+                item,
+                redact_all_scalars=redact_all_scalars,
+                depth=depth + 1,
+                max_depth=max_depth,
+            )
+            for item in value
+        ]
+    if isinstance(value, str):
+        if redact_all_scalars or value_looks_sensitive(value):
+            return REDACTED
+        return value
+    if redact_all_scalars and value is not None:
+        return REDACTED
+    return value

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -27,6 +27,7 @@ from apme_engine.engine.models import ViolationDict
 from apme_engine.graph.content_graph import ContentGraph
 from apme_engine.graph.rule_base import GraphRule
 from apme_engine.graph.scanner import (
+    expand_dirty_node_ids,
     graph_report_to_violations,
     rescan_dirty,
     scan,
@@ -792,6 +793,7 @@ class GraphRemediationEngine:
             Fresh violations from the rescan.
         """
         dirty = graph.dirty_nodes
+        effective_dirty = expand_dirty_node_ids(graph, self._rules, dirty)
         if self._rescan_fn is not None:
             new_violations = await self._rescan_fn(graph, dirty)
         else:
@@ -803,14 +805,14 @@ class GraphRemediationEngine:
             new_violations,
             pass_number=pass_num,
             phase="scanned",
-            dirty_node_ids=dirty,
+            dirty_node_ids=effective_dirty,
         )
 
         if resolve_fixed_by is not None:
             _resolve_dirty_violations(
                 graph,
                 new_violations,
-                dirty,
+                effective_dirty,
                 fixed_by=resolve_fixed_by,
                 pass_number=pass_num,
                 status=resolve_status,

--- a/src/apme_engine/rule_catalog.py
+++ b/src/apme_engine/rule_catalog.py
@@ -88,14 +88,23 @@ def _collect_native_rules() -> list[reporting_pb2.RuleDefinition]:
     """Collect rules from the Native validator via ``load_graph_rules()``.
 
     Returns:
-        List of RuleDefinition protos for all enabled native rules.
+        List of RuleDefinition protos for all native rules, including
+        disabled-by-default audit rules registered with ``enabled=False``.
     """
     try:
-        from apme_engine.graph.scanner import load_graph_rules
+        from apme_engine.graph.scanner import (
+            DISABLED_BY_DEFAULT_GRAPH_RULE_IDS,
+            load_graph_rules,
+        )
 
         rules_dir = str(_GRAPH_RULES_DIR)
-        graph_rules = load_graph_rules(rules_dir=rules_dir)
+        graph_rules, _ = load_graph_rules(
+            rules_dir=rules_dir,
+            opt_in_rule_ids=sorted(DISABLED_BY_DEFAULT_GRAPH_RULE_IDS),
+            preserve_disabled_defaults=True,
+        )
         defs = []
+        loaded_ids = {gr.rule_id for gr in graph_rules}
         for gr in graph_rules:
             defs.append(
                 reporting_pb2.RuleDefinition(
@@ -113,6 +122,22 @@ def _collect_native_rules() -> list[reporting_pb2.RuleDefinition]:
                     ansible_core_version=get_version_spec_str(gr.rule_id),
                 )
             )
+        missing_disabled = DISABLED_BY_DEFAULT_GRAPH_RULE_IDS - loaded_ids
+        if missing_disabled:
+            for fm_def in _collect_from_frontmatter(_GRAPH_RULES_DIR, "native"):
+                if fm_def.rule_id in missing_disabled:
+                    defs.append(
+                        reporting_pb2.RuleDefinition(
+                            rule_id=fm_def.rule_id,
+                            default_severity=fm_def.default_severity,
+                            category=fm_def.category,
+                            source=fm_def.source,
+                            description=fm_def.description,
+                            scope=fm_def.scope,
+                            enabled=False,
+                            ansible_core_version=fm_def.ansible_core_version,
+                        )
+                    )
         logger.info("Collected %d native rules", len(defs))
         return defs
     except Exception:

--- a/src/apme_engine/validators/collection_health/scanner.py
+++ b/src/apme_engine/validators/collection_health/scanner.py
@@ -150,7 +150,7 @@ def _scan_collection(
         logger.debug("No ContentGraph for collection %s %s", fqcn, version)
         return []
 
-    rules = load_graph_rules(
+    rules, _ = load_graph_rules(
         rules_dir=native_rules_dir(),
         rule_id_list=list(CURATED_RULE_IDS),
     )

--- a/src/apme_gateway/api/router.py
+++ b/src/apme_gateway/api/router.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
 import os
 import uuid
@@ -22,6 +23,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 
+from apme_engine.graph.audit_metadata import sanitize_audit_metadata_value
 from apme_engine.graph.severity import severity_from_proto, severity_to_label
 from apme_gateway.api.schemas import (
     ActiveOperationSummary,
@@ -1471,6 +1473,15 @@ def _to_violation_detail(
     if not suppressed and rule_only_hashes:
         fp_rule = _violation_fingerprint(v.rule_id, "", mode="rule_only")  # type: ignore[attr-defined]
         suppressed = fp_rule in rule_only_hashes
+    audit_metadata: dict[str, object] | None = None
+    raw_audit = getattr(v, "audit_metadata", "") or ""
+    if raw_audit:
+        try:
+            parsed_audit = json.loads(raw_audit)
+            if isinstance(parsed_audit, dict):
+                audit_metadata = {key: sanitize_audit_metadata_value(key, value) for key, value in parsed_audit.items()}
+        except json.JSONDecodeError:
+            audit_metadata = None
     return ViolationDetail(
         id=v.id,  # type: ignore[attr-defined]
         rule_id=v.rule_id,  # type: ignore[attr-defined]
@@ -1490,6 +1501,7 @@ def _to_violation_detail(
         node_type=getattr(v, "node_type", "") or "",
         ai_reason=v.ai_reason,  # type: ignore[attr-defined]
         ai_suggestion=v.ai_suggestion,  # type: ignore[attr-defined]
+        audit_metadata=audit_metadata,
         suppressed=suppressed,
         review_status=getattr(v, "review_status", None),
     )

--- a/src/apme_gateway/api/schemas.py
+++ b/src/apme_gateway/api/schemas.py
@@ -83,6 +83,7 @@ class ViolationDetail(BaseModel):  # type: ignore[misc]
         node_type: ContentGraph NodeType value (task, block, play, …).
         ai_reason: Why the AI could not fix this violation (ai_abstained only).
         ai_suggestion: Manual remediation guidance from the AI (ai_abstained only).
+        audit_metadata: Parsed audit rule payloads when present.
         suppressed: True if this violation matches an active suppression (ADR-055).
         review_status: Human/gate decision (ADR-062); null if never reviewed.
     """
@@ -105,6 +106,7 @@ class ViolationDetail(BaseModel):  # type: ignore[misc]
     node_type: str = ""
     ai_reason: str = ""
     ai_suggestion: str = ""
+    audit_metadata: dict[str, object] | None = None
     suppressed: bool = False
     review_status: str | None = None
 

--- a/src/apme_gateway/db/__init__.py
+++ b/src/apme_gateway/db/__init__.py
@@ -79,6 +79,8 @@ def _migrate_violations_table(conn: object) -> None:
         migrations.append("ALTER TABLE violations ADD COLUMN ai_reason TEXT NOT NULL DEFAULT ''")
     if "ai_suggestion" not in existing:
         migrations.append("ALTER TABLE violations ADD COLUMN ai_suggestion TEXT NOT NULL DEFAULT ''")
+    if "audit_metadata" not in existing:
+        migrations.append("ALTER TABLE violations ADD COLUMN audit_metadata TEXT NOT NULL DEFAULT ''")
 
     for stmt in migrations:
         conn.execute(text(stmt))

--- a/src/apme_gateway/db/models.py
+++ b/src/apme_gateway/db/models.py
@@ -164,6 +164,7 @@ class Violation(Base):
         ai_reason: Why the AI could not fix this violation (ai_abstained only).
         ai_suggestion: Manual remediation guidance from the AI (ai_abstained only).
         review_status: Human/gate decision (ADR-062); null if never reviewed.
+        audit_metadata: JSON blob for audit rule payloads (variables_used, etc.).
         scan: Back-reference to owning Scan.
     """
 
@@ -189,6 +190,7 @@ class Violation(Base):
     ai_reason: Mapped[str] = mapped_column(Text, nullable=False, default="")
     ai_suggestion: Mapped[str] = mapped_column(Text, nullable=False, default="")
     review_status: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    audit_metadata: Mapped[str] = mapped_column(Text, nullable=False, default="")
 
     scan: Mapped[Scan] = relationship(back_populates="violations")
 

--- a/src/apme_gateway/grpc_reporting/servicer.py
+++ b/src/apme_gateway/grpc_reporting/servicer.py
@@ -18,6 +18,7 @@ from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from apme.v1 import reporting_pb2, reporting_pb2_grpc
+from apme_engine.graph.audit_metadata import build_audit_metadata_blob
 from apme_engine.graph.severity import severity_from_proto, severity_to_label
 from apme_gateway.db import get_session
 from apme_gateway.db.models import (
@@ -314,6 +315,7 @@ def _add_violations(db: AsyncSession, scan_id: str, violations: Sequence[object]
             line_val = v.line  # type: ignore[attr-defined]
         elif oneof == "line_range":
             line_val = v.line_range.start  # type: ignore[attr-defined]
+        audit_blob = build_audit_metadata_blob(dict(v.metadata))  # type: ignore[attr-defined]
         db.add(
             Violation(
                 scan_id=scan_id,
@@ -335,6 +337,7 @@ def _add_violations(db: AsyncSession, scan_id: str, violations: Sequence[object]
                 ai_reason=v.metadata.get("ai_reason", ""),  # type: ignore[attr-defined]
                 ai_suggestion=v.metadata.get("ai_suggestion", ""),  # type: ignore[attr-defined]
                 review_status=None,
+                audit_metadata=audit_blob,
             )
         )
 

--- a/tests/rule_doc_integration_test.py
+++ b/tests/rule_doc_integration_test.py
@@ -29,7 +29,6 @@ _GRAPH_RULE_KNOWN_FAILURES: dict[str, str] = {
     "L093": "requires role ancestry with default_variables/role_variables populated",
     "M028": "first_found is a lookup plugin; terms live inside Jinja2 expressions",
     "R117": "role metadata rule; requires ROLE graph node with play DEPENDENCY edge",
-    "R402": "informational listing rule (no GraphRule equivalent yet)",
     "L074": "role name check requires ROLE graph node; single-file harness has no role directory",
     "L080": "requires file_path under roles/; single-file harness uses a temp path",
     "L081": "checks file basename pattern; single-file harness uses a generated temp filename",
@@ -46,6 +45,8 @@ _GRAPH_RULE_KNOWN_FAILURES: dict[str, str] = {
     "M017": "example uses action: mapping form that ARI engine normalizes into module key",
     "M021": "example uses empty args: that ARI engine strips before graph",
     "M023": "example uses lookup plugin syntax not evaluated by graph rules",
+    "R402": "disabled-by-default audit rule; not in default load_graph_rules() set",
+    "R404": "disabled-by-default debug rule; not in default load_graph_rules() set",
 }
 
 
@@ -144,7 +145,7 @@ def _run_graph_rules_on_graph(graph: ContentGraph) -> list[dict[str, object]]:
         List of violation dicts.
     """
     rules_dir = str(_native_rules_dir())
-    rules = load_graph_rules(rules_dir=rules_dir)
+    rules, _ = load_graph_rules(rules_dir=rules_dir)
     report = graph_scan(graph, rules)
     return cast(list[dict[str, object]], graph_report_to_violations(report))
 

--- a/tests/test_L110_debug_sensitive_vars_graph.py
+++ b/tests/test_L110_debug_sensitive_vars_graph.py
@@ -18,9 +18,9 @@ from apme_engine.graph.rules.L110_debug_sensitive_vars_graph import (
     DebugSensitiveVarsGraphRule,
     _extract_jinja_vars,
     _find_sensitive_vars_in_debug,
-    _var_looks_sensitive,
 )
 from apme_engine.graph.scanner import scan
+from apme_engine.graph.sensitivity import var_looks_sensitive
 
 
 def _make_debug_graph(
@@ -156,64 +156,68 @@ class TestExtractJinjaVars:
 
 
 class TestVarLooksSensitive:
-    """Tests for _var_looks_sensitive helper."""
+    """Tests for var_looks_sensitive helper."""
 
     def test_password_variants(self) -> None:
         """Password variants are sensitive."""
-        assert _var_looks_sensitive("password")
-        assert _var_looks_sensitive("db_password")
-        assert _var_looks_sensitive("PASSWORD")
-        assert _var_looks_sensitive("passwd")
-        assert _var_looks_sensitive("user_pwd")
+        assert var_looks_sensitive("password")
+        assert var_looks_sensitive("db_password")
+        assert var_looks_sensitive("PASSWORD")
+        assert var_looks_sensitive("passwd")
+        assert var_looks_sensitive("user_pwd")
+        assert var_looks_sensitive("ansible_ssh_pass")
 
     def test_secret_variants(self) -> None:
         """Secret variants are sensitive."""
-        assert _var_looks_sensitive("secret")
-        assert _var_looks_sensitive("app_secret")
-        assert _var_looks_sensitive("secrets")
+        assert var_looks_sensitive("secret")
+        assert var_looks_sensitive("app_secret")
+        assert var_looks_sensitive("secrets")
 
     def test_token_variants(self) -> None:
         """Token variants are sensitive."""
-        assert _var_looks_sensitive("token")
-        assert _var_looks_sensitive("auth_token")
-        assert _var_looks_sensitive("access_token")
-        assert _var_looks_sensitive("api_token")
+        assert var_looks_sensitive("token")
+        assert var_looks_sensitive("auth_token")
+        assert var_looks_sensitive("access_token")
+        assert var_looks_sensitive("api_token")
 
     def test_api_key_variants(self) -> None:
         """API key variants are sensitive."""
-        assert _var_looks_sensitive("api_key")
-        assert _var_looks_sensitive("apikey")
+        assert var_looks_sensitive("api_key")
+        assert var_looks_sensitive("apikey")
 
     def test_credential_variants(self) -> None:
         """Credential variants are sensitive."""
-        assert _var_looks_sensitive("credential")
-        assert _var_looks_sensitive("credentials")
-        assert _var_looks_sensitive("db_cred")
+        assert var_looks_sensitive("credential")
+        assert var_looks_sensitive("credentials")
+        assert var_looks_sensitive("db_cred")
 
     def test_key_variants(self) -> None:
         """Key variants are sensitive."""
-        assert _var_looks_sensitive("private_key")
-        assert _var_looks_sensitive("ssh_key")
+        assert var_looks_sensitive("private_key")
+        assert var_looks_sensitive("ssh_key")
 
     def test_non_sensitive(self) -> None:
         """Non-sensitive names return False."""
-        assert not _var_looks_sensitive("username")
-        assert not _var_looks_sensitive("hostname")
-        assert not _var_looks_sensitive("port")
-        assert not _var_looks_sensitive("config")
+        assert not var_looks_sensitive("username")
+        assert not var_looks_sensitive("hostname")
+        assert not var_looks_sensitive("port")
+        assert not var_looks_sensitive("config")
 
     def test_false_positive_avoidance(self) -> None:
         """Substring matches that are not word-bounded are rejected."""
-        assert not _var_looks_sensitive("secretary_name")
-        assert not _var_looks_sensitive("tokenized_value")
-        assert not _var_looks_sensitive("accreditation")
-        assert not _var_looks_sensitive("passwords_enabled")
+        assert not var_looks_sensitive("secretary_name")
+        assert not var_looks_sensitive("tokenized_value")
+        assert not var_looks_sensitive("accreditation")
+        assert not var_looks_sensitive("passwords_enabled")
+        assert not var_looks_sensitive("pass_rate")
+        assert not var_looks_sensitive("pass_count")
+        assert not var_looks_sensitive("auth_method")
 
     def test_bracket_notation_credentials(self) -> None:
         """Bracket notation like credentials['token'] is sensitive."""
-        assert _var_looks_sensitive("credentials['token']")
-        assert _var_looks_sensitive('credentials["password"]')
-        assert _var_looks_sensitive("vault['secret']")
+        assert var_looks_sensitive("credentials['token']")
+        assert var_looks_sensitive('credentials["password"]')
+        assert var_looks_sensitive("vault['secret']")
 
 
 class TestFindSensitiveVarsInDebug:
@@ -575,13 +579,13 @@ class TestDebugSensitiveVarsGraphRule:
 
     def test_access_key_sensitive(self) -> None:
         """access_key is recognized as sensitive."""
-        assert _var_looks_sensitive("access_key")
-        assert _var_looks_sensitive("aws_access_key")
+        assert var_looks_sensitive("access_key")
+        assert var_looks_sensitive("aws_access_key")
 
     def test_client_key_sensitive(self) -> None:
         """client_key is recognized as sensitive."""
-        assert _var_looks_sensitive("client_key")
-        assert _var_looks_sensitive("ssl_client_key")
+        assert var_looks_sensitive("client_key")
+        assert var_looks_sensitive("ssl_client_key")
 
     def test_nested_var_extraction(self) -> None:
         """Extract nested vars from Jinja templates."""

--- a/tests/test_audit_metadata.py
+++ b/tests/test_audit_metadata.py
@@ -1,0 +1,61 @@
+"""Tests for audit metadata serialization and redaction."""
+
+from __future__ import annotations
+
+import json
+
+from apme_engine.graph.audit_metadata import (
+    build_audit_metadata_blob,
+    sanitize_audit_metadata_value,
+    serialize_audit_metadata_value,
+)
+from apme_engine.graph.sensitivity import redact_url_userinfo
+
+
+def test_redact_url_userinfo_strips_credentials() -> None:
+    """URLs with embedded credentials are redacted."""
+    raw = "https://user:secret@example.com/path"
+    assert redact_url_userinfo(raw) == "https://[REDACTED]@example.com/path"
+
+
+def test_build_audit_metadata_blob_decodes_proto_strings() -> None:
+    """Gateway persistence decodes per-key JSON metadata once."""
+    payload = [{"name": "x", "source": "play"}]
+    blob = build_audit_metadata_blob({"variables_used": json.dumps(payload)})
+    parsed = json.loads(blob)
+    assert parsed["variables_used"] == payload
+
+
+def test_build_audit_metadata_blob_resanitizes_cleartext_values() -> None:
+    """Gateway persistence re-sanitizes decoded audit payloads before storage."""
+    payload = [{"name": "db_password", "value": "s3cret", "source": "play"}]
+    blob = build_audit_metadata_blob({"variable_set": json.dumps(payload)})
+    parsed = json.loads(blob)
+    assert parsed["variable_set"][0]["name"] == "[REDACTED]"
+    assert parsed["variable_set"][0]["value"] == "[REDACTED]"
+
+
+def test_sanitize_inbound_src_redacts_url_credentials() -> None:
+    """Inbound audit URLs are scrubbed before serialization."""
+    sanitized = sanitize_audit_metadata_value(
+        "inbound_src",
+        ["https://admin:pass@host/file.tar.gz"],
+    )
+    assert sanitized == ["https://[REDACTED]@host/file.tar.gz"]
+    encoded = serialize_audit_metadata_value(sanitized, key="inbound_src")
+    assert encoded is not None
+    assert json.loads(encoded) == ["https://[REDACTED]@host/file.tar.gz"]
+
+
+def test_sanitize_variable_set_redacts_nested_dict_secrets() -> None:
+    """Nested dict values under benign keys are redacted in variable_set."""
+    sanitized = sanitize_audit_metadata_value(
+        "variable_set",
+        [{"name": "config", "value": {"db_password": "s3cret"}, "source": "play"}],
+    )
+    assert isinstance(sanitized, list)
+    entry = sanitized[0]
+    assert isinstance(entry, dict)
+    nested = entry["value"]
+    assert isinstance(nested, dict)
+    assert nested["db_password"] == "[REDACTED]"

--- a/tests/test_content_graph.py
+++ b/tests/test_content_graph.py
@@ -961,6 +961,123 @@ class TestGraphReportToViolations:
         assert violations[0]["line"] == 1
 
 
+    def test_audit_json_detail_keys_serialized(self) -> None:
+        """Audit rule payloads (variables_used, variable_set) survive conversion."""
+        import json
+
+        from apme_engine.daemon.violation_convert import violation_dict_to_proto, violation_proto_to_dict
+        from apme_engine.engine.models import RuleMetadata, YAMLValue
+        from apme_engine.graph.rule_base import GraphRuleResult
+        from apme_engine.graph.scanner import (
+            GraphNodeResult,
+            GraphScanReport,
+            graph_report_to_violations,
+        )
+
+        variables_used: list[YAMLValue] = [
+            cast(YAMLValue, {"name": "nginx_port", "source": "play", "task": "site.yml/plays[0]/tasks[0]"})
+        ]
+        variable_set: list[YAMLValue] = [cast(YAMLValue, {"name": "nginx_port", "value": "8080", "source": "play"})]
+        node = ContentNode(
+            identity=NodeIdentity(path="site.yml/plays[0]", node_type=NodeType.PLAY),
+            file_path="site.yml",
+            line_start=1,
+        )
+        report = GraphScanReport(
+            node_results=[
+                GraphNodeResult(
+                    node_id="site.yml/plays[0]",
+                    node=node,
+                    rule_results=[
+                        GraphRuleResult(
+                            rule=RuleMetadata(rule_id="R402", severity="info", scope="play"),
+                            verdict=True,
+                            detail={
+                                "message": "Play references 1 variable use(s) across tasks",
+                                "variables_used": variables_used,
+                            },
+                            node_id="site.yml/plays[0]",
+                            file=("site.yml", 1),
+                        ),
+                        GraphRuleResult(
+                            rule=RuleMetadata(rule_id="R404", severity="info", scope="task"),
+                            verdict=True,
+                            detail={
+                                "message": "Task has 1 variable(s) in scope",
+                                "variable_set": variable_set,
+                            },
+                            node_id="site.yml/plays[0]/tasks[0]",
+                            file=("site.yml", 5),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        violations = graph_report_to_violations(report)
+        assert len(violations) == 2
+        r402 = next(v for v in violations if v["rule_id"] == "R402")
+        r404 = next(v for v in violations if v["rule_id"] == "R404")
+        assert json.loads(str(r402["variables_used"])) == variables_used
+        assert json.loads(str(r404["variable_set"])) == variable_set
+
+        proto = violation_dict_to_proto(r402)
+        assert json.loads(proto.metadata["variables_used"]) == variables_used
+        roundtrip = violation_proto_to_dict(proto)
+        assert isinstance(roundtrip["variables_used"], list)
+        assert roundtrip["variables_used"] == variables_used
+
+    def test_audit_json_skips_non_serializable_values(self) -> None:
+        """Non-serializable audit metadata is omitted instead of aborting conversion."""
+
+        class _NotSerializable:
+            def __str__(self) -> str:
+                msg = "cannot serialize"
+                raise TypeError(msg)
+
+        from apme_engine.engine.models import RuleMetadata, YAMLDict
+        from apme_engine.graph.rule_base import GraphRuleResult
+        from apme_engine.graph.scanner import (
+            GraphNodeResult,
+            GraphScanReport,
+            graph_report_to_violations,
+        )
+
+        node = ContentNode(
+            identity=NodeIdentity(path="site.yml/plays[0]/tasks[0]", node_type=NodeType.TASK),
+            file_path="site.yml",
+            line_start=5,
+        )
+        bad_value: object = _NotSerializable()
+        report = GraphScanReport(
+            node_results=[
+                GraphNodeResult(
+                    node_id=node.node_id,
+                    node=node,
+                    rule_results=[
+                        GraphRuleResult(
+                            rule=RuleMetadata(rule_id="R404", severity="info", scope="task"),
+                            verdict=True,
+                            detail=cast(
+                                YAMLDict,
+                                {
+                                    "message": "Task has 1 variable(s) in scope",
+                                    "variable_set": [
+                                        {"name": "bad", "value": bad_value, "source": "play"},
+                                    ],
+                                },
+                            ),
+                            node_id=node.node_id,
+                            file=("site.yml", 5),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        violations = graph_report_to_violations(report)
+        assert len(violations) == 1
+        assert "variable_set" not in violations[0]
+
+
 # ---------------------------------------------------------------------------
 # GraphBuilder block structure integration (Issue #164)
 # ---------------------------------------------------------------------------

--- a/tests/test_content_graph.py
+++ b/tests/test_content_graph.py
@@ -960,7 +960,6 @@ class TestGraphReportToViolations:
         assert violations[0]["file"] == "playbook.yml"
         assert violations[0]["line"] == 1
 
-
     def test_audit_json_detail_keys_serialized(self) -> None:
         """Audit rule payloads (variables_used, variable_set) survive conversion."""
         import json

--- a/tests/test_gateway_api.py
+++ b/tests/test_gateway_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -209,6 +210,39 @@ async def test_get_scan_detail_with_children(client: AsyncClient) -> None:
     assert len(body["proposals"]) == 1
     assert body["proposals"][0]["status"] == "approved"
     assert len(body["logs"]) == 1
+
+
+async def test_get_scan_detail_resanitizes_audit_metadata(client: AsyncClient) -> None:
+    """Activity detail re-sanitizes persisted audit metadata on read.
+
+    Args:
+        client: Async HTTP test client.
+    """
+    await _seed(add_violation=False)
+    async with get_session() as db:
+        db.add(
+            Violation(
+                scan_id="scan-1",
+                rule_id="R404",
+                level="info",
+                message="audit",
+                file="a.yml",
+                line=5,
+                audit_metadata=json.dumps(
+                    {"variable_set": [{"name": "db_password", "value": "s3cret", "source": "play"}]}
+                ),
+            )
+        )
+        await db.commit()
+
+    resp = await client.get("/api/v1/activity/scan-1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["violations"]) == 1
+    audit = body["violations"][0]["audit_metadata"]
+    assert audit is not None
+    assert audit["variable_set"][0]["name"] == "[REDACTED]"
+    assert audit["variable_set"][0]["value"] == "[REDACTED]"
 
 
 async def test_get_scan_not_found(client: AsyncClient) -> None:

--- a/tests/test_gateway_dependencies.py
+++ b/tests/test_gateway_dependencies.py
@@ -193,6 +193,7 @@ async def test_report_fix_deduplicates_duplicate_python_packages() -> None:
         source="cli",
         manifest=manifest,
     )
+
     await servicer.ReportFixCompleted(event, _mock_context())
 
     async with get_session() as db:

--- a/tests/test_gateway_servicer.py
+++ b/tests/test_gateway_servicer.py
@@ -102,6 +102,67 @@ async def test_report_fix_with_violations() -> None:
     assert scan.violations[0].rule_id == "L001"
 
 
+async def test_report_fix_persists_structured_audit_metadata() -> None:
+    """Audit metadata JSON strings are decoded once before Gateway persistence."""
+    import json
+
+    servicer = ReportingServicer()
+    payload = [{"name": "my_var", "source": "play", "task": "tasks[0]"}]
+    viol = common_pb2.Violation(
+        rule_id="R402",
+        severity=common_pb2.SEVERITY_INFO,
+        message="audit",
+        file="a.yml",
+        line=1,
+        metadata={"variables_used": json.dumps(payload)},
+    )
+    event = reporting_pb2.FixCompletedEvent(
+        scan_id="audit-scan",
+        session_id="sess-1",
+        project_path="/p",
+        remaining_violations=[viol],
+    )
+    await servicer.ReportFixCompleted(event, _mock_context())
+
+    async with get_session() as db:
+        scan = await q.get_scan(db, "audit-scan")
+    assert scan is not None
+    assert len(scan.violations) == 1
+    stored = json.loads(scan.violations[0].audit_metadata)
+    assert stored["variables_used"] == payload
+
+
+async def test_report_fix_resanitizes_variable_set_before_persistence() -> None:
+    """Gateway persistence scrubs cleartext values from audit metadata blobs."""
+    import json
+
+    servicer = ReportingServicer()
+    payload = [{"name": "db_password", "value": "s3cret", "source": "play"}]
+    viol = common_pb2.Violation(
+        rule_id="R404",
+        severity=common_pb2.SEVERITY_INFO,
+        message="audit",
+        file="a.yml",
+        line=1,
+        metadata={"variable_set": json.dumps(payload)},
+    )
+    event = reporting_pb2.FixCompletedEvent(
+        scan_id="audit-r404",
+        session_id="sess-1",
+        project_path="/p",
+        remaining_violations=[viol],
+    )
+    await servicer.ReportFixCompleted(event, _mock_context())
+
+    async with get_session() as db:
+        scan = await q.get_scan(db, "audit-r404")
+    assert scan is not None
+    assert len(scan.violations) == 1
+    stored = json.loads(scan.violations[0].audit_metadata)
+    assert stored["variable_set"][0]["name"] == "[REDACTED]"
+    assert stored["variable_set"][0]["value"] == "[REDACTED]"
+
+
 async def test_report_fix_with_logs() -> None:
     """Pipeline logs in the event are persisted."""
     servicer = ReportingServicer()

--- a/tests/test_generate_rule_catalog.py
+++ b/tests/test_generate_rule_catalog.py
@@ -1,0 +1,362 @@
+"""Unit tests for generate_rule_catalog heuristics.
+
+Covers ``_is_incidental_reference`` (test-detection) and
+``_parse_frontmatter`` (YAML frontmatter parsing) in
+``tools/generate_rule_catalog.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_TOOLS_DIR = str(REPO_ROOT / "tools")
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)
+
+_mod: types.ModuleType = importlib.import_module("generate_rule_catalog")
+_is_incidental_reference = _mod._is_incidental_reference
+_parse_frontmatter = _mod._parse_frontmatter
+_normalize_validator = _mod._normalize_validator
+_rule_ids_from_module_name = _mod._rule_ids_from_module_name
+
+
+# ---------------------------------------------------------------------------
+# _is_incidental_reference
+# ---------------------------------------------------------------------------
+
+
+class TestIsIncidentalReference:
+    """Tests for the incidental-reference detection heuristic."""
+
+    def test_filename_contains_rule_id(self) -> None:
+        """File named after the rule is never incidental.
+
+        Tests:
+            Filename ``test_L039_rules.py`` contains ``L039``.
+        """
+        text = 'rule_id = "L039"  # just a string in fixture data'
+        assert not _is_incidental_reference("L039", text, "test_L039_rules.py")
+
+    def test_class_name_contains_rule_id(self) -> None:
+        """File with a test class embedding the rule ID is genuine.
+
+        Tests:
+            ``class TestL039Rule`` matches the context pattern.
+        """
+        text = 'class TestL039Rule:\n    rule_id = "L039"\n'
+        assert not _is_incidental_reference("L039", text, "test_misc.py")
+
+    def test_def_test_contains_rule_id(self) -> None:
+        """File with a test function embedding the rule ID is genuine.
+
+        Tests:
+            ``def test_l039_fires`` matches the context pattern.
+        """
+        text = 'def test_l039_fires():\n    assert "L039" in results\n'
+        assert not _is_incidental_reference("L039", text, "test_other.py")
+
+    def test_import_contains_rule_id(self) -> None:
+        """File importing something with the rule ID is genuine.
+
+        Tests:
+            ``import ...L039`` matches the context pattern.
+        """
+        text = 'from apme_engine.validators.native.rules.L039_undefined import Rule\n"L039"\n'
+        assert not _is_incidental_reference("L039", text, "test_validators.py")
+
+    def test_rule_id_assignment(self) -> None:
+        """File with ``rule_id = "L039"`` is genuine.
+
+        Tests:
+            Direct rule_id assignment matches the assignment pattern.
+        """
+        text = 'rule_id = "L039"\nsome_other_code()\n'
+        assert not _is_incidental_reference("L039", text, "test_generic.py")
+
+    def test_rule_id_colon_assignment(self) -> None:
+        """File with ``rule_id: "L039"`` (dict-style) is genuine.
+
+        Tests:
+            Colon-separated assignment matches the assignment pattern.
+        """
+        text = '{"rule_id": "L039", "severity": "low"}\n'
+        assert not _is_incidental_reference("L039", text, "test_generic.py")
+
+    def test_incidental_fixture_data(self) -> None:
+        """Rule ID appearing only in fixture data is incidental.
+
+        Tests:
+            No class/def/import context for the rule ID.
+        """
+        text = 'SAMPLE_DATA = ["L039", "L040", "M001"]\ndef test_count():\n    pass\n'
+        assert _is_incidental_reference("L039", text, "test_summary.py")
+
+    def test_incidental_string_literal(self) -> None:
+        """Rule ID in a data list without import/class/def context is incidental.
+
+        Tests:
+            ``"L039"`` appears in sample data, no structural context.
+        """
+        text = 'SAMPLE_IDS = ["L039", "M001"]\ndef test_something_else():\n    pass\n'
+        assert _is_incidental_reference("L039", text, "test_unrelated.py")
+
+    def test_case_insensitive_filename_match(self) -> None:
+        """Filename check is case-insensitive.
+
+        Tests:
+            ``test_l039.py`` matches rule ID ``L039``.
+        """
+        text = '"L039" in some list'
+        assert not _is_incidental_reference("L039", text, "test_l039.py")
+
+
+class TestRuleIdsFromModuleName:
+    """Tests for grouped rule module name expansion."""
+
+    def test_m001_m004_range(self) -> None:
+        """M001_M004_introspect expands to four rule IDs."""
+        assert _rule_ids_from_module_name("M001_M004_introspect") == {
+            "M001",
+            "M002",
+            "M003",
+            "M004",
+        }
+
+    def test_non_range_module(self) -> None:
+        """Unrelated module names return empty set."""
+        assert _rule_ids_from_module_name("L039_undefined_variable_graph") == set()
+
+
+# ---------------------------------------------------------------------------
+# _parse_frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestParseFrontmatter:
+    """Tests for YAML frontmatter extraction from markdown files."""
+
+    def test_simple_frontmatter(self, tmp_path: Path) -> None:
+        """Parses simple key-value frontmatter.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        md = tmp_path / "rule.md"
+        md.write_text("---\nrule_id: L001\ndescription: Test rule\n---\n# Rule\n")
+        result = _parse_frontmatter(md)
+        assert result["rule_id"] == "L001"
+        assert result["description"] == "Test rule"
+
+    def test_no_frontmatter(self, tmp_path: Path) -> None:
+        """Returns empty dict when no frontmatter is present.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        md = tmp_path / "plain.md"
+        md.write_text("# Just a heading\n\nSome content.\n")
+        result = _parse_frontmatter(md)
+        assert result == {}
+
+    def test_quoted_values(self, tmp_path: Path) -> None:
+        """Handles quoted YAML values in frontmatter.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        md = tmp_path / "quoted.md"
+        md.write_text('---\nrule_id: "M030"\ndescription: "A quoted description"\n---\n')
+        result = _parse_frontmatter(md)
+        assert result["rule_id"] == "M030"
+        assert result["description"] == "A quoted description"
+
+    def test_status_field(self, tmp_path: Path) -> None:
+        """Parses status and status_reason fields.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        md = tmp_path / "stub.md"
+        md.write_text("---\nrule_id: L999\nstatus: stub\nstatus_reason: Covered by ansible-lint\n---\n")
+        result = _parse_frontmatter(md)
+        assert result["rule_id"] == "L999"
+        assert result["status"] == "stub"
+        assert result["status_reason"] == "Covered by ansible-lint"
+
+    def test_validator_field(self, tmp_path: Path) -> None:
+        """Parses the validator field from frontmatter.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        md = tmp_path / "opa.md"
+        md.write_text("---\nrule_id: P005\nvalidator: opa\ndescription: OPA rule\n---\n")
+        result = _parse_frontmatter(md)
+        assert result["validator"] == "opa"
+
+    def test_multiline_description_yaml(self, tmp_path: Path) -> None:
+        """Handles YAML folded scalar (``>``) in frontmatter via yaml.safe_load.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        md = tmp_path / "folded.md"
+        md.write_text("---\nrule_id: L050\ndescription: >\n  A long\n  description\n---\n")
+        result = _parse_frontmatter(md)
+        assert result["rule_id"] == "L050"
+        assert "long" in result["description"]
+
+    def test_none_values_excluded(self, tmp_path: Path) -> None:
+        """Keys with None values are excluded from the result.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        md = tmp_path / "nonevals.md"
+        md.write_text("---\nrule_id: L060\nstatus:\n---\n")
+        result = _parse_frontmatter(md)
+        assert result["rule_id"] == "L060"
+        assert "status" not in result
+
+    def test_import_error_fallback_warns_stderr(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """ImportError for PyYAML emits a stderr warning before regex fallback.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+            monkeypatch: Pytest monkeypatch fixture.
+            capsys: Pytest capture fixture for stdout/stderr.
+        """
+        import builtins
+
+        md = tmp_path / "rule.md"
+        md.write_text("---\nrule_id: L001\ndescription: Test rule\n---\n")
+
+        real_import = builtins.__import__
+
+        def fake_import(
+            name: str,
+            globals: Mapping[str, object] | None = None,
+            locals: Mapping[str, object] | None = None,
+            fromlist: Sequence[str] = (),
+            level: int = 0,
+        ) -> object:
+            if name == "yaml":
+                raise ImportError("PyYAML not installed")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        result = _parse_frontmatter(md)
+        assert result["rule_id"] == "L001"
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "PyYAML" in captured.err
+
+
+class TestNormalizeValidator:
+    """Tests for validator name normalization from frontmatter."""
+
+    def test_known_native(self) -> None:
+        """Lowercase native maps to Native."""
+        assert _normalize_validator("native") == "Native"
+
+    def test_known_ansible(self) -> None:
+        """Lowercase ansible maps to Ansible."""
+        assert _normalize_validator("ansible") == "Ansible"
+
+    def test_unknown_string_capitalized(self) -> None:
+        """Unknown validator strings are title-cased."""
+        assert _normalize_validator("custom") == "Custom"
+
+    def test_empty_defaults_to_native(self) -> None:
+        """Empty string defaults to Native."""
+        assert _normalize_validator("") == "Native"
+
+
+class TestGetTestCache:
+    """Tests for rule_id -> test file cache construction."""
+
+    def test_import_graph_rule_module_counts_as_tested(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Importing a graph rule module links the rule ID to that test file.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        test_file = tests_dir / "test_r402_loader.py"
+        test_file.write_text(
+            "from apme_engine.validators.native.rules.R402_list_all_used_variables_graph import "
+            "ListAllUsedVariablesGraphRule\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_mod, "TESTS_DIR", tests_dir)
+        monkeypatch.setattr(_mod, "_TEST_CACHE", None)
+        cache = _mod._get_test_cache()
+        assert "test_r402_loader.py" in cache.get("R402", [])
+
+    def test_grouped_module_import_expands_rule_range(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Grouped modules like M001_M004_introspect credit each rule in the range.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        test_file = tests_dir / "test_ansible_cache.py"
+        test_file.write_text(
+            "from apme_engine.validators.ansible.rules import M001_M004_introspect\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_mod, "TESTS_DIR", tests_dir)
+        monkeypatch.setattr(_mod, "_TEST_CACHE", None)
+        cache = _mod._get_test_cache()
+        for rid in ("M001", "M002", "M003", "M004"):
+            assert "test_ansible_cache.py" in cache.get(rid, [])
+
+    def test_incidental_string_literal_excluded(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """String literals mentioning a rule ID without imports are incidental.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        test_file = tests_dir / "test_misc.py"
+        test_file.write_text(
+            'SAMPLE_IDS = ["R402", "L039"]\ndef test_something_else():\n    pass\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_mod, "TESTS_DIR", tests_dir)
+        monkeypatch.setattr(_mod, "_TEST_CACHE", None)
+        cache = _mod._get_test_cache()
+        assert "R402" not in cache
+
+
+class TestParseFrontmatterYamlFallback:
+    """Tests for YAML-error fallback in frontmatter parsing."""
+
+    def test_yaml_error_falls_back_to_regex(self, tmp_path: Path) -> None:
+        """Invalid YAML still yields rule_id via regex fallback.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        md = tmp_path / "broken.md"
+        md.write_text("---\nrule_id: R402\nstatus: [unclosed\ndescription: ok\n---\n", encoding="utf-8")
+        result = _parse_frontmatter(md)
+        assert result["rule_id"] == "R402"

--- a/tests/test_graph_remediation.py
+++ b/tests/test_graph_remediation.py
@@ -12,7 +12,9 @@ from apme_engine.engine.models import ViolationDict
 from apme_engine.graph.content_graph import (
     ContentGraph,
     ContentNode,
+    EdgeType,
     NodeIdentity,
+    NodeScope,
     NodeType,
 )
 from apme_engine.graph.rule_base import (
@@ -24,7 +26,7 @@ from apme_engine.graph.scanner import (
     rescan_dirty,
     scan,
 )
-from apme_engine.graph.types import RemediationResolution
+from apme_engine.graph.types import RemediationResolution, RuleScope
 from apme_engine.remediation.graph_engine import (
     GraphRemediationEngine,
     splice_modifications,
@@ -83,6 +85,44 @@ def _make_node(
     )
 
 
+def _make_play_task_graph(*, task_module: str = "apt") -> tuple[ContentGraph, ContentNode, ContentNode, ContentNode]:
+    """Build a playbook graph with one play containing one task.
+
+    Args:
+        task_module: Module name to assign to the task node.
+
+    Returns:
+        Tuple of ``(graph, playbook, play, task)``.
+    """
+    graph = ContentGraph()
+    playbook = ContentNode(
+        identity=NodeIdentity(path="site.yml", node_type=NodeType.PLAYBOOK),
+        file_path="/workspace/site.yml",
+        scope=NodeScope.OWNED,
+    )
+    play = ContentNode(
+        identity=NodeIdentity(path="site.yml/plays[0]", node_type=NodeType.PLAY),
+        file_path="/workspace/site.yml",
+        line_start=1,
+        scope=NodeScope.OWNED,
+    )
+    task = ContentNode(
+        identity=NodeIdentity(path="site.yml/plays[0]/tasks[0]", node_type=NodeType.TASK),
+        file_path="/workspace/site.yml",
+        line_start=3,
+        line_end=6,
+        module=task_module,
+        yaml_lines=_TASK_YAML_APT if task_module == "apt" else _TASK_YAML_FQCN,
+        scope=NodeScope.OWNED,
+    )
+    graph.add_node(playbook)
+    graph.add_node(play)
+    graph.add_node(task)
+    graph.add_edge(playbook.node_id, play.node_id, EdgeType.CONTAINS)
+    graph.add_edge(play.node_id, task.node_id, EdgeType.CONTAINS)
+    return graph, playbook, play, task
+
+
 class _FQCNRule(GraphRule):
     """Mock rule that flags non-FQCN module names."""
 
@@ -119,6 +159,49 @@ class _AlwaysPassRule(GraphRule):
 
     def process(self, graph: ContentGraph, node_id: str) -> GraphRuleResult | None:
         return GraphRuleResult(verdict=False, node_id=node_id)
+
+
+class _PlayAggregateRule(GraphRule):
+    """Mock play-scoped rule that reflects descendant task module state."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            rule_id="R402",
+            description="Play still contains short module names",
+            enabled=True,
+            precedence=5,
+            scope=RuleScope.PLAY,
+        )
+
+    def match(self, graph: ContentGraph, node_id: str) -> bool:
+        node = graph.get_node(node_id)
+        return node is not None and node.node_type == NodeType.PLAY
+
+    def process(self, graph: ContentGraph, node_id: str) -> GraphRuleResult | None:
+        node = graph.get_node(node_id)
+        if node is None:
+            return None
+        short_modules = []
+        for desc_id in graph.structural_descendants(node_id):
+            desc = graph.get_node(desc_id)
+            if desc is None or desc.node_type != NodeType.TASK:
+                continue
+            if desc.module and "." not in desc.module:
+                short_modules.append(desc.module)
+        if not short_modules:
+            return GraphRuleResult(
+                rule=self.get_metadata(),
+                verdict=False,
+                node_id=node_id,
+                file=(node.file_path, node.line_start or 0),
+            )
+        return GraphRuleResult(
+            rule=self.get_metadata(),
+            verdict=True,
+            node_id=node_id,
+            file=(node.file_path, node.line_start or 0),
+            detail={"message": f"Play references short modules: {', '.join(sorted(short_modules))}"},
+        )
 
 
 def _fqcn_transform(task: CommentedMap, violation: ViolationDict) -> bool:
@@ -203,6 +286,18 @@ class TestRescanDirty:
         report = rescan_dirty(graph, [_FQCNRule()], frozenset({n.node_id}))
         assert report.nodes_scanned == 1
         assert not graph_report_to_violations(report)
+
+    def test_play_scoped_rules_rescan_enclosing_play(self) -> None:
+        """Dirty task rescans enclosing play when a play-scoped rule is enabled."""
+        graph, _playbook, play, task = _make_play_task_graph(task_module="apt")
+
+        report = rescan_dirty(graph, [_PlayAggregateRule()], frozenset({task.node_id}))
+
+        assert report.nodes_scanned == 2
+        violations = graph_report_to_violations(report)
+        assert len(violations) == 1
+        assert violations[0]["rule_id"] == "R402"
+        assert violations[0]["path"] == play.node_id
 
 
 # ---------------------------------------------------------------------------
@@ -387,6 +482,20 @@ class TestGraphRemediationEngine:
         fixed = graph.query_violations(status="fixed")
         assert len(fixed) >= 1
         assert any(v["rule_id"] == "M001" for v in fixed)
+        assert graph.collect_violations() == []
+
+    async def test_play_scoped_violation_resolved_after_task_fix(self) -> None:
+        """Aggregate play violations are resolved when descendant tasks are fixed."""
+        graph, _playbook, _play, _task = _make_play_task_graph(task_module="apt")
+        rules: list[GraphRule] = [_FQCNRule(), _PlayAggregateRule()]
+        registry = _build_registry_with_fqcn()
+
+        engine = GraphRemediationEngine(registry, graph, rules)
+        await engine.remediate()
+
+        fixed = graph.query_violations(status="fixed")
+        assert any(v["rule_id"] == "M001" for v in fixed)
+        assert any(v["rule_id"] == "R402" for v in fixed)
         assert graph.collect_violations() == []
 
     async def test_progress_callback(self) -> None:

--- a/tests/test_graph_scanner.py
+++ b/tests/test_graph_scanner.py
@@ -284,12 +284,12 @@ class TestLoadGraphRules:
 
     def test_empty_dir_returns_empty(self) -> None:
         """Verify empty rules_dir returns empty list."""
-        rules = load_graph_rules(rules_dir="")
+        rules, _ = load_graph_rules(rules_dir="")
         assert rules == []
 
     def test_nonexistent_dir_returns_empty(self) -> None:
         """Verify non-existent directory is skipped."""
-        rules = load_graph_rules(rules_dir="/nonexistent/path")
+        rules, _ = load_graph_rules(rules_dir="/nonexistent/path")
         assert rules == []
 
     def test_all_graph_rules_load_without_errors(self) -> None:
@@ -324,3 +324,26 @@ class TestLoadGraphRules:
         )
         assert errors == [], f"Graph rule load errors: {errors}"
         assert len(classes) >= len(graph_files), f"Loaded {len(classes)} rules from {len(graph_files)} *_graph.py files"
+
+    def test_default_load_skips_disabled_by_default_rules(self) -> None:
+        """Disabled-by-default rules are omitted when no rule_id_list is given."""
+        from pathlib import Path
+
+        import apme_engine.graph.rules as rules_pkg
+
+        rules_dir = str(Path(rules_pkg.__file__).parent)
+        rule_ids = {r.rule_id for r in load_graph_rules(rules_dir=rules_dir)[0]}
+        assert "R402" not in rule_ids
+        assert "R404" not in rule_ids
+
+    def test_graph_rule_opt_in_from_rule_configs(self) -> None:
+        """RuleConfig enabled flags map to native graph opt-in IDs."""
+        from apme.v1.primary_pb2 import RuleConfig
+        from apme_engine.graph.scanner import graph_rule_opt_in_from_rule_configs
+
+        configs = [
+            RuleConfig(rule_id="R402", enabled=True),
+            RuleConfig(rule_id="L039", enabled=True),
+            RuleConfig(rule_id="R404", enabled=False),
+        ]
+        assert graph_rule_opt_in_from_rule_configs(configs) == ["R402"]

--- a/tests/test_graph_scanner.py
+++ b/tests/test_graph_scanner.py
@@ -338,7 +338,7 @@ class TestLoadGraphRules:
 
     def test_graph_rule_opt_in_from_rule_configs(self) -> None:
         """RuleConfig enabled flags map to native graph opt-in IDs."""
-        from apme.v1.primary_pb2 import RuleConfig
+        from apme.v1.engine_pb2 import RuleConfig
         from apme_engine.graph.scanner import graph_rule_opt_in_from_rule_configs
 
         configs = [

--- a/tests/test_rule_catalog.py
+++ b/tests/test_rule_catalog.py
@@ -71,6 +71,16 @@ def test_collect_all_rules_non_empty_and_fields() -> None:
     assert ids == sorted(ids), "collect_all_rules must return rules sorted by rule_id"
 
 
+def test_collect_all_rules_registers_disabled_by_default_audit_rules() -> None:
+    """R402/R404 appear in the catalog with ``enabled=False`` for ADR-041 opt-in."""
+    rules = collect_all_rules()
+    by_id = {r.rule_id: r for r in rules}
+    for rule_id in ("R402", "R404"):
+        assert rule_id in by_id, f"{rule_id} must be registered in collect_all_rules()"
+        assert by_id[rule_id].enabled is False, f"{rule_id} must remain disabled by default in catalog"
+        assert by_id[rule_id].source == "native"
+
+
 def test_collect_gitleaks_rules_sec_placeholder_critical() -> None:
     """Gitleaks contributes a single ``SEC:*`` placeholder with critical severity.
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1062,7 +1062,7 @@ class TestSessionGraphRemediate:
         progress_queue: asyncio.Queue[ProgressUpdate | None] = asyncio.Queue()
 
         with (
-            patch("apme_engine.graph.scanner.load_graph_rules", return_value=[]),
+            patch("apme_engine.graph.scanner.load_graph_rules", return_value=([], [])),
             patch("apme_engine.remediation.graph_engine.GraphRemediationEngine") as MockGRE,
             patch("apme_engine.remediation.graph_engine.splice_modifications", return_value=mock_patches),
             patch("apme_engine.remediation.partition.add_classification_to_violations"),
@@ -1146,7 +1146,7 @@ class TestSessionGraphRemediate:
             return []
 
         with (
-            patch("apme_engine.graph.scanner.load_graph_rules", return_value=[]),
+            patch("apme_engine.graph.scanner.load_graph_rules", return_value=([], [])),
             patch("apme_engine.remediation.graph_engine.GraphRemediationEngine") as MockGRE,
             patch("apme_engine.remediation.graph_engine.splice_modifications", return_value=[]),
             patch("apme_engine.remediation.partition.add_classification_to_violations"),
@@ -1203,7 +1203,7 @@ class TestSessionGraphRemediate:
             return []
 
         with (
-            patch("apme_engine.graph.scanner.load_graph_rules", return_value=[]),
+            patch("apme_engine.graph.scanner.load_graph_rules", return_value=([], [])),
             patch("apme_engine.remediation.graph_engine.GraphRemediationEngine") as MockGRE,
             patch("apme_engine.remediation.graph_engine.splice_modifications", return_value=[]),
             patch("apme_engine.remediation.partition.add_classification_to_violations"),
@@ -1272,7 +1272,7 @@ class TestSessionGraphRemediate:
         )
 
         with (
-            patch("apme_engine.graph.scanner.load_graph_rules", return_value=[]),
+            patch("apme_engine.graph.scanner.load_graph_rules", return_value=([], [])),
             patch("apme_engine.remediation.graph_engine.GraphRemediationEngine") as MockGRE,
             patch("apme_engine.remediation.graph_engine.splice_modifications", return_value=[]),
             patch("apme_engine.remediation.partition.add_classification_to_violations"),
@@ -1361,7 +1361,7 @@ class TestSessionGraphRemediate:
             return []
 
         with (
-            patch("apme_engine.graph.scanner.load_graph_rules", return_value=[]),
+            patch("apme_engine.graph.scanner.load_graph_rules", return_value=([], [])),
             patch("apme_engine.remediation.graph_engine.GraphRemediationEngine") as MockGRE,
             patch("apme_engine.remediation.graph_engine.splice_modifications", return_value=[]),
             patch("apme_engine.remediation.partition.add_classification_to_violations"),
@@ -1462,7 +1462,7 @@ class TestSessionRescanBridge:
             return mock_engine
 
         with (
-            patch("apme_engine.graph.scanner.load_graph_rules", return_value=[]),
+            patch("apme_engine.graph.scanner.load_graph_rules", return_value=([], [])),
             patch(
                 "apme_engine.remediation.graph_engine.GraphRemediationEngine",
                 side_effect=capture_gre_init,
@@ -1516,9 +1516,9 @@ class TestSessionRescanBridge:
 
         captured_rules_dir: list[str | None] = [None]
 
-        def mock_load_graph_rules(rules_dir: str = "", **kwargs: object) -> list[object]:
+        def mock_load_graph_rules(rules_dir: str = "", **kwargs: object) -> tuple[list[object], list[str]]:
             captured_rules_dir[0] = rules_dir
-            return []
+            return [], []
 
         async def async_scan_fn_rules(_paths: list[str]) -> list[ViolationDict]:
             return []

--- a/tests/test_session_venv_e2e.py
+++ b/tests/test_session_venv_e2e.py
@@ -265,7 +265,7 @@ def test_native_violations_with_session_venv(dep_dir: str) -> None:
     import apme_engine.graph.rules as _rules_pkg
 
     rules_dir = str(Path(_rules_pkg.__file__).parent)
-    rules = load_graph_rules(rules_dir=rules_dir)
+    rules, _ = load_graph_rules(rules_dir=rules_dir)
     report = graph_scan(graph, rules)
     violations = cast(list[dict[str, object]], graph_report_to_violations(report))
 

--- a/tests/test_terrible_playbook_integration.py
+++ b/tests/test_terrible_playbook_integration.py
@@ -101,7 +101,7 @@ def _run_graph_rules(graph: ContentGraph) -> list[ViolationDict]:
     Returns:
         List of violation dicts.
     """
-    rules = load_graph_rules(rules_dir=str(_native_rules_dir()))
+    rules, _ = load_graph_rules(rules_dir=str(_native_rules_dir()))
     report = graph_scan(graph, rules)
     return graph_report_to_violations(report)
 

--- a/tests/test_validator_servicers.py
+++ b/tests/test_validator_servicers.py
@@ -183,12 +183,33 @@ class TestNativeValidatorServicer:
         )
 
         servicer = NativeValidatorServicer()
-        with patch("apme_engine.daemon.native_validator_server._run_graph", return_value=mock_result):
+        with patch("apme_engine.daemon.native_validator_server._run_graph", return_value=mock_result) as mock_run:
             resp = await servicer.Validate(request, FakeGrpcContext())  # type: ignore[arg-type]
 
         assert len(resp.violations) == 1  # type: ignore[attr-defined]
         assert resp.violations[0].rule_id == "L026"  # type: ignore[attr-defined]
         assert resp.request_id == "native-1"  # type: ignore[attr-defined]
+        mock_run.assert_called_once_with(graph_data, None, [])
+
+    async def test_validate_passes_graph_rule_opt_in(self) -> None:
+        """graph_rule_opt_in from ValidateRequest is forwarded to _run_graph."""
+        from apme_engine.daemon.native_validator_server import NativeValidatorServicer, _GraphRunResult
+        from apme_engine.graph.content_graph import ContentGraph
+
+        graph = ContentGraph()
+        graph_data = json.dumps(graph.to_dict()).encode()
+        request = validate_pb2.ValidateRequest(
+            request_id="native-opt-in",
+            content_graph_data=graph_data,
+            graph_rule_opt_in=["R402", "R404"],
+        )
+        mock_result = _GraphRunResult(violations=[])
+
+        servicer = NativeValidatorServicer()
+        with patch("apme_engine.daemon.native_validator_server._run_graph", return_value=mock_result) as mock_run:
+            await servicer.Validate(request, FakeGrpcContext())  # type: ignore[arg-type]
+
+        mock_run.assert_called_once_with(graph_data, None, ["R402", "R404"])
 
     async def test_validate_returns_diagnostics(self) -> None:
         """Validate returns ValidatorDiagnostics with violation count."""
@@ -279,7 +300,7 @@ class TestNativeValidatorServicer:
         graph_data = json.dumps(graph.to_dict()).encode()
 
         with (
-            patch("apme_engine.daemon.native_validator_server.load_graph_rules", return_value=[]),
+            patch("apme_engine.daemon.native_validator_server.load_graph_rules", return_value=([], [])),
             patch("apme_engine.daemon.native_validator_server.rescan_dirty") as mock_rescan,
             patch("apme_engine.daemon.native_validator_server.graph_scan") as mock_scan,
         ):
@@ -301,7 +322,7 @@ class TestNativeValidatorServicer:
         graph_data = json.dumps(graph.to_dict()).encode()
 
         with (
-            patch("apme_engine.daemon.native_validator_server.load_graph_rules", return_value=[]),
+            patch("apme_engine.daemon.native_validator_server.load_graph_rules", return_value=([], [])),
             patch("apme_engine.daemon.native_validator_server.rescan_dirty") as mock_rescan,
             patch("apme_engine.daemon.native_validator_server.graph_scan") as mock_scan,
         ):
@@ -338,8 +359,9 @@ class TestNativeValidatorServicer:
             resp = await servicer.Validate(request, FakeGrpcContext())  # type: ignore[arg-type]
 
         mock_run.assert_called_once()
-        _data, dirty_arg = mock_run.call_args[0]
+        _data, dirty_arg, opt_in_arg = mock_run.call_args[0]
         assert dirty_arg == frozenset({"node-a", "node-b"})
+        assert opt_in_arg == []
         assert len(resp.violations) == 0  # type: ignore[attr-defined]
 
     async def test_validate_empty_dirty_node_ids_triggers_full_scan(self) -> None:
@@ -365,8 +387,9 @@ class TestNativeValidatorServicer:
             await servicer.Validate(request, FakeGrpcContext())  # type: ignore[arg-type]
 
         mock_run.assert_called_once()
-        _data, dirty_arg = mock_run.call_args[0]
+        _data, dirty_arg, opt_in_arg = mock_run.call_args[0]
         assert dirty_arg is None
+        assert opt_in_arg == []
 
 
 class TestGitleaksValidatorServicerDiagnostics:

--- a/tests/test_violation_convert.py
+++ b/tests/test_violation_convert.py
@@ -187,6 +187,66 @@ class TestViolationDictToProto:
         assert proto.node_type == ""
         assert list(proto.co_fixes) == []
 
+    def test_audit_json_metadata_round_trip(self) -> None:
+        """JSON audit metadata survives proto conversion."""
+        import json
+
+        payload: list[dict[str, str]] = [{"name": "nginx_port", "value": "8080", "source": "play"}]
+        v: ViolationDict = {
+            "rule_id": "R404",
+            "variable_set": json.dumps(payload),
+        }
+        proto = violation_dict_to_proto(v)
+        assert json.loads(proto.metadata["variable_set"]) == payload
+        restored = violation_proto_to_dict(proto)
+        restored_val = restored.get("variable_set")
+        assert json.dumps(restored_val, sort_keys=True) == json.dumps(payload, sort_keys=True)
+
+    def test_audit_json_metadata_preserialized_string_is_sanitized(self) -> None:
+        """Pre-serialized audit JSON is re-sanitized before proto persistence."""
+        import json
+
+        payload: list[dict[str, str]] = [{"name": "db_password", "value": "s3cret", "source": "play"}]
+        v: ViolationDict = {
+            "rule_id": "R404",
+            "variable_set": json.dumps(payload),
+        }
+        proto = violation_dict_to_proto(v)
+        stored = json.loads(proto.metadata["variable_set"])
+        assert stored[0]["name"] == "[REDACTED]"
+        assert stored[0]["value"] == "[REDACTED]"
+
+    def test_variables_used_preserialized_string_is_sanitized(self) -> None:
+        """Pre-serialized variables_used JSON is re-sanitized before persistence."""
+        import json
+
+        payload: list[dict[str, str]] = [{"name": "db_password", "source": "play", "task": "tasks[0]"}]
+        v: ViolationDict = {
+            "rule_id": "R402",
+            "variables_used": json.dumps(payload),
+        }
+        proto = violation_dict_to_proto(v)
+        stored = json.loads(proto.metadata["variables_used"])
+        assert stored[0]["name"] == "[REDACTED]"
+
+    def test_audit_json_metadata_invalid_json_passthrough(self) -> None:
+        """Malformed audit JSON in proto metadata round-trips as raw string."""
+        proto = Violation(rule_id="R404")
+        proto.metadata["variable_set"] = "not-json"
+        restored = violation_proto_to_dict(proto)
+        assert restored.get("variable_set") == "not-json"
+
+
+class TestCheckCliConverter:
+    """Ensure check uses the full daemon violation converter."""
+
+    def test_check_imports_daemon_converter(self) -> None:
+        """check.py must expose audit metadata via daemon violation_convert."""
+        from apme_engine.cli import check as check_mod
+        from apme_engine.daemon.violation_convert import violation_proto_to_dict as daemon_fn
+
+        assert check_mod.violation_proto_to_dict is daemon_fn
+
 
 class TestViolationProtoToDict:
     """Tests for converting proto violations to dict."""
@@ -208,6 +268,16 @@ class TestViolationProtoToDict:
         assert d["file"] == "playbook.yml"
         assert d["line"] == 10
         assert d["path"] == "tasks"
+
+    def test_module_fqcn_synthesized_from_metadata(self) -> None:
+        """CLI JSON includes consolidated module_fqcn from proto metadata."""
+        proto = Violation(
+            rule_id="L046",
+            metadata={"resolved_fqcn": "ansible.builtin.command"},
+        )
+        d = violation_proto_to_dict(proto)
+        assert d.get("module_fqcn") == "ansible.builtin.command"
+        assert d.get("resolved_fqcn") == "ansible.builtin.command"
 
     def test_severity_critical(self) -> None:
         """Proto SEVERITY_CRITICAL converts to 'critical' label."""

--- a/tools/generate_rule_catalog.py
+++ b/tools/generate_rule_catalog.py
@@ -69,10 +69,16 @@ class Rule:
     has_doc: bool = False
     impl_file: str = ""
     test_files: list[str] = field(default_factory=list)
+    status: str = ""
+    status_reason: str = ""
 
 
 def _parse_frontmatter(path: Path) -> dict[str, str]:
     """Parse YAML-ish frontmatter from a markdown file.
+
+    Uses ``yaml.safe_load`` for correct handling of multiline scalars
+    (folded ``>``, literal ``|``, etc.).  Falls back to regex extraction
+    when PyYAML is unavailable.
 
     Args:
         path: Path to the markdown file.
@@ -84,7 +90,21 @@ def _parse_frontmatter(path: Path) -> dict[str, str]:
     m = _FRONTMATTER.match(text)
     if not m:
         return {}
-    pairs = _KV.findall(m.group(1))
+    raw = m.group(1)
+    try:
+        import yaml
+
+        parsed = yaml.safe_load(raw)
+        if isinstance(parsed, dict):
+            return {str(k): str(v).strip() for k, v in parsed.items() if v is not None}
+    except ImportError:
+        print(
+            f"WARNING: PyYAML not available; using regex fallback for {path}",
+            file=sys.stderr,
+        )
+    except yaml.YAMLError as exc:
+        print(f"WARNING: YAML parse error in {path}: {exc}; falling back to regex", file=sys.stderr)
+    pairs = _KV.findall(raw)
     return {k: v.strip("\"'") for k, v in pairs}
 
 
@@ -130,32 +150,59 @@ def _get_fixable_ids() -> set[str]:
     return set()
 
 
-def _find_pytest_files_for_rule(rule_id: str) -> list[str]:
-    """Find pytest files that reference a specific rule ID.
+def _is_incidental_reference(rule_id: str, text: str, filename: str) -> bool:
+    """Check if a rule_id mention in a test file is just fixture/example data.
 
-    Searches test file contents for the quoted rule_id string.  Only scans
-    Python files under tests/.
+    A reference is considered incidental if the test file doesn't import or
+    instantiate anything related to the rule.  Files named after rule
+    categories (e.g. ``test_ansible_rules.py``) or containing a class/def
+    whose name includes the rule ID are genuine.
 
     Args:
-        rule_id: Rule identifier to search for.
+        rule_id: Rule identifier found in the file.
+        text: Full file content.
+        filename: Base filename.
 
     Returns:
-        List of test filenames (relative to tests/) that reference this rule.
+        True if the reference is likely incidental fixture data.
     """
-    matches: list[str] = []
-    if not TESTS_DIR.is_dir():
-        return matches
-    pat = re.compile(rf'(?:"|\'|rule_id["\s:=]+){re.escape(rule_id)}(?:"|\')')
-    for py in sorted(TESTS_DIR.rglob("*.py")):
-        if py.name.startswith("_"):
-            continue
-        try:
-            text = py.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
-        if pat.search(text):
-            matches.append(py.relative_to(TESTS_DIR).as_posix())
-    return matches
+    rid_lower = rule_id.lower().replace("-", "_")
+    if rid_lower in filename.lower():
+        return False
+    rule_context = re.compile(
+        rf"(?:class\s+\w*{re.escape(rule_id)}\w*|"
+        rf"def\s+test_\w*{re.escape(rid_lower)}\w*|"
+        rf"import\s+.*{re.escape(rule_id)}|"
+        rf"Rule.*{re.escape(rule_id)})",
+        re.IGNORECASE,
+    )
+    if rule_context.search(text):
+        return False
+    rule_id_assignment = re.compile(rf'rule_id\s*[=:]\s*["\']{re.escape(rule_id)}["\']')
+    return not rule_id_assignment.search(text)
+
+
+_RULE_RANGE_IN_MODULE = re.compile(r"([A-Z])(\d+)_\1(\d+)_")
+
+
+def _rule_ids_from_module_name(module_fragment: str) -> set[str]:
+    """Expand grouped rule modules (e.g. M001_M004_introspect) to rule IDs.
+
+    Args:
+        module_fragment: Import path segment or module stem.
+
+    Returns:
+        Rule IDs covered by a range module name, or empty set.
+    """
+    m = _RULE_RANGE_IN_MODULE.search(module_fragment)
+    if not m:
+        return set()
+    letter, start_s, end_s = m.group(1), m.group(2), m.group(3)
+    start, end = int(start_s), int(end_s)
+    if end < start or end - start > 50:
+        return set()
+    width = max(len(start_s), len(end_s))
+    return {f"{letter}{i:0{width}d}" for i in range(start, end + 1)}
 
 
 _TEST_CACHE: dict[str, list[str]] | None = None
@@ -180,6 +227,11 @@ def _get_test_cache() -> dict[str, list[str]]:
         return cache
 
     all_rule_id_pat = re.compile(r'["\']((?:A|L|M|R|P)\d+|SEC:[a-zA-Z0-9_*-]+)["\']')
+    import_rule_id_pat = re.compile(
+        r"(?:from\s+\S+\.(?:rules|validators)\.\S*(?:_|\b)([A-Z]\d+)|"
+        r"class\s+\w*?([A-Z]\d+)\w*(?:Rule|Test)|"
+        r"def\s+test_\w*?([a-z]\d+))",
+    )
     for py in sorted(TESTS_DIR.rglob("*.py")):
         if py.name.startswith("_"):
             continue
@@ -188,8 +240,19 @@ def _get_test_cache() -> dict[str, list[str]]:
         except OSError:
             continue
         rel = py.relative_to(TESTS_DIR).as_posix()
+        seen_ids: set[str] = set()
         for m in all_rule_id_pat.finditer(text):
             rid = m.group(1)
+            if _is_incidental_reference(rid, text, py.name):
+                continue
+            seen_ids.add(rid)
+        for m in import_rule_id_pat.finditer(text):
+            rid = (m.group(1) or m.group(2) or (m.group(3) or "").upper()).strip()
+            if rid:
+                seen_ids.add(rid)
+        for m in re.finditer(r"from\s+[\w.]+\s+import\s+(\w+)", text):
+            seen_ids.update(_rule_ids_from_module_name(m.group(1)))
+        for rid in seen_ids:
             cache.setdefault(rid, [])
             if rel not in cache[rid]:
                 cache[rid].append(rel)
@@ -238,6 +301,26 @@ def _find_doc(rule_id: str, doc_dir: Path) -> Path | None:
         if md.stem.startswith(rule_id):
             return md
     return None
+
+
+_VALIDATOR_NAMES: dict[str, str] = {
+    "opa": "OPA",
+    "native": "Native",
+    "ansible": "Ansible",
+    "gitleaks": "Gitleaks",
+}
+
+
+def _normalize_validator(raw: str) -> str:
+    """Normalize a validator name preserving canonical casing.
+
+    Args:
+        raw: Raw validator string from frontmatter.
+
+    Returns:
+        Canonical validator name, defaulting to ``Native``.
+    """
+    return _VALIDATOR_NAMES.get(raw.lower().strip(), raw.capitalize()) if raw else "Native"
 
 
 def _collect_opa_rules() -> list[Rule]:
@@ -322,16 +405,20 @@ def _collect_native_rules() -> list[Rule]:
         test_cache = _get_test_cache()
         pytest_files = test_cache.get(rid, [])
 
+        fm_validator = _normalize_validator(fm.get("validator", ""))
+
         rules.append(
             Rule(
                 rule_id=rid,
-                validator="Native",
+                validator=fm_validator,
                 description=fm.get("description", ""),
                 has_impl=False,
                 impl_file="",
                 has_doc=True,
                 has_test=bool(pytest_files),
                 test_files=pytest_files,
+                status=fm.get("status", ""),
+                status_reason=fm.get("status_reason", ""),
             )
         )
 
@@ -626,11 +713,33 @@ def generate() -> str:
     no_severity = [m for m in meta if m.severity_source == "fallback"]
     adr_mismatch = [m for m in meta if m.adr043_mismatch]
 
-    if no_impl:
-        lines.append(f"### Doc-only rules (no implementation) — {len(no_impl)}")
+    resolved_statuses = {"stub", "delegated"}
+    no_impl_resolved = [r for r in no_impl if r.status in resolved_statuses]
+    no_impl_planned = [r for r in no_impl if r.status == "planned"]
+    no_impl_unknown = [r for r in no_impl if r.status not in resolved_statuses and r.status != "planned"]
+
+    if no_impl_unknown:
+        lines.append(f"### Doc-only rules (no implementation) — {len(no_impl_unknown)}")
         lines.append("")
-        for r in no_impl:
+        for r in no_impl_unknown:
             lines.append(f"- **{r.rule_id}** ({r.validator}): {r.description}")
+        lines.append("")
+
+    if no_impl_planned:
+        lines.append(f"### Planned rules (implementation pending) — {len(no_impl_planned)}")
+        lines.append("")
+        for r in no_impl_planned:
+            reason = f" — {r.status_reason}" if r.status_reason else ""
+            lines.append(f"- **{r.rule_id}** ({r.validator}): {r.description}{reason}")
+        lines.append("")
+
+    if no_impl_resolved:
+        lines.append(f"### Resolved without implementation — {len(no_impl_resolved)}")
+        lines.append("")
+        for r in no_impl_resolved:
+            label = "Delegated" if r.status == "delegated" else "Stub"
+            reason = f" — {r.status_reason}" if r.status_reason else ""
+            lines.append(f"- **{r.rule_id}** ({r.validator}): [{label}] {r.description}{reason}")
         lines.append("")
 
     if no_test:


### PR DESCRIPTION
## Summary

Split from #347 (per review). This is **PR 1 of 3** — shared infrastructure and doc-only rule resolutions without R402/R404 implementations.

- Adds sensitivity/audit-metadata plumbing, graph-rule opt-in loading, and gateway persistence for audit metadata
- Resolves remaining doc-only rule gaps: P001–P004 delegated to Ansible validator, L031/M029 stubbed, R501 planned
- Refactors L039/L110 to shared `_variable_helpers.py`; consolidates violation conversion into `daemon/violation_convert.py`

Fixes #247 (partial — R402/R404 follow in stacked PRs)

## Changes

- `sensitivity.py` / `audit_metadata.py`: redaction helpers for audit payloads (`variables_used`, `variable_set`, `inbound_src`)
- `validate.proto`: `graph_rule_opt_in` field for disabled-by-default R402/R404
- Gateway: `audit_metadata` column + REST exposure with re-sanitization on read
- `tools/generate_rule_catalog.py`: improved test-detection heuristics and doc-only rule status
- Review follow-ups: non-JSON audit string sanitization, malformed JSON logging, URL userinfo redaction edge case

## Stacked PRs

| PR | Branch | Scope |
|----|--------|-------|
| **This PR** | `fix/247-doc-only-rule-infra` | Shared infra + doc-only resolutions |
| Next | `feat/R402-list-all-used-variables` | R402 rule (base: this branch) |
| Next | `feat/R404-show-variables` | R404 rule (base: this branch) |

## Test plan

- [x] `tox -e unit`
- [x] `tox -e lint` (pre-commit on commit)
- [x] CI green on latest push (`1bb6987b`)

## Follow-up issues

- #373 — catalog tested heuristic for planned rules
- #375 — register delegated P001–P004 in Gateway catalog
- #376 — bump grpcio floor to match codegen guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-scan GraphRule opt-in support for disabled-by-default rules during validation and remediation.
  * Exposed `audit_metadata` in violation details, including API/OpenAPI support, with sanitization for safe display and storage.
* **Bug Fixes**
  * Improved audit-metadata JSON parsing with graceful handling of malformed/non-serializable values.
  * Strengthened scan/rescan behavior for aggregate-scope correctness and play-scoped remediation.
* **Documentation**
  * Regenerated the rule catalog coverage and updated the API schema for `audit_metadata`.
* **Tests**
  * Expanded coverage for opt-in rule loading and audit-metadata conversion/redaction end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
