### PR TITLE
feat(native): implement R404 show-variables graph rule

### DIFF
--- a/docs/rules/RULE_CATALOG.md
+++ b/docs/rules/RULE_CATALOG.md
@@ -6,7 +6,7 @@
 
 | Metric | Count |
 |--------|-------|
-| Implemented | 151/157 |
+| Implemented | 152/157 |
 | Tested | 154/157 |
 | Documented | 156/157 |
 | Deterministic fixer (Tier 1) | 25/157 |
@@ -214,7 +214,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | R118 | R | OPA | info | task | manual | Task downloads from an external source (inbound transfer). | Yes | Yes | Yes | — |
 | R401 | R | Native | info | playbook | manual | Report inbound transfer sources. | Yes | Yes | Yes | — |
 | R402 | R | Native | info | play | manual | Report variables used at end of sequence. | Yes | Yes | Yes | — |
-| R404 | R | Native | info | task | manual | Expose variable_set for the task. | — | Yes | Yes | — |
+| R404 | R | Native | info | task | manual | Expose variable_set for the task. | Yes | Yes | Yes | — |
 | R501 | R | Native | info | collection | manual | Suggest collection/role dependency. | — | — | Yes | — |
 | SEC:* | SEC | Gitleaks | critical | task | ai | Secret/credential detection (delegated to Gitleaks binary). | Yes | Yes | — | — |
 
@@ -274,7 +274,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | M028 | high | task | ai | first_found lookup auto-splitting paths on delimiters is deprecated (2.23) | Yes | Yes | Yes | — |
 | R118 | info | task | manual | Task downloads from an external source (inbound transfer). | Yes | Yes | Yes | — |
 
-### Native (96 rules, 94 impl, 95 tested, 4 fixers)
+### Native (96 rules, 95 impl, 95 tested, 4 fixers)
 
 | Rule ID | Severity | Scope | Tier | Description | Impl | Test | Doc | Fix |
 |---------|----------|-------|------|-------------|------|------|-----|-----|
@@ -372,7 +372,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | R117 | info | role | manual | Role is from Galaxy/external source. | Yes | Yes | Yes | — |
 | R401 | info | playbook | manual | Report inbound transfer sources. | Yes | Yes | Yes | — |
 | R402 | info | play | manual | Report variables used at end of sequence. | Yes | Yes | Yes | — |
-| R404 | info | task | manual | Expose variable_set for the task. | — | Yes | Yes | — |
+| R404 | info | task | manual | Expose variable_set for the task. | Yes | Yes | Yes | — |
 | R501 | info | collection | manual | Suggest collection/role dependency. | — | — | Yes | — |
 
 ### Ansible (11 rules, 7 impl, 9 tested, 4 fixers)
@@ -399,9 +399,8 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 
 ## Coverage Gaps
 
-### Planned rules (implementation pending) — 2
+### Planned rules (implementation pending) — 1
 
-- **R404** (Native): Expose variable_set for the task. — Informational/debug rule that would expose the resolved variable_set for each task. Disabled by default. Planned for future implementation using VariableProvenanceResolver.
 - **R501** (Native): Suggest collection/role dependency. — Advisory rule requiring collection dependency resolution context. The rule needs access to the Galaxy/collection index to suggest which collection provides an unresolved module. Planned for future implementation.
 
 ### Resolved without implementation — 4

--- a/src/apme_engine/graph/audit_metadata.py
+++ b/src/apme_engine/graph/audit_metadata.py
@@ -66,10 +66,8 @@ def _sanitize_audit_structure(key: str, value: object) -> object:
                 patched["name"] = REDACTED
             val = patched.get("value")
             if isinstance(val, (dict, list)):
-                patched["value"] = redact_sensitive_structure(val)
-            elif val is not None and (
-                (var_looks_sensitive(str(name)) if name is not None else False) or value_looks_sensitive(val)
-            ):
+                patched["value"] = redact_sensitive_structure(val, redact_all_scalars=True)
+            elif val is not None:
                 patched["value"] = REDACTED
             sanitized_vars.append(patched)
         return sanitized_vars

--- a/src/apme_engine/graph/rules/R404_show_variables.md
+++ b/src/apme_engine/graph/rules/R404_show_variables.md
@@ -3,24 +3,46 @@ rule_id: R404
 validator: native
 description: Expose variable_set for the task.
 scope: task
-status: planned
-status_reason: >
-  Informational/debug rule that would expose the resolved variable_set for
-  each task. Disabled by default. Planned for future implementation using
-  VariableProvenanceResolver.
+status: implemented
 ---
 
 ## Show variables (R404)
 
 Expose variable_set for the task. This is an **informational/debug rule**
-intended for development and troubleshooting. Disabled by default.
+intended for development and troubleshooting. **Disabled by default.**
 
-### Status
+Uses `VariableProvenanceResolver` to expose the full variable set available
+to each task, including variable origin (local, play, role_default, etc.).
+To avoid persisting secrets through debug/audit surfaces, sensitive variable
+**names** are masked via ``var_looks_sensitive``. Scalar **values** are always
+emitted as ``[REDACTED]`` (see value redaction limits below). Values under an
+effective ``no_log`` scope are also fully redacted.
 
-**Planned** — no `_graph.py` implementation yet. This rule would use
-`VariableProvenanceResolver` to expose the full variable set available to
-each task for debugging purposes. It is disabled by default and intended
-for development workflows only.
+**Value redaction limits:** scalar values (strings, numbers, booleans) are
+always emitted as ``[REDACTED]`` even when benign (for example
+``http_port: 8080``). Only dict/list values preserve outer structure, with
+leaf scalars still redacted. The ``value`` field therefore carries shape for
+collections but no cleartext for scalars — treat R404 as a scope/name debugger,
+not a literal value dump.
+
+**Performance note:** each task currently constructs a fresh
+``VariableProvenanceResolver`` and re-walks the scope chain. Plays with many
+tasks may repeat identical ancestry work; caching resolvers per play ancestry
+is a possible future optimization.
+
+### Example: violation
+
+```yaml
+- name: Example play
+  hosts: localhost
+  connection: local
+  vars:
+    server_port: 443
+  tasks:
+    - name: Show scope
+      ansible.builtin.debug:
+        msg: "test"
+```
 
 ### Example: pass
 

