### PR TITLE
feat(gateway): unify SCM submit into single endpoint (ADR-050)

### DIFF
--- a/.sdlc/adrs/ADR-050-post-remediation-pr-creation.md
+++ b/.sdlc/adrs/ADR-050-post-remediation-pr-creation.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
-2026-04-07
+2026-04-07 (revised 2026-07-06)
 
 ## Context
 
@@ -93,41 +93,79 @@ SECURITY.md.
 
 ### 3. REST API
 
+A single unified endpoint handles both push-only and push-and-PR workflows:
+
 ```
-POST /api/v1/activity/{activity_id}/pull-request
+POST /api/v1/projects/{project_id}/operation/submit
 ```
 
 Request body:
 
 ```json
 {
+  "activity_id": null,
   "branch_name": "apme/remediate-2026-04-07",
+  "create_pr": true,
   "title": "fix: APME automated remediation",
-  "body": "Auto-generated PR with APME remediation results.\n\n..."
+  "body": "Auto-generated PR with APME remediation results.\n\n...",
+  "scm_token": null
 }
 ```
 
 All fields are optional — the Gateway generates sensible defaults:
+- `activity_id`: when provided, loads patched files from the database
+  (historical scan); when omitted, uses the live in-memory operation
 - `branch_name`: `apme/remediate-{short_scan_id}`
+- `create_pr`: `true` (default — creates a PR after pushing)
 - `title`: `fix: APME remediation — {fixed_count} findings resolved`
 - `body`: Markdown summary with violation counts, what was fixed, and a link
   back to the activity detail in the APME UI
+
+**Two state sources:** The endpoint supports both live operations (from the
+in-memory `OperationRegistry`) and historical activities (from the database).
+This is critical for scheduled/CI-triggered scans where no user is present at
+the operation panel — the patched files persist in the database and can be
+submitted to SCM at any later time.
+
+When `create_pr` is `false`, the endpoint creates the branch and pushes
+patched files but does **not** open a pull request. This supports workflows
+where teams use branch-based policies, CI triggers, or prefer to open PRs
+manually.
 
 Response:
 
 ```json
 {
-  "pr_url": "https://github.com/org/repo/pull/42",
   "branch_name": "apme/remediate-abc123",
+  "commit_sha": "a1b2c3d4e5f6",
+  "pr_url": "https://github.com/org/repo/pull/42",
   "provider": "github"
 }
 ```
 
+When `create_pr` is `false`, `pr_url` is `null`.
+
 Error responses:
-- `404` — activity not found or has no patched files
-- `409` — PR already created for this activity (idempotency guard)
-- `422` — no SCM token configured (project or global)
+- `404` — operation not found, not completed, or has no patched files
+- `409` — PR already created for this operation (idempotency guard), or
+  operation is not a completed remediation
+- `422` — no SCM token configured (project or global), or SCM provider
+  cannot be detected
 - `502` — SCM provider API error (upstream failure)
+
+#### Superseded endpoints
+
+The following endpoints are **removed** in favour of the unified
+`/operation/submit`:
+
+- `POST /api/v1/activity/{activity_id}/pull-request` — original per-activity
+  PR creation (ADR-050 initial design)
+- `POST /api/v1/projects/{project_id}/operation/create-pr` — duplicate
+  per-operation PR creation (ADR-052)
+
+Both lacked the `create_pr` flag and duplicated SCM logic. The unified
+endpoint consolidates them under the project operation model (ADR-052) with
+a single SCM code path.
 
 ### 4. Workflow
 
@@ -141,23 +179,24 @@ Gateway runs FixSession → SessionResult with patched files
 Gateway persists activity record (patched files stored in DB)
         │
         ▼
-User reviews results in Activity Detail page
+User reviews results in Operation panel
         │
         ▼
-User clicks "Create PR"
+User clicks "Create PR" (or "Push Branch" if create_pr=false)
         │
         ▼
 Gateway:
-  1. Resolve SCM token (project → global fallback)
+  1. Resolve SCM token (inline → project → global fallback)
   2. Determine SCM provider from repo_url
   3. Create branch from project's default branch
   4. Push patched files to the new branch
-  5. Create PR against default branch
-  6. Store PR URL in activity record
-  7. Return PR URL to UI
+  5. If create_pr=true: create PR against default branch
+  6. Store PR URL (if created) in scan record
+  7. Transition operation to PR_SUBMITTED
+  8. Return branch_name, commit_sha, pr_url to UI
         │
         ▼
