### PR TITLE
feat(containers): migrate Python services to UBI10 base

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -70,6 +70,8 @@ private/
 # IDE
 .idea/
 .vscode/
+.claude/
+.cursor/
 *.swp
 *.swo
 *~

--- a/.sdlc/adrs/ADR-037-project-centric-ui-model.md
+++ b/.sdlc/adrs/ADR-037-project-centric-ui-model.md
@@ -252,7 +252,7 @@ Tag sessions and scans with a project name.
 
 ## Implementation Notes
 
-- Gateway container needs `apt-get install git` in Dockerfile
+- Gateway container needs `git` installed in Dockerfile (`microdnf install -y git` on UBI10)
 - No new persistent volume — clones go to temp directories
 - Health score formula: `max(0, 100 - (high * 10 + medium * 3 + low * 1))`
   from latest scan, clamped to 0–100

--- a/.sdlc/context/architecture.md
+++ b/.sdlc/context/architecture.md
@@ -242,7 +242,7 @@ If neither Podman nor a local binary is available, OPA validation is skipped (gr
 
 The Gitleaks container follows a similar multi-stage pattern:
 
-1. **Gitleaks binary** is copied from the official `zricethezav/gitleaks` image into a Python 3.12 slim image
+1. **Gitleaks binary** is copied from the official `zricethezav/gitleaks` image into a Python 3.12 UBI10 base image
 2. **apme-gitleaks-validator** (Python gRPC wrapper) starts on port 50056, receives `ValidateRequest` with `content_graph_data`
 
 The validator supports two scanning strategies:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,21 +103,20 @@ yaml = YAML(typ='safe')  # Prevents arbitrary code execution
 
 #### Dockerfile Best Practices
 ```dockerfile
-# Use specific versions, not :latest
-FROM python:3.12-slim-bookworm
+# Use specific versions, not :latest (ADR-061: UBI10 application bases)
+FROM registry.access.redhat.com/ubi10/python-312-minimal:10.2
 
-# Run as non-root user
-RUN useradd -r -s /bin/false apme
-USER apme
+# Run as non-root user (UBI Python images default to UID 1001)
+USER 1001
 
 # Don't store secrets in ENV
 # BAD: ENV API_KEY=secret123
 # GOOD: Use runtime secrets
 
 # Minimize attack surface
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    required-package \
-    && rm -rf /var/lib/apt/lists/*
+USER root
+RUN microdnf install -y required-package && microdnf clean all
+USER 1001
 ```
 
 #### Image Scanning

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -1,7 +1,13 @@
 # syntax=docker/dockerfile:1
 # Shared base for all Python APME services.
 # Installs core dependencies once; service images inherit via FROM apme-base.
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+# Base OS: UBI10 (ADR-061).
+ARG UBI_PYTHON_IMAGE=registry.access.redhat.com/ubi10/python-312-minimal:10.2
+FROM ${UBI_PYTHON_IMAGE}
+
+COPY --from=ghcr.io/astral-sh/uv:0.10.12 /uv /uvx /usr/local/bin/
+
+USER root
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
@@ -22,3 +28,5 @@ RUN --mount=type=cache,target=/tmp/uv-cache \
     uv sync --frozen --no-dev --extra ai --extra gateway
 
 ENV PATH="/app/.venv/bin:$PATH"
+
+USER 1001

--- a/containers/galaxy-proxy/Dockerfile
+++ b/containers/galaxy-proxy/Dockerfile
@@ -7,7 +7,7 @@ FROM $BASE_IMAGE
 
 # ansible-galaxy collection download is used for tarball fetching (ADR-045).
 # Install ansible-core into the image venv so the binary is on PATH.
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,target=/tmp/uv-cache \
     uv pip install --python /app/.venv/bin/python "ansible-core>=2.16,<2.19"
 
 EXPOSE 8765

--- a/containers/gateway/Dockerfile
+++ b/containers/gateway/Dockerfile
@@ -5,8 +5,9 @@
 ARG BASE_IMAGE=localhost/apme-base:latest
 FROM $BASE_IMAGE
 
-RUN apt-get update && apt-get install -y --no-install-recommends git \
-    && rm -rf /var/lib/apt/lists/*
+USER root
+RUN microdnf install -y git && microdnf clean all
+USER 1001
 
 ENV APME_DB_PATH=/data/apme.db
 ENV APME_GATEWAY_GRPC_LISTEN=0.0.0.0:50060

--- a/containers/podman/build.sh
+++ b/containers/podman/build.sh
@@ -31,4 +31,7 @@ podman build "${BUILD_ARGS[@]}" -t apme-gateway:latest -f containers/gateway/Doc
 podman build "${BUILD_ARGS[@]}" -t apme-cli:latest -f containers/cli/Dockerfile .
 podman build "${BUILD_ARGS[@]}" -t apme-ui:latest -f containers/ui/Dockerfile .
 
+echo "==> Checking UBI volume write permissions (ADR-061)..."
+bash containers/podman/check-volume-permissions.sh
+
 echo "Images built. Start with: tox -e up"

--- a/containers/podman/check-volume-permissions.sh
+++ b/containers/podman/check-volume-permissions.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verify UBI service images can write to mounted volume paths as UID 1001 (ADR-061).
+# Run after image build; invoked from containers/podman/build.sh.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+RUNTIME_UID="${APME_UBI_RUNTIME_UID:-1001}"
+PROBE_ROOT="$(mktemp -d)"
+cleanup() { rm -rf "$PROBE_ROOT"; }
+trap cleanup EXIT
+
+prep_dir() {
+  local dir=$1
+  mkdir -p "$dir"
+  if ! chown "${RUNTIME_UID}:0" "$dir" 2>/dev/null; then
+    chmod 1777 "$dir"
+  fi
+}
+
+check_write() {
+  local image=$1
+  local mount_path=$2
+  local host_dir=$3
+
+  if ! podman image exists "$image" 2>/dev/null; then
+    echo "==> Skip volume check for $image (image not built)"
+    return 0
+  fi
+
+  echo "==> Volume write check: $image -> $mount_path (UID $RUNTIME_UID)"
+  podman run --rm \
+    --user "${RUNTIME_UID}" \
+    --entrypoint sh \
+    -v "${host_dir}:${mount_path}:Z" \
+    "$image" \
+    -c "touch '${mount_path}/.write-test' && test -f '${mount_path}/.write-test' && rm -f '${mount_path}/.write-test'"
+}
+
+prep_dir "${PROBE_ROOT}/sessions"
+prep_dir "${PROBE_ROOT}/data"
+prep_dir "${PROBE_ROOT}/cache"
+
+check_write apme-primary:latest /sessions "${PROBE_ROOT}/sessions"
+check_write apme-gateway:latest /data "${PROBE_ROOT}/data"
+check_write apme-galaxy-proxy:latest /cache "${PROBE_ROOT}/cache"
+
+echo "Volume permission checks passed (UID ${RUNTIME_UID})."

--- a/docs/architecture/17-scaling-and-deployment.md
+++ b/docs/architecture/17-scaling-and-deployment.md
@@ -169,18 +169,18 @@ network.
 
 | Image | Base | Contents |
 |-------|------|----------|
-| `apme-primary` | Python 3.12 slim | Engine, Primary server, VenvSessionManager |
-| `apme-native` | Python 3.12 slim | Native validator server |
-| `apme-opa` | Python 3.12 slim + OPA binary | OPA validator server + Rego bundle |
-| `apme-ansible` | Python 3.12 slim | Ansible validator server |
-| `apme-gitleaks` | Python 3.12 slim + gitleaks binary | Gitleaks validator server |
-| `apme-collection-health` | Python 3.12 slim | Collection health validator server |
-| `apme-dep-audit` | Python 3.12 slim + pip-audit | Python CVE scanner server |
-| `apme-galaxy-proxy` | Python 3.12 slim | PEP 503 proxy server |
-| `apme-gateway` | Python 3.12 slim | FastAPI + gRPC Reporting + SQLite |
+| `apme-primary` | Python 3.12 UBI10 | Engine, Primary server, VenvSessionManager |
+| `apme-native` | Python 3.12 UBI10 | Native validator server |
+| `apme-opa` | Python 3.12 UBI10 + OPA binary | OPA validator server + Rego bundle |
+| `apme-ansible` | Python 3.12 UBI10 | Ansible validator server |
+| `apme-gitleaks` | Python 3.12 UBI10 + gitleaks binary | Gitleaks validator server |
+| `apme-collection-health` | Python 3.12 UBI10 | Collection health validator server |
+| `apme-dep-audit` | Python 3.12 UBI10 + pip-audit | Python CVE scanner server |
+| `apme-galaxy-proxy` | Python 3.12 UBI10 | PEP 503 proxy server |
+| `apme-gateway` | Python 3.12 UBI10 | FastAPI + gRPC Reporting + SQLite |
 | `apme-ui` | nginx alpine | React SPA static files |
-| `apme-abbenay` | Python 3.12 slim | AI inference gateway |
-| `apme-cli` | Python 3.12 slim | CLI tools only |
+| `apme-abbenay` | Python 3.12 slim | AI inference gateway (external image) |
+| `apme-cli` | Python 3.12 UBI10 | CLI tools only |
 
 All containers run as non-root (see `SECURITY.md`).
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -228,7 +228,7 @@ The Settings page (`/settings`) provides a model picker that queries available A
 The OPA container uses a multi-stage Dockerfile:
 
 1. **Stage 1**: Copies the `opa` binary from `docker.io/openpolicyagent/opa:latest`
-2. **Stage 2**: Python slim image with `grpcio`, project code, and the Rego bundle
+2. **Stage 2**: Python 3.12 UBI10 base image with `grpcio`, project code, and the Rego bundle
 
 At runtime, `entrypoint.sh`:
 
@@ -344,7 +344,7 @@ on first boot. Systemd manages automatic startup and lifecycle.
 
 **Highlights:**
 
-- CentOS Stream 10 base image
+- RHEL 10 image mode base (ADR-061)
 - Systemd quadlet files for each service (automatic restart, dependency ordering)
 - Atomic upgrades with automatic rollback on failure (`bootc switch`)
 - Persistent storage at `/var/lib/apme/`

--- a/tests/test_container_volume_permissions.py
+++ b/tests/test_container_volume_permissions.py
@@ -1,0 +1,56 @@
+"""Tests for UBI volume permission verification script (ADR-061)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECK_SH = REPO_ROOT / "containers" / "podman" / "check-volume-permissions.sh"
+BUILD_SH = REPO_ROOT / "containers" / "podman" / "build.sh"
+
+
+def test_build_sh_invokes_volume_permission_check() -> None:
+    """build.sh must run the ADR-061 volume permission gate after image build."""
+    content = BUILD_SH.read_text(encoding="utf-8")
+    assert "check-volume-permissions.sh" in content
+
+
+def test_volume_permission_script_is_executable_bash() -> None:
+    """Volume check script must exist and use bash with strict mode."""
+    content = CHECK_SH.read_text(encoding="utf-8")
+    assert content.startswith("#!/usr/bin/env bash")
+    assert "set -euo pipefail" in content
+    assert "apme-primary:latest" in content
+    assert "/sessions" in content
+    assert "apme-gateway:latest" in content
+    assert "/data" in content
+    assert "apme-galaxy-proxy:latest" in content
+    assert "/cache" in content
+    assert "APME_UBI_RUNTIME_UID:-1001" in content
+
+
+@pytest.mark.skipif(  # type: ignore[untyped-decorator]
+    os.environ.get("APME_SKIP_PODMAN") == "1",
+    reason="Podman checks disabled via APME_SKIP_PODMAN=1",
+)
+def test_volume_permission_script_runs_when_images_exist() -> None:
+    """Run the volume check when service images are already built."""
+    required = ("apme-primary:latest", "apme-gateway:latest", "apme-galaxy-proxy:latest")
+    missing = [
+        image for image in required if subprocess.run(["podman", "image", "exists", image], check=False).returncode != 0
+    ]
+    if missing:
+        pytest.skip(f"Images not built: {', '.join(missing)}")
+
+    result = subprocess.run(
+        ["bash", str(CHECK_SH)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Summary

- Rewrites [`containers/base/Dockerfile`](containers/base/Dockerfile) to use `ubi10/python-312-minimal:10.2` with a pinned `uv:0.10.12` binary copy
- Updates [`containers/gateway/Dockerfile`](containers/gateway/Dockerfile) to install `git` via `microdnf` (replacing `apt-get`)
- Aligns galaxy-proxy uv cache mount with base `UV_CACHE_DIR`
- Excludes `.claude/` and `.cursor/` from container build context (fixes Podman xattr failures)
- Updates Python-stack documentation for UBI10 bases

Depends on #384 (ADR-061). Implements ADR-061 step 2.

## Test plan

- [x] `tox -e build` — all 11 service images build successfully
- [x] `tox -e unit` — 2638 passed
- [x] Dockerfile pinning hygiene tests pass
- [ ] UI and bootc remain on previous bases until PR 3


Made with [Cursor](https://cursor.com)