--- a/src/apme_engine/graph/rules/R404_show_variables_graph.py
+++ b/src/apme_engine/graph/rules/R404_show_variables_graph.py
@@ -1,0 +1,243 @@
+"""GraphRule R404: expose the resolved variable set for each task.
+
+Informational/debug rule (severity INFO) that reports the variable
+names, sources, and redacted values visible in the scope of a task node
+via ``VariableProvenanceResolver``. Intended for development and
+troubleshooting workflows.
+
+This rule is disabled by default — enable by including ``R404`` in the
+rule_id_list when loading rules.
+"""
+
+from dataclasses import dataclass
+from typing import cast
+
+from apme_engine.graph.content_graph import ContentGraph, ContentNode, NodeType
+from apme_engine.graph.rule_base import GraphRule, GraphRuleResult
+from apme_engine.graph.sensitivity import (
+    REDACTED,
+    redact_sensitive_structure,
+    var_looks_sensitive,
+)
+from apme_engine.graph.types import RuleTag as Tag
+from apme_engine.graph.types import Severity, YAMLDict, YAMLValue
+from apme_engine.graph.variable_helpers import (
+    TASK_TYPES,
+    no_log_true_in_scope,
+)
+from apme_engine.graph.variable_provenance import VariableProvenance, VariableProvenanceResolver
+
+_MAX_VARIABLE_SET = 500
+
+
+def _find_enclosing_play(graph: ContentGraph, node_id: str) -> ContentNode | None:
+    """Walk ancestors to find the nearest PLAY node.
+
+    Args:
+        graph: The content graph.
+        node_id: Starting node.
+
+    Returns:
+        The enclosing play ``ContentNode``, or ``None``.
+    """
+    for ancestor in graph.ancestors(node_id):
+        if ancestor.node_type == NodeType.PLAY:
+            return ancestor
+    return None
+
+
+def _play_no_log_context(graph: ContentGraph, task_node_id: str) -> tuple[str | None, set[str] | None]:
+    """Return play context used to resolve ``no_log`` for a task.
+
+    Args:
+        graph: ContentGraph under scan.
+        task_node_id: Task node being reported.
+
+    Returns:
+        Tuple of ``(play_context_id, play_scope)`` for ``no_log_true_in_scope``.
+    """
+    play = _find_enclosing_play(graph, task_node_id)
+    if play is None:
+        return None, None
+    return play.node_id, graph.play_scoped_node_ids(play.node_id)
+
+
+def _should_redact_value(graph: ContentGraph, task_node_id: str, prov: VariableProvenance) -> bool:
+    """Return True when a variable value must be redacted in audit output.
+
+    Args:
+        graph: ContentGraph under scan.
+        task_node_id: Task node being reported.
+        prov: Resolved variable provenance entry.
+
+    Returns:
+        True when the value should be fully hidden rather than shape-preserved.
+    """
+    if prov.defining_node_id:
+        play_context_id, play_scope = _play_no_log_context(graph, task_node_id)
+        if no_log_true_in_scope(
+            graph,
+            prov.defining_node_id,
+            play_context_id=play_context_id,
+            play_scope=play_scope,
+        ):
+            return True
+    return var_looks_sensitive(prov.name)
+
+
+def _display_var_name(prov: VariableProvenance) -> str:
+    """Return a safe variable name for audit output.
+
+    Args:
+        prov: Resolved variable provenance entry.
+
+    Returns:
+        Variable name or ``[REDACTED]`` when the name looks sensitive.
+    """
+    return REDACTED if var_looks_sensitive(prov.name) else prov.name
+
+
+def _redact_sensitive_keys(value: object, *, _depth: int = 0, _max_depth: int = 32) -> object:
+    """Recursively redact nested values while preserving overall structure.
+
+    Walks dicts and lists, replacing sensitive-keyed values and all scalar
+    leaves with ``[REDACTED]`` so R404 can expose scope without cleartext.
+
+    Args:
+        value: Arbitrary nested structure from variable provenance.
+        _depth: Current recursion depth (internal).
+        _max_depth: Maximum nesting depth before redacting entirely.
+
+    Returns:
+        Structure with sensitive-keyed values replaced.
+    """
+    return redact_sensitive_structure(
+        value,
+        redact_all_scalars=True,
+        depth=_depth,
+        max_depth=_max_depth,
+    )
+
+
+def _serialize_value(value: object, *, redact: bool = False) -> str | object | None:
+    """Serialize a variable value for audit output.
+
+    Dicts and lists return redacted native structures (outer audit metadata
+    serialization performs JSON). Scalars are always returned as
+    ``[REDACTED]`` to avoid cleartext secret persistence.
+
+    Args:
+        value: Variable value from provenance.
+        redact: When True, omit the cleartext value entirely.
+
+    Returns:
+        String, structure, or None for None values.
+    """
+    if redact:
+        return REDACTED
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return _redact_sensitive_keys(value)
+    return REDACTED
+
+
+@dataclass
+class ShowVariablesGraphRule(GraphRule):
+    """Expose the full variable set available to a task for debugging.
+
+    Reports every variable name, a redacted value placeholder/structure,
+    and the provenance source (local, play, role_default, etc.) for each
+    task/handler node.
+
+    Attributes:
+        rule_id: Rule identifier.
+        description: Rule description.
+        enabled: Whether the rule is enabled.
+        name: Rule name.
+        version: Rule version.
+        severity: Severity level.
+        tags: Rule tags.
+    """
+
+    rule_id: str = "R404"
+    description: str = "Expose variable_set for the task"
+    enabled: bool = False
+    name: str = "ShowVariables"
+    version: str = "v0.0.1"
+    severity: Severity = Severity.INFO
+    tags: tuple[str, ...] = (Tag.DEBUG,)
+
+    def match(self, graph: ContentGraph, node_id: str) -> bool:
+        """Match task and handler nodes.
+
+        Args:
+            graph: The full ContentGraph.
+            node_id: ID of the node to check.
+
+        Returns:
+            True for task and handler nodes.
+        """
+        node = graph.get_node(node_id)
+        if node is None:
+            return False
+        return node.node_type in TASK_TYPES
+
+    def process(self, graph: ContentGraph, node_id: str) -> GraphRuleResult | None:
+        """Resolve and report all variables in scope for this task.
+
+        Args:
+            graph: The full ContentGraph.
+            node_id: ID of the task node.
+
+        Returns:
+            GraphRuleResult with ``variable_set`` list, or None if node missing.
+        """
+        node = graph.get_node(node_id)
+        if node is None:
+            return None
+
+        resolver = VariableProvenanceResolver(graph)
+        resolved = resolver.resolve_variables(node_id)
+        play_context_id, play_scope = _play_no_log_context(graph, node_id)
+        task_no_log = no_log_true_in_scope(
+            graph,
+            node_id,
+            play_context_id=play_context_id,
+            play_scope=play_scope,
+        )
+
+        if not resolved:
+            return GraphRuleResult(
+                verdict=False,
+                node_id=node_id,
+                file=(node.file_path, node.line_start),
+            )
+
+        var_list: list[YAMLValue] = []
+        for prov in sorted(resolved.values(), key=lambda p: p.name):
+            redact = task_no_log or _should_redact_value(graph, node_id, prov)
+            var_list.append(
+                cast(
+                    YAMLValue,
+                    {
+                        "name": _display_var_name(prov),
+                        "value": _serialize_value(prov.value, redact=redact),
+                        "source": prov.source.value,
+                    },
+                )
+            )
+        total_vars = len(var_list)
+        truncated = total_vars > _MAX_VARIABLE_SET
+        if truncated:
+            var_list = var_list[:_MAX_VARIABLE_SET]
+        detail: YAMLDict = {
+            "message": f"Task has {total_vars} variable(s) in scope" + (" (truncated)" if truncated else ""),
+            "variable_set": cast(YAMLValue, var_list),
+        }
+        return GraphRuleResult(
+            verdict=True,
+            detail=detail,
+            node_id=node_id,
+            file=(node.file_path, node.line_start),
+        )

