### PR TITLE
build(containers): use root for UBI build steps in service images

### DIFF
--- a/containers/ansible/Dockerfile
+++ b/containers/ansible/Dockerfile
@@ -4,10 +4,16 @@
 ARG BASE_IMAGE=localhost/apme-base:latest
 FROM $BASE_IMAGE
 
+USER root
+
 # Pre-warm UV cache for supported ansible-core versions
 ENV UV_CACHE_DIR=/opt/uv-cache
-RUN chmod +x containers/ansible/prebuild-venvs.sh \
-    && containers/ansible/prebuild-venvs.sh
+RUN mkdir -p /opt/uv-cache \
+    && chmod +x containers/ansible/prebuild-venvs.sh \
+    && containers/ansible/prebuild-venvs.sh \
+    && chown -R 1001:0 /opt/uv-cache
+
+USER 1001
 
 ENV APME_ANSIBLE_VALIDATOR_LISTEN=0.0.0.0:50053
 ENV APME_COLLECTION_CACHE=/sessions

--- a/containers/galaxy-proxy/Dockerfile
+++ b/containers/galaxy-proxy/Dockerfile
@@ -5,10 +5,14 @@
 ARG BASE_IMAGE=localhost/apme-base:latest
 FROM $BASE_IMAGE
 
+USER root
+
 # ansible-galaxy collection download is used for tarball fetching (ADR-045).
 # Install ansible-core into the image venv so the binary is on PATH.
 RUN --mount=type=cache,target=/tmp/uv-cache \
     uv pip install --python /app/.venv/bin/python "ansible-core>=2.16,<2.19"
+
+USER 1001
 
 EXPOSE 8765
 

--- a/containers/opa/Dockerfile
+++ b/containers/opa/Dockerfile
@@ -4,11 +4,15 @@ ARG BASE_IMAGE=localhost/apme-base:latest
 FROM docker.io/openpolicyagent/opa:1.17.1 AS opa-bin
 FROM $BASE_IMAGE
 
+USER root
+
 COPY --from=opa-bin /opa /usr/local/bin/opa
 
 RUN cp -r /app/src/apme_engine/validators/opa/bundle /bundle \
     && cp /app/containers/opa/entrypoint.sh /entrypoint.sh \
     && chmod +x /entrypoint.sh
+
+USER 1001
 
 ENV APME_OPA_VALIDATOR_LISTEN=0.0.0.0:50054
 EXPOSE 50054

--- a/containers/podman/down.sh
+++ b/containers/podman/down.sh
@@ -14,6 +14,16 @@ podman pod rm  apme-pod 2>/dev/null || true
 echo "Pod stopped."
 
 if [[ "${1:-}" == "--wipe" ]]; then
