### PR TITLE
chore: add self-review, cold subagent review, and automated reviewer learning loop to PR skills

### DIFF
--- a/.agents/skills/pr-address-feedback/SKILL.md
+++ b/.agents/skills/pr-address-feedback/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: pr-address-feedback
 description: >
-  Guide for handling pull request reviews, including automated (Copilot) and
-  human reviewer feedback. Use when responding to PR comments, resolving
-  review threads, or updating PRs after review.
+  Guide for handling pull request reviews, including automated (Copilot,
+  CodeRabbit) and human reviewer feedback. Use when responding to PR comments,
+  resolving review threads, or updating PRs after review.
 argument-hint: "<PR number>"
 user-invocable: true
 metadata:
   author: APME Team
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # PR Address Feedback
@@ -77,9 +77,126 @@ EOF
 )"
 ```
 
-## Copilot review patterns
+## Automated reviews as agent learning opportunities
 
-Copilot automated reviews surface recurring categories. Address these
+Every automated reviewer comment (Copilot, CodeRabbit) on an agent-authored
+PR is a defect in our own review process. These tools apply the same
+principles every time — if one found something, the agent's pre-submit
+self-review (see the `pr-new` skill, Step 3) should have found it first.
+Without tightening that loop, we will never ship a PR without comments.
+
+After fixing each automated finding, ask: _which principle from the
+pr-new self-review should have caught this?_ If one exists but
+didn't trigger, the principle needs to be clearer or the agent didn't
+apply it. If no principle covers it, add one — but frame it as a
+general evaluation criterion, not a specific instance. Adding "don't
+do X" only prevents X; strengthening a principle prevents the entire
+class of issues X belongs to.
+
+## How automated reviewers evaluate code
+
+Automated reviewers (Copilot, CodeRabbit) succeed because they apply a
+small number of universal evaluation criteria to every line of the diff.
+Understanding these criteria lets the agent anticipate findings rather
+than react to them.
+
+**Semantic truthfulness.** Every declaration is read as a contract.
+The reviewer checks whether types, return values, error codes, version
+ranges, log levels, comments, and docstrings accurately describe what
+the code actually does. Any gap — a comment that says "all" when the
+code means "some", a return type that promises `T` but can produce
+`None`, a docstring that lists parameters the function no longer
+accepts — gets flagged.
+
+**Information exposure.** The reviewer asks "should this data be visible
+here?" for every piece of information that escapes internal scope:
+logged data, error messages, API responses, documentation examples.
+User content in info-level logs, credentials on CLI examples, internal
+paths in error messages — all get flagged because the reviewer assumes
+the minimum-exposure principle.
+
+**Caller safety.** The reviewer reads every public interface from the
+caller's perspective and asks "could this surprise me?" Nullable
+returns not reflected in the type, missing null guards on
+platform-provided arguments, unsafe casts, optional fields typed as
+required, hidden side effects (logging, I/O, global state) that the
+name or signature doesn't advertise — all get flagged because the
+reviewer assumes callers trust the type signature and expect no
+undisclosed behavior.
+
+**Drift between prose and code.** Any time a comment, docstring, ADR,
+README, or inline annotation co-exists with the code it describes,
+the reviewer checks whether the prose is still true after the diff.
+Renamed functions with old docstrings, changed triggers with old
+workflow descriptions, removed features with lingering references —
+all flagged.
+
+**Supply-chain mutability.** References to external resources (action
+tags, dependency versions, base images) that can change without
+review get flagged. The reviewer assumes that anything not pinned to
+a specific immutable identifier is a vector for silent behavior change.
+
+**Internal consistency.** Every module's exports, code paths, and
+naming conventions are checked against each other. If nine code paths
+use a registry lookup but the tenth hardcodes a value, or if one
+export capitalizes differently from its siblings, the reviewer flags
+the deviation because inconsistency signals copy-paste drift or an
+unfinished refactor.
+
+**Adversarial input tracing.** The reviewer constructs edge-case
+scenarios for public functions: what happens with an empty-but-not-falsy
+value, a field combination after partial deletion, a response that
+satisfies the gRPC status check but lacks expected fields? If the traced
+path fails silently, sends a vacuous request, or produces a return value
+that violates the declared type, the reviewer flags it.
+
+**Inherited contract completeness.** When the diff extends a class or
+implements a Protocol, the reviewer checks that the subclass honors the
+full runtime contract — not just the compiler-required members but
+expected behaviors. A validator that writes files (violating ADR-009),
+a gRPC servicer using synchronous calls (violating ADR-007), a
+transform that modifies state without calling `submit()` — all get
+flagged because mypy enforces structure but runtime contracts include
+semantics the type checker cannot verify.
+
+**Dead weight.** Unused imports, unreachable branches, written-but-never-
+read variables, parameters accepted but ignored — anything the code
+pays for but doesn't use. The reviewer assumes dead code obscures intent
+and may mask bugs.
+
+### APME-specific patterns
+
+These are known project-specific applications of the principles above.
+They serve as a quick reference, not an exhaustive list — the principles
+above should catch novel issues these don't cover.
+
+- **Validator read-only invariant**: validators must never modify files
+  (ADR-009). If a validator writes, creates, or deletes any file, flag it.
+- **Proto-servicer parity**: every RPC in `primary.proto` /
+  `validate.proto` must have a matching servicer method in
+  `daemon/`. Missing handlers mean gRPC returns UNIMPLEMENTED at runtime.
+- **Rule ID conventions**: L/M/R/P/SEC per ADR-008, EXT- for plugins
+  (ADR-042). Misformatted rule IDs break filtering and reporting.
+- **Executor discipline**: blocking work (engine scan, subprocess calls,
+  venv builds) must use `run_in_executor()`, never block the event loop
+  (ADR-007). Look for synchronous `subprocess.run()` or file I/O in
+  async server methods.
+- **Dependency direction**: engine never imports from gateway
+  (ADR-020, ADR-029). If `apme_engine` imports `apme_gateway`, flag it.
+- **Session venv ownership**: only Primary writes to `/sessions`
+  (ADR-022). Other services mount it read-only.
+- **tox-only invocation**: never invoke `ruff`, `mypy`, `pytest`, or
+  `prek` directly in docs, scripts, or CI (ADR-047). Always use
+  `tox -e <env>`.
+- **GitHub Actions pinning**: pin to commit SHAs with a tag comment
+  (`actions/checkout@SHA # v4`), not mutable tags.
+- **OPA is subprocess, not REST**: the OPA validator invokes `opa eval`
+  via subprocess — do not introduce httpx or HTTP client dependencies
+  for OPA (verified in code, documented in AGENTS.md invariant 9).
+
+## Automated review patterns
+
+Copilot and CodeRabbit surface recurring categories. Address these
 proactively before pushing to avoid review round-trips:
 
 ### Supply-chain security
