### PR TITLE
fix(security): resolve open Dependabot and CodeQL alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ gateway = [
     "python-multipart>=0.0.31",
 ]
 dev = [
-    "pytest",
+    "pytest>=9.0.3",
     "pytest-cov",
     "pytest-mock",
     "pytest-asyncio>=0.24",
@@ -208,7 +208,12 @@ where = ["src"]
 [tool.uv]
 constraint-dependencies = [
     "cryptography>=48.0.1",
+    "idna>=3.15",
     "msgpack>=1.2.1",
+    "pip>=26.1",
+    "pygments>=2.20.0",
+    "requests>=2.33.0",
+    "urllib3>=2.7.0",
 ]
 
 [tool.uv.workspace]

--- a/src/galaxy_proxy/proxy/cache.py
+++ b/src/galaxy_proxy/proxy/cache.py
@@ -16,6 +16,46 @@ def _default_cache_dir() -> Path:
     return base / "ansible-collection-proxy"
 
 
+def _safe_wheel_path(base: Path, filename: str) -> Path:
+    """Resolve a wheel filename under *base*, rejecting traversal attempts.
+
+    Validates the untrusted filename as a single safe path component, then
+    reconstructs the result purely from the trusted base directory so static
+    analysis can verify the path stays within the cache root.
+
+    Args:
+        base: Base directory the file must reside under.
+        filename: Untrusted wheel filename to resolve.
+
+    Returns:
+        Resolved path confirmed to be under base.
+
+    Raises:
+        ValueError: When the filename is invalid or escapes the base directory.
+    """
+    base_resolved = base.resolve()
+    if (
+        not filename
+        or filename != os.path.basename(filename)
+        or ".." in filename
+        or os.sep in filename
+        or (os.altsep and os.altsep in filename)
+    ):
+        msg = f"Invalid wheel filename: {filename!r}"
+        raise ValueError(msg)
+
+    part = filename
+    if part == ".":
+        msg = f"Invalid wheel filename component: {filename!r}"
+        raise ValueError(msg)
+
+    safe_path = base_resolved.joinpath(part).resolve()
+    if not safe_path.is_relative_to(base_resolved):
+        msg = f"Path escapes cache directory: {filename!r}"
+        raise ValueError(msg)
+    return safe_path
+
+
 @dataclass
 class CachedMetadata:
     """Cached Galaxy version listing for a collection.
@@ -47,25 +87,6 @@ class ProxyCache:
         self.wheels_dir.mkdir(parents=True, exist_ok=True)
         self.metadata_dir.mkdir(parents=True, exist_ok=True)
 
-    def _safe_path(self, base: Path, filename: str) -> Path:
-        """Resolve a filename under base, rejecting traversal attempts.
-
-        Args:
-            base: Base directory the file must reside under.
-            filename: Untrusted filename to resolve.
-
-        Returns:
-            Resolved path confirmed to be under base.
-
-        Raises:
-            ValueError: When the resolved path escapes the base directory.
-        """
-        resolved = (base / filename).resolve()
-        if not resolved.is_relative_to(base.resolve()):
-            msg = f"Path escapes cache directory: {filename!r}"
-            raise ValueError(msg)
-        return resolved
-
     def get_wheel(self, filename: str) -> bytes | None:
         """Return cached wheel bytes, or None if not cached.
 
@@ -75,7 +96,7 @@ class ProxyCache:
         Returns:
             Cached wheel bytes, or None if the file is not present.
         """
-        path = self._safe_path(self.wheels_dir, filename)
+        path = _safe_wheel_path(self.wheels_dir, filename)
         if path.exists():
             return path.read_bytes()
         return None
@@ -93,7 +114,7 @@ class ProxyCache:
         Raises:
             OSError: When the temporary file cannot be written or renamed.
         """
-        path = self._safe_path(self.wheels_dir, filename)
+        path = _safe_wheel_path(self.wheels_dir, filename)
         fd, tmp = tempfile.mkstemp(dir=self.wheels_dir, suffix=".tmp")
         tmp_path = Path(tmp)
         try:
@@ -114,7 +135,7 @@ class ProxyCache:
         Returns:
             Path to the cached file, or None if it does not exist.
         """
-        path = self._safe_path(self.wheels_dir, filename)
+        path = _safe_wheel_path(self.wheels_dir, filename)
         return path if path.exists() else None
 
     def get_metadata(self, namespace: str, name: str) -> CachedMetadata | None:

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,12 @@ resolution-markers = [
 [manifest]
 constraints = [
     { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "msgpack", specifier = ">=1.2.1" },
+    { name = "pip", specifier = ">=26.1" },
+    { name = "pygments", specifier = ">=2.20.0" },
+    { name = "requests", specifier = ">=2.33.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
 [[package]]
@@ -104,11 +109,11 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "cryptography", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
-    { name = "resolvelib", version = "1.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "resolvelib", version = "1.0.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/80/2925a0564f6f99a8002c3be3885b83c3a1dc5f57ebf00163f528889865f5/ansible_core-2.17.14.tar.gz", hash = "sha256:7c17fee39f8c29d70e3282a7e9c10bd70d5cd4fd13ddffc5dcaa52adbd142ff8", size = 3119687, upload-time = "2025-09-08T18:28:03.158Z" }
 wheels = [
@@ -123,11 +128,11 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "cryptography", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pyyaml", marker = "python_full_version == '3.11.*'" },
-    { name = "resolvelib", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "resolvelib", version = "1.2.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/cd/9dec1ad58657bcdf9759232db86bfe67006e0eb1c718775b89be0973554c/ansible_core-2.19.8.tar.gz", hash = "sha256:676e70925b775d2c8526b2bcea59c4b2195221bd6e4e3c0537e89387e08608bd", size = 3417261, upload-time = "2026-03-23T17:40:48.408Z" }
 wheels = [
@@ -143,11 +148,11 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14'",
 ]
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-    { name = "resolvelib", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "resolvelib", version = "1.2.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/7c/57263940ef61d7a829baef6e752556b1434f3a66ae05885c80753efbca50/ansible_core-2.20.4.tar.gz", hash = "sha256:2060c06195ada0cca0ac3128025d1167f567479da465897d818982fbe28bed1f", size = 3334074, upload-time = "2026-03-23T17:39:36.24Z" }
 wheels = [
@@ -190,17 +195,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "ansible-builder", marker = "python_full_version < '3.11'" },
-    { name = "ansible-compat", marker = "python_full_version < '3.11'" },
-    { name = "ansible-creator", marker = "python_full_version < '3.11'" },
-    { name = "ansible-dev-environment", marker = "python_full_version < '3.11'" },
-    { name = "ansible-lint", marker = "python_full_version < '3.11'" },
-    { name = "ansible-navigator", marker = "python_full_version < '3.11'" },
-    { name = "ansible-sign", version = "0.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "molecule", marker = "python_full_version < '3.11'" },
-    { name = "pytest-ansible", marker = "python_full_version < '3.11'" },
-    { name = "setuptools", marker = "python_full_version < '3.11'" },
-    { name = "tox-ansible", marker = "python_full_version < '3.11'" },
+    { name = "ansible-builder" },
+    { name = "ansible-compat" },
+    { name = "ansible-creator" },
+    { name = "ansible-dev-environment" },
+    { name = "ansible-lint" },
+    { name = "ansible-navigator" },
+    { name = "ansible-sign", version = "0.1.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "molecule" },
+    { name = "pytest-ansible" },
+    { name = "setuptools" },
+    { name = "tox-ansible" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/56/4670159a8994337d1a9b87ddc06124822a45a75dfdd558c75ab89cbc0a91/ansible_dev_tools-25.10.0.tar.gz", hash = "sha256:9ad11813379c7d513c47fdfc913ca72fbe26ebd2d2f12fd0d6d6fbcd28c86224", size = 1034662, upload-time = "2025-11-04T14:28:45.249Z" }
 wheels = [
@@ -217,17 +222,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "ansible-builder", marker = "python_full_version >= '3.11'" },
-    { name = "ansible-compat", marker = "python_full_version >= '3.11'" },
-    { name = "ansible-creator", marker = "python_full_version >= '3.11'" },
-    { name = "ansible-dev-environment", marker = "python_full_version >= '3.11'" },
-    { name = "ansible-lint", marker = "python_full_version >= '3.11'" },
-    { name = "ansible-navigator", marker = "python_full_version >= '3.11'" },
-    { name = "ansible-sign", version = "0.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "molecule", marker = "python_full_version >= '3.11'" },
-    { name = "pytest-ansible", marker = "python_full_version >= '3.11'" },
-    { name = "setuptools", marker = "python_full_version >= '3.11'" },
-    { name = "tox-ansible", marker = "python_full_version >= '3.11'" },
+    { name = "ansible-builder" },
+    { name = "ansible-compat" },
+    { name = "ansible-creator" },
+    { name = "ansible-dev-environment" },
+    { name = "ansible-lint" },
+    { name = "ansible-navigator" },
+    { name = "ansible-sign", version = "0.1.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "molecule" },
+    { name = "pytest-ansible" },
+    { name = "setuptools" },
+    { name = "tox-ansible" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/e3/498f046961e9f40714c1333f6943c13512e5ee4d6ac6288639767369e857/ansible_dev_tools-26.4.1.tar.gz", hash = "sha256:b9b2968a11a45bc354b56f35e0a9ddbc5d338540dab14dd8cb85a3edc453a8ff", size = 1053809, upload-time = "2026-04-08T12:02:26.266Z" }
 wheels = [
@@ -307,8 +312,8 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "distlib", marker = "python_full_version < '3.11'" },
-    { name = "python-gnupg", marker = "python_full_version < '3.11'" },
+    { name = "distlib" },
+    { name = "python-gnupg" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/f8/d4d3b96a901690d1e7db7330b3f9bb833254d419613b5c33ed7beae346c2/ansible_sign-0.1.2.tar.gz", hash = "sha256:b1664331bd93700c1754fb4e541e0914412560e5e221113224dcfd84d9da452c", size = 46083, upload-time = "2025-07-07T13:59:19.027Z" }
 wheels = [
@@ -325,8 +330,8 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "distlib", marker = "python_full_version >= '3.11'" },
-    { name = "python-gnupg", marker = "python_full_version >= '3.11'" },
+    { name = "distlib" },
+    { name = "python-gnupg" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/30/bbd2646e67625151e60ed4f3411252df48a0af23b44a1bcd1228ca98afc3/ansible_sign-0.1.5.tar.gz", hash = "sha256:d1c9b5ef4329501615b18fe2bf035f63a429f7c05e653d32ac59fc01892eaf74", size = 106439, upload-time = "2026-02-25T11:40:28.195Z" }
 wheels = [
@@ -425,7 +430,7 @@ requires-dist = [
     { name = "pip-audit", specifier = ">=2.7" },
     { name = "protobuf", specifier = ">=6.31.1,<7" },
     { name = "pydoclint", marker = "extra == 'dev'", specifier = ">=0.8.0" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-mock", marker = "extra == 'dev'" },
@@ -1030,7 +1035,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1362,11 +1367,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1904,11 +1909,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
@@ -2200,11 +2205,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -2231,7 +2236,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2242,9 +2247,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -2621,7 +2626,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2629,9 +2634,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -3148,11 +3153,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Resolves 8 open Dependabot alerts and 3 open CodeQL path-injection alerts on `main`
- Upgrades regressed transitive Python dependencies (`idna`, `urllib3`, `requests`, `pip`, `pygments`, `pytest`) that slipped back to vulnerable versions when `ansible-dev-tools` was added in #378
- Adds `uv` constraint-dependencies floors so future lockfile refreshes cannot downgrade these packages again

## Changes
- **Dependabot (pip):** bump `idna` → 3.18, `urllib3` → 2.7.0, `requests` → 2.34.2, `pip` → 26.1.2, `pygments` → 2.20.0, `pytest` → 9.1.1
- **pyproject.toml:** add `constraint-dependencies` for all six packages; require `pytest>=9.0.3` in dev extras
- **CodeQL (py/path-injection):** extract `_safe_wheel_path()` in `galaxy_proxy/proxy/cache.py` — validates single-segment filenames, reconstructs paths from the trusted cache root, and uses symlink-aware `resolve()` containment checks (same pattern as `_validate_tarball_dir` in `server.py`)

## Test plan
- [x] `tox -e lint` — ruff, mypy, uv-lock, pydoclint pass (skillmark has pre-existing upstream warnings unrelated to this PR)
- [x] `tox -e unit` passes
- [x] `tests/test_galaxy_proxy_server.py` wheel/traversal tests pass
- [ ] Dependabot alerts auto-close after merge
- [ ] CodeQL path-injection alerts clear on next scan

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wheel cache path handling to prevent invalid or unsafe file paths from being used.
  * Strengthened dependency version constraints for several packages to reduce unexpected install or runtime issues.

* **Chores**
  * Updated development dependency versions and locked additional package constraints for more consistent environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->