--- a/src/apme_engine/graph/scanner.py
+++ b/src/apme_engine/graph/scanner.py
@@ -467,6 +467,10 @@ def graph_report_to_violations(report: GraphScanReport) -> list[ViolationDict]:
     supports rules like L111 that scan sibling files and emit multiple
     per-file violations from a single graph node.
 
+    Note:
+        Increments ``report.audit_serialization_failures`` in place for each
+        audit metadata value that fails to serialize.
+
     Args:
         report: Completed scan report from ``scan()``.
 

--- a/src/apme_engine/remediation/partition.py
+++ b/src/apme_engine/remediation/partition.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from apme_engine.engine.models import ViolationDict
 from apme_engine.engine.models import RemediationClass, RemediationResolution, RuleScope
+from apme_engine.graph.scanner import DISABLED_BY_DEFAULT_GRAPH_RULE_IDS
 from apme_engine.remediation.registry import TransformRegistry
 
 AI_PROPOSABLE_SCOPES: frozenset[str] = frozenset({RuleScope.TASK, RuleScope.BLOCK})
@@ -203,6 +204,10 @@ def _to_str_value(val: object, default: str) -> str:
 def count_by_remediation_class(violations: list[ViolationDict]) -> dict[str, int]:
     """Count violations by remediation class.
 
+    Disabled-by-default audit/debug graph rules (for example R402/R404) are
+    excluded so opt-in informational findings do not inflate user-facing
+    remediation totals.
+
     Args:
         violations: List of violations with remediation_class field.
 
@@ -212,6 +217,9 @@ def count_by_remediation_class(violations: list[ViolationDict]) -> dict[str, int
     counts: dict[str, int] = {rc.value: 0 for rc in RemediationClass}
     default = RemediationClass.AI_CANDIDATE.value
     for v in violations:
+        bare_id = normalize_rule_id(str(v.get("rule_id", "")))
+        if bare_id in DISABLED_BY_DEFAULT_GRAPH_RULE_IDS:
+            continue
         rc = _to_str_value(v.get("remediation_class"), default)
         if rc in counts:
             counts[rc] += 1
@@ -240,6 +248,9 @@ def is_ai_reviewable(violation: ViolationDict) -> bool:
 def count_by_resolution(violations: list[ViolationDict]) -> dict[str, int]:
     """Count violations by remediation resolution.
 
+    Disabled-by-default audit/debug graph rules (for example R402/R404) are
+    excluded so opt-in informational findings do not inflate user-facing totals.
+
     Args:
         violations: List of violations with remediation_resolution field.
 
@@ -249,6 +260,9 @@ def count_by_resolution(violations: list[ViolationDict]) -> dict[str, int]:
     default = RemediationResolution.UNRESOLVED.value
     counts: dict[str, int] = {}
     for v in violations:
+        bare_id = normalize_rule_id(str(v.get("rule_id", "")))
+        if bare_id in DISABLED_BY_DEFAULT_GRAPH_RULE_IDS:
+            continue
         res = _to_str_value(v.get("remediation_resolution"), default)
         counts[res] = counts.get(res, 0) + 1
     return counts

--- a/tests/test_audit_metadata.py
+++ b/tests/test_audit_metadata.py
@@ -84,3 +84,15 @@ def test_sanitize_variable_set_redacts_nested_dict_secrets() -> None:
     nested = entry["value"]
     assert isinstance(nested, dict)
     assert nested["db_password"] == "[REDACTED]"
+
+
+def test_sanitize_variable_set_redacts_benign_scalar_values() -> None:
+    """Scalar values in variable_set are always redacted to match R404 policy."""
+    sanitized = sanitize_audit_metadata_value(
+        "variable_set",
+        [{"name": "http_port", "value": 8080, "source": "play"}],
+    )
+    assert isinstance(sanitized, list)
+    entry = sanitized[0]
+    assert isinstance(entry, dict)
+    assert entry["value"] == "[REDACTED]"