@@ -214,16 +331,23 @@ gh api graphql -f query='{
 
 * **Verify Intentional State:** Unresolved threads should only be ones you intentionally left open (disputed). Verify that any thread still showing `isResolved: false` was left open on purpose. Do NOT blindly resolve all threads just to clear the list.
 
-### After pushing fixes: check for a new Copilot review
+### After pushing fixes: check for new automated reviews
 
-Copilot may run again on new commits. Re-check whether it left a new review or
-line comments so you can reply and resolve any new threads.
+Copilot and CodeRabbit may run again on new commits. Re-check whether
+they left new reviews or line comments so you can reply and resolve any
+new threads.
 
 ```bash
 # New Copilot review (replace N with PR number, ISO8601 with last push time)
 gh api repos/ansible/apme/pulls/N/reviews --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .submitted_at > "ISO8601") | {submitted_at, state, body: .body[0:200]}'
 
-# New Copilot inline comments (line comments not attached to a review)
+# New Copilot inline comments
 gh api repos/ansible/apme/pulls/N/comments --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]" and .created_at > "ISO8601") | {created_at, path, body: .body[0:200]}'
+
+# New CodeRabbit review
+gh api repos/ansible/apme/pulls/N/reviews --jq '.[] | select(.user.login == "coderabbitai[bot]" and .submitted_at > "ISO8601") | {submitted_at, state, body: .body[0:200]}'
+
+# New CodeRabbit inline comments
+gh api repos/ansible/apme/pulls/N/comments --jq '.[] | select(.user.login == "coderabbitai[bot]" and .created_at > "ISO8601") | {created_at, path, body: .body[0:200]}'
 ```
 

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[branch-name] [--title 'PR title']"
 user-invocable: true
 metadata:
   author: APME Team
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # PR New
@@ -43,7 +43,183 @@ If the branch has pre-existing violations (e.g., from an old base), rebase onto 
 Do **not** run `ruff`, `mypy`, `prek`, or `pytest` directly — always use tox (ADR-047).
 See the `/tox` skill for the full environment reference.
 
