### PR TITLE
ci(deprecation-scrape): update create-issue-from-file to v6.0.0

### DIFF
--- a/.github/workflows/deprecation-scrape.yml
+++ b/.github/workflows/deprecation-scrape.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Create issue for new deprecation gaps
         if: steps.scrape.outputs.gap_count != '0'
-        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5e4f9729a0 # v5.0.1
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: "feat(rules): ${{ steps.scrape.outputs.gap_count }} new ansible-core deprecation(s) need rules (core ${{ steps.scrape.outputs.ansible_version }})"
           content-filepath: /tmp/gaps.md


### PR DESCRIPTION
## Summary
- Update `peter-evans/create-issue-from-file` action from v5.0.1 to v6.0.0
- Previous SHA `e8ef132d6df98ed982188e460ebb3b5e4f9729a0` no longer exists in upstream repo (force-pushed/deleted)
- Workflow has been failing monthly since April 2026

## Test plan
- [ ] Manually trigger `deprecation-scrape` workflow via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)