+  for vol in apme-sessions apme-gateway-data apme-proxy-cache; do
+    if podman volume exists "$vol" 2>/dev/null; then
+      podman volume rm "$vol"
+      echo "Removed volume: $vol"
+    else
+      echo "No volume found: $vol"
+    fi
+  done
+
+  # Legacy hostPath cache (pre-PVC local deployments).
   CACHE_PATH="${APME_CACHE_HOST_PATH:-${XDG_CACHE_HOME:-$HOME/.cache}/apme}"
 
   if [[ "$CACHE_PATH" != /* ]]; then

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -6,7 +6,7 @@
 # (read-only) via the sessions volume.
 # CLI is run on-the-fly with: ./run-cli.sh [args]
 # Start from repo root: podman play kube pod.yaml
-# Requires: images built first (./build.sh) and cache paths (defaults below).
+# Requires: images built first (./build.sh). PVCs are created from pvc.yaml on start.
 apiVersion: v1
 kind: Pod
 metadata:
@@ -174,17 +174,14 @@ spec:
           mountPath: /cache
   volumes:
     - name: gateway-data
-      hostPath:
-        path: __APME_CACHE_PATH__/gateway
-        type: DirectoryOrCreate
+      persistentVolumeClaim:
+        claimName: apme-gateway-data
     - name: sessions
-      hostPath:
-        path: __APME_CACHE_PATH__/sessions
-        type: DirectoryOrCreate
+      persistentVolumeClaim:
+        claimName: apme-sessions
     - name: proxy-cache
-      hostPath:
-        path: __APME_CACHE_PATH__/proxy
-        type: DirectoryOrCreate
+      persistentVolumeClaim:
+        claimName: apme-proxy-cache
     - name: abbenay-config
       hostPath:
         path: ${APME_ROOT}/containers/abbenay/config.yaml

--- a/containers/podman/pvc.yaml
+++ b/containers/podman/pvc.yaml
@@ -1,0 +1,45 @@
+# Podman named volumes for local development (same PVC shape as deploy/helm/apme).
+# Applied by containers/podman/up.sh before pod.yaml. Ignored by Kubernetes when
+# using the Helm chart, which defines its own PVCs in templates/pvc.yaml.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: apme-sessions
+  annotations:
+    volume.podman.io/uid: "1001"
+    volume.podman.io/gid: "0"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: apme-gateway-data
+  annotations:
+    volume.podman.io/uid: "1001"
+    volume.podman.io/gid: "0"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: apme-proxy-cache
+  annotations:
+    volume.podman.io/uid: "1001"
+    volume.podman.io/gid: "0"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -82,15 +82,11 @@ if podman pod exists apme-pod 2>/dev/null; then
 fi
 
 # Pod YAML cannot use env vars; we inject values via envsubst.
-# CACHE_PATH is escaped for sed since it may contain special chars;
-# everything else goes through envsubst so secrets stay out of argv.
-ESCAPED_PATH=$(printf '%s\n' "$CACHE_PATH" | sed -e 's/\\/\\\\/g' -e 's/[&|]/\\&/g')
 export OPENROUTER_API_KEY VERTEX_ANTHROPIC_API_KEY APME_AI_MODEL APME_ROOT="$ROOT"
 export APME_FEEDBACK_ENABLED APME_FEEDBACK_GITHUB_REPO APME_FEEDBACK_GITHUB_TOKEN
 
-# Build the pod YAML: substitute cache path and env vars.
-POD_YAML=$(sed "s|path: __APME_CACHE_PATH__|path: ${ESCAPED_PATH}|" containers/podman/pod.yaml \
-  | envsubst '$OPENROUTER_API_KEY $VERTEX_ANTHROPIC_API_KEY $APME_AI_MODEL $APME_ROOT $APME_FEEDBACK_ENABLED $APME_FEEDBACK_GITHUB_REPO $APME_FEEDBACK_GITHUB_TOKEN')
+POD_YAML=$(envsubst '$OPENROUTER_API_KEY $VERTEX_ANTHROPIC_API_KEY $APME_AI_MODEL $APME_ROOT $APME_FEEDBACK_ENABLED $APME_FEEDBACK_GITHUB_REPO $APME_FEEDBACK_GITHUB_TOKEN' \
+  < containers/podman/pod.yaml)
 
 # When a CA bundle is provided, inject the standard CA env vars and mounts for
 # the containers that make outbound HTTPS requests (gateway, abbenay, galaxy-proxy).
@@ -278,9 +274,10 @@ if [[ -n "$ABBENAY_CA_BUNDLE" ]]; then
   _relabel_host_path_for_podman "$ABBENAY_CA_BUNDLE"
 fi
 
+podman kube play containers/podman/pvc.yaml
 echo "$POD_YAML" | podman play kube -
 
-echo "Pod apme-pod started (cache: $CACHE_PATH). Run a scan: containers/podman/run-cli.sh"
+echo "Pod apme-pod started (volumes: apme-sessions, apme-gateway-data, apme-proxy-cache). Run a scan: containers/podman/run-cli.sh"
 
 if [[ -n "$APME_FEEDBACK_GITHUB_REPO" && -n "$APME_FEEDBACK_GITHUB_TOKEN" ]]; then
   echo "Issue reporting enabled (repo: $APME_FEEDBACK_GITHUB_REPO)"

--- a/containers/ui/Dockerfile
+++ b/containers/ui/Dockerfile
@@ -21,6 +21,7 @@ FROM ${UBI_NGINX_IMAGE}
 USER root
 RUN dnf install -y gettext && dnf clean all
 
+COPY containers/ui/nginx.conf /etc/nginx/nginx.conf
 COPY containers/ui/nginx.conf.template /etc/nginx/conf.d/default.conf.template
 COPY containers/ui/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/containers/ui/nginx.conf
+++ b/containers/ui/nginx.conf
@@ -1,0 +1,31 @@
+# Main nginx config for APME UI (UBI10 nginx-126).
+# The stock UBI image listens on :8080 and does not include /etc/nginx/conf.d/;
+# gateway owns :8080 in the pod, UI serves on :8081 via conf.d/default.conf.
+worker_processes auto;
+error_log /var/log/nginx/error.log notice;
+pid /run/nginx.pid;
+
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    include /opt/app-root/etc/nginx.d/*.conf;
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -171,15 +171,19 @@ bases (ADR-061).
 - The UI container mounts emptyDir volumes for nginx writable paths
 - No privilege escalation is required
 
-For vanilla Kubernetes, set explicit security contexts:
+For vanilla Kubernetes, set explicit security contexts (UBI images run as UID 1001):
 
 ```yaml
 podSecurityContext:
-  fsGroup: 1000
+  fsGroup: 1001
 securityContext:
   runAsNonRoot: true
-  runAsUser: 1000
+  runAsUser: 1001
 ```
+
+`fsGroup` ensures PVC mounts for `/sessions`, `/data`, and `/cache` are writable by
+the application UID. Local Podman uses the same PVC definitions in
+`containers/podman/pvc.yaml` (with `volume.podman.io/uid` annotations).
 
 ## Uninstall
 

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -316,10 +316,10 @@ podAnnotations: {}
 
 # -- Pod-level security context.
 # Defaults to empty so OCP restricted-v2 SCC can inject its own UID/GID range.
-# For vanilla Kubernetes set: podSecurityContext: { fsGroup: 1000 }
+# For vanilla Kubernetes set: podSecurityContext: { fsGroup: 1001 }
 podSecurityContext: {}
 
 # -- Container-level security context.
 # Defaults to empty so OCP restricted-v2 SCC can inject its own UID/GID range.
-# For vanilla Kubernetes set: securityContext: { runAsNonRoot: true, runAsUser: 1000 }
+# For vanilla Kubernetes set: securityContext: { runAsNonRoot: true, runAsUser: 1001 }
 securityContext: {}

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -363,7 +363,7 @@ async def submit_operation(
                 existing_head = head
 
         if existing_head is None:
-            await provider.create_branch(project.repo_url, project.branch, branch_name, token)
+            parent_sha = await provider.create_branch(project.repo_url, project.branch, branch_name, token)
             files = {pf.path: pf.content for pf in patched}
             commit_sha = await provider.push_files(
                 project.repo_url,
@@ -371,6 +371,7 @@ async def submit_operation(
                 files,
                 commit_title,
                 token,
+                parent_commit_sha=parent_sha,
             )
         elif body.create_pr:
             # Two-step UI flow: branch was pushed earlier; only open the PR now.

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -355,15 +355,35 @@ async def submit_operation(
     commit_title = body.title or f"fix: APME remediation — {scan.fixed_count} findings resolved"
 
     try:
-        await provider.create_branch(project.repo_url, project.branch, branch_name, token)
-        files = {pf.path: pf.content for pf in patched}
-        commit_sha = await provider.push_files(
-            project.repo_url,
-            branch_name,
-            files,
-            commit_title,
-            token,
-        )
+        existing_head: str | None = None
+        branch_head_sha = getattr(provider, "branch_head_sha", None)
+        if callable(branch_head_sha):
+            head = await branch_head_sha(project.repo_url, branch_name, token)
+            if isinstance(head, str) and head:
+                existing_head = head
+
+        if existing_head is None:
+            await provider.create_branch(project.repo_url, project.branch, branch_name, token)
+            files = {pf.path: pf.content for pf in patched}
+            commit_sha = await provider.push_files(
+                project.repo_url,
+                branch_name,
+                files,
+                commit_title,
+                token,
+            )
+        elif body.create_pr:
+            # Two-step UI flow: branch was pushed earlier; only open the PR now.
+            commit_sha = existing_head
+        else:
+            files = {pf.path: pf.content for pf in patched}
+            commit_sha = await provider.push_files(
+                project.repo_url,
+                branch_name,
+                files,
+                commit_title,
+                token,
+            )
 
         pr_url: str | None = None
         if body.create_pr:

--- a/src/apme_gateway/grpc_reporting/servicer.py
+++ b/src/apme_gateway/grpc_reporting/servicer.py
@@ -379,8 +379,6 @@ def _add_manifest(db: AsyncSession, scan_id: str, manifest: object) -> None:
     for c in manifest.collections:  # type: ignore[attr-defined]
         if c.fqcn in seen_fqcns:
             logger.debug("Skipping duplicate collection FQCN '%s' for scan '%s'", c.fqcn, scan_id)
-            logger.debug("Skipping duplicate collection FQCN '%s' for scan '%s'", c.fqcn, scan_id)
-            logger.debug("Skipping duplicate collection FQCN '%s' for scan '%s'", c.fqcn, scan_id)
             continue
         seen_fqcns.add(c.fqcn)
         db.add(
@@ -393,7 +391,12 @@ def _add_manifest(db: AsyncSession, scan_id: str, manifest: object) -> None:
                 supplier=c.supplier,
             )
         )
+    seen_pkg_names: set[str] = set()
     for p in manifest.python_packages:  # type: ignore[attr-defined]
+        if p.name in seen_pkg_names:
+            logger.debug("Skipping duplicate python package '%s' for scan '%s'", p.name, scan_id)
+            continue
+        seen_pkg_names.add(p.name)
         db.add(
             ScanPythonPackage(
                 scan_id=scan_id,

--- a/src/apme_gateway/scm/base.py
+++ b/src/apme_gateway/scm/base.py
@@ -35,7 +35,7 @@ class ScmProvider(Protocol):
         base_branch: str,
         new_branch: str,
         token: str,
-    ) -> None:
+    ) -> str:
         """Create a new branch from the tip of *base_branch*.
 
         Args:
@@ -43,6 +43,9 @@ class ScmProvider(Protocol):
             base_branch: Branch to fork from.
             new_branch: Name for the new branch.
             token: Authentication token.
+
+        Returns:
+            Commit SHA at the tip of *new_branch*.
         """
         ...
 
@@ -53,6 +56,8 @@ class ScmProvider(Protocol):
         files: dict[str, bytes],
         commit_message: str,
         token: str,
+        *,
+        parent_commit_sha: str | None = None,
     ) -> str:
         """Push file contents to *branch* and return the commit SHA.
 
@@ -62,6 +67,8 @@ class ScmProvider(Protocol):
             files: Mapping of relative path → file content.
             commit_message: Commit message for the push.
             token: Authentication token.
+            parent_commit_sha: Optional parent commit when the branch ref is not
+                yet readable (e.g. immediately after branch creation).
 
         Returns:
             The SHA of the new commit.

--- a/src/apme_gateway/scm/github.py
+++ b/src/apme_gateway/scm/github.py
@@ -110,6 +110,33 @@ class GitHubProvider:
         """
         return httpx.AsyncClient(timeout=timeout, verify=_http_verify())
 
+    async def branch_head_sha(
+        self,
+        repo_url: str,
+        branch: str,
+        token: str,
+    ) -> str | None:
+        """Return the commit SHA at the tip of *branch*, if it exists.
+
+        Args:
+            repo_url: HTTPS clone URL.
+            branch: Branch name.
+            token: GitHub PAT.
+
+        Returns:
+            Commit SHA when the branch exists, else ``None``.
+        """
+        owner, repo = _parse_owner_repo(repo_url)
+        async with self._client(timeout=30) as client:
+            resp = await client.get(
+                f"{self._api}/repos/{owner}/{repo}/git/ref/heads/{branch}",
+                headers=self._headers(token),
+            )
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            return str(resp.json()["object"]["sha"])
+
     async def create_branch(
         self,
         repo_url: str,
@@ -126,6 +153,10 @@ class GitHubProvider:
             token: GitHub PAT or app installation token.
         """
         owner, repo = _parse_owner_repo(repo_url)
+        if await self.branch_head_sha(repo_url, new_branch, token):
+            logger.info("Branch %s already exists on %s/%s", new_branch, owner, repo)
+            return
+
         async with self._client(timeout=30) as client:
             ref_resp = await client.get(
                 f"{self._api}/repos/{owner}/{repo}/git/ref/heads/{base_branch}",
@@ -256,9 +287,10 @@ class GitHubProvider:
         """
         owner, repo = _parse_owner_repo(repo_url)
         async with self._client(timeout=30) as client:
+            headers = self._headers(token)
             resp = await client.post(
                 f"{self._api}/repos/{owner}/{repo}/pulls",
-                headers=self._headers(token),
+                headers=headers,
                 json={
                     "title": title,
                     "body": body,
@@ -266,6 +298,22 @@ class GitHubProvider:
                     "base": base_branch,
                 },
             )
+            if resp.status_code == 422:
+                existing = await client.get(
+                    f"{self._api}/repos/{owner}/{repo}/pulls",
+                    headers=headers,
+                    params={
+                        "head": f"{owner}:{head_branch}",
+                        "base": base_branch,
+                        "state": "open",
+                    },
+                )
+                existing.raise_for_status()
+                pulls = existing.json()
+                if pulls:
+                    pr_url = pulls[0]["html_url"]
+                    logger.info("Reusing existing PR %s on %s/%s", pr_url, owner, repo)
+                    return PullRequestResult(pr_url=pr_url, branch_name=head_branch, provider="github")
             resp.raise_for_status()
             data = resp.json()
 

--- a/src/apme_gateway/scm/github.py
+++ b/src/apme_gateway/scm/github.py
@@ -12,7 +12,7 @@ import base64
 import logging
 import os
 import ssl
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import httpx
 
@@ -80,6 +80,36 @@ def _parse_owner_repo(repo_url: str) -> tuple[str, str]:
     return owner, repo
 
 
+def _branch_ref_url(api: str, owner: str, repo: str, branch: str) -> str:
+    """Build the GitHub git ref URL for a branch head (slashes URL-encoded).
+
+    Args:
+        api: GitHub API base URL.
+        owner: Repository owner.
+        repo: Repository name.
+        branch: Branch name.
+
+    Returns:
+        Fully qualified REST URL for the branch ref.
+    """
+    return f"{api}/repos/{owner}/{repo}/git/ref/heads/{quote(branch, safe='')}"
+
+
+def _branch_refs_update_url(api: str, owner: str, repo: str, branch: str) -> str:
+    """Build the GitHub git refs update URL for a branch head.
+
+    Args:
+        api: GitHub API base URL.
+        owner: Repository owner.
+        repo: Repository name.
+        branch: Branch name.
+
+    Returns:
+        Fully qualified REST URL for updating the branch ref.
+    """
+    return f"{api}/repos/{owner}/{repo}/git/refs/heads/{quote(branch, safe='')}"
+
+
 class GitHubProvider:
     """GitHub REST API v3 implementation of :class:`ScmProvider`."""
 
@@ -129,7 +159,7 @@ class GitHubProvider:
         owner, repo = _parse_owner_repo(repo_url)
         async with self._client(timeout=30) as client:
             resp = await client.get(
-                f"{self._api}/repos/{owner}/{repo}/git/ref/heads/{branch}",
+                _branch_ref_url(self._api, owner, repo, branch),
                 headers=self._headers(token),
             )
             if resp.status_code == 404:
@@ -143,7 +173,7 @@ class GitHubProvider:
         base_branch: str,
         new_branch: str,
         token: str,
-    ) -> None:
+    ) -> str:
         """Create a Git ref for *new_branch* from the HEAD of *base_branch*.
 
         Args:
@@ -151,19 +181,23 @@ class GitHubProvider:
             base_branch: Source branch.
             new_branch: New branch name.
             token: GitHub PAT or app installation token.
+
+        Returns:
+            Commit SHA at the tip of *new_branch* after creation (or if it already exists).
         """
         owner, repo = _parse_owner_repo(repo_url)
-        if await self.branch_head_sha(repo_url, new_branch, token):
+        existing = await self.branch_head_sha(repo_url, new_branch, token)
+        if existing:
             logger.info("Branch %s already exists on %s/%s", new_branch, owner, repo)
-            return
+            return existing
 
         async with self._client(timeout=30) as client:
             ref_resp = await client.get(
-                f"{self._api}/repos/{owner}/{repo}/git/ref/heads/{base_branch}",
+                _branch_ref_url(self._api, owner, repo, base_branch),
                 headers=self._headers(token),
             )
             ref_resp.raise_for_status()
-            sha = ref_resp.json()["object"]["sha"]
+            sha = str(ref_resp.json()["object"]["sha"])
 
             create_resp = await client.post(
                 f"{self._api}/repos/{owner}/{repo}/git/refs",
@@ -172,6 +206,7 @@ class GitHubProvider:
             )
             create_resp.raise_for_status()
         logger.info("Created branch %s from %s@%s on %s/%s", new_branch, base_branch, sha[:8], owner, repo)
+        return sha
 
     async def push_files(
         self,
@@ -180,6 +215,8 @@ class GitHubProvider:
         files: dict[str, bytes],
         commit_message: str,
         token: str,
+        *,
+        parent_commit_sha: str | None = None,
     ) -> str:
         """Push files atomically via the Git Trees + Commits API.
 
@@ -189,6 +226,8 @@ class GitHubProvider:
             files: Mapping of path → content.
             commit_message: Commit message.
             token: GitHub PAT.
+            parent_commit_sha: Optional parent commit when the branch ref is not
+                yet readable (e.g. immediately after :meth:`create_branch`).
 
         Returns:
             SHA of the new commit.
@@ -197,12 +236,15 @@ class GitHubProvider:
         async with self._client(timeout=60) as client:
             headers = self._headers(token)
 
-            ref_resp = await client.get(
-                f"{self._api}/repos/{owner}/{repo}/git/ref/heads/{branch}",
-                headers=headers,
-            )
-            ref_resp.raise_for_status()
-            commit_sha_head = ref_resp.json()["object"]["sha"]
+            if parent_commit_sha:
+                commit_sha_head = parent_commit_sha
+            else:
+                ref_resp = await client.get(
+                    _branch_ref_url(self._api, owner, repo, branch),
+                    headers=headers,
+                )
+                ref_resp.raise_for_status()
+                commit_sha_head = str(ref_resp.json()["object"]["sha"])
 
             commit_detail = await client.get(
                 f"{self._api}/repos/{owner}/{repo}/git/commits/{commit_sha_head}",
@@ -254,7 +296,7 @@ class GitHubProvider:
             commit_sha: str = commit_resp.json()["sha"]
 
             update_resp = await client.patch(
-                f"{self._api}/repos/{owner}/{repo}/git/refs/heads/{branch}",
+                _branch_refs_update_url(self._api, owner, repo, branch),
                 headers=headers,
                 json={"sha": commit_sha},
             )

--- a/tests/test_gateway_dependencies.py
+++ b/tests/test_gateway_dependencies.py
@@ -169,6 +169,41 @@ async def test_report_fix_with_manifest_persists() -> None:
         assert pkgs[0].name == "jmespath"
 
 
+async def test_report_fix_deduplicates_duplicate_python_packages() -> None:
+    """Duplicate python package names in manifest do not fail persistence."""
+    servicer = ReportingServicer()
+    manifest = common_pb2.ProjectManifest(
+        python_packages=[
+            common_pb2.PythonPackageRef(
+                name="ansible-collection-ansible-posix",
+                version="2.2.1",
+                supplier="Ansible (github.com/ansible)",
+            ),
+            common_pb2.PythonPackageRef(
+                name="ansible-collection-ansible-posix",
+                version="2.2.1",
+                supplier="Ansible (github.com/ansible)",
+            ),
+        ],
+    )
+    event = reporting_pb2.FixCompletedEvent(
+        scan_id="scan-dedupe",
+        session_id="sess-dedupe",
+        project_path="/proj",
+        source="cli",
+        manifest=manifest,
+    )
+    await servicer.ReportFixCompleted(event, _mock_context())
+
+    async with get_session() as db:
+        from sqlalchemy import select
+
+        p_result = await db.execute(select(ScanPythonPackage).where(ScanPythonPackage.scan_id == "scan-dedupe"))
+        pkgs = list(p_result.scalars().all())
+        assert len(pkgs) == 1
+        assert pkgs[0].name == "ansible-collection-ansible-posix"
+
+
 async def test_report_fix_without_manifest_ok() -> None:
     """Fix event without manifest still persists normally."""
     servicer = ReportingServicer()

--- a/tests/test_gateway_pull_request.py
+++ b/tests/test_gateway_pull_request.py
@@ -648,6 +648,40 @@ class TestSubmitEndpoint:
         assert data["pr_url"] == "https://github.com/org/repo/pull/99"
         assert data["commit_sha"] == "db_commit_sha"
 
+    async def test_submit_create_pr_skips_push_when_branch_exists(self, client: AsyncClient) -> None:
+        """PR-only submit reuses an existing branch from the prior push step.
+
+        Args:
+            client: Async test client.
+        """
+        await _seed_project_with_remediation(scm_token="ghp_test123")
+
+        with (
+            patch("apme_gateway.scm.get_provider") as mock_get,
+            patch("apme_gateway.config.load_config") as mock_cfg,
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.branch_head_sha = AsyncMock(return_value="existing_commit_sha")
+            mock_provider.create_branch = AsyncMock()
+            mock_provider.push_files = AsyncMock(return_value="should_not_push")
+            mock_provider.create_pull_request = AsyncMock(return_value=_MOCK_PR_RESULT)
+            mock_get.return_value = mock_provider
+            mock_cfg.return_value.scm_token = ""
+            mock_cfg.return_value.github_api_url = "https://api.github.com"
+
+            resp = await client.post(
+                "/api/v1/projects/proj-1/operation/submit",
+                json={"activity_id": "scan-1", "create_pr": True},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pr_url"] == "https://github.com/org/repo/pull/99"
+        assert data["commit_sha"] == "existing_commit_sha"
+        mock_provider.create_branch.assert_not_called()
+        mock_provider.push_files.assert_not_called()
+        mock_provider.create_pull_request.assert_called_once()
+
     async def test_activity_id_wrong_project(self, client: AsyncClient) -> None:
         """Reject activity_id that does not belong to the project.
 

--- a/tests/test_gateway_pull_request.py
+++ b/tests/test_gateway_pull_request.py
@@ -421,7 +421,7 @@ class TestSubmitEndpoint:
             patch("apme_gateway.config.load_config") as mock_cfg,
         ):
             mock_provider = AsyncMock()
-            mock_provider.create_branch = AsyncMock()
+            mock_provider.create_branch = AsyncMock(return_value="parent_sha")
             mock_provider.push_files = AsyncMock(return_value="abc123def")
             mock_provider.create_pull_request = AsyncMock(return_value=_MOCK_PR_RESULT)
             mock_get.return_value = mock_provider
@@ -451,7 +451,7 @@ class TestSubmitEndpoint:
             patch("apme_gateway.config.load_config") as mock_cfg,
         ):
             mock_provider = AsyncMock()
-            mock_provider.create_branch = AsyncMock()
+            mock_provider.create_branch = AsyncMock(return_value="parent_sha")
             mock_provider.push_files = AsyncMock(return_value="deadbeef")
             mock_get.return_value = mock_provider
             mock_cfg.return_value.scm_token = ""
@@ -466,6 +466,8 @@ class TestSubmitEndpoint:
         data = resp.json()
         assert data["pr_url"] is None
         assert data["commit_sha"] == "deadbeef"
+        mock_provider.push_files.assert_called_once()
+        assert mock_provider.push_files.call_args.kwargs.get("parent_commit_sha") == "parent_sha"
         mock_provider.create_pull_request.assert_not_called()
 
     async def test_no_operation(self, client: AsyncClient) -> None:
@@ -543,7 +545,7 @@ class TestSubmitEndpoint:
             patch("apme_gateway.config.load_config") as mock_cfg,
         ):
             mock_provider = AsyncMock()
-            mock_provider.create_branch = AsyncMock()
+            mock_provider.create_branch = AsyncMock(return_value="parent_sha")
             mock_provider.push_files = AsyncMock(return_value="abc123")
             mock_provider.create_pull_request = AsyncMock(return_value=_MOCK_PR_RESULT)
             mock_get.return_value = mock_provider
@@ -568,7 +570,7 @@ class TestSubmitEndpoint:
             patch("apme_gateway.config.load_config") as mock_cfg,
         ):
             mock_provider = AsyncMock()
-            mock_provider.create_branch = AsyncMock()
+            mock_provider.create_branch = AsyncMock(return_value="parent_sha")
             mock_provider.push_files = AsyncMock(return_value="abc123")
             mock_provider.create_pull_request = AsyncMock(
                 return_value=PullRequestResult(
@@ -631,7 +633,7 @@ class TestSubmitEndpoint:
             patch("apme_gateway.config.load_config") as mock_cfg,
         ):
             mock_provider = AsyncMock()
-            mock_provider.create_branch = AsyncMock()
+            mock_provider.create_branch = AsyncMock(return_value="parent_sha")
             mock_provider.push_files = AsyncMock(return_value="db_commit_sha")
             mock_provider.create_pull_request = AsyncMock(return_value=_MOCK_PR_RESULT)
             mock_get.return_value = mock_provider
@@ -662,7 +664,7 @@ class TestSubmitEndpoint:
         ):
             mock_provider = AsyncMock()
             mock_provider.branch_head_sha = AsyncMock(return_value="existing_commit_sha")
-            mock_provider.create_branch = AsyncMock()
+            mock_provider.create_branch = AsyncMock(return_value="parent_sha")
             mock_provider.push_files = AsyncMock(return_value="should_not_push")
             mock_provider.create_pull_request = AsyncMock(return_value=_MOCK_PR_RESULT)
             mock_get.return_value = mock_provider


### PR DESCRIPTION
## Summary
- Fix `tox -e build` failures after the UBI10 base image migration (ADR-061), where `apme-base` ends as `USER 1001` but several service images still needed root for build-time steps.

## Changes
- **OPA** (`containers/opa/Dockerfile`): Switch to root before copying the Rego bundle and entrypoint to `/bundle` and `/entrypoint.sh`, then drop back to `USER 1001`.
- **Ansible** (`containers/ansible/Dockerfile`): Switch to root for the UV cache pre-warm script, create `/opt/uv-cache`, and `chown` it to UID 1001.
- **Galaxy Proxy** (`containers/galaxy-proxy/Dockerfile`): Switch to root for the `uv pip install` build step that uses the cache mount.

All three follow the same pattern already used by `containers/gateway/Dockerfile`.

## Test plan
- [x] `tox -e build` passes (all images build; ADR-061 volume write checks pass)
- [ ] `tox -e lint` — pre-existing `skillmark` failures on upstream/main (unrelated to this PR)
- [ ] `tox -e unit` — pre-existing pytest-xdist collection errors on upstream/main (unrelated to this PR)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved submit behavior to reuse an existing branch head and to reuse an existing open pull request when applicable.
  * Enhanced Podman local storage by switching pod volumes (sessions/gateway/proxy-cache) to persistent volume claims.
* **Bug Fixes**
  * Improved manifest reporting persistence to deduplicate duplicate Python packages.
  * Improved `--wipe` to also remove known Podman volumes when present.
  * UI container now uses the provided top-level Nginx configuration.
* **Documentation**
  * Updated Helm vanilla Kubernetes security guidance to use UID/GID `1001`.
* **Tests**
  * Added unit tests for PR-only submit behavior and duplicate Python package handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->