--- a/tests/test_content_graph.py
+++ b/tests/test_content_graph.py
@@ -975,7 +975,10 @@ class TestGraphReportToViolations:
         r402 = next(v for v in violations if v["rule_id"] == "R402")
         r404 = next(v for v in violations if v["rule_id"] == "R404")
         assert json.loads(str(r402["variables_used"])) == variables_used
-        assert json.loads(str(r404["variable_set"])) == variable_set
+        expected_variable_set = [
+            {"name": "nginx_port", "value": "[REDACTED]", "source": "play"},
+        ]
+        assert json.loads(str(r404["variable_set"])) == expected_variable_set
 
         proto = violation_dict_to_proto(r402)
         assert json.loads(proto.metadata["variables_used"]) == variables_used
@@ -1026,7 +1029,8 @@ class TestGraphReportToViolations:
         assert violations[0]["line"] == 1
 
     def test_audit_json_skips_non_serializable_values(self) -> None:
-        """Non-serializable audit metadata is omitted instead of aborting conversion."""
+        """Non-serializable audit metadata scalars are redacted before conversion."""
+        import json
 
         class _NotSerializable:
             def __str__(self) -> str:
@@ -1074,7 +1078,8 @@ class TestGraphReportToViolations:
         )
         violations = graph_report_to_violations(report)
         assert len(violations) == 1
-        assert "variable_set" not in violations[0]
+        parsed = json.loads(str(violations[0]["variable_set"]))
+        assert parsed[0]["value"] == "[REDACTED]"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_generate_rule_catalog.py
+++ b/tests/test_generate_rule_catalog.py
@@ -247,14 +247,14 @@ class TestParseFrontmatter:
 
         def fake_import(
             name: str,
-            globals: Mapping[str, object] | None = None,  # noqa: A002
-            locals: Mapping[str, object] | None = None,  # noqa: A002
+            globals_: Mapping[str, object] | None = None,
+            locals_: Mapping[str, object] | None = None,
             fromlist: Sequence[str] = (),
             level: int = 0,
         ) -> object:
             if name == "yaml":
                 raise ImportError("PyYAML not installed")
-            return real_import(name, globals, locals, fromlist, level)
+            return real_import(name, globals_, locals_, fromlist, level)
 
         monkeypatch.setattr(builtins, "__import__", fake_import)
         result = _parse_frontmatter(md)
@@ -275,9 +275,16 @@ class TestNormalizeValidator:
         """Lowercase ansible maps to Ansible."""
         assert _normalize_validator("ansible") == "Ansible"
 