-### Step 3: Update documentation
+### Step 3: Self-review the diff
+
+**This step is mandatory.** Do not skip it. Do not combine it with
+Step 2. After quality gates pass, review the **full PR diff** — all commits
+since the branch diverged from the base branch, not just the last
+commit or unstaged changes:
+
+```bash
+git diff upstream/main...HEAD
+```
+
+Read every changed line against these questions. For each question,
+name at least one specific file and line you verified. If you cannot,
+you haven't actually reviewed the diff.
+
+**Artifact-type sweep.** Before answering the questions below, list
+every distinct artifact type in the diff (e.g., Python, proto, Rego,
+Ansible YAML, shell script, Dockerfile, JSON config, Markdown). For
+each question, you must cite at least one file of _each_ artifact
+type — not just Python. If a question feels inapplicable to an
+artifact type, translate it:
+
+- "caller" in proto means any service or CLI that invokes an RPC
+  (e.g., Primary calling `Validator.Validate`, CLI calling
+  `FixSession`)
+- "type signature" in Rego means a rule's expected input/output
+  shape (e.g., `input.hierarchy` must contain certain keys)
+- "manifest parity" means every gRPC service in `proto/*.proto` has
+  a matching servicer in `daemon/` and every RPC method has a handler
+- "constructed scenario" for async servers means: what happens when
+  `run_in_executor()` blocks longer than expected, when a validator
+  never responds, or when `asyncio.gather()` returns a mix of results
+  and exceptions?
+- "dependencies pinned to intent" for Dockerfiles means: does the
+  base image tag, `pip install` version spec, or `COPY` path express
+  exactly what you mean?
+
+1. **Does every statement mean what it says?** Check every type
+   annotation, return value, error code, version range, log level,
+   comment, and docstring. If the code declares it, the runtime must
+   honor it on every path.
+
+2. **Does this expose more than it should?** Check every log call,
+   error message, and user-facing string. Does it contain user content,
+   credentials, or internal state? Could a caller or log reader learn
+   something they shouldn't? Also check every capability grant:
+   permission scopes, CORS origins, container capabilities. Does each
+   grant the minimum necessary?
+
+3. **Would a caller be surprised?** Read every public function from
+   the caller's perspective. Can it return a value the type doesn't
+   cover? Does it mutate an argument the caller owns? Does it throw
+   where the signature implies it won't? Does it have side effects
+   (logging, I/O, global state) that its name or signature doesn't
+   advertise? Does it behave differently from sibling functions in
+   the same module?
+
+4. **Is everything still true after this change?** Diff comments and
+   docstrings against the code they describe. Did you rename something
+   but leave the old name in prose? Did you change behavior but leave
+   an old description? Check ADRs, `CLAUDE.md`, `AGENTS.md`, and
+   `docs/` for stale references.
+
+5. **Are dependencies and versions pinned to intent?** Check every
+   version range, action tag, and base image. Does each one express
+   what you actually mean — not tighter, not looser?
+
+6. **Is there dead weight?** Check for unused imports, unreachable
+   branches, written-but-never-read variables, parameters accepted
+   but ignored.
+
+7. **Is this internally and externally consistent?** Within each
+   module: do all code paths use the same patterns (e.g., registry
+   lookups vs hardcoded values)? Are exports named consistently?
+   Across the repo: do proto RPCs have matching servicer methods in
+   `daemon/`? Do rule IDs follow ADR-008 conventions (L/M/R/P/SEC)?
+   Does `_DEFAULT_PORTS` match the services actually started? Are
+   `event_emitter` calls consistent with the reporting sink protocol?
+   Cross-artifact mismatches (proto declaration vs Python
+   implementation) are the easiest to miss and the most embarrassing
+   to ship.
+
+8. **Would a constructed scenario break this?** For each public
+   function, construct one realistic failure case: an edge-case
+   input, a specific field combination after deletion/filtering,
+   an empty-but-not-falsy value. Trace it through the code path.
+   If it fails silently, sends a vacuous request, or produces a
+   return value that violates the declared type, that's a finding.
+   Also construct _temporal_ failures: what happens when an async
+   dependency never responds, times out, or responds after the
+   consumer has moved on? What happens when `asyncio.gather()`
+   returns a mix of results and exceptions — does every caller
+   handle `return_exceptions=True` correctly?
+
+9. **Do inherited contracts hold?** When implementing a Protocol
+   or extending a base class, check that the subclass honors the
+   full runtime contract — not just the compiler-required members,
+   but expected behaviors (validators must be read-only per ADR-009,
+   gRPC servicers must use `grpc.aio` per ADR-007, transforms must
+   call `submit()` for changes to take effect per ADR-044).
+
+Only proceed to Step 3b after completing this review.
+
+### Step 3b: Cold subagent review
+
+**This step is mandatory.** The self-review in Step 3 is necessary but
+insufficient — it suffers from confirmation bias because the reviewing
+agent wrote the code. Spin up a **read-only subagent** with no
+conversation history to review the diff cold.
+
+The subagent sees only the diff and the review questions. It has no
+memory of the intent, iterations, or trade-offs that led to the code.
+This forces it to read every line at face value — the same way Copilot
+or a human reviewer would.
+
+```text
+Launch a Task subagent with:
+  subagent_type: "generalPurpose"
+  readonly: true
+  run_in_background: false
+```
+
+Use this prompt template (fill in the repository path and diff):
+
+```text
+You are reviewing a pull request diff. You have no prior context about
+why these changes were made — review every line at face value.
+
+Repository: <absolute path to repo>
+Base branch: upstream/main
+
+Run `git diff upstream/main...HEAD` to get the full diff, then read
+every changed file in full (not just the diff hunks — you need
+surrounding context to evaluate contracts and consistency).
+
+Evaluate the diff against these 9 questions. For each question, either
+report a concrete finding (file, line, what's wrong, why it matters)
+or state "No findings." Do not pad with observations that aren't
+actionable.
+
+1. Does every statement mean what it says? (types, return values,
+   comments, docstrings — does the runtime honor them on every path?)
+2. Does this expose more than it should? (logs, errors, user strings,
+   capability grants, container permissions)
+3. Would a caller be surprised? (nullable returns, hidden side effects,
+   undisclosed I/O, inconsistency with sibling functions)
+4. Is everything still true after this change? (prose vs code drift —
+   renamed symbols with old docstrings, changed behavior with old
+   descriptions, stale ADR/doc references)
+5. Are dependencies and versions pinned to intent?
+6. Is there dead weight? (unused imports, unreachable branches,
+   written-but-never-read variables)
+7. Is this internally and externally consistent? (patterns, naming,
+   cross-artifact parity — e.g., proto RPCs must have matching
+   servicer methods in daemon/, rule IDs must follow ADR-008)
+8. Would a constructed scenario break this? (edge-case inputs,
+   empty-but-not-falsy values, temporal failures — async dependency
+   never responds, asyncio.gather with return_exceptions=True
+   returning a mix of results and exceptions)
+9. Do inherited contracts hold? (Protocol/base class implementations
+   honor runtime semantics — validators are read-only per ADR-009,
+   gRPC servicers use grpc.aio per ADR-007)
+
+Return ONLY findings. Format each as:
+  **[Q#] file:line — description**
+
+If there are no findings across all 9 questions, return:
+  "No findings."
+```
+
+**Act on every finding.** Fix the code, then re-run `tox -e lint` and
+`tox -e unit`. Do not dismiss findings without a clear technical
+justification documented in the self-review output.
+
+If the subagent returns "No findings", proceed to Step 4.
+
+### Step 4: Update documentation
 
 Check whether your changes affect areas covered by existing docs. Update any that apply:
 
