### PR TITLE
feat(containers): migrate UI and bootc to UBI10/RHEL10 bases

### DIFF
--- a/containers/ui/Dockerfile
+++ b/containers/ui/Dockerfile
@@ -1,9 +1,14 @@
 # Standalone UI: React SPA served by nginx.
 # Talks only to the gateway container — never directly to the engine pod.
-# Two-stage build: Node for Vite build, nginx for serving.
+# Two-stage build: Node for Vite build, nginx for serving (UBI10, ADR-061).
+
+ARG UBI_NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-22-minimal:10.2
+ARG UBI_NGINX_IMAGE=registry.access.redhat.com/ubi10/nginx-126:10.2
 
 # --- Stage 1: Build ---
-FROM node:22-alpine AS build
+FROM ${UBI_NODEJS_IMAGE} AS build
+
+USER root
 WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json* ./
 RUN npm ci
@@ -11,11 +16,18 @@ COPY frontend/ .
 RUN npm run build
 
 # --- Stage 2: Serve ---
-FROM nginx:1-alpine
+FROM ${UBI_NGINX_IMAGE}
+
+USER root
+RUN dnf install -y gettext && dnf clean all
+
 COPY containers/ui/nginx.conf.template /etc/nginx/conf.d/default.conf.template
 COPY containers/ui/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 COPY --from=build /app/dist /usr/share/nginx/html
+
+RUN chmod -R g+w /etc/nginx/conf.d /var/log/nginx /run
+USER 1001
 
 EXPOSE 8081
 ENTRYPOINT ["/entrypoint.sh"]

--- a/deploy/bootc/Containerfile
+++ b/deploy/bootc/Containerfile
@@ -15,10 +15,11 @@
 #
 # See deploy/bootc/README.md for full documentation.
 
-FROM quay.io/centos-bootc/centos-bootc:stream10
+ARG BOOTC_BASE_IMAGE=registry.redhat.io/rhel10/rhel-bootc:10.2
+FROM ${BOOTC_BASE_IMAGE}
 
-# Install Podman for running APME containers
-RUN dnf install -y podman podman-plugins && \
+# Install Podman for running APME containers (podman-plugins merged into podman on EL10)
+RUN dnf install -y podman && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
@@ -33,7 +34,7 @@ RUN mkdir -p /var/lib/apme/sessions \
 
 # Drop configuration directory
 RUN mkdir -p /etc/apme/env
-COPY deploy/bootc/etc/apme/env/apme.env /etc/apme/env/apme.env
+COPY deploy/bootc/apme.env.example /etc/apme/env/apme.env
 
 # Install quadlet files for systemd service management.
 # Podman quadlet (.container, .pod) files go into the system generator directory.

--- a/deploy/bootc/Containerfile
+++ b/deploy/bootc/Containerfile
@@ -32,9 +32,10 @@ RUN mkdir -p /var/lib/apme/sessions \
              /var/lib/apme/proxy-cache && \
     chown -R apme:apme /var/lib/apme
 
-# Drop configuration directory
+# Drop configuration directory (0600: may contain API keys at runtime)
 RUN mkdir -p /etc/apme/env
-COPY deploy/bootc/apme.env.example /etc/apme/env/apme.env
+COPY --chmod=0600 deploy/bootc/apme.env.example /etc/apme/env/apme.env
+RUN chown apme:apme /etc/apme/env/apme.env
 
 # Install quadlet files for systemd service management.
 # Podman quadlet (.container, .pod) files go into the system generator directory.

--- a/deploy/bootc/README.md
+++ b/deploy/bootc/README.md
@@ -5,7 +5,7 @@ Deploy APME as an atomic, image-based Linux VM using
 
 ## Architecture
 
-The bootc image builds on CentOS Stream 10 and includes:
+The bootc image builds on **RHEL 10 image mode** (`rhel10/rhel-bootc`, ADR-061) and includes:
 
 - **Podman** for container runtime
 - **Quadlet files** that define each APME service as a systemd-managed container
@@ -21,8 +21,23 @@ networking.
 ## Prerequisites
 
 - A host capable of building OCI images (`podman build`)
+- **`podman login registry.redhat.io`** for production bootc builds (RHEL 10
+  bootc base requires Red Hat registry authentication)
 - `bootc-image-builder` for converting to disk images (qcow2, raw, AMI)
 - Target hypervisor or cloud for deploying the disk image
