### PR TITLE
docs(adrs): add ADR-060 REST API versioning contract, accept ADR-041 and ADR-045

### DIFF
--- a/.sdlc/adrs/ADR-038-public-data-api.md
+++ b/.sdlc/adrs/ADR-038-public-data-api.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -255,3 +255,4 @@ The CLI `--json` output currently drops the violation `metadata` map (rule-speci
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-03-25 | Brad Thornton | Initial proposal from PR #102/#107 review discussion |
+| 2026-07-08 | Brad Thornton | Accepted — pull API, project lookup, and dashboard endpoints implemented; webhooks and token auth remain |

--- a/.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md
+++ b/.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Implemented
 
 ## Date
 

--- a/.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md
+++ b/.sdlc/adrs/ADR-041-rule-catalog-override-architecture.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -266,3 +266,4 @@ Deploying a plugin to one pod means deploying it to all pods. Removing a plugin 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-03-25 | Brad (cidrblock) | Initial proposal |
+| 2026-07-08 | Brad Thornton | Accepted — core decision fully implemented |

--- a/.sdlc/adrs/ADR-045-galaxy-auth-delegation.md
+++ b/.sdlc/adrs/ADR-045-galaxy-auth-delegation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Implemented
 
 ## Date
 

--- a/.sdlc/adrs/ADR-045-galaxy-auth-delegation.md
+++ b/.sdlc/adrs/ADR-045-galaxy-auth-delegation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -271,3 +271,4 @@ These changes are valuable regardless of the auth delegation decision:
 | 2026-03-28 | AI-assisted | Restructured to match ADR template (Copilot review) |
 | 2026-03-28 | Human review | Galaxy server defs are global, not per-project (cache coherence) |
 | 2026-03-28 | Human review | Implementation split into 3 PRs: proxy, CLI+proto, UI |
+| 2026-07-08 | Brad Thornton | Accepted — core decision fully implemented |

--- a/.sdlc/adrs/ADR-052-project-operation-sse-architecture.md
+++ b/.sdlc/adrs/ADR-052-project-operation-sse-architecture.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -145,3 +145,12 @@ the implementation simple and avoids schema changes for transient state.
 - ADR-037 — Gateway project model
 - ADR-039 — FixSession as unified client path
 - ADR-050 — post-remediation PR creation
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-04-14 | APME Team | Initial proposal |
+| 2026-07-08 | Brad Thornton | Accepted — operation registry, SSE router, state machine, and frontend hooks implemented; legacy WebSocket removal remains |

--- a/.sdlc/adrs/ADR-055-violation-fingerprint-suppression.md
+++ b/.sdlc/adrs/ADR-055-violation-fingerprint-suppression.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -287,3 +287,4 @@ Suppressed violations are always available for audit. The default display hides 
 |------|--------|--------|
 | 2026-05-21 | Brad (cidrblock) | Initial proposal |
 | 2026-05-21 | David (djdanielsson) | Address review: YAML-aware normalization for block scalars, rule_id canonicalization, explicit delimiter in all modes |
+| 2026-07-08 | Brad Thornton | Accepted — CLI suppress, fingerprint lib, Gateway CRUD, and UI implemented; rule_module mode and export/import remain |

--- a/.sdlc/adrs/ADR-056-apme-owns-scm-commit-push.md
+++ b/.sdlc/adrs/ADR-056-apme-owns-scm-commit-push.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -305,3 +305,4 @@ After acceptance, this ADR introduces a new architectural invariant for
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-07-06 | B. Thornton | Initial proposal |
+| 2026-07-08 | Brad Thornton | Accepted — Gateway SCM submit, GitHub provider, and diff-only responses implemented; explicit commit author and bundle export remain |

--- a/.sdlc/adrs/ADR-060-rest-api-versioning-contract.md
+++ b/.sdlc/adrs/ADR-060-rest-api-versioning-contract.md
@@ -1,0 +1,195 @@
+# ADR-060: REST API Versioning Contract
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-08
+
+## Context
+
+The Gateway REST API (`/api/v1`) was originally designed as a
+backend-for-frontend (BFF) for the APME dashboard UI. ADR-038 formalized
+it as the public data-sharing interface for platform consumers, with a
+one-line stability clause: "Breaking changes require a new version prefix
+(`/api/v2`). Additive changes are allowed under `/api/v1`."
+
+That clause is insufficient now. A Backstage plugin team is actively
+building against the API, making it a real external contract with a
+separate development lifecycle. Without an enforced invariant:
+
+- An agent refactoring Gateway routes could rename a field or change a
+  response shape without realizing it breaks the Backstage plugin.
+- A well-intentioned "cleanup" could remove a deprecated field that an
+  external consumer still relies on.
+- Response envelope changes (pagination, error format) could silently
+  break client parsing.
+
+The API is no longer an internal detail — it is a public interface with
+external consumers who cannot coordinate releases with us.
+
+### What constitutes a breaking change
+
+- Removing or renaming a field from a response body
+- Changing a field's type (e.g. string → integer, object → array)
+- Changing the semantic meaning of a field
+- Removing an endpoint
+- Changing an endpoint's URL path
+- Making a previously optional request parameter required
+- Changing response status codes for existing success/error cases
+- Changing the pagination or envelope structure
+- Removing or renaming a query parameter
+
+### What is NOT a breaking change
+
+- Adding a new endpoint
+- Adding a new optional field to a response body
+- Adding a new optional query parameter
+- Adding a new enum value to a field (when clients are expected to
+  tolerate unknown values)
+- Adding a new error code for a previously-unhandled case
+
+## Decision
+
+**We will treat the Gateway REST API under `/api/v1` as a versioned
+public contract. Breaking changes to existing endpoints require a new
+version prefix (`/api/v2`). This is an architectural invariant.**
+
+Specifically:
+
+1. **No breaking changes under `/api/v1`.** Any change that would alter
+   the behavior, shape, or availability of an existing endpoint for
+   existing callers requires a version bump to `/api/v2`.
+
+2. **Additive changes are permitted.** New endpoints, new optional
+   response fields, and new optional query parameters may be added under
+   `/api/v1` without a version bump.
+
+3. **Version bumps require an ADR.** Moving to `/api/v2` is an
+   architectural decision that must be documented with migration
+   guidance for existing consumers.
+
+4. **Deprecation before removal using RFC 9745 and RFC 8594.** If a
+   field or endpoint will be removed in a future version, the Gateway
+   must signal deprecation using standard HTTP headers:
+   - [`Deprecation`](https://www.rfc-editor.org/rfc/rfc9745.html)
+     (RFC 9745): set to `true` or an ISO 8601 date indicating when the
+     endpoint was deprecated.
+   - [`Sunset`](https://www.rfc-editor.org/rfc/rfc8594.html)
+     (RFC 8594): set to an HTTP-date indicating when the endpoint will
+     be removed.
+   - A `Link` header with `rel="sunset"` pointing to migration
+     documentation.
+
+   These headers must be present for at least one release cycle before
+   the endpoint is removed in the next major version. Implementation
+   is via FastAPI middleware on the Gateway.
+
+5. **This rule applies to agents.** AI agents must not modify existing
+   endpoint response schemas, URL paths, or query parameter semantics
+   without explicit human approval and an accompanying version bump ADR.
+
+## Alternatives Considered
+
+### Alternative 1: Rely on ADR-038 stability clause
+
+**Description**: Keep the existing one-line clause in ADR-038 without
+elevating it to an invariant.
+
+**Pros**:
+- No additional documentation
+- Already stated
+
+**Cons**:
+- Not enforced — agents don't read ADR-038 before modifying routes
+- Not an invariant in AGENTS.md, so it has no teeth
+- Buried in a "Proposed" ADR alongside unrelated topics (webhooks, auth)
+
+**Why not chosen**: A contract with external consumers needs a stronger
+commitment than a single sentence in a proposed ADR.
+
+### Alternative 2: Full OpenAPI schema validation in CI
+
+**Description**: Generate an OpenAPI schema from FastAPI and diff it
+against a checked-in baseline in CI. Any breaking diff fails the build.
+
+**Pros**:
+- Fully automated enforcement
+- Catches accidental breaks before merge
+
+**Cons**:
+- Significant implementation effort
+- OpenAPI diffing tools have false positives
+- Premature while the API is still maturing
+
+**Why not chosen**: Worth pursuing as a follow-up, but the invariant
+provides immediate protection. Automated enforcement can be added
+incrementally.
+
+## Consequences
+
+### Positive
+
+- External consumers (Backstage plugin, CI/CD integrations) can depend
+  on the API without fear of silent breakage
+- Forces intentional API evolution — version bumps are deliberate
+  decisions, not accidents
+- AI agents are explicitly constrained from casual route refactoring
+
+### Negative
+
+- Limits agility for internal UI changes that share the same routes —
+  if the UI needs a different response shape, it must either use a new
+  endpoint or negotiate a version bump
+- Accumulated deprecated fields may create API cruft over time
+
+### Neutral
+
+- The CLI is unaffected — it communicates via gRPC to Primary, not REST
+- Internal gRPC interfaces between engine services are not covered by
+  this ADR (they have no external consumers)
+
+## Implementation Notes
+
+- Add as architectural invariant 17 in `AGENTS.md`
+- **RFC 9745/8594 middleware**: implement as FastAPI middleware that
+  reads a deprecation registry (endpoint → deprecation date, sunset
+  date, migration link) and injects `Deprecation`, `Sunset`, and
+  `Link` headers into responses for registered endpoints
+- Future work: OpenAPI schema diffing in CI for automated enforcement
+- The Backstage plugin team should be given a link to the existing
+  endpoint documentation and this ADR as the stability guarantee
+
+## Related Decisions
+
+- [ADR-029](ADR-029-web-gateway-architecture.md): Web Gateway
+  architecture (defines the Gateway and its REST surface)
+- [ADR-038](ADR-038-public-data-api.md): Public Data API for Platform
+  Consumers (formalizes the API as public, contains the original
+  stability clause this ADR elevates)
+- [ADR-001](ADR-001-grpc-communication.md): gRPC for inter-service
+  communication (internal interfaces, not covered by this ADR)
+
+## References
+
+- [RFC 9745](https://www.rfc-editor.org/rfc/rfc9745.html) — The
+  Deprecation HTTP Header Field
+- [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594.html) — The Sunset
+  HTTP Header Field
+- [PR #351](https://github.com/ansible/apme/pull/351) — Productization
+  plan pre-read (independently identified RFC 9745/8594 as the
+  deprecation mechanism)
+- [PR #378](https://github.com/ansible/apme/pull/378) — Discussion
+  that prompted this ADR
+- Backstage plugin team (external consumer actively building against
+  `/api/v1`)
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-07-08 | Brad Thornton | Initial proposal, accepted |

--- a/.sdlc/adrs/ADR-060-rest-api-versioning-contract.md
+++ b/.sdlc/adrs/ADR-060-rest-api-versioning-contract.md
@@ -75,8 +75,9 @@ Specifically:
    field or endpoint will be removed in a future version, the Gateway
    must signal deprecation using standard HTTP headers:
    - [`Deprecation`](https://www.rfc-editor.org/rfc/rfc9745.html)
-     (RFC 9745): set to `true` or an ISO 8601 date indicating when the
-     endpoint was deprecated.
+     (RFC 9745): set to `@<unix-timestamp>` (an SF-Integer per the
+     Structured Fields syntax) or `?1` (boolean true) indicating the
+     endpoint is deprecated.
    - [`Sunset`](https://www.rfc-editor.org/rfc/rfc8594.html)
      (RFC 8594): set to an HTTP-date indicating when the endpoint will
      be removed.

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -41,7 +41,9 @@ Decisions that are fully reflected in the codebase.
 | [ADR-033](ADR-033-centralized-log-bridge.md) | Centralized Log Bridge with gRPC Transport | 2026-03-22 |
 | [ADR-037](ADR-037-project-centric-ui-model.md) | Project-Centric UI Model with Session Abstraction | 2026-03-24 |
 | [ADR-039](ADR-039-unified-operation-stream.md) | Unified Operation Stream — Check and Remediate | 2026-03-24 |
+| [ADR-041](ADR-041-rule-catalog-override-architecture.md) | Rule Catalog & Override Architecture | 2026-03-25 |
 | [ADR-044](ADR-044-node-identity-progression-model.md) | Node Identity and Progression Model | 2026-03-27 |
+| [ADR-045](ADR-045-galaxy-auth-delegation.md) | Delegate Galaxy Authentication to ansible-galaxy, Galaxy Config as Scan Metadata | 2026-03-28 |
 | [ADR-047](ADR-047-tox-developer-orchestration.md) | tox as Sole Developer Orchestration Tool | 2026-03-30 |
 
 ## Accepted
@@ -53,9 +55,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-012](ADR-012-scale-pods-not-services.md) | Scale Pods, Not Services Within a Pod | 2026-02 |
 | [ADR-016](ADR-016-single-branch-main.md) | Single-branch `main` Strategy | 2026-03 |
 | [ADR-040](ADR-040-scan-metadata-enrichment.md) | Scan Metadata Enrichment | 2026-03-25 |
-| [ADR-041](ADR-041-rule-catalog-override-architecture.md) | Rule Catalog & Override Architecture | 2026-03-25 |
 | [ADR-043](ADR-043-default-severity-assignment.md) | Default Severity Assignment for Rule Catalog | 2026-03-26 |
-| [ADR-045](ADR-045-galaxy-auth-delegation.md) | Delegate Galaxy Authentication to ansible-galaxy, Galaxy Config as Scan Metadata | 2026-03-28 |
 | [ADR-048](ADR-048-pod-internal-admin-endpoints.md) | Pod-Internal Admin Endpoints Rely on Network Isolation | 2026-04-01 |
 | [ADR-049](ADR-049-gateway-in-daemon.md) | Gateway Embedded in Local Daemon | 2026-04-01 |
 | [ADR-050](ADR-050-post-remediation-pr-creation.md) | Post-Remediation PR Creation via Gateway SCM Integration | 2026-04-07 (revised 2026-07-06) |

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -54,14 +54,18 @@ Decisions that have been accepted but are not yet fully implemented.
 |-----|-------|------|
 | [ADR-012](ADR-012-scale-pods-not-services.md) | Scale Pods, Not Services Within a Pod | 2026-02 |
 | [ADR-016](ADR-016-single-branch-main.md) | Single-branch `main` Strategy | 2026-03 |
+| [ADR-038](ADR-038-public-data-api.md) | Public Data API for Platform Consumers | 2026-03-25 |
 | [ADR-040](ADR-040-scan-metadata-enrichment.md) | Scan Metadata Enrichment | 2026-03-25 |
 | [ADR-043](ADR-043-default-severity-assignment.md) | Default Severity Assignment for Rule Catalog | 2026-03-26 |
 | [ADR-048](ADR-048-pod-internal-admin-endpoints.md) | Pod-Internal Admin Endpoints Rely on Network Isolation | 2026-04-01 |
 | [ADR-049](ADR-049-gateway-in-daemon.md) | Gateway Embedded in Local Daemon | 2026-04-01 |
 | [ADR-050](ADR-050-post-remediation-pr-creation.md) | Post-Remediation PR Creation via Gateway SCM Integration | 2026-04-07 (revised 2026-07-06) |
 | [ADR-051](ADR-051-dependency-health-scanning.md) | Dependency Health Scanning | 2026-04-07 |
+| [ADR-052](ADR-052-project-operation-sse-architecture.md) | Project Operation SSE Architecture | 2026-04-14 |
 | [ADR-053](ADR-053-github-integration-strategy.md) | GitHub Integration Strategy | 2026-04-10 |
 | [ADR-054](ADR-054-production-deployment.md) | Production Deployment — Helm Chart and bootc VM Image | 2026-04-10 |
+| [ADR-055](ADR-055-violation-fingerprint-suppression.md) | Content-Based Violation Fingerprinting and Suppression | 2026-05-21 |
+| [ADR-056](ADR-056-apme-owns-scm-commit-push.md) | APME Owns SCM Commit and Push | 2026-07-06 |
 | [ADR-057](ADR-057-per-rule-version-applicability.md) | Per-Rule Ansible-Core Version Applicability | 2026-07-07 |
 | [ADR-059](ADR-059-graph-library-extraction.md) | Extract Shared Graph Analysis Library | 2026-07-08 |
 | [ADR-060](ADR-060-rest-api-versioning-contract.md) | REST API Versioning Contract | 2026-07-08 |
@@ -75,12 +79,8 @@ Decisions under consideration — not yet accepted or implemented.
 | [ADR-027](ADR-027-agentic-project-remediation.md) | Agentic Project-Level AI Remediation | 2026-03-19 |
 | [ADR-034](ADR-034-multi-pod-health-registration.md) | Multi-Pod Health Registration | 2026-03-23 |
 | [ADR-036](ADR-036-two-pass-remediation-engine.md) | Two-Pass Remediation Engine with Project-Level Transforms | 2026-03-23 |
-| [ADR-038](ADR-038-public-data-api.md) | Public Data API for Platform Consumers | 2026-03-25 |
 | [ADR-042](ADR-042-third-party-plugin-services.md) | Third-Party Plugin Services | 2026-03-20 |
 | [ADR-046](ADR-046-ai-assisted-report-generation.md) | AI-Assisted Report Generation | 2026-03-30 |
-| [ADR-052](ADR-052-project-operation-sse-architecture.md) | Project Operation SSE Architecture | 2026-04-14 |
-| [ADR-055](ADR-055-violation-fingerprint-suppression.md) | Content-Based Violation Fingerprinting and Suppression | 2026-05-21 |
-| [ADR-056](ADR-056-apme-owns-scm-commit-push.md) | APME Owns SCM Commit and Push | 2026-07-06 |
 | [ADR-058](ADR-058-collection-dependency-suggestion.md) | Collection Dependency Suggestion for Unresolved Modules (R501) | 2026-06-23 |
 
 ## Superseded

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -53,7 +53,9 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-012](ADR-012-scale-pods-not-services.md) | Scale Pods, Not Services Within a Pod | 2026-02 |
 | [ADR-016](ADR-016-single-branch-main.md) | Single-branch `main` Strategy | 2026-03 |
 | [ADR-040](ADR-040-scan-metadata-enrichment.md) | Scan Metadata Enrichment | 2026-03-25 |
+| [ADR-041](ADR-041-rule-catalog-override-architecture.md) | Rule Catalog & Override Architecture | 2026-03-25 |
 | [ADR-043](ADR-043-default-severity-assignment.md) | Default Severity Assignment for Rule Catalog | 2026-03-26 |
+| [ADR-045](ADR-045-galaxy-auth-delegation.md) | Delegate Galaxy Authentication to ansible-galaxy, Galaxy Config as Scan Metadata | 2026-03-28 |
 | [ADR-048](ADR-048-pod-internal-admin-endpoints.md) | Pod-Internal Admin Endpoints Rely on Network Isolation | 2026-04-01 |
 | [ADR-049](ADR-049-gateway-in-daemon.md) | Gateway Embedded in Local Daemon | 2026-04-01 |
 | [ADR-050](ADR-050-post-remediation-pr-creation.md) | Post-Remediation PR Creation via Gateway SCM Integration | 2026-04-07 (revised 2026-07-06) |
@@ -62,6 +64,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-054](ADR-054-production-deployment.md) | Production Deployment — Helm Chart and bootc VM Image | 2026-04-10 |
 | [ADR-057](ADR-057-per-rule-version-applicability.md) | Per-Rule Ansible-Core Version Applicability | 2026-07-07 |
 | [ADR-059](ADR-059-graph-library-extraction.md) | Extract Shared Graph Analysis Library | 2026-07-08 |
+| [ADR-060](ADR-060-rest-api-versioning-contract.md) | REST API Versioning Contract | 2026-07-08 |
 
 ## Proposed
 
@@ -73,9 +76,7 @@ Decisions under consideration — not yet accepted or implemented.
 | [ADR-034](ADR-034-multi-pod-health-registration.md) | Multi-Pod Health Registration | 2026-03-23 |
 | [ADR-036](ADR-036-two-pass-remediation-engine.md) | Two-Pass Remediation Engine with Project-Level Transforms | 2026-03-23 |
 | [ADR-038](ADR-038-public-data-api.md) | Public Data API for Platform Consumers | 2026-03-25 |
-| [ADR-041](ADR-041-rule-catalog-override-architecture.md) | Rule Catalog & Override Architecture | 2026-03-25 |
 | [ADR-042](ADR-042-third-party-plugin-services.md) | Third-Party Plugin Services | 2026-03-20 |
-| [ADR-045](ADR-045-galaxy-auth-delegation.md) | Delegate Galaxy Authentication to ansible-galaxy, Galaxy Config as Scan Metadata | 2026-03-28 |
 | [ADR-046](ADR-046-ai-assisted-report-generation.md) | AI-Assisted Report Generation | 2026-03-30 |
 | [ADR-052](ADR-052-project-operation-sse-architecture.md) | Project Operation SSE Architecture | 2026-04-14 |
 | [ADR-055](ADR-055-violation-fingerprint-suppression.md) | Content-Based Violation Fingerprinting and Suppression | 2026-05-21 |
@@ -94,7 +95,7 @@ Decisions replaced by newer ADRs.
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-060)
+2. Use the next available number (currently ADR-061)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,16 @@ one needs to change, write an ADR first.
     | **Kubernetes / OpenShift** | **Helm chart** (`deploy/helm/apme/`) |
     | Production single-node VM | bootc image |
 
+17. **REST API is a versioned public contract** (ADR-060). The Gateway
+    REST API under `/api/v1` is consumed by external teams (Backstage
+    plugin, CI/CD integrations). **No breaking changes to existing
+    endpoints without a version bump to `/api/v2`.** Adding new endpoints
+    or new optional fields is fine. Removing/renaming fields, changing
+    types, removing endpoints, or altering query parameter semantics all
+    require a new API version and an accompanying ADR. Agents must not
+    modify existing endpoint response schemas, URL paths, or query
+    parameter semantics without explicit human approval.
+
 ## Agent Roles
 
 ### 1. Spec Writer Agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Full details: [architecture.md](/.sdlc/context/architecture.md) | [deployment.md
 | [ADR-008](/.sdlc/adrs/ADR-008-rule-id-conventions.md) | Rule IDs: L=Lint, M=Modernize, R=Risk, P=Policy, SEC=Secrets |
 | [ADR-009](/.sdlc/adrs/ADR-009-remediation-engine.md) | Validators are read-only; remediation is separate |
 | [ADR-054](/.sdlc/adrs/ADR-054-production-deployment.md) | **Helm chart for K8s/OCP**, bootc for VM |
+| [ADR-060](/.sdlc/adrs/ADR-060-rest-api-versioning-contract.md) | REST API is a versioned public contract — no breaking changes without version bump |
 
 Full list: `.sdlc/adrs/README.md`
 


### PR DESCRIPTION
## Summary

- Adds **ADR-060** establishing the Gateway REST API (`/api/v1`) as a versioned public contract — no breaking changes without a version bump to `/api/v2`
- Deprecation lifecycle uses **RFC 9745** (Deprecation header) and **RFC 8594** (Sunset header)
- Added as **architectural invariant 17** in `AGENTS.md` and to the Key ADRs table in `CLAUDE.md`
- ADR status audit: moves implemented and accepted ADRs out of the Proposed section

## Changes

### New ADR
- **ADR-060** (`.sdlc/adrs/ADR-060-rest-api-versioning-contract.md`): REST API versioning contract — defines breaking vs non-breaking changes, RFC 9745/8594 deprecation headers, agent constraints

### Status → Implemented (fully reflected in code)
- **ADR-041**: Rule Catalog & Override Architecture
- **ADR-045**: Galaxy Auth Delegation

### Status → Accepted (decision made, partially implemented)
- **ADR-038**: Public Data API for Platform Consumers
- **ADR-052**: Project Operation SSE Architecture
- **ADR-055**: Content-Based Violation Fingerprinting and Suppression
- **ADR-056**: APME Owns SCM Commit and Push

### Other
- `AGENTS.md`: new invariant 17 (REST API is a versioned public contract)
- `CLAUDE.md`: ADR-060 added to Key ADRs table
- `.sdlc/adrs/README.md`: index updated — ADRs moved between sections, next number bumped to 061

## Motivation

A Backstage plugin team is actively building against the Gateway REST API. The API needs a formal stability guarantee (ADR-060). While auditing ADR status for this change, we identified 6 ADRs still marked Proposed despite having their core decisions reflected in code.

## Test plan

- [ ] Docs-only change — no `tox -e lint` or `tox -e unit` impact
- [ ] ADR index sections are internally consistent (Implemented → Accepted → Proposed)
- [ ] Each ADR's status field matches its README section
- [ ] No code changes