@@ -63,7 +239,7 @@ If a new rule was added, regenerate the catalog:
 python tools/generate_rule_catalog.py
 ```
 
-### Step 4: Update SDLC artifacts (if applicable)
+### Step 5: Update SDLC artifacts (if applicable)
 
 If the change involves an architectural decision (new service, new protocol, new deployment strategy, new tooling adoption), create an ADR in `.sdlc/adrs/` using the `adr-new` skill. The file should follow the naming convention `ADR-NNN-slug.md`.
 
@@ -73,7 +249,7 @@ If requirements or tasks were affected, update them using the `req-new` or `task
 
 The agent should invoke these skills proactively when context warrants it, informing the user of any artifacts created. All artifacts are reviewed in the PR diff.
 
-### Step 5: Commit with conventional commits
+### Step 6: Commit with conventional commits
 
 Use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format:
 
@@ -107,7 +283,7 @@ Examples:
 - `build: add ruff linter and prek pre-commit hooks`
 - `docs: add prek section to DEVELOPMENT.md`
 
-### Step 6: Check branch/artifact alignment
+### Step 7: Check branch/artifact alignment
 
 Before pushing, verify the branch name matches the artifact IDs being committed:
 
@@ -132,7 +308,7 @@ If option 1 selected, use `/branch-align` to rename before pushing.
 
 **Why this matters:** Reviewers and future contributors use branch names to find related work. A branch named `req-005` that contains `REQ-011` creates confusion.
 