-    def test_unknown_string_capitalized(self) -> None:
-        """Unknown validator strings are title-cased."""
-        assert _normalize_validator("custom") == "Custom"
+    def test_unknown_validator_warns_and_defaults_to_native(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Unknown validator strings warn and default to Native.
+
+        Args:
+            capsys: Pytest capture fixture for stderr.
+        """
+        assert _normalize_validator("custom") == "Native"
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "custom" in captured.err
 
     def test_empty_defaults_to_native(self) -> None:
         """Empty string defaults to Native."""
@@ -298,8 +305,7 @@ class TestGetTestCache:
         tests_dir.mkdir()
         test_file = tests_dir / "test_r402_loader.py"
         test_file.write_text(
-            "from apme_engine.validators.native.rules.R402_list_all_used_variables_graph import "
-            "ListAllUsedVariablesGraphRule\n",
+            "from apme_engine.graph.rules.R402_list_all_used_variables_graph import ListAllUsedVariablesGraphRule\n",
             encoding="utf-8",
         )
         monkeypatch.setattr(_mod, "TESTS_DIR", tests_dir)

--- a/tests/test_generate_rule_catalog.py
+++ b/tests/test_generate_rule_catalog.py
@@ -333,6 +333,28 @@ class TestGetTestCache:
         for rid in ("M001", "M002", "M003", "M004"):
             assert "test_ansible_cache.py" in cache.get(rid, [])
 
+    def test_parenthesized_grouped_module_import_expands_rule_range(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Parenthesized multiline imports still credit grouped rule modules.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        test_file = tests_dir / "test_ansible_cache_paren.py"
+        test_file.write_text(
+            "from apme_engine.validators.ansible.rules import (\n    M001_M004_introspect,\n)\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_mod, "TESTS_DIR", tests_dir)
+        monkeypatch.setattr(_mod, "_TEST_CACHE", None)
+        cache = _mod._get_test_cache()
+        for rid in ("M001", "M002", "M003", "M004"):
+            assert "test_ansible_cache_paren.py" in cache.get(rid, [])
+
     def test_incidental_string_literal_excluded(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """String literals mentioning a rule ID without imports are incidental.
 

--- a/tests/test_generate_rule_catalog.py
+++ b/tests/test_generate_rule_catalog.py
@@ -333,6 +333,25 @@ class TestGetTestCache:
         for rid in ("M001", "M002", "M003", "M004"):
             assert "test_ansible_cache.py" in cache.get(rid, [])
 
+    def test_direct_rule_id_import_from_rules_package(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Package-level direct rule ID imports (e.g. ``from ...rules import R404``).
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        test_file = tests_dir / "test_r404_direct.py"
+        test_file.write_text(
+            "from apme_engine.graph.rules import R404\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_mod, "TESTS_DIR", tests_dir)
+        monkeypatch.setattr(_mod, "_TEST_CACHE", None)
+        cache = _mod._get_test_cache()
+        assert "test_r404_direct.py" in cache.get("R404", [])
+
     def test_parenthesized_grouped_module_import_expands_rule_range(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_graph_remediation.py
+++ b/tests/test_graph_remediation.py
@@ -166,7 +166,7 @@ class _PlayAggregateRule(GraphRule):
 
     def __init__(self) -> None:
         super().__init__(
-            rule_id="R402",
+            rule_id="TPLAY1",
             description="Play still contains short module names",
             enabled=True,
             precedence=5,
@@ -296,7 +296,7 @@ class TestRescanDirty:
         assert report.nodes_scanned == 2
         violations = graph_report_to_violations(report)
         assert len(violations) == 1
-        assert violations[0]["rule_id"] == "R402"
+        assert violations[0]["rule_id"] == "TPLAY1"
         assert violations[0]["path"] == play.node_id
 
 
@@ -495,7 +495,7 @@ class TestGraphRemediationEngine:
 
         fixed = graph.query_violations(status="fixed")
         assert any(v["rule_id"] == "M001" for v in fixed)
-        assert any(v["rule_id"] == "R402" for v in fixed)
+        assert any(v["rule_id"] == "TPLAY1" for v in fixed)
         assert graph.collect_violations() == []
 
     async def test_progress_callback(self) -> None:

--- a/tests/test_remaining_graph_rules.py
+++ b/tests/test_remaining_graph_rules.py
@@ -2640,7 +2640,7 @@ class TestR404ShowVariablesGraphRule:
         Args:
             rule: Rule instance under test (unused; kept for fixture symmetry).
         """
-        secret = "mysql://user:secret@db.example.com/prod"
+        secret = "mysql://user:secret@db.example.com/prod"  # noqa: S105
         assert value_looks_sensitive(secret)
         sanitized = sanitize_audit_metadata_value(
             "variable_set",
@@ -2657,7 +2657,7 @@ class TestR404ShowVariablesGraphRule:
         Args:
             rule: Rule instance under test (unused; kept for fixture symmetry).
         """
-        token = "sk-live-abc123xyz"
+        token = "sk-live-abc123xyz"  # noqa: S105
         assert value_looks_sensitive(token)
         sanitized = sanitize_audit_metadata_value(
             "variable_set",

--- a/tests/test_remaining_graph_rules.py
+++ b/tests/test_remaining_graph_rules.py
@@ -1,6 +1,6 @@
 """Unit and integration tests for Phase 2J+K GraphRules.
 
-Covers L056, R401, R402, collection metadata rules (L087, L088,
+Covers L056, R401, R402, R404, collection metadata rules (L087, L088,
 L096, L103-L105), and plugin/schema rules (L089, L090, L095).
 """
 
@@ -13,6 +13,7 @@ import pytest
 
 from apme_engine.engine.graph_builder import GraphBuilder
 from apme_engine.engine.models import YAMLDict
+from apme_engine.graph.audit_metadata import sanitize_audit_metadata_value
 from apme_engine.graph.content_graph import (
     ContentGraph,
     ContentNode,
@@ -42,7 +43,14 @@ from apme_engine.graph.rules.M030_broken_conditional_expressions_graph import (
 )
 from apme_engine.graph.rules.R401_list_all_inbound_src_graph import ListAllInboundSrcGraphRule
 from apme_engine.graph.rules.R402_list_all_used_variables_graph import ListAllUsedVariablesGraphRule
+from apme_engine.graph.rules.R404_show_variables_graph import (
+    ShowVariablesGraphRule,
+    _redact_sensitive_keys,
+    _serialize_value,
+    _should_redact_value,
+)
 from apme_engine.graph.scanner import scan
+from apme_engine.graph.sensitivity import REDACTED, value_looks_sensitive
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1719,7 +1727,7 @@ def _make_play_with_tasks(
         play_vars: Play-level ``vars:`` mapping.
         play_no_log: Play-level ``no_log`` setting.
         tasks: List of dicts with keys ``module``, ``module_options``,
-            ``when_expr``, ``name``.
+            ``when_expr``, ``name``, ``variables``, and ``no_log``.
 
     Returns:
         Tuple of ``(graph, play_node_id)``.
@@ -2476,3 +2484,374 @@ class TestR402ListAllUsedVariablesGraphRule:
         result = rule.process(g, play_a.node_id)
         assert result is not None
         assert result.verdict is False
+
+
+# ===========================================================================
+# R404 — ShowVariables
+# ===========================================================================
+
+
+class TestR404ShowVariablesGraphRule:
+    """Tests for R404 ShowVariablesGraphRule."""
+
+    @pytest.fixture  # type: ignore[untyped-decorator]
+    def rule(self) -> ShowVariablesGraphRule:
+        """Create a rule instance (enabled for testing).
+
+        Returns:
+            A ShowVariablesGraphRule with enabled=True.
+        """
+        return ShowVariablesGraphRule(enabled=True)
+
+    def test_disabled_by_default(self) -> None:
+        """R404 is disabled by default."""
+        rule = ShowVariablesGraphRule()
+        assert rule.rule_id == "R404"
+        assert rule.enabled is False
+
+    def test_match_task_node(self, rule: ShowVariablesGraphRule) -> None:
+        """Matches TASK nodes.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, nid = _make_task()
+        assert rule.match(g, nid)
+
+    def test_no_match_play_node(self, rule: ShowVariablesGraphRule) -> None:
+        """Does not match PLAY nodes.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, play_id = _make_play_with_tasks()
+        assert not rule.match(g, play_id)
+
+    def test_no_variables_verdict_false(self, rule: ShowVariablesGraphRule) -> None:
+        """Task with no variables in scope returns verdict=False.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, nid = _make_task(module="ansible.builtin.command", module_options={"cmd": "whoami"})
+        result = rule.process(g, nid)
+        assert result is not None
+        assert result.verdict is False
+
+    def test_variables_reported(self, rule: ShowVariablesGraphRule) -> None:
+        """Task with play variables in scope reports them.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, play_id = _make_play_with_tasks(
+            play_vars={"server_port": 443},
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        play_node = g.get_node(play_id)
+        assert play_node is not None
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        assert len(task_ids) == 1
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.verdict is True
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        names = [v["name"] for v in var_list]
+        assert "server_port" in names
+
+    def test_value_field_present(self, rule: ShowVariablesGraphRule) -> None:
+        """Variable entries include a redacted ``value`` field.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, _ = _make_play_with_tasks(
+            play_vars={"app_name": "myapp"},
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        var_map: dict[object, dict[str, object]] = {v["name"]: v for v in var_list}
+        assert "app_name" in var_map
+        assert var_map["app_name"]["value"] == REDACTED
+        assert var_map["app_name"]["source"] == "play"
+
+    def test_dict_value_serialized(self, rule: ShowVariablesGraphRule) -> None:
+        """Dict variable values preserve structure while redacting leaf scalars.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, _ = _make_play_with_tasks(
+            play_vars={"config": {"key": "val", "num": 42}},
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        var_map: dict[object, dict[str, object]] = {v["name"]: v for v in var_list}
+        assert "config" in var_map
+        assert var_map["config"]["value"] == {"key": REDACTED, "num": REDACTED}
+
+    def test_sensitive_var_value_redacted(self, rule: ShowVariablesGraphRule) -> None:
+        """Sensitive variable names have values redacted in output.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, _ = _make_play_with_tasks(
+            play_vars={"db_password": "s3cr3t"},
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        redacted = [v for v in var_list if v["value"] == REDACTED]
+        assert any(v["name"] == REDACTED for v in redacted)
+
+    def test_ansible_ssh_pass_value_redacted(self, rule: ShowVariablesGraphRule) -> None:
+        """``ansible_ssh_pass`` name is redacted via the ``pass`` sensitive segment.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, _ = _make_play_with_tasks(
+            play_vars={"ansible_ssh_pass": "s3cr3t"},
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        assert any(v["name"] == REDACTED for v in var_list)
+
+    def test_misnamed_scalar_secret_redacted(self, rule: ShowVariablesGraphRule) -> None:
+        """Cleartext credentials in generically named vars are detected and redacted.
+
+        Args:
+            rule: Rule instance under test (unused; kept for fixture symmetry).
+        """
+        secret = "mysql://user:secret@db.example.com/prod"
+        assert value_looks_sensitive(secret)
+        sanitized = sanitize_audit_metadata_value(
+            "variable_set",
+            [{"name": "connection_string", "value": secret, "source": "play"}],
+        )
+        assert isinstance(sanitized, list)
+        entry = sanitized[0]
+        assert isinstance(entry, dict)
+        assert entry["value"] == REDACTED
+
+    def test_opaque_token_under_benign_name_redacted(self, rule: ShowVariablesGraphRule) -> None:
+        """Known opaque token prefixes redact generically named variables.
+
+        Args:
+            rule: Rule instance under test (unused; kept for fixture symmetry).
+        """
+        token = "sk-live-abc123xyz"
+        assert value_looks_sensitive(token)
+        sanitized = sanitize_audit_metadata_value(
+            "variable_set",
+            [{"name": "session_token", "value": token, "source": "play"}],
+        )
+        assert isinstance(sanitized, list)
+        entry = sanitized[0]
+        assert isinstance(entry, dict)
+        assert entry["value"] == REDACTED
+
+    def test_vault_ciphertext_redacted(self, rule: ShowVariablesGraphRule) -> None:
+        """Ansible Vault ciphertext scalars are redacted in variable_set.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        vault_blob = "$ANSIBLE_VAULT;1.1;AES256;deadbeef\n53616c74"
+        g, _ = _make_play_with_tasks(
+            play_vars={"app_config": vault_blob},
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        var_map = {v["name"]: v for v in var_list}
+        assert var_map["app_config"]["value"] == REDACTED
+
+    def test_nested_sensitive_dict_keys_redacted(self, rule: ShowVariablesGraphRule) -> None:
+        """Nested dict keys matching sensitive patterns are redacted.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, _ = _make_play_with_tasks(
+            play_vars={"db_config": {"host": "prod-db", "password": "s3cr3t"}},
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        var_map = {v["name"]: v for v in var_list}
+        parsed = var_map["db_config"]["value"]
+        assert isinstance(parsed, dict)
+        assert parsed["host"] == REDACTED
+        assert parsed["password"] == REDACTED
+
+    def test_nested_scalar_secret_under_benign_key_redacted(self, rule: ShowVariablesGraphRule) -> None:
+        """Credential-like scalars nested under benign dict keys are redacted.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, _ = _make_play_with_tasks(
+            play_vars={
+                "db_config": {"endpoint": "mysql://user:secret@db.example.com/prod"},
+            },
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        var_map = {v["name"]: v for v in var_list}
+        parsed = var_map["db_config"]["value"]
+        assert isinstance(parsed, dict)
+        assert parsed["endpoint"] == REDACTED
+
+    def test_serialize_value_redacts_none_under_no_log(self) -> None:
+        """Redaction applies even when the underlying value is None."""
+        assert _serialize_value(None, redact=True) == REDACTED
+
+    def test_serialize_value_list_json(self) -> None:
+        """List values preserve structure while redacting scalar elements."""
+        assert _serialize_value([1, 2], redact=False) == [REDACTED, REDACTED]
+
+    def test_serialize_value_redacts_dict_without_json_leak(self) -> None:
+        """Redact=True returns placeholder without serializing nested content."""
+        assert _serialize_value({"password": "secret"}, redact=True) == REDACTED  # noqa: S105
+
+    def test_no_log_scope_redacts_values(self, rule: ShowVariablesGraphRule) -> None:
+        """Variables under an effective no_log scope have values redacted.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, _ = _make_play_with_tasks(
+            play_vars={"app_name": "myapp"},
+            play_no_log=True,
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        var_map = {v["name"]: v for v in var_list}
+        assert var_map["app_name"]["value"] == REDACTED
+
+    def test_should_redact_when_defining_task_has_no_log(self) -> None:
+        """Variables defined under a prior task's no_log are redacted on later tasks."""
+        from apme_engine.graph.variable_provenance import ProvenanceSource, VariableProvenance
+
+        g, _ = _make_play_with_tasks(
+            tasks=[
+                {
+                    "module": "ansible.builtin.set_fact",
+                    "module_options": {"cacheable_token": "opaque-secret"},
+                    "no_log": True,
+                },
+                {"module": "ansible.builtin.debug", "module_options": {"msg": "done"}},
+            ],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        prov = VariableProvenance(
+            name="cacheable_token",
+            value="opaque-secret",
+            source=ProvenanceSource.LOCAL,
+            defining_node_id=task_ids[0],
+        )
+        assert _should_redact_value(g, task_ids[1], prov) is True
+
+    def test_no_log_false_overrides_play_true_still_redacts_values(self, rule: ShowVariablesGraphRule) -> None:
+        """Task no_log: false still emits redacted values for audit safety.
+
+        Play-defined variables remain redacted when the play sets no_log: true,
+        and the rule now redacts scalar values even outside ``no_log``.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g, _ = _make_play_with_tasks(
+            play_vars={"app_name": "myapp"},
+            play_no_log=True,
+            tasks=[
+                {
+                    "module": "ansible.builtin.debug",
+                    "module_options": {"msg": "test"},
+                    "no_log": False,
+                },
+            ],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        var_map = {v["name"]: v for v in var_list}
+        assert var_map["app_name"]["value"] == REDACTED
+
+    def test_truncates_large_variable_sets(self, rule: ShowVariablesGraphRule) -> None:
+        """R404 caps reported variable_set entries at 500 entries.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        play_vars = {f"var_{i}": i for i in range(501)}
+        g, _ = _make_play_with_tasks(
+            play_vars=cast(YAMLDict, play_vars),
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
+        result = rule.process(g, task_ids[0])
+        assert result is not None
+        assert result.detail is not None
+        var_list = cast(list[dict[str, object]], result.detail["variable_set"])
+        assert len(var_list) == 500
+        assert "(truncated)" in cast(str, result.detail["message"])
+
+    def test_redact_sensitive_keys_depth_limit(self) -> None:
+        """Deeply nested structures redact subtrees once depth exceeds the cap."""
+        nested: dict[str, object] = {"child": {"inner": "value"}}
+        redacted = _redact_sensitive_keys(nested, _max_depth=1)
+        assert redacted == {"child": {"inner": REDACTED}}
+
+    def test_missing_node_returns_none(self, rule: ShowVariablesGraphRule) -> None:
+        """Process on a missing node returns None.
+
+        Args:
+            rule: Rule instance under test.
+        """
+        g = ContentGraph()
+        assert rule.process(g, "nonexistent") is None
+
+    def test_via_scanner(self) -> None:
+        """R404 fires through the graph scanner when enabled."""
+        g, _ = _make_play_with_tasks(
+            play_vars={"flag": True},
+            tasks=[{"module": "ansible.builtin.debug", "module_options": {"msg": "test"}}],
+        )
+        report = scan(g, [ShowVariablesGraphRule(enabled=True)])
+        findings = [rr for nr in report.node_results for rr in nr.rule_results if rr.verdict]
+        assert len(findings) == 1

--- a/tests/test_remaining_graph_rules.py
+++ b/tests/test_remaining_graph_rules.py
@@ -2769,7 +2769,7 @@ class TestR404ShowVariablesGraphRule:
             tasks=[
                 {
                     "module": "ansible.builtin.set_fact",
-                    "module_options": {"cacheable_token": "opaque-secret"},
+                    "module_options": {"cached_value": "opaque-data"},
                     "no_log": True,
                 },
                 {"module": "ansible.builtin.debug", "module_options": {"msg": "done"}},
@@ -2777,8 +2777,8 @@ class TestR404ShowVariablesGraphRule:
         )
         task_ids = [n.node_id for n in g.nodes(NodeType.TASK)]
         prov = VariableProvenance(
-            name="cacheable_token",
-            value="opaque-secret",
+            name="cached_value",
+            value="opaque-data",
             source=ProvenanceSource.LOCAL,
             defining_node_id=task_ids[0],
         )

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -239,6 +239,27 @@ class TestPartition:
         assert counts[RemediationClass.AI_CANDIDATE.value] == 1
         assert counts[RemediationClass.MANUAL_REVIEW.value] == 1
 
+    def test_count_by_remediation_class_skips_audit_debug_rules(self) -> None:
+        """Disabled-by-default audit rules do not inflate remediation totals."""
+        violations: list[ViolationDict] = [
+            {"rule_id": "L021", "remediation_class": RemediationClass.AI_CANDIDATE},
+            {"rule_id": "R402", "remediation_class": RemediationClass.MANUAL_REVIEW},
+            {"rule_id": "R404", "remediation_class": RemediationClass.MANUAL_REVIEW},
+        ]
+        counts = count_by_remediation_class(violations)
+        assert counts[RemediationClass.AI_CANDIDATE.value] == 1
+        assert counts[RemediationClass.MANUAL_REVIEW.value] == 0
+
+    def test_count_by_resolution_skips_audit_debug_rules(self) -> None:
+        """Disabled-by-default audit rules do not inflate resolution totals."""
+        violations: list[ViolationDict] = [
+            {"rule_id": "L021", "remediation_resolution": RemediationResolution.UNRESOLVED},
+            {"rule_id": "R404", "remediation_resolution": RemediationResolution.INFORMATIONAL},
+        ]
+        counts = count_by_resolution(violations)
+        assert counts[RemediationResolution.UNRESOLVED.value] == 1
+        assert RemediationResolution.INFORMATIONAL.value not in counts
+
     def test_count_by_resolution(self) -> None:
         """Verifies count_by_resolution returns correct counts."""
         violations: list[ViolationDict] = [

--- a/tests/test_violation_convert.py
+++ b/tests/test_violation_convert.py
@@ -191,10 +191,10 @@ class TestViolationDictToProto:
         """JSON audit metadata survives proto conversion."""
         import json
 
-        payload: list[dict[str, str]] = [{"name": "nginx_port", "value": "8080", "source": "play"}]
+        payload: list[dict[str, str]] = [{"name": "nginx_port", "value": "[REDACTED]", "source": "play"}]
         v: ViolationDict = {
             "rule_id": "R404",
-            "variable_set": json.dumps(payload),
+            "variable_set": json.dumps([{"name": "nginx_port", "value": "8080", "source": "play"}]),
         }
         proto = violation_dict_to_proto(v)
         assert json.loads(proto.metadata["variable_set"]) == payload

--- a/tools/generate_rule_catalog.py
+++ b/tools/generate_rule_catalog.py
@@ -184,6 +184,7 @@ def _is_incidental_reference(rule_id: str, text: str, filename: str) -> bool:
 
 
 _RULE_RANGE_IN_MODULE = re.compile(r"([A-Z])(\d+)_\1(\d+)_")
+_SINGLE_RULE_ID = re.compile(r"[A-Z]\d+")
 
 
 def _rule_ids_from_module_name(module_fragment: str) -> set[str]:
@@ -223,11 +224,15 @@ def _rule_ids_from_imports(text: str) -> set[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.ImportFrom):
             continue
+        module_parts = node.module.split(".") if node.module else []
+        is_rule_package = "rules" in module_parts or "validators" in module_parts
         if node.module:
             for fragment in node.module.split("."):
                 ids.update(_rule_ids_from_module_name(fragment))
         for alias in node.names:
             ids.update(_rule_ids_from_module_name(alias.name))
+            if is_rule_package and _SINGLE_RULE_ID.fullmatch(alias.name):
+                ids.add(alias.name)
     return ids
 
 

--- a/tools/generate_rule_catalog.py
+++ b/tools/generate_rule_catalog.py
@@ -19,6 +19,7 @@ Outputs:
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 from dataclasses import dataclass, field
@@ -205,6 +206,31 @@ def _rule_ids_from_module_name(module_fragment: str) -> set[str]:
     return {f"{letter}{i:0{width}d}" for i in range(start, end + 1)}
 
 
+def _rule_ids_from_imports(text: str) -> set[str]:
+    """Extract rule IDs from ``from ... import`` statements (incl. parenthesized).
+
+    Args:
+        text: Python source of a test module.
+
+    Returns:
+        Rule IDs implied by imported module fragments and symbol names.
+    """
+    ids: set[str] = set()
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return ids
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.module:
+            for fragment in node.module.split("."):
+                ids.update(_rule_ids_from_module_name(fragment))
+        for alias in node.names:
+            ids.update(_rule_ids_from_module_name(alias.name))
+    return ids
+
+
 _TEST_CACHE: dict[str, list[str]] | None = None
 
 
@@ -250,9 +276,7 @@ def _get_test_cache() -> dict[str, list[str]]:
             rid = (m.group(1) or m.group(2) or (m.group(3) or "").upper()).strip()
             if rid:
                 seen_ids.add(rid)
-        for m in re.finditer(r"from\s+([\w.]+)\s+import\s+([\w, ]+)", text):
-            for fragment in (*m.group(1).split("."), *(n.strip() for n in m.group(2).split(","))):
-                seen_ids.update(_rule_ids_from_module_name(fragment))
+        seen_ids.update(_rule_ids_from_imports(text))
         for rid in seen_ids:
             cache.setdefault(rid, [])
             if rel not in cache[rid]:

--- a/tools/generate_rule_catalog.py
+++ b/tools/generate_rule_catalog.py
@@ -250,8 +250,9 @@ def _get_test_cache() -> dict[str, list[str]]:
             rid = (m.group(1) or m.group(2) or (m.group(3) or "").upper()).strip()
             if rid:
                 seen_ids.add(rid)
-        for m in re.finditer(r"from\s+[\w.]+\s+import\s+(\w+)", text):
-            seen_ids.update(_rule_ids_from_module_name(m.group(1)))
+        for m in re.finditer(r"from\s+([\w.]+)\s+import\s+([\w, ]+)", text):
+            for fragment in (*m.group(1).split("."), *(n.strip() for n in m.group(2).split(","))):
+                seen_ids.update(_rule_ids_from_module_name(fragment))
         for rid in seen_ids:
             cache.setdefault(rid, [])
             if rel not in cache[rid]:
@@ -320,7 +321,13 @@ def _normalize_validator(raw: str) -> str:
     Returns:
         Canonical validator name, defaulting to ``Native``.
     """
-    return _VALIDATOR_NAMES.get(raw.lower().strip(), raw.capitalize()) if raw else "Native"
+    if not raw:
+        return "Native"
+    normalized = _VALIDATOR_NAMES.get(raw.lower().strip())
+    if normalized is None:
+        print(f"WARNING: unknown validator '{raw}' in frontmatter; defaulting to Native", file=sys.stderr)
+        return "Native"
+    return normalized
 
 
 def _collect_opa_rules() -> list[Rule]:


### PR DESCRIPTION
## Summary

Split from #347 (per review). **PR 3 of 3** — R404 only (independent of R402).

> **Merge order:** #354 and #355 are merged; this branch is rebased on `main`.

- Implements disabled-by-default per-task debug rule `R404` (`ShowVariablesGraphRule`)
- Documents scalar value redaction limits and per-task resolver performance note in rule `.md`
- Includes catalog entry and focused tests

Depends on #354, #355 (both merged)

## Review feedback addressed

- **Scalar values always `[REDACTED]`:** documented that benign scalars carry no cleartext; dict/list shapes are preserved with redacted leaves. `audit_metadata` sanitizer now matches producer policy (`redact_all_scalars=True` for nested structures; all scalar `variable_set` values redacted).
- **Resolver per task:** documented as a future optimization opportunity.
- **Compound Jinja expressions:** already fixed on main via `extract_bare_refs` in `variable_helpers.py` (from #355).
- **Remediation totals:** `count_by_remediation_class` and `count_by_resolution` exclude disabled-by-default audit rules (R402/R404).
- **Catalog tooling:** unknown validator frontmatter warns and defaults to Native; grouped rule ID ranges in import paths are expanded.
- **Test nitpicks:** synthetic rule ID in graph remediation test, `globals_`/`locals_` rename, strengthened R404 redaction assertions, scanner docstring side-effect note.

## Test plan

- [x] `tox -e lint`
- [x] `tox -e unit -- tests/test_remaining_graph_rules.py -k R404 tests/test_audit_metadata.py tests/test_content_graph.py tests/test_violation_convert.py tests/test_remediation.py tests/test_generate_rule_catalog.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the R404 variable visibility rule for task and handler analysis.
  - Reports variable names, sources, and safely redacted values, including support for sensitive data, `no_log`, nested structures, and large result sets.

- **Bug Fixes**
  - Sensitive and non-sensitive scalar values are now consistently redacted in audit metadata.
  - Remediation totals now exclude disabled-by-default audit and debugging rules.

- **Documentation**
  - Updated rule catalogs and R404 guidance to reflect its implemented status and current validator totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->