+
+Contributors without RHEL registry access can build with the CentOS Stream 10
+bootc fallback:
+
+```bash
+podman build -f deploy/bootc/Containerfile \
+  --build-arg BOOTC_BASE_IMAGE=quay.io/centos-bootc/centos-bootc:stream10 \
+  -t apme-bootc:latest .
+```
+
+APME **application** container images use UBI10 (`ubi10/python-312-minimal`,
+`ubi10/nodejs-22-minimal`, `ubi10/nginx-126`). The bootc image is the **host
+OS** layer and uses `rhel-bootc`, not a UBI application base.
 
 ## Build
 
@@ -167,8 +182,7 @@ deploy/bootc/
 ├── Containerfile                     # bootc image definition
 ├── README.md                         # This file
 ├── apme-firewall.xml                 # firewalld service definition
-├── etc/apme/env/
-│   └── apme.env                      # Runtime configuration
+├── apme.env.example                  # Runtime configuration → /etc/apme/env/apme.env
 └── quadlet/
     ├── apme.pod                      # Pod definition (ports, dependencies)
     ├── apme-primary.container        # Primary orchestrator

--- a/deploy/bootc/apme.env.example
+++ b/deploy/bootc/apme.env.example
@@ -1,0 +1,13 @@
+# APME bootc runtime configuration (ADR-054 / ADR-061).
+# Shipped to /etc/apme/env/apme.env in the bootc image.
+# Edit on the deployed VM; do not commit secrets.
+#
+# AI provider (optional — leave empty to disable Abbenay-backed remediation)
+APME_AI_MODEL=
+OPENROUTER_API_KEY=
+VERTEX_ANTHROPIC_API_KEY=
+
+# Gateway feedback (optional)
+APME_FEEDBACK_ENABLED=false
+APME_FEEDBACK_GITHUB_REPO=
+APME_FEEDBACK_GITHUB_TOKEN=

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -163,7 +163,9 @@ engine:
 
 ## OpenShift compatibility
 
-The chart works under OpenShift's `restricted-v2` SCC without modification:
+The chart works under OpenShift's `restricted-v2` SCC without modification.
+APME application container images are built on **UBI10** Application Stream
+bases (ADR-061).
 
 - `podSecurityContext` and `securityContext` default to empty (OCP injects UID/GID)
 - The UI container mounts emptyDir volumes for nginx writable paths

--- a/docs/architecture/17-scaling-and-deployment.md
+++ b/docs/architecture/17-scaling-and-deployment.md
@@ -178,7 +178,7 @@ network.
 | `apme-dep-audit` | Python 3.12 UBI10 + pip-audit | Python CVE scanner server |
 | `apme-galaxy-proxy` | Python 3.12 UBI10 | PEP 503 proxy server |
 | `apme-gateway` | Python 3.12 UBI10 | FastAPI + gRPC Reporting + SQLite |
-| `apme-ui` | nginx alpine | React SPA static files |
+| `apme-ui` | nginx UBI10 | React SPA static files |
 | `apme-abbenay` | Python 3.12 slim | AI inference gateway (external image) |
 | `apme-cli` | Python 3.12 UBI10 | CLI tools only |
 


### PR DESCRIPTION
## Summary

- Rewrites [`containers/ui/Dockerfile`](containers/ui/Dockerfile) to use `ubi10/nodejs-22-minimal` (build) and `ubi10/nginx-126` (serve)
- Switches [`deploy/bootc/Containerfile`](deploy/bootc/Containerfile) to `rhel10/rhel-bootc:10.2` with `BOOTC_BASE_IMAGE` fallback for CentOS Stream dev builds
- Adds [`deploy/bootc/apme.env.example`](deploy/bootc/apme.env.example) (fixes bootc build — prior `env/` path was gitignored)
- Drops obsolete `podman-plugins` package on EL10
- Updates bootc, Helm, and architecture docs for UBI10 completion

Depends on #385 (Python UBI10 base). Implements ADR-061 step 3.

## Test plan

- [x] `tox -e build` — all 11 service images build successfully
- [x] `tox -e unit` — 2638 passed
- [x] bootc build with `--build-arg BOOTC_BASE_IMAGE=quay.io/centos-bootc/centos-bootc:stream10`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switched container builds to UBI/RHEL-based images, aligning runtime environments across the app and deployment stack.
  * Added a bootc environment template with placeholders for model, API key, and feedback settings.

* **Documentation**
  * Updated deployment and architecture docs to reflect the new image bases and bootc build requirements.
  * Clarified OpenShift compatibility notes and runtime configuration file locations.

* **Bug Fixes**
  * Improved container permissions and non-root runtime setup for safer deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->