-### Step 7: Push and create the pull request
+### Step 8: Push and create the pull request
 
 ```bash
 git push -u origin HEAD
@@ -191,6 +367,7 @@ The Summary, Changes, and Test plan sections must stay current with all commits 
 
 ### Responding to review feedback
 
-After pushing the PR, reviewers (human or Copilot) may leave comments. Follow
-the **`pr-address-feedback`** skill for the full procedure: checking CI status,
-replying to comments, resolving threads, and re-checking for new Copilot reviews.
+After pushing the PR, reviewers (human, Copilot, or CodeRabbit) may leave
+comments. Follow the **`pr-address-feedback`** skill for the full procedure:
+checking CI status, replying to comments, resolving threads, and re-checking
+for new automated reviews.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,8 +372,8 @@ anything else**. If a matching skill exists, read it and follow its instructions
 | `/lean-ci` | CI workflow helpers |
 | `/phase-new` | Create project phase |
 | `/pr-contributor-review` | Review external contributor PRs |
-| `/pr-new` | Create and submit pull requests |
-| `/pr-address-feedback` | Handle PR review feedback |
+| `/pr-new` | Create and submit pull requests (includes self-review + cold subagent review) |
+| `/pr-address-feedback` | Handle PR review feedback (includes automated reviewer learning loop) |
 | `/prd-import` | Import product requirements |
 | `/req-new` | Create requirement spec |
 | `/rfe-capture` | Capture request for enhancement |


### PR DESCRIPTION
## Summary
- Ports the self-review checklist, cold subagent review, and automated reviewer
  learning loop from vscode-ansible-1 into APME's `pr-new` and `pr-address-feedback`
  skills, adapted for APME's Python/gRPC/Ansible domain.

## Changes
- **pr-new**: Added mandatory Step 3 (self-review with 9 structured evaluation
  questions and artifact-type sweep) and Step 3b (cold subagent review to counter
  confirmation bias). Renumbered Steps 3-7 to 4-8. Bumped version to 1.1.0.
- **pr-address-feedback**: Added "Automated reviews as agent learning opportunities"
  section, "How automated reviewers evaluate code" with 9 universal criteria,
  "APME-specific patterns" subsection (9 project-specific checks with ADR refs),
  and CodeRabbit bot detection alongside Copilot. Bumped version to 1.2.0.
- **AGENTS.md**: Updated `/pr-new` and `/pr-address-feedback` skill table entries.

## Quality of life
- Generalized all reviewer references from Copilot-only to support both Copilot
  and CodeRabbit automated reviewers.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (2661 passed, 0 failed)
- [x] Self-review completed (Step 3)
- [x] Cold subagent review completed (Step 3b) — 3 findings triaged:
  1 fixed (version bump), 1 out of scope (pre-existing), 1 N/A (no drift)

closes: #361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the PR workflow with a required self-review step and a second-pass review before creating a pull request.
  * Added clearer guidance for handling automated review feedback from multiple review tools.
* **Documentation**
  * Updated skill and command references with newer versions and clearer descriptions.
  * Broadened review guidance to cover more quality checks, consistency checks, and repository-specific rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->