-UI shows PR link — user reviews and merges in SCM
+UI shows PR link (or branch link) — user reviews in SCM
 ```
 
 ### 5. Patched File Storage
@@ -357,3 +396,4 @@ globally via `APME_GITHUB_API_URL`.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-04-07 | AI Agent | Initial proposal |
+| 2026-07-06 | AI Agent | Consolidated to unified `/operation/submit` endpoint with `create_pr` flag; removed `POST /activity/{id}/pull-request` and `POST /operation/create-pr`; status → Accepted |

--- a/.sdlc/adrs/ADR-050-post-remediation-pr-creation.md
+++ b/.sdlc/adrs/ADR-050-post-remediation-pr-creation.md
@@ -146,9 +146,9 @@ Response:
 When `create_pr` is `false`, `pr_url` is `null`.
 
 Error responses:
-- `404` — operation not found, not completed, or has no patched files
-- `409` — PR already created for this operation (idempotency guard), or
-  operation is not a completed remediation
+- `404` — operation/activity not found, project not found, or no patched files
+- `409` — PR already created (idempotency guard), operation not completed,
+  operation is not a remediate scan, or no patches available
 - `422` — no SCM token configured (project or global), or SCM provider
   cannot be detected
 - `502` — SCM provider API error (upstream failure)

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -56,6 +56,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-043](ADR-043-default-severity-assignment.md) | Default Severity Assignment for Rule Catalog | 2026-03-26 |
 | [ADR-048](ADR-048-pod-internal-admin-endpoints.md) | Pod-Internal Admin Endpoints Rely on Network Isolation | 2026-04-01 |
 | [ADR-049](ADR-049-gateway-in-daemon.md) | Gateway Embedded in Local Daemon | 2026-04-01 |
+| [ADR-050](ADR-050-post-remediation-pr-creation.md) | Post-Remediation PR Creation via Gateway SCM Integration | 2026-04-07 (revised 2026-07-06) |
 | [ADR-051](ADR-051-dependency-health-scanning.md) | Dependency Health Scanning | 2026-04-07 |
 | [ADR-053](ADR-053-github-integration-strategy.md) | GitHub Integration Strategy | 2026-04-10 |
 | [ADR-054](ADR-054-production-deployment.md) | Production Deployment — Helm Chart and bootc VM Image | 2026-04-10 |
@@ -74,7 +75,6 @@ Decisions under consideration — not yet accepted or implemented.
 | [ADR-042](ADR-042-third-party-plugin-services.md) | Third-Party Plugin Services | 2026-03-20 |
 | [ADR-045](ADR-045-galaxy-auth-delegation.md) | Delegate Galaxy Authentication to ansible-galaxy, Galaxy Config as Scan Metadata | 2026-03-28 |
 | [ADR-046](ADR-046-ai-assisted-report-generation.md) | AI-Assisted Report Generation | 2026-03-30 |
-| [ADR-050](ADR-050-post-remediation-pr-creation.md) | Post-Remediation PR Creation via Gateway SCM Integration | 2026-04-07 |
 | [ADR-052](ADR-052-project-operation-sse-architecture.md) | Project Operation SSE Architecture | 2026-04-14 |
 | [ADR-055](ADR-055-violation-fingerprint-suppression.md) | Content-Based Violation Fingerprinting and Suppression | 2026-05-21 |
 

--- a/frontend/src/hooks/useProjectOperationActions.ts
+++ b/frontend/src/hooks/useProjectOperationActions.ts
@@ -62,9 +62,10 @@ export function useProjectOperationActions(projectId: string) {
     );
   }, [projectId]);
 
-  const createPR = useCallback(async () => {
-    return postJson<{ pr_url: string; branch_name: string; provider: string }>(
-      `/projects/${projectId}/operation/create-pr`,
+  const createPR = useCallback(async (options?: { create_pr?: boolean; branch_name?: string }) => {
+    return postJson<{ branch_name: string; commit_sha: string; pr_url: string | null; provider: string }>(
+      `/projects/${projectId}/operation/submit`,
+      options,
     );
   }, [projectId]);
 

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -18,7 +18,7 @@ import {
   FlexItem,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { createPullRequest, createSuppression, deleteActivity, getActivity } from '../services/api';
+import { createSuppression, deleteActivity, getActivity, submitActivity } from '../services/api';
 import { useFeedbackEnabled } from '../hooks/useFeedbackEnabled';
 import type { ActivityDetail, ViolationDetail } from '../types/api';
 
@@ -152,12 +152,14 @@ export function ActivityDetailPage() {
   };
 
   const handleCreatePR = async () => {
-    if (!activityId) return;
+    if (!activityId || !detail?.project_id) return;
     setPrCreating(true);
     setPrError(null);
     try {
-      const result = await createPullRequest(activityId);
-      setDetail((prev) => prev ? { ...prev, pr_url: result.pr_url } : prev);
+      const result = await submitActivity(detail.project_id, activityId);
+      if (result.pr_url) {
+        setDetail((prev) => prev ? { ...prev, pr_url: result.pr_url } : prev);
+      }
     } catch (err) {
       setPrError(err instanceof Error ? err.message : 'Failed to create pull request');
     } finally {
@@ -190,7 +192,7 @@ export function ActivityDetailPage() {
   };
 
   const isRemediate = detail.scan_type === 'fix' || detail.scan_type === 'remediate';
-  const canCreatePR = isRemediate && detail.patches.length > 0 && !detail.pr_url;
+  const canCreatePR = isRemediate && detail.patches.length > 0 && !detail.pr_url && !!detail.project_id;
 
   return (
     <PageLayout>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -8,8 +8,6 @@ import type {
   CollectionSummary,
   CreateGalaxyServerRequest,
   CreateProjectRequest,
-  CreatePullRequestRequest,
-  CreatePullRequestResponse,
   CreateSuppressionRequest,
   DashboardSummary,
   DepHealthSummary,
@@ -29,6 +27,7 @@ import type {
   RuleStats,
   SessionDetail,
   SessionSummary,
+  SubmitResponse,
   SuppressionRecord,
   TopViolation,
   TrendPoint,
@@ -93,14 +92,14 @@ export async function deleteActivity(scanId: string): Promise<void> {
   if (!res.ok) throw new Error(`${res.status}`);
 }
 
-export function createPullRequest(
+export function submitActivity(
+  projectId: string,
   activityId: string,
-  body?: CreatePullRequestRequest,
-): Promise<CreatePullRequestResponse> {
-  return request(`/activity/${activityId}/pull-request`, {
+): Promise<SubmitResponse> {
+  return request(`/projects/${projectId}/operation/submit`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body ?? {}),
+    body: JSON.stringify({ activity_id: activityId }),
   });
 }
 

--- a/frontend/src/test/api.test.ts
+++ b/frontend/src/test/api.test.ts
@@ -217,6 +217,23 @@ describe("api service", () => {
     );
   });
 
-  // ADR-050 Pull Request API tests removed — PR creation moved to
-  // POST /projects/{id}/operation/submit via useProjectOperationActions
+  it("submitActivity posts activity_id to /operation/submit", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({
+      branch_name: "apme/remediate-abc12345",
+      commit_sha: "deadbeef",
+      pr_url: "https://github.com/org/repo/pull/1",
+      provider: "github",
+    }));
+    const { submitActivity } = await import("../services/api");
+    const result = await submitActivity("proj-1", "act-42");
+    expect(result.branch_name).toBe("apme/remediate-abc12345");
+    expect(result.pr_url).toBe("https://github.com/org/repo/pull/1");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/projects/proj-1/operation/submit",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ activity_id: "act-42" }),
+      }),
+    );
+  });
 });

--- a/frontend/src/test/api.test.ts
+++ b/frontend/src/test/api.test.ts
@@ -217,41 +217,6 @@ describe("api service", () => {
     );
   });
 
-  // ADR-050 Pull Request API tests
-
-  it("createPullRequest calls POST with correct path and body", async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({
-      pr_url: "https://github.com/org/repo/pull/42",
-      branch_name: "apme/remediate-abc",
-      provider: "github",
-    }));
-    const { createPullRequest } = await import("../services/api");
-    const result = await createPullRequest("scan-123", { title: "Fix issues" });
-    expect(result.pr_url).toBe("https://github.com/org/repo/pull/42");
-    expect(result.provider).toBe("github");
-    expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/activity/scan-123/pull-request",
-      expect.objectContaining({
-        method: "POST",
-        headers: expect.objectContaining({ "Content-Type": "application/json" }),
-      }),
-    );
-  });
-
-  it("createPullRequest sends empty body when no options provided", async () => {
-    mockFetch.mockReturnValueOnce(jsonResponse({
-      pr_url: "https://github.com/org/repo/pull/1",
-      branch_name: "apme/remediate-xyz",
-      provider: "github",
-    }));
-    const { createPullRequest } = await import("../services/api");
-    await createPullRequest("scan-456");
-    expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/activity/scan-456/pull-request",
-      expect.objectContaining({
-        method: "POST",
-        body: "{}",
-      }),
-    );
-  });
+  // ADR-050 Pull Request API tests removed — PR creation moved to
+  // POST /projects/{id}/operation/submit via useProjectOperationActions
 });

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -182,17 +182,21 @@ export interface UpdateProjectRequest {
   scm_provider?: string;
 }
 
-// ── PR creation types (ADR-050) ──────────────────────────────────────
+// ── SCM submit types (ADR-050) ───────────────────────────────────────
 
-export interface CreatePullRequestRequest {
+export interface SubmitRequest {
+  activity_id?: string;
   branch_name?: string;
+  create_pr?: boolean;
   title?: string;
   body?: string;
+  scm_token?: string;
 }
 
-export interface CreatePullRequestResponse {
-  pr_url: string;
+export interface SubmitResponse {
   branch_name: string;
+  commit_sha: string;
+  pr_url: string | null;
   provider: string;
 }
 

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -1,7 +1,7 @@
 """REST + SSE endpoints for project operations (ADR-052).
 
 Provides ``POST``, ``GET``, ``POST /approve``, ``POST /cancel``,
-``POST /create-pr``, and ``GET /events`` under
+``POST /submit``, and ``GET /events`` under
 ``/api/v1/projects/{project_id}/operation``.
 """
 
@@ -12,6 +12,7 @@ import contextlib
 import json
 import logging
 import uuid
+from collections.abc import Sequence
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -19,12 +20,15 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from apme_engine.severity_defaults import severity_from_proto, severity_to_label
+from apme_gateway.api.schemas import SubmitRequest, SubmitResponse
 from apme_gateway.db import get_session
 from apme_gateway.db import queries as q
+from apme_gateway.db.models import PatchedFile, Scan
 from apme_gateway.operation_registry import _now_iso, get_operation_registry
 from apme_gateway.operation_types import (
     TERMINAL_STATUSES,
     OperationResult,
+    OperationState,
     OperationStatus,
     ProgressEntry,
     Proposal,
@@ -218,105 +222,209 @@ async def cancel_operation(project_id: str) -> dict[str, str]:
     return {"status": "cancelled"}
 
 
-@operation_router.post("/create-pr")  # type: ignore[untyped-decorator]
-async def create_pr_from_operation(project_id: str) -> dict[str, Any]:
-    """Create a pull request from a completed remediation.
+@operation_router.post("/submit")  # type: ignore[untyped-decorator]
+async def submit_operation(
+    project_id: str,
+    body: SubmitRequest | None = None,
+) -> SubmitResponse:
+    """Push patched files to a branch and optionally open a PR (ADR-050).
 
-    Delegates to the existing ``/activity/{id}/pull-request`` logic
-    internally — the scan must be persisted already.
+    This is the unified SCM submit endpoint that replaces the former
+    ``/activity/{id}/pull-request`` and ``/operation/create-pr`` endpoints.
+
+    Two modes:
+
+    - **Live operation** (no ``activity_id``): uses the in-memory
+      ``OperationRegistry`` for the project — requires a completed
+      remediation operation.
+    - **Historical activity** (``activity_id`` provided): loads patched
+      files from the database — works for any past remediation that still
+      has stored patches.
 
     Args:
         project_id: Target project UUID.
+        body: Optional submit options (branch name, create_pr flag, etc.).
 
     Returns:
-        PR URL and metadata.
+        Branch, commit SHA, optional PR URL, and provider.
 
     Raises:
-        HTTPException: 404/409/422 depending on state.
+        HTTPException: 404/409/422/502 depending on state.
     """
     from apme_gateway.config import load_config
     from apme_gateway.scm import detect_provider, get_provider
 
-    registry = get_operation_registry()
-    state = registry.get_by_project(project_id)
-    if state is None:
-        raise HTTPException(status_code=404, detail="No operation for this project")
-    if state.status != OperationStatus.COMPLETED:
-        raise HTTPException(
-            status_code=409,
-            detail=f"Cannot create PR: operation is '{state.status.value}', not 'completed'",
-        )
-    if state.scan_type != "remediate":
-        raise HTTPException(status_code=409, detail="PR creation requires a remediate operation")
-    if not state.result or not state.result.patches:
-        raise HTTPException(status_code=409, detail="No patches available for PR creation")
-
-    registry.transition(state.operation_id, OperationStatus.SUBMITTING_PR)
+    if body is None:
+        body = SubmitRequest()
 
     cfg = load_config()
 
-    async with get_session() as db:
-        scan = await q.get_scan(db, state.scan_id)
-        if scan is None:
-            registry.transition(state.operation_id, OperationStatus.COMPLETED)
-            raise HTTPException(status_code=404, detail="Scan not persisted yet")
-        if scan.pr_url:
-            registry.set_pr_url(state.operation_id, scan.pr_url)
-            return {"pr_url": scan.pr_url, "status": "already_created"}
+    if body.activity_id:
+        scan_id, state = body.activity_id, None
+    else:
+        scan_id, state = _resolve_live_operation(project_id)
 
-        project = await q.get_project(db, state.project_id)
+    async with get_session() as db:
+        scan = await q.get_scan(db, scan_id)
+        if scan is None:
+            if state:
+                registry = get_operation_registry()
+                registry.transition(state.operation_id, OperationStatus.COMPLETED)
+            raise HTTPException(status_code=404, detail="Activity not found")
+
+        if body.activity_id and scan.project_id != project_id:
+            raise HTTPException(
+                status_code=404,
+                detail="Activity does not belong to this project",
+            )
+
+        if scan.pr_url:
+            if state:
+                get_operation_registry().set_pr_url(state.operation_id, scan.pr_url)
+            raise HTTPException(
+                status_code=409,
+                detail=f"PR already created for this activity: {scan.pr_url}",
+            )
+
+        project = await q.get_project(db, project_id)
         if project is None:
-            registry.transition(state.operation_id, OperationStatus.COMPLETED)
+            if state:
+                get_operation_registry().transition(
+                    state.operation_id,
+                    OperationStatus.COMPLETED,
+                )
             raise HTTPException(status_code=404, detail="Project not found")
 
-        patched = await q.get_patched_files(db, state.scan_id)
+        patched = await q.get_patched_files(db, scan_id)
         if not patched:
-            registry.transition(state.operation_id, OperationStatus.COMPLETED)
+            if state:
+                get_operation_registry().transition(
+                    state.operation_id,
+                    OperationStatus.COMPLETED,
+                )
             raise HTTPException(status_code=404, detail="No patched files found")
 
-    token = project.scm_token or cfg.scm_token
+    if state:
+        get_operation_registry().transition(
+            state.operation_id,
+            OperationStatus.SUBMITTING_PR,
+        )
+
+    inline_token = body.scm_token.strip() if body.scm_token else None
+    token = inline_token or project.scm_token or cfg.scm_token
     if not token:
-        registry.transition(state.operation_id, OperationStatus.COMPLETED)
+        if state:
+            get_operation_registry().transition(
+                state.operation_id,
+                OperationStatus.COMPLETED,
+            )
         raise HTTPException(status_code=422, detail="No SCM token configured")
 
     provider_type = project.scm_provider or detect_provider(project.repo_url)
     if not provider_type:
-        registry.transition(state.operation_id, OperationStatus.COMPLETED)
-        raise HTTPException(status_code=422, detail=f"Cannot detect SCM provider from URL: {project.repo_url}")
+        if state:
+            get_operation_registry().transition(
+                state.operation_id,
+                OperationStatus.COMPLETED,
+            )
+        raise HTTPException(
+            status_code=422,
+            detail=f"Cannot detect SCM provider from URL: {project.repo_url}",
+        )
 
     api_base = cfg.github_api_url if provider_type == "github" else None
     try:
         provider = get_provider(provider_type, api_base_url=api_base)
     except ValueError as exc:
-        registry.transition(state.operation_id, OperationStatus.COMPLETED)
+        if state:
+            get_operation_registry().transition(
+                state.operation_id,
+                OperationStatus.COMPLETED,
+            )
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    short_id = state.scan_id[:8]
-    branch_name = f"apme/remediate-{short_id}"
-    pr_title = f"fix: APME remediation — {scan.fixed_count} findings resolved"
+    short_id = scan_id[:8]
+    branch_name = body.branch_name or f"apme/remediate-{short_id}"
+    commit_title = body.title or f"fix: APME remediation — {scan.fixed_count} findings resolved"
 
     try:
         await provider.create_branch(project.repo_url, project.branch, branch_name, token)
         files = {pf.path: pf.content for pf in patched}
-        await provider.push_files(project.repo_url, branch_name, files, pr_title, token)
-        result = await provider.create_pull_request(
+        commit_sha = await provider.push_files(
             project.repo_url,
-            project.branch,
             branch_name,
-            pr_title,
-            f"Automated remediation by APME — {scan.fixed_count} findings fixed.",
+            files,
+            commit_title,
             token,
         )
+
+        pr_url: str | None = None
+        if body.create_pr:
+            pr_body = body.body or _build_pr_body(scan, patched)
+            pr_result = await provider.create_pull_request(
+                project.repo_url,
+                project.branch,
+                branch_name,
+                commit_title,
+                pr_body,
+                token,
+            )
+            pr_url = pr_result.pr_url
     except Exception as exc:
-        logger.exception("SCM provider error creating PR for operation %s", state.operation_id)
-        registry.transition(state.operation_id, OperationStatus.COMPLETED, error=str(exc))
+        logger.exception("SCM provider error for project %s", project_id)
+        if state:
+            get_operation_registry().transition(
+                state.operation_id,
+                OperationStatus.COMPLETED,
+                error=str(exc),
+            )
         raise HTTPException(status_code=502, detail="SCM provider error") from exc
 
-    async with get_session() as db:
-        await q.set_scan_pr_url(db, state.scan_id, result.pr_url)
+    if pr_url:
+        async with get_session() as db:
+            await q.set_scan_pr_url(db, scan_id, pr_url)
+        if state:
+            get_operation_registry().set_pr_url(state.operation_id, pr_url)
+    elif state:
+        get_operation_registry().transition(
+            state.operation_id,
+            OperationStatus.PR_SUBMITTED,
+        )
 
-    registry.set_pr_url(state.operation_id, result.pr_url)
-    return {"pr_url": result.pr_url, "branch_name": result.branch_name, "provider": result.provider}
+    return SubmitResponse(
+        branch_name=branch_name,
+        commit_sha=commit_sha,
+        pr_url=pr_url,
+        provider=provider_type,
+    )
+
+
+def _resolve_live_operation(project_id: str) -> tuple[str, OperationState]:
+    """Look up the live operation for a project and validate it.
+
+    Args:
+        project_id: Target project UUID.
+
+    Returns:
+        Tuple of (scan_id, operation_state).
+
+    Raises:
+        HTTPException: 404 if no operation, 409 if wrong state.
+    """
+    registry = get_operation_registry()
+    state: OperationState | None = registry.get_by_project(project_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="No active operation for this project")
+    if state.status != OperationStatus.COMPLETED:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot submit: operation is '{state.status.value}', not 'completed'",
+        )
+    if state.scan_type != "remediate":
+        raise HTTPException(status_code=409, detail="Submit requires a remediate operation")
+    if not state.result or not state.result.patches:
+        raise HTTPException(status_code=409, detail="No patches available for submission")
+    return state.scan_id, state
 
 
 # ── SSE endpoint ──────────────────────────────────────────────────────
@@ -402,6 +510,41 @@ def _sse_format(event: str, data: dict[str, Any]) -> str:
     """
     payload = json.dumps(data, default=str)
     return f"event: {event}\ndata: {payload}\n\n"
+
+
+# ── PR body builder ───────────────────────────────────────────────────
+
+
+def _build_pr_body(scan: Scan, patched_files: Sequence[PatchedFile]) -> str:
+    """Generate a Markdown PR body from scan data (ADR-050).
+
+    Args:
+        scan: The Scan ORM row.
+        patched_files: PatchedFile rows for this activity.
+
+    Returns:
+        Markdown string.
+    """
+    lines: list[str] = [
+        "## APME Automated Remediation",
+        "",
+        f"**Findings resolved:** {scan.fixed_count}",
+        f"**Total violations (before):** {scan.total_violations}",
+        f"**Scan type:** {scan.scan_type}",
+        "",
+        "### Files modified",
+        "",
+    ]
+    for pf in patched_files:
+        lines.append(f"- `{pf.path}`")
+    lines.extend(
+        [
+            "",
+            "---",
+            "*This PR was auto-generated by [APME](https://github.com/ansible/apme).*",
+        ]
+    )
+    return "\n".join(lines)
 
 
 # ── Operation driver (replaces WebSocket tunnel logic) ────────────────

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -278,6 +278,12 @@ async def submit_operation(
                 detail="Activity does not belong to this project",
             )
 
+        if body.activity_id and scan.scan_type != "remediate":
+            raise HTTPException(
+                status_code=409,
+                detail="Submit requires a remediate activity",
+            )
+
         if scan.pr_url:
             if state:
                 get_operation_registry().set_pr_url(state.operation_id, scan.pr_url)
@@ -388,7 +394,7 @@ async def submit_operation(
     elif state:
         get_operation_registry().transition(
             state.operation_id,
-            OperationStatus.PR_SUBMITTED,
+            OperationStatus.COMPLETED,
         )
 
     return SubmitResponse(

--- a/src/apme_gateway/api/router.py
+++ b/src/apme_gateway/api/router.py
@@ -14,7 +14,7 @@ import contextlib
 import logging
 import os
 import uuid
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect
@@ -37,8 +37,6 @@ from apme_gateway.api.schemas import (
     ComponentHealth,
     CreateGalaxyServerRequest,
     CreateProjectRequest,
-    CreatePullRequestRequest,
-    CreatePullRequestResponse,
     CreateSuppressionRequest,
     DashboardSummary,
     DepHealthSummary,
@@ -70,7 +68,7 @@ from apme_gateway.api.schemas import (
 )
 from apme_gateway.db import get_session
 from apme_gateway.db import queries as q
-from apme_gateway.db.models import GalaxyServer, PatchedFile, Project, Rule, RuleOverride, Scan, ScanManifest
+from apme_gateway.db.models import GalaxyServer, Project, Rule, RuleOverride, Scan, ScanManifest
 
 logger = logging.getLogger(__name__)
 
@@ -1497,162 +1495,6 @@ async def delete_activity(activity_id: str) -> None:
         deleted = await q.delete_scan(db, activity_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-
-@router.post("/activity/{activity_id}/pull-request")  # type: ignore[untyped-decorator]
-async def create_pull_request(
-    activity_id: str,
-    body: CreatePullRequestRequest | None = None,
-) -> CreatePullRequestResponse:
-    """Create a pull request from a remediation activity's patched files (ADR-050).
-
-    Resolves the SCM token (project → global fallback), determines the
-    provider, creates a branch, pushes patched files, and opens a PR.
-
-    Args:
-        activity_id: UUID of the remediation activity (``scans.scan_id``).
-        body: Optional PR customisation (branch name, title, body).
-
-    Returns:
-        PR URL and metadata.
-
-    Raises:
-        HTTPException: 404/409/422/502 depending on the failure mode.
-    """
-    from apme_gateway.config import load_config
-    from apme_gateway.scm import detect_provider, get_provider
-
-    if body is None:
-        body = CreatePullRequestRequest()
-
-    cfg = load_config()
-
-    async with get_session() as db:
-        scan = await q.get_scan(db, activity_id)
-        if scan is None:
-            raise HTTPException(status_code=404, detail="Activity not found")
-
-        if scan.pr_url:
-            raise HTTPException(
-                status_code=409,
-                detail=f"PR already created for this activity: {scan.pr_url}",
-            )
-
-        if scan.project_id is None:
-            raise HTTPException(
-                status_code=404,
-                detail="Activity is not linked to a project",
-            )
-
-        project = await q.get_project(db, scan.project_id)
-        if project is None:
-            raise HTTPException(status_code=404, detail="Associated project not found")
-
-        patched = await q.get_patched_files(db, activity_id)
-        if not patched:
-            raise HTTPException(
-                status_code=404,
-                detail="No patched files found for this activity",
-            )
-
-    # Token priority: inline request > project config > global env
-    # Strip whitespace to prevent whitespace-only tokens overriding valid fallbacks
-    inline_token = body.scm_token.strip() if body.scm_token else None
-    token = inline_token or project.scm_token or cfg.scm_token
-    if not token:
-        raise HTTPException(
-            status_code=422,
-            detail="No SCM token configured (set project scm_token or APME_SCM_TOKEN)",
-        )
-
-    provider_type = project.scm_provider or detect_provider(project.repo_url)
-    if not provider_type:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Cannot detect SCM provider from URL: {project.repo_url}",
-        )
-
-    api_base = cfg.github_api_url if provider_type == "github" else None
-    try:
-        provider = get_provider(provider_type, api_base_url=api_base)
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-
-    short_id = activity_id[:8]
-    branch_name = body.branch_name or f"apme/remediate-{short_id}"
-    pr_title = body.title or f"fix: APME remediation — {scan.fixed_count} findings resolved"
-    pr_body = body.body or _build_pr_body(scan, patched)
-
-    try:
-        await provider.create_branch(project.repo_url, project.branch, branch_name, token)
-        files = {pf.path: pf.content for pf in patched}
-        await provider.push_files(
-            project.repo_url,
-            branch_name,
-            files,
-            pr_title,
-            token,
-        )
-        result = await provider.create_pull_request(
-            project.repo_url,
-            project.branch,
-            branch_name,
-            pr_title,
-            pr_body,
-            token,
-        )
-    except Exception as exc:
-        logger.exception("SCM provider error creating PR for activity %s", activity_id)
-        raise HTTPException(
-            status_code=502,
-            detail="SCM provider error while creating pull request",
-        ) from exc
-
-    async with get_session() as db:
-        updated = await q.set_scan_pr_url(db, activity_id, result.pr_url)
-        if not updated:
-            raise HTTPException(
-                status_code=409,
-                detail="PR was already created for this activity (concurrent request)",
-            )
-
-    return CreatePullRequestResponse(
-        pr_url=result.pr_url,
-        branch_name=result.branch_name,
-        provider=result.provider,
-    )
-
-
-def _build_pr_body(scan: Scan, patched_files: Sequence[PatchedFile]) -> str:
-    """Generate a Markdown PR body from activity data (ADR-050).
-
-    Args:
-        scan: The Scan ORM row.
-        patched_files: PatchedFile rows for this activity.
-
-    Returns:
-        Markdown string.
-    """
-    lines: list[str] = [
-        "## APME Automated Remediation",
-        "",
-        f"**Findings resolved:** {scan.fixed_count}",
-        f"**Total violations (before):** {scan.total_violations}",
-        f"**Scan type:** {scan.scan_type}",
-        "",
-        "### Files modified",
-        "",
-    ]
-    for pf in patched_files:
-        lines.append(f"- `{pf.path}`")
-    lines.extend(
-        [
-            "",
-            "---",
-            "*This PR was auto-generated by [APME](https://github.com/ansible/apme).*",
-        ]
-    )
-    return "\n".join(lines)
 
 
 @router.get("/violations/top")  # type: ignore[untyped-decorator]

--- a/src/apme_gateway/api/schemas.py
+++ b/src/apme_gateway/api/schemas.py
@@ -609,38 +609,49 @@ class PythonPackageDetail(BaseModel):  # type: ignore[misc]
     projects: list[PythonPackageProjectRef] = Field(default_factory=list)
 
 
-# ── PR creation schemas (ADR-050) ────────────────────────────────────
+# ── SCM submit schemas (ADR-050) ─────────────────────────────────────
 
 
-class CreatePullRequestRequest(BaseModel):  # type: ignore[misc]
-    """Request body for creating a PR from a remediation activity (ADR-050).
+class SubmitRequest(BaseModel):  # type: ignore[misc]
+    """Request body for the unified SCM submit endpoint (ADR-050).
 
+    Pushes patched files to a branch and optionally opens a PR.
     All fields are optional — the Gateway generates sensible defaults.
 
+    When ``activity_id`` is provided, patched files are loaded from the
+    database (supports historical scans).  When omitted, the endpoint
+    uses the live in-memory operation for the project.
+
     Attributes:
+        activity_id: Optional scan/activity ID to submit from DB history.
         branch_name: Name for the new branch (default auto-generated).
+        create_pr: Whether to open a PR after pushing (default ``True``).
         title: PR title (default auto-generated from remediation stats).
         body: PR body in Markdown (default auto-generated).
-        scm_token: One-time SCM token for this PR (overrides project/global token).
+        scm_token: One-time SCM token (overrides project/global token).
     """
 
+    activity_id: str | None = None
     branch_name: str | None = None
+    create_pr: bool = True
     title: str | None = None
     body: str | None = None
     scm_token: str | None = None
 
 
-class CreatePullRequestResponse(BaseModel):  # type: ignore[misc]
-    """Response after successfully creating a PR (ADR-050).
+class SubmitResponse(BaseModel):  # type: ignore[misc]
+    """Response after a successful SCM submit (ADR-050).
 
     Attributes:
-        pr_url: Web URL of the created pull request.
-        branch_name: Name of the head branch.
+        branch_name: Name of the head branch that was created.
+        commit_sha: SHA of the commit pushed to the branch.
+        pr_url: Web URL of the PR, or ``None`` if ``create_pr`` was false.
         provider: SCM provider that was used (e.g. ``github``).
     """
 
-    pr_url: str
     branch_name: str
+    commit_sha: str
+    pr_url: str | None = None
     provider: str
 
 

--- a/tests/test_gateway_pull_request.py
+++ b/tests/test_gateway_pull_request.py
@@ -691,6 +691,58 @@ class TestSubmitEndpoint:
         assert resp.status_code == 404
         assert "No patched files" in resp.json()["detail"]
 
+    async def test_activity_id_check_scan_rejected(self, client: AsyncClient) -> None:
+        """Reject activity_id that references a check scan (not remediate).
+
+        Args:
+            client: Async test client.
+        """
+        async with get_session() as db:
+            db.add(
+                Project(
+                    id="proj-1",
+                    name="test-project",
+                    repo_url="https://github.com/org/repo.git",
+                    branch="main",
+                    created_at="2026-01-01T00:00:00Z",
+                    scm_token="ghp_test",
+                )
+            )
+            db.add(
+                Session(
+                    session_id="sess-1",
+                    project_path="/proj",
+                    first_seen="t0",
+                    last_seen="t1",
+                )
+            )
+            db.add(
+                Scan(
+                    scan_id="scan-check",
+                    session_id="sess-1",
+                    project_id="proj-1",
+                    project_path="/proj",
+                    source="gateway",
+                    created_at="2026-01-01T00:00:00Z",
+                    scan_type="check",
+                    total_violations=5,
+                    auto_fixable=3,
+                )
+            )
+            await db.commit()
+
+        with patch("apme_gateway.config.load_config") as mock_cfg:
+            mock_cfg.return_value.scm_token = ""
+            mock_cfg.return_value.github_api_url = "https://api.github.com"
+
+            resp = await client.post(
+                "/api/v1/projects/proj-1/operation/submit",
+                json={"activity_id": "scan-check"},
+            )
+
+        assert resp.status_code == 409
+        assert "remediate" in resp.json()["detail"]
+
     async def test_activity_id_pr_already_exists(self, client: AsyncClient) -> None:
         """Reject when activity already has a PR URL.
 

--- a/tests/test_gateway_pull_request.py
+++ b/tests/test_gateway_pull_request.py
@@ -1,4 +1,4 @@
-"""Unit tests for the post-remediation PR creation feature (ADR-050)."""
+"""Unit tests for the SCM integration feature (ADR-050)."""
 
 from __future__ import annotations
 
@@ -13,6 +13,8 @@ from httpx import ASGITransport, AsyncClient
 from apme_gateway.app import create_app
 from apme_gateway.db import close_db, get_session, init_db
 from apme_gateway.db.models import PatchedFile, Project, Scan, Session
+from apme_gateway.operation_registry import get_operation_registry
+from apme_gateway.operation_types import OperationResult, OperationStatus
 from apme_gateway.scm.base import PullRequestResult, detect_provider
 from apme_gateway.scm.github import GitHubProvider, _custom_ca_bundle, _http_verify, _parse_owner_repo
 from apme_gateway.scm.registry import get_provider
@@ -20,7 +22,7 @@ from apme_gateway.scm.registry import get_provider
 
 @pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
 async def _db(tmp_path: Path) -> AsyncIterator[None]:
-    """Initialise a fresh DB per test.
+    """Initialise a fresh DB and clear operation registry per test.
 
     Args:
         tmp_path: Pytest-provided temporary directory.
@@ -30,6 +32,8 @@ async def _db(tmp_path: Path) -> AsyncIterator[None]:
     """
     await init_db(str(tmp_path / "test.db"))
     yield
+    registry = get_operation_registry()
+    await registry.shutdown()
     await close_db()
 
 
@@ -368,16 +372,49 @@ _MOCK_PR_RESULT = PullRequestResult(
 )
 
 
-class TestCreatePullRequestEndpoint:
-    """Tests for POST /api/v1/activity/{id}/pull-request."""
+def _setup_completed_operation(
+    *,
+    project_id: str = "proj-1",
+    scan_id: str = "scan-1",
+    scan_type: str = "remediate",
+    patches: list[dict[str, str]] | None = None,
+) -> None:
+    """Register a completed remediation operation in the registry.
 
-    async def test_success(self, client: AsyncClient) -> None:
-        """Successful PR creation returns URL and updates scan.
+    Args:
+        project_id: Project UUID.
+        scan_id: Scan UUID.
+        scan_type: Operation type.
+        patches: Patch diffs to include in the result.
+    """
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id=f"op-{scan_id}",
+        project_id=project_id,
+        scan_id=scan_id,
+        scan_type=scan_type,
+    )
+    registry.transition(state.operation_id, OperationStatus.SCANNING)
+    result = OperationResult(
+        total_violations=5,
+        fixable=3,
+        remediated_count=3,
+        patches=patches or [{"file": "playbooks/main.yml", "diff": "--- a\n+++ b"}],
+    )
+    registry.set_result(state.operation_id, result)
+
+
+class TestSubmitEndpoint:
+    """Tests for POST /api/v1/projects/{id}/operation/submit."""
+
+    async def test_success_with_pr(self, client: AsyncClient) -> None:
+        """Successful submit with create_pr=true returns PR URL.
 
         Args:
             client: Async test client.
         """
         await _seed_project_with_remediation(scm_token="ghp_test123")
+        _setup_completed_operation()
 
         with (
             patch("apme_gateway.scm.get_provider") as mock_get,
@@ -385,58 +422,94 @@ class TestCreatePullRequestEndpoint:
         ):
             mock_provider = AsyncMock()
             mock_provider.create_branch = AsyncMock()
-            mock_provider.push_files = AsyncMock(return_value="abc123")
+            mock_provider.push_files = AsyncMock(return_value="abc123def")
             mock_provider.create_pull_request = AsyncMock(return_value=_MOCK_PR_RESULT)
             mock_get.return_value = mock_provider
             mock_cfg.return_value.scm_token = ""
             mock_cfg.return_value.github_api_url = "https://api.github.com"
 
-            resp = await client.post("/api/v1/activity/scan-1/pull-request")
+            resp = await client.post("/api/v1/projects/proj-1/operation/submit")
 
         assert resp.status_code == 200
         data = resp.json()
         assert data["pr_url"] == "https://github.com/org/repo/pull/99"
+        assert data["commit_sha"] == "abc123def"
         assert data["provider"] == "github"
+        assert data["branch_name"].startswith("apme/remediate-")
 
-        detail = await client.get("/api/v1/activity/scan-1")
-        assert detail.json()["pr_url"] == "https://github.com/org/repo/pull/99"
-
-    async def test_activity_not_found(self, client: AsyncClient) -> None:
-        """Return 404 for nonexistent activity.
+    async def test_push_only_without_pr(self, client: AsyncClient) -> None:
+        """Submit with create_pr=false pushes but does not open a PR.
 
         Args:
             client: Async test client.
         """
-        resp = await client.post("/api/v1/activity/nonexistent/pull-request")
+        await _seed_project_with_remediation(scm_token="ghp_test123")
+        _setup_completed_operation()
+
+        with (
+            patch("apme_gateway.scm.get_provider") as mock_get,
+            patch("apme_gateway.config.load_config") as mock_cfg,
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.create_branch = AsyncMock()
+            mock_provider.push_files = AsyncMock(return_value="deadbeef")
+            mock_get.return_value = mock_provider
+            mock_cfg.return_value.scm_token = ""
+            mock_cfg.return_value.github_api_url = "https://api.github.com"
+
+            resp = await client.post(
+                "/api/v1/projects/proj-1/operation/submit",
+                json={"create_pr": False},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pr_url"] is None
+        assert data["commit_sha"] == "deadbeef"
+        mock_provider.create_pull_request.assert_not_called()
+
+    async def test_no_operation(self, client: AsyncClient) -> None:
+        """Return 404 when no operation exists for the project.
+
+        Args:
+            client: Async test client.
+        """
+        await _seed_project_with_remediation(scm_token="ghp_test")
+        resp = await client.post("/api/v1/projects/proj-1/operation/submit")
         assert resp.status_code == 404
 
-    async def test_pr_already_created(self, client: AsyncClient) -> None:
-        """Return 409 if a PR was already created.
+    async def test_operation_not_completed(self, client: AsyncClient) -> None:
+        """Return 409 when operation is not in completed state.
 
         Args:
             client: Async test client.
         """
-        await _seed_project_with_remediation(
-            scm_token="ghp_test",
-            pr_url="https://github.com/org/repo/pull/1",
+        await _seed_project_with_remediation(scm_token="ghp_test")
+        registry = get_operation_registry()
+        registry.create(
+            operation_id="op-running",
+            project_id="proj-1",
+            scan_id="scan-1",
+            scan_type="remediate",
         )
-        resp = await client.post("/api/v1/activity/scan-1/pull-request")
+        registry.transition("op-running", OperationStatus.SCANNING)
+
+        resp = await client.post("/api/v1/projects/proj-1/operation/submit")
         assert resp.status_code == 409
-        assert "already created" in resp.json()["detail"]
+        assert "not 'completed'" in resp.json()["detail"]
 
-    async def test_no_patched_files(self, client: AsyncClient) -> None:
-        """Return 404 when activity has no patched files.
+    async def test_check_operation_rejected(self, client: AsyncClient) -> None:
+        """Return 409 when operation is a check, not remediate.
 
         Args:
             client: Async test client.
         """
-        await _seed_project_with_remediation(
-            scm_token="ghp_test",
-            add_patched_files=False,
-        )
-        resp = await client.post("/api/v1/activity/scan-1/pull-request")
-        assert resp.status_code == 404
-        assert "No patched files" in resp.json()["detail"]
+        await _seed_project_with_remediation(scm_token="ghp_test")
+        _setup_completed_operation(scan_type="check")
+
+        resp = await client.post("/api/v1/projects/proj-1/operation/submit")
+        assert resp.status_code == 409
+        assert "remediate" in resp.json()["detail"]
 
     async def test_no_scm_token(self, client: AsyncClient) -> None:
         """Return 422 when no SCM token is configured.
@@ -445,12 +518,13 @@ class TestCreatePullRequestEndpoint:
             client: Async test client.
         """
         await _seed_project_with_remediation()
+        _setup_completed_operation()
 
         with patch("apme_gateway.config.load_config") as mock_cfg:
             mock_cfg.return_value.scm_token = ""
             mock_cfg.return_value.github_api_url = "https://api.github.com"
 
-            resp = await client.post("/api/v1/activity/scan-1/pull-request")
+            resp = await client.post("/api/v1/projects/proj-1/operation/submit")
 
         assert resp.status_code == 422
         assert "No SCM token" in resp.json()["detail"]
@@ -462,6 +536,7 @@ class TestCreatePullRequestEndpoint:
             client: Async test client.
         """
         await _seed_project_with_remediation()
+        _setup_completed_operation()
 
         with (
             patch("apme_gateway.scm.get_provider") as mock_get,
@@ -475,7 +550,7 @@ class TestCreatePullRequestEndpoint:
             mock_cfg.return_value.scm_token = "ghp_global_token"
             mock_cfg.return_value.github_api_url = "https://api.github.com"
 
-            resp = await client.post("/api/v1/activity/scan-1/pull-request")
+            resp = await client.post("/api/v1/projects/proj-1/operation/submit")
 
         assert resp.status_code == 200
 
@@ -486,6 +561,7 @@ class TestCreatePullRequestEndpoint:
             client: Async test client.
         """
         await _seed_project_with_remediation(scm_token="ghp_test")
+        _setup_completed_operation()
 
         with (
             patch("apme_gateway.scm.get_provider") as mock_get,
@@ -506,7 +582,7 @@ class TestCreatePullRequestEndpoint:
             mock_cfg.return_value.github_api_url = "https://api.github.com"
 
             resp = await client.post(
-                "/api/v1/activity/scan-1/pull-request",
+                "/api/v1/projects/proj-1/operation/submit",
                 json={
                     "branch_name": "custom/branch",
                     "title": "Custom title",
@@ -525,6 +601,7 @@ class TestCreatePullRequestEndpoint:
             client: Async test client.
         """
         await _seed_project_with_remediation(scm_token="ghp_test")
+        _setup_completed_operation()
 
         with (
             patch("apme_gateway.scm.get_provider") as mock_get,
@@ -536,10 +613,106 @@ class TestCreatePullRequestEndpoint:
             mock_cfg.return_value.scm_token = ""
             mock_cfg.return_value.github_api_url = "https://api.github.com"
 
-            resp = await client.post("/api/v1/activity/scan-1/pull-request")
+            resp = await client.post("/api/v1/projects/proj-1/operation/submit")
 
         assert resp.status_code == 502
         assert "SCM provider error" in resp.json()["detail"]
+
+    async def test_activity_id_from_db(self, client: AsyncClient) -> None:
+        """Submit with activity_id loads patched files from DB.
+
+        Args:
+            client: Async test client.
+        """
+        await _seed_project_with_remediation(scm_token="ghp_test123")
+
+        with (
+            patch("apme_gateway.scm.get_provider") as mock_get,
+            patch("apme_gateway.config.load_config") as mock_cfg,
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.create_branch = AsyncMock()
+            mock_provider.push_files = AsyncMock(return_value="db_commit_sha")
+            mock_provider.create_pull_request = AsyncMock(return_value=_MOCK_PR_RESULT)
+            mock_get.return_value = mock_provider
+            mock_cfg.return_value.scm_token = ""
+            mock_cfg.return_value.github_api_url = "https://api.github.com"
+
+            resp = await client.post(
+                "/api/v1/projects/proj-1/operation/submit",
+                json={"activity_id": "scan-1"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pr_url"] == "https://github.com/org/repo/pull/99"
+        assert data["commit_sha"] == "db_commit_sha"
+
+    async def test_activity_id_wrong_project(self, client: AsyncClient) -> None:
+        """Reject activity_id that does not belong to the project.
+
+        Args:
+            client: Async test client.
+        """
+        await _seed_project_with_remediation(scm_token="ghp_test")
+
+        with patch("apme_gateway.config.load_config") as mock_cfg:
+            mock_cfg.return_value.scm_token = ""
+            mock_cfg.return_value.github_api_url = "https://api.github.com"
+
+            resp = await client.post(
+                "/api/v1/projects/wrong-project/operation/submit",
+                json={"activity_id": "scan-1"},
+            )
+
+        assert resp.status_code == 404
+        assert "does not belong" in resp.json()["detail"]
+
+    async def test_activity_id_no_patched_files(self, client: AsyncClient) -> None:
+        """Reject activity_id when no patched files exist in DB.
+
+        Args:
+            client: Async test client.
+        """
+        await _seed_project_with_remediation(
+            scm_token="ghp_test",
+            add_patched_files=False,
+        )
+
+        with patch("apme_gateway.config.load_config") as mock_cfg:
+            mock_cfg.return_value.scm_token = ""
+            mock_cfg.return_value.github_api_url = "https://api.github.com"
+
+            resp = await client.post(
+                "/api/v1/projects/proj-1/operation/submit",
+                json={"activity_id": "scan-1"},
+            )
+
+        assert resp.status_code == 404
+        assert "No patched files" in resp.json()["detail"]
+
+    async def test_activity_id_pr_already_exists(self, client: AsyncClient) -> None:
+        """Reject when activity already has a PR URL.
+
+        Args:
+            client: Async test client.
+        """
+        await _seed_project_with_remediation(
+            scm_token="ghp_test",
+            pr_url="https://github.com/org/repo/pull/1",
+        )
+
+        with patch("apme_gateway.config.load_config") as mock_cfg:
+            mock_cfg.return_value.scm_token = ""
+            mock_cfg.return_value.github_api_url = "https://api.github.com"
+
+            resp = await client.post(
+                "/api/v1/projects/proj-1/operation/submit",
+                json={"activity_id": "scan-1"},
+            )
+
+        assert resp.status_code == 409
+        assert "already created" in resp.json()["detail"]
 
 
 class TestProjectScmApi:


### PR DESCRIPTION
## Summary
- Consolidate two separate PR-creation endpoints into a single unified
  `POST /projects/{project_id}/operation/submit` endpoint per ADR-050
- Support both live operation submission and historical activity submission
  (via optional `activity_id`), enabling PR creation from scheduled scans

## Changes
- **New endpoint**: `POST /api/v1/projects/{project_id}/operation/submit`
  with `SubmitRequest`/`SubmitResponse` schemas supporting `create_pr`,
  `branch_name`, `title`, `body`, `scm_token`, and `activity_id` fields
- **Removed endpoints**:
  - `POST /api/v1/activity/{activity_id}/pull-request`
  - `POST /api/v1/projects/{project_id}/operation/create-pr`
- **Frontend**: Updated `useProjectOperationActions` hook and `api.ts` to
  use the new endpoint; restored "Create PR" button on Activity Detail page
  using `submitActivity()` with `activity_id`
- **Validation**: activity_id path now enforces `scan_type == "remediate"`,
  matching the live-operation path
- **Status semantics**: push-only (create_pr=false) transitions to COMPLETED
  instead of PR_SUBMITTED, since no PR was created
- **Tests**: `TestSubmitEndpoint` with 14 tests covering live operation,
  push-only, custom branch/title, token fallback, error handling, activity_id
  (from DB, wrong project, no patches, PR exists, check scan rejected);
  frontend test for `submitActivity`

## Quality of life
- ADR-050 updated to Accepted status with unified API specification
- ADR-050 error-code summary aligned with implementation
- ADR index (`README.md`) updated to reflect accepted status

## Test plan
- [x] `tox -e lint` passes (pre-existing `skillmark` warnings only)
- [x] `tox -e unit` — all 37 gateway tests pass
- [x] ADR-050 updated and accepted