### PR TITLE
feat(gateway): ADR-062 Phase 2 draft/commit and engine id bridge

### DIFF
--- a/.agents/skills/pr-address-feedback/SKILL.md
+++ b/.agents/skills/pr-address-feedback/SKILL.md
@@ -82,16 +82,18 @@ EOF
 Every automated reviewer comment (Copilot, CodeRabbit) on an agent-authored
 PR is a defect in our own review process. These tools apply the same
 principles every time — if one found something, the agent's pre-submit
-self-review (see the `pr-new` skill, Step 3) should have found it first.
-Without tightening that loop, we will never ship a PR without comments.
+self-review (see the `pr-new` skill, Step 3 + Step 3b Rule of Five)
+should have found it first. Without tightening that loop, we will never
+ship a PR without comments.
 
 After fixing each automated finding, ask: _which principle from the
-pr-new self-review should have caught this?_ If one exists but
-didn't trigger, the principle needs to be clearer or the agent didn't
-apply it. If no principle covers it, add one — but frame it as a
-general evaluation criterion, not a specific instance. Adding "don't
-do X" only prevents X; strengthening a principle prevents the entire
-class of issues X belongs to.
+pr-new self-review (Step 3 questions or Rule of Five pass 1–5) should
+have caught this?_ If one exists but didn't trigger, the principle needs
+to be clearer or the agent didn't apply it. If no principle covers it,
+strengthen the matching Rule of Five lens (or Step 3 question) — frame
+it as a general evaluation criterion, not a specific instance. Adding
+"don't do X" only prevents X; strengthening a principle prevents the
+entire class of issues X belongs to.
 
 ## How automated reviewers evaluate code
 

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -419,12 +419,15 @@ After all passes return, the parent agent must:
 1. **Deduplicate** findings and build a table: finding → which passes →
    severity → fix-now vs follow-up.
 2. **Ship-blockers** = any finding in **≥2 passes**, plus any single-pass
-   **critical** (data corruption, security exposure, ADR-060 break,
-   invariant violation).
+   **critical** or **major** finding (data corruption, security exposure,
+   ADR-060 break, invariant violation, or a Pass-rated major defect in
+   one lens). Single-pass **medium/low** may be follow-ups; single-pass
+   major must be fixed or explicitly demoted with human approval before
+   Step 4.
 3. **Act on ship-blockers.** Fix code (or demote ADR/PR framing and open
    a tracked follow-up). Re-run `tox -e lint` and `tox -e unit`.
 4. **Re-run Rule of Five** after substantive fixes until:
-   - no new multi-pass ship-blockers, and
+   - no new multi-pass or single-pass major/critical ship-blockers, and
    - Pass 5's verdict is merge-ready (or framing is honestly demoted).
 5. Document dismissed findings with a clear technical justification.
 

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -306,7 +306,9 @@ empty-but-not-falsy values, post-filter field combinations, async
 dependency never responds / asyncio.gather(return_exceptions=True)
 mix, concurrent select-then-insert, non-unique dict keys, mixed members
 of a group stamped with one decision, unbounded SQL IN vs SQLite
-limits.
+limits (prefer ``col.in_(select(...))`` over materializing large id
+lists into bound parameters; chunk at ~900 when a Python list is
+unavoidable).
 
 Do NOT discuss architecture philosophy. Rank findings
 critical/high/medium/low.

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -308,7 +308,9 @@ mix, concurrent select-then-insert, non-unique dict keys, mixed members
 of a group stamped with one decision, unbounded SQL IN vs SQLite
 limits (prefer ``col.in_(select(...))`` over materializing large id
 lists into bound parameters; chunk at ~900 when a Python list is
-unavoidable).
+unavoidable; when checking membership of a *small* candidate set
+against a large table, query the intersection of those candidates —
+never load the full table into Python just to filter a handful of ids).
 
 Do NOT discuss architecture philosophy. Rank findings
 critical/high/medium/low.

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -325,8 +325,15 @@ critical/high/medium/low.
 - Dual input shapes that normalize differently (ORM vs dict, dataclass
   vs mapping, servicer vs flush path)
 - Overlay fields that drift (tier/source/gate/status→review must stay
-  aligned for all pre-group sources)
-- Schema/API mistakes (ADR-060: no breaking changes to /api/v1)
+  aligned for all pre-group sources). When a column documents
+  "empty means fall back to X" (e.g. ``stamp_rule_ids_json`` →
+  ``rule_ids_json``), every stamp/filter path must honor that
+  fallback — skipping the filter when empty is a contract break.
+- Schema/API mistakes (ADR-060: no breaking changes to /api/v1).
+  Tightening previously-lenient validation (e.g. turning ignored
+  unknown ids into hard 400s) is a semantic break even if the
+  OpenAPI shape is unchanged — prefer log+ignore / intersection
+  unless an ADR explicitly hardens the contract.
 - Cross-artifact parity (proto RPC ↔ daemon servicer; rule IDs ADR-008;
   _DEFAULT_PORTS ↔ started services)
 - Test gaps for behaviors the code/docs claim

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[branch-name] [--title 'PR title']"
 user-invocable: true
 metadata:
   author: APME Team
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # PR New
@@ -202,89 +202,234 @@ artifact type, translate it:
 
 Only proceed to Step 3b after completing this review.
 
-### Step 3b: Cold subagent review
+### Step 3b: Rule of Five (cold multi-agent review)
 
-**This step is mandatory.** The self-review in Step 3 is necessary but
-insufficient — it suffers from confirmation bias because the reviewing
-agent wrote the code. Spin up a **read-only subagent** with no
-conversation history to review the diff cold.
+**This step is mandatory.** Step 3 is necessary but insufficient — it
+suffers from confirmation bias because the reviewing agent wrote the
+code. Spin up **independent read-only subagents** with no conversation
+history. Each pass uses a progressively broader lens (in-the-small →
+in-the-large). Findings that appear in **≥2 passes** are ship-blockers
+until fixed or explicitly demoted with a documented follow-up.
 
-The subagent sees only the diff and the review questions. It has no
-memory of the intent, iterations, or trade-offs that led to the code.
-This forces it to read every line at face value — the same way Copilot
-or a human reviewer would.
+This replaces the former single cold 9-question subagent. The nine
+questions are **folded into the five lenses** below so coverage is not
+lost.
+
+#### Scale
+
+| PR size | Passes | Which lenses |
+|---------|--------|--------------|
+| Small / chore / docs-only / single-file fix | **3** | Pass 1, 2, 5 |
+| Nontrivial feature, ADR, multi-service, persistence, API | **5** | Pass 1–5 |
+
+When unsure, use **5**.
+
+#### Model selection (capabilities, not slugs)
+
+Do **not** pin vendor model names or slugs in this skill — they rot.
+When launching each Task subagent, choose a model by **capability
+tier**, mapping to whatever the current agent runtime offers.
+
+| Tier | Attributes to prefer | Use for |
+|------|----------------------|---------|
+| **fast** | Low latency, lower cost, solid at local reasoning and grep-style consistency checks; does not need deep architectural judgment | Pass **1**, Pass **2** |
+| **strong** | Best available reasoning / long-context judgment in the current runtime; willing to challenge product framing and system design | Pass **3**, Pass **4**, Pass **5** |
+
+**Selection rules:**
+
+1. Match the tier’s **attributes**, not a remembered product name.
+2. If the runtime only exposes one model, use it for every pass
+   (correctness over cost).
+3. If several models fit a tier, pick the cheapest that still matches
+   the attributes — do not “upgrade” Pass 1–2 to strong by default.
+4. Never downgrade Pass 3–5 to fast to save money; those passes catch
+   ship-blockers that mechanical review misses.
+5. Parent aggregation stays on the parent model (no extra subagent).
+
+#### Shared preamble (every pass)
+
+Every subagent prompt must start with this block (fill in repo path,
+branch, and PR number if known):
 
 ```text
-Launch a Task subagent with:
+You are Review Pass <N> of <TOTAL> for an APME pull request.
+You have no prior context about why these changes were made — review
+every line at face value.
+
+Repository: <absolute path to repo>
+Branch: <branch-name>
+Base: upstream/main
+PR: #<number or "unopened">
+
+Run `git diff upstream/main...HEAD` for the full diff. Then:
+1. List every distinct artifact type in the diff (Python, proto, Rego,
+   Ansible YAML, shell, Dockerfile, JSON/YAML config, Markdown, TS/TSX,
+   etc.). Your findings must cover each type that appears — translate
+   the lens if needed (e.g. "caller" in proto = any RPC invoker;
+   "pin to intent" in Dockerfiles = base image / pip / COPY paths).
+2. Read each changed file in full (not just hunks). For new functions,
+   tests, or stubs, also read sibling files for convention consistency
+   (mocks, typing style, error handling).
+3. Return ONLY actionable findings. No praise. No padding.
+   Format: **[Pass N / severity] file:line — description**
+   If truly nothing for your lens: "No findings."
+```
+
+Launch all passes in **one message** (parallel Task calls). Set each
+subagent’s model according to the tier table above (fast vs strong) —
+pass the runtime’s current model id that best matches the tier’s
+attributes; omit `model` only when the runtime has a single option.
+
+```text
+Launch each Task subagent with:
   subagent_type: "generalPurpose"
   readonly: true
   run_in_background: false
+  model: <runtime id matching Pass N's tier>
 ```
 
-Use this prompt template (fill in the repository path and diff):
+#### Pass 1 — classic bugs (narrow / in-the-small)
+
+**Tier: fast.** Covers former cold-review **Q1, Q3, Q8** (bugs and edge paths).
 
 ```text
-You are reviewing a pull request diff. You have no prior context about
-why these changes were made — review every line at face value.
+<shared preamble with N=1>
 
-Repository: <absolute path to repo>
-Base branch: upstream/main
+**Lens — classic code review:** Find concrete bugs in the changed code:
+logic errors, off-by-ones, incorrect conditionals, race conditions,
+wrong types, missing null checks, broken edge cases, return values that
+violate declared types, caller-surprising behavior (nullable returns,
+hidden mutation/I/O, throws the signature denies).
 
-Run `git diff upstream/main...HEAD` to get the full diff, then read
-every changed file in full (not just the diff hunks — you need
-surrounding context to evaluate contracts and consistency).  For new
-code (functions, tests, stubs), also read sibling files to verify
-convention consistency (mock patterns, type annotation style, error
-handling patterns).
+Also construct at least one realistic failure per public entry point:
+empty-but-not-falsy values, post-filter field combinations, async
+dependency never responds / asyncio.gather(return_exceptions=True)
+mix, concurrent select-then-insert, non-unique dict keys, mixed members
+of a group stamped with one decision, unbounded SQL IN vs SQLite
+limits.
 
-Evaluate the diff against these 9 questions. For each question, either
-report a concrete finding (file, line, what's wrong, why it matters)
-or state "No findings." Do not pad with observations that aren't
-actionable.
-
-1. Does every statement mean what it says? (types, return values,
-   comments, docstrings — does the runtime honor them on every path?)
-2. Does this expose more than it should? (logs, errors, user strings,
-   capability grants, container permissions)
-3. Would a caller be surprised? (nullable returns, hidden side effects,
-   undisclosed I/O, inconsistency with sibling functions)
-4. Is everything still true after this change? (prose vs code drift —
-   renamed symbols with old docstrings, changed behavior with old
-   descriptions, stale ADR/doc references; ADR "all/every" claims
-   that no longer match filtered implementation)
-5. Are dependencies and versions pinned to intent?
-6. Is there dead weight? (unused imports, unreachable branches,
-   written-but-never-read variables; also repeated parse/work,
-   O(n) queue ops, `len(list(seq))`, and O(P×V) nested scans that
-   should be O(1) / O(P+V))
-7. Is this internally and externally consistent? (patterns, naming,
-   cross-artifact parity — e.g., proto RPCs must have matching
-   servicer methods in daemon/, rule IDs must follow ADR-008;
-   dual input shapes must normalize identically; overlay fields
-   like tier/source/gate must stay aligned)
-8. Would a constructed scenario break this? (edge-case inputs,
-   empty-but-not-falsy values, temporal failures — async dependency
-   never responds, asyncio.gather with return_exceptions=True
-   returning a mix of results and exceptions; concurrent
-   select-then-insert races; non-unique dict keys that overwrite;
-   mixed members of a group stamped with one decision; unbounded
-   SQL IN lists vs SQLite parameter limits)
-9. Do inherited contracts hold? (Protocol/base class implementations
-   honor runtime semantics — validators are read-only per ADR-009,
-   gRPC servicers use grpc.aio per ADR-007)
-
-Return ONLY findings. Format each as:
-  **[Q#] file:line — description**
-
-If there are no findings across all 9 questions, return:
-  "No findings."
+Do NOT discuss architecture philosophy. Rank findings
+critical/high/medium/low.
 ```
 
-**Act on every finding.** Fix the code, then re-run `tox -e lint` and
-`tox -e unit`. Do not dismiss findings without a clear technical
-justification documented in the self-review output.
+#### Pass 2 — consistency, drift, and waste
 
-If the subagent returns "No findings", proceed to Step 4.
+**Tier: fast.** Covers former cold-review **Q4, Q5, Q6, Q7**.
+
+```text
+<shared preamble with N=2>
+
+**Lens — consistency & drift:** Assume Pass 1 caught obvious bugs. Hunt for:
+- Docstring/ADR/comment vs code drift (especially "all"/"every" claims
+  vs filtered implementation)
+- Dual input shapes that normalize differently (ORM vs dict, dataclass
+  vs mapping, servicer vs flush path)
+- Overlay fields that drift (tier/source/gate/status→review must stay
+  aligned for all pre-group sources)
+- Schema/API mistakes (ADR-060: no breaking changes to /api/v1)
+- Cross-artifact parity (proto RPC ↔ daemon servicer; rule IDs ADR-008;
+  _DEFAULT_PORTS ↔ started services)
+- Test gaps for behaviors the code/docs claim
+- Silent no-ops, dead branches, wrong defaults
+- **Dependencies pinned to intent** — version ranges, GitHub Action
+  tags, base images, pip/uv specs (not tighter, not looser)
+- **Dead weight** — unused imports/params; paid-for-but-wasteful work:
+  double JSON parse, list.pop(0)/insert(0,…) vs deque, len(list(seq)),
+  O(P×V) nested scans that should be O(P+V)
+- Pydantic/schema mutable defaults (`=[]`) vs sibling Field(default_factory=list)
+
+Explain briefly why a Pass-1-style review would miss each finding.
+```
+
+#### Pass 3 — Right Thing / product fitness
+
+**Tier: strong.** Covers former cold-review **Q3 (product surprise), Q9 (invariants)**.
+
+```text
+<shared preamble with N=3>
+
+**Lens — are we doing the Right Thing?** Read the governing ADR(s),
+AGENTS.md architectural invariants, and the implementation. Ask:
+- Does this actually solve the stated goal, or is it a half-measure /
+  framing overclaim?
+- Are lifecycle triggers complete, or will users lose state unexpectedly?
+- Is the grain/grouping/API shape honest for the UX story?
+- Do filters or demotions contradict docs/ADR claims?
+- Any invariant violations (validators read-only ADR-009, grpc.aio
+  ADR-007, engine never queries out ADR-020/029, REST additive-only
+  ADR-060, transforms submit() ADR-044, tox-only ADR-047, etc.)?
+- Do Protocol / base-class implementations honor full runtime contracts,
+  not just compiler-required members?
+
+Return **[Right Thing / Design Risk]** with recommendation:
+fix-now vs follow-up issue. Be skeptical.
+```
+
+#### Pass 4 — system architecture (in-the-large)
+
+**Tier: strong.** Covers former cold-review **Q7–Q9** at system scale.
+
+```text
+<shared preamble with N=4>
+
+**Lens — system architecture:** Zoom out beyond this PR's files:
+- Dependency direction (gateway vs engine; no inverted imports)
+- Where state lives and failure modes (concurrency, restart,
+  multi-instance, partial flush/claim)
+- Scaling: algorithmic cost, SQLite parameter limits, fan-out under load
+- Whether schemas/analytics support the views claimed in ADR/docs
+- Frontend/API contract readiness for the stated UX
+- Migration/backfill for existing deployments
+- Interaction with surrounding RPC/event timing (e.g. FixSession /
+  ReportFixCompleted)
+
+Compare ADR/doc claims to what shipped. Label each finding
+"fix in this PR" vs "track as issue".
+```
+
+#### Pass 5 — adversarial / exposure / simplify
+
+**Tier: strong.** Covers former cold-review **Q2, Q8** plus deliberate simplification.
+
+```text
+<shared preamble with N=5>
+
+**Lens — break it / rethink it:** Be creatively adversarial:
+- Weird but realistic scenarios that corrupt durable state, double-count
+  analytics, or bypass filters
+- **Information exposure** — logs, errors, user-facing strings,
+  persisted diffs/explanations: credentials, secrets, user content,
+  internal paths? Capability grants, CORS origins, container caps —
+  minimum necessary?
+- Multi-tenant / empty project_id / confused or hostile clients against
+  additive API fields
+- Time travel: clock skew, flush-then-rebuild inconsistency, partial
+  claim failures
+- If you deleted 50% of this design, what still ships the goal?
+
+Return: (1) adversarial findings that could be real bugs,
+(2) simplify/kill recommendations,
+(3) short verdict: converged enough to merge, or what must change first?
+```
+
+#### Aggregate, act, converge
+
+After all passes return, the parent agent must:
+
+1. **Deduplicate** findings and build a table: finding → which passes →
+   severity → fix-now vs follow-up.
+2. **Ship-blockers** = any finding in **≥2 passes**, plus any single-pass
+   **critical** (data corruption, security exposure, ADR-060 break,
+   invariant violation).
+3. **Act on ship-blockers.** Fix code (or demote ADR/PR framing and open
+   a tracked follow-up). Re-run `tox -e lint` and `tox -e unit`.
+4. **Re-run Rule of Five** after substantive fixes until:
+   - no new multi-pass ship-blockers, and
+   - Pass 5's verdict is merge-ready (or framing is honestly demoted).
+5. Document dismissed findings with a clear technical justification.
+
+Do not proceed to Step 4 until convergence (or an explicit user decision
+to accept remaining follow-ups).
 
 ### Step 4: Update documentation
 

--- a/.sdlc/adrs/ADR-062-ephemeral-proposal-working-set.md
+++ b/.sdlc/adrs/ADR-062-ephemeral-proposal-working-set.md
@@ -209,14 +209,25 @@ match.
 ## Implementation Notes
 
 - Phase 1: schema + group-on-inject + analytics table + flush scaffolding +
-  historical rebuild + additive API (this ADR).
-- Phase 2: scan-scoped draft/commit; gate commit writes `review_status` and
-  analytics; PR/push = publish flush.
+  historical rebuild + additive API (this ADR) — **done** (#391).
+- Phase 2: scan-scoped draft/commit; gate commit writes analytics (and
+  `review_status` when violation ids are already linked — live stubs often
+  stamp at FixCompleted after the id bridge); `engine_proposal_id` bridge
+  keyed by `(file, source, rule_id, line_start)` because `primary.Proposal`
+  has no `path` field; `PATCH .../operation/proposals` + SSE
+  `proposal_updated`; `abandon_working_set` resets draft status to pending;
+  PR/push = publish flush — **done** (this change set). UI wiring of PATCH /
+  `proposal_updated` is a follow-up (types only in this change set).
 - Phase 3: Option C two-gate engine/UI; AI reporting over analytics /
-  `review_status`.
+  `review_status`. Adding `path` to `primary.Proposal` (proto) would tighten
+  the id bridge for multi-finding same-line collisions.
 - SQLite: extend `_migrate_*` pattern in `apme_gateway.db` (no Alembic).
 - Non-interactive Tier 1 auto-apply sets `review_status=deterministic_approved`
   when fixed violations are persisted.
+- Abandon safeguard keys on `proposals.draft=1` only so non-interactive
+  approved working sets still auto-flush on the next remediate. Live stubs
+  attach `project_id` early; `link_scan_to_project` excludes the linking
+  scan from flush-before-attach.
 
 ## Related Decisions
 
@@ -239,3 +250,4 @@ match.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-07-09 | Brad Thornton | Initial acceptance from #379 durability design |
+| 2026-07-09 | Brad Thornton | Phase 2: draft PATCH, gate-commit stamps, id bridge, abandon |

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -46,6 +46,10 @@ export interface ProposalDetail {
   diff_hunk?: string;
   explanation?: string;
   suggestion?: string;
+  /** Live FixSession / OperationRegistry id when bridged (ADR-062 Phase 2). */
+  engine_proposal_id?: string | null;
+  /** True while optimistic UI edits are not yet gate-committed. */
+  draft?: boolean;
 }
 
 export interface ActivitySummary {

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -49,10 +49,13 @@ class OperateRequest(BaseModel):  # type: ignore[misc]
     Attributes:
         action: ``check`` or ``remediate``.
         options: Additional operation options.
+        abandon_working_set: When True, allow a new remediate to flush an
+            interactive draft working set (ADR-062 Phase 2).
     """
 
     action: str = Field(..., pattern="^(check|remediate)$")
     options: dict[str, Any] = Field(default_factory=dict)
+    abandon_working_set: bool = False
 
 
 class OperateResponse(BaseModel):  # type: ignore[misc]
@@ -75,6 +78,28 @@ class ApproveRequest(BaseModel):  # type: ignore[misc]
     approved_ids: list[str] = Field(default_factory=list)
 
 
+class DraftProposalUpdate(BaseModel):  # type: ignore[misc]
+    """One optimistic checkbox update (ADR-062 Phase 2).
+
+    Attributes:
+        proposal_id: Gateway ``proposal_id`` or live ``engine_proposal_id``.
+        status: pending, approved, or declined.
+    """
+
+    proposal_id: str
+    status: str
+
+
+class DraftProposalsRequest(BaseModel):  # type: ignore[misc]
+    """Body for ``PATCH /proposals``.
+
+    Attributes:
+        updates: Status updates for working-set proposals.
+    """
+
+    updates: list[DraftProposalUpdate] = Field(default_factory=list)
+
+
 # ── REST endpoints ────────────────────────────────────────────────────
 
 
@@ -82,7 +107,9 @@ class ApproveRequest(BaseModel):  # type: ignore[misc]
 async def initiate_operation(project_id: str, body: OperateRequest) -> OperateResponse:
     """Initiate a new check or remediate operation for a project.
 
-    Rejects with 409 if the project already has an active operation.
+    Rejects with 409 if the project already has an active operation, or if
+    a remediate would wipe an interactive draft working set without
+    ``abandon_working_set=true`` (ADR-062 Phase 2).
 
     Args:
         project_id: Target project UUID.
@@ -92,7 +119,8 @@ async def initiate_operation(project_id: str, body: OperateRequest) -> OperateRe
         The new operation identifier.
 
     Raises:
-        HTTPException: 404 if project not found, 409 if operation active.
+        HTTPException: 404 if project not found; 409 if operation active or
+            ``working_set_in_progress`` without abandon opt-in.
     """
     from apme_gateway._galaxy_inject import load_galaxy_server_defs
     from apme_gateway.config import load_config
@@ -103,6 +131,37 @@ async def initiate_operation(project_id: str, body: OperateRequest) -> OperateRe
         raise HTTPException(status_code=404, detail="Project not found")
 
     registry = get_operation_registry()
+    # Reject an active operation before abandoning drafts — otherwise a
+    # abandon_working_set retry would wipe another tab's review then 409.
+    prior_op = registry.get_by_project(proj.id)
+    if prior_op is not None and prior_op.status not in TERMINAL_STATUSES:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Project already has an active operation {prior_op.operation_id}",
+        )
+    extra_scan_ids = [prior_op.scan_id] if prior_op is not None else []
+
+    if body.action == "remediate":
+        from apme_gateway.proposals.draft import (  # noqa: PLC0415
+            abandon_project_drafts,
+            project_has_draft_proposals,
+        )
+
+        async with get_session() as db:
+            has_draft = await project_has_draft_proposals(db, proj.id, extra_scan_ids=extra_scan_ids)
+            if has_draft and not body.abandon_working_set:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "working_set_in_progress",
+                        "message": "Project has an interactive draft working set; "
+                        "retry with abandon_working_set=true to discard it.",
+                    },
+                )
+            if has_draft and body.abandon_working_set:
+                await abandon_project_drafts(db, proj.id, extra_scan_ids=extra_scan_ids)
+                await db.commit()
+
     operation_id = uuid.uuid4().hex
     scan_id = uuid.uuid4().hex
     scan_type = body.action
@@ -162,14 +221,18 @@ async def get_operation_state(project_id: str) -> dict[str, Any]:
 
 @operation_router.post("/approve")  # type: ignore[untyped-decorator]
 async def approve_proposals(project_id: str, body: ApproveRequest) -> dict[str, str]:
-    """Submit approval decisions for AI proposals.
+    """Submit approval decisions for live proposals (engine ids).
 
-    Resolves the operation's ``approval_future`` so the background gRPC
-    task can send the approval to Primary.
+    Gate-commits Gateway working-set rows (omit = decline) and rolls
+    analytics when claimable, then resolves the operation's
+    ``approval_future`` so the background gRPC task can send the approval
+    to Primary. ``review_status`` is stamped when violation ids are already
+    linked; otherwise FixCompleted stamps after the id bridge. Request /
+    response shape is unchanged (ADR-060).
 
     Args:
         project_id: Target project UUID.
-        body: Approved proposal IDs.
+        body: Approved **engine** proposal IDs.
 
     Returns:
         Confirmation message.
@@ -189,8 +252,76 @@ async def approve_proposals(project_id: str, body: ApproveRequest) -> dict[str, 
     if state.approval_future is None or state.approval_future.done():
         raise HTTPException(status_code=409, detail="Approval already submitted")
 
+    # Gate commit: mirror omit=reject + analytics before waking Primary.
+    # review_status often waits until FixCompleted (stubs lack violation_ids).
+    # Scope to this round's offered ids so a later gate does not rewrite prior
+    # decisions on the same scan.
+    from apme_gateway.proposals.draft import commit_gate_decisions  # noqa: PLC0415
+
+    offered = [p.id for p in (state.proposals or [])]
+    async with get_session() as db:
+        await commit_gate_decisions(
+            db,
+            scan_id=state.scan_id,
+            project_id=project_id,
+            approved_engine_ids=body.approved_ids,
+            offered_engine_ids=offered,
+        )
+        await db.commit()
+
     state.approval_future.set_result(body.approved_ids)
     return {"status": "approved"}
+
+
+@operation_router.patch("/proposals")  # type: ignore[untyped-decorator]
+async def patch_draft_proposals(project_id: str, body: DraftProposalsRequest) -> dict[str, Any]:
+    """Optimistic draft checkbox updates (ADR-062 Phase 2).
+
+    Updates Gateway ``proposals.status`` and sets ``draft=1``. Does not
+    stamp ``review_status``, write analytics, or resolve ``approval_future``.
+
+    Args:
+        project_id: Target project UUID.
+        body: Draft status updates (gateway or engine proposal ids).
+
+    Returns:
+        Updated proposal summaries.
+
+    Raises:
+        HTTPException: 404/409 on missing operation or bad state; 400 on bad ids.
+    """
+    registry = get_operation_registry()
+    state = registry.get_by_project(project_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="No operation for this project")
+    if state.status != OperationStatus.AWAITING_APPROVAL:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Operation is in '{state.status.value}', not 'awaiting_approval'",
+        )
+
+    from apme_gateway.proposals.draft import apply_draft_updates  # noqa: PLC0415
+    from apme_gateway.proposals.flush import proposal_to_detail_dict  # noqa: PLC0415
+
+    updates = [{"proposal_id": u.proposal_id, "status": u.status} for u in body.updates]
+    try:
+        async with get_session() as db:
+            rows = await apply_draft_updates(db, scan_id=state.scan_id, updates=updates)
+            await db.commit()
+            payloads = [proposal_to_detail_dict(r) for r in rows]
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Mirror onto in-memory registry proposals when engine ids match.
+    if state.proposals:
+        by_engine = {p.id: p for p in state.proposals}
+        for item in payloads:
+            eng = str(item.get("engine_proposal_id") or "")
+            if eng and eng in by_engine:
+                by_engine[eng].status = str(item.get("status") or by_engine[eng].status)
+
+    registry.broadcast_proposal_updated(state.operation_id, payloads)
+    return {"updated": payloads}
 
 
 @operation_router.post("/cancel")  # type: ignore[untyped-decorator]
@@ -596,7 +727,9 @@ async def finalize_operation_scan(
 
     The engine commits the scan via ``ReportFixCompleted`` asynchronously. If
     the gateway tries to insert ``scan_patches`` before that row exists, SQLite
-    raises a foreign-key error. Poll until the scan row appears or timeout.
+    raises a foreign-key error. Live proposal stubs may create an early Scan
+    row (ADR-062 Phase 2); poll until ``ReportFixCompleted`` has replaced the
+    placeholder session id (not ``op-*``) or timeout.
 
     Args:
         project_id: Owning project UUID.
@@ -616,7 +749,9 @@ async def finalize_operation_scan(
     while time.monotonic() < deadline:
         async with get_session() as db:
             scan = await q.get_scan(db, scan_id)
-            if scan is not None:
+            # Stub rows from ProposalsReady use session_id ``op-<scan>``;
+            # ReportFixCompleted rewrites session_id to the real hash.
+            if scan is not None and not str(scan.session_id or "").startswith("op-"):
                 if clone_commit:
                     await q.update_project_commit(db, project_id, clone_commit)
                 await q.link_scan_to_project(
@@ -735,6 +870,40 @@ async def _drive_operation(
                 ai_proposed_count = sum(1 for i in items if i.status != "declined")
                 ai_declined_count = sum(1 for i in items if i.status == "declined")
                 registry.set_proposals(operation_id, items)
+                # ADR-062 Phase 2: upsert Gateway stubs with engine_proposal_id.
+                from apme_gateway.proposals.draft import upsert_live_proposal_stubs  # noqa: PLC0415
+
+                # primary.Proposal has no path; bridge uses file+rule+line_start.
+                stub_payloads = [
+                    {
+                        "id": p.id,
+                        "rule_id": p.rule_id,
+                        "file": p.file,
+                        "tier": p.tier,
+                        "confidence": p.confidence,
+                        "explanation": p.explanation,
+                        "diff_hunk": p.diff_hunk,
+                        "status": p.status,
+                        "suggestion": p.suggestion,
+                        "line_start": p.line_start,
+                        "source": getattr(p, "source", "") or ("ai" if p.tier >= 2 else "deterministic"),
+                    }
+                    for p in props.proposals
+                ]
+                try:
+                    async with get_session() as db:
+                        await upsert_live_proposal_stubs(
+                            db,
+                            scan_id=scan_id,
+                            project_id=project_id,
+                            proposals=stub_payloads,
+                        )
+                        await db.commit()
+                except Exception:
+                    logger.exception(
+                        "Failed to upsert live proposal stubs for scan %s",
+                        scan_id[:12],
+                    )
 
             elif kind == "approval_ack":
                 ack = event.approval_ack  # type: ignore[attr-defined]

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -83,11 +83,12 @@ class DraftProposalUpdate(BaseModel):  # type: ignore[misc]
 
     Attributes:
         proposal_id: Gateway ``proposal_id`` or live ``engine_proposal_id``.
-        status: pending, approved, or declined.
+        status: pending, approved, or declined (``proposed``/``rejected``
+            accepted as synonyms and normalized in ``apply_draft_updates``).
     """
 
     proposal_id: str
-    status: str
+    status: str = Field(..., pattern="^(pending|approved|declined|proposed|rejected)$")
 
 
 class DraftProposalsRequest(BaseModel):  # type: ignore[misc]
@@ -263,8 +264,14 @@ async def approve_proposals(project_id: str, body: ApproveRequest) -> dict[str, 
     offered_set = set(offered)
     approved_set = {str(i) for i in body.approved_ids}
     unknown = sorted(approved_set - offered_set)
+    # ADR-060: do not harden /approve into a 400 for unknown ids — prior
+    # behavior ignored extras. Log and proceed with the offered intersection.
     if unknown:
-        raise HTTPException(status_code=400, detail=f"Unknown proposal ids: {unknown}")
+        logger.warning(
+            "Ignoring %s unknown approve id(s) for project %s (not in offered set)",
+            len(unknown),
+            project_id[:12],
+        )
     # Preserve offered order; only ids that were actually presented this round.
     approved = [pid for pid in offered if pid in approved_set]
     async with get_session() as db:

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -131,50 +131,51 @@ async def initiate_operation(project_id: str, body: OperateRequest) -> OperateRe
         raise HTTPException(status_code=404, detail="Project not found")
 
     registry = get_operation_registry()
-    # Reject an active operation before abandoning drafts — otherwise a
-    # abandon_working_set retry would wipe another tab's review then 409.
-    prior_op = registry.get_by_project(proj.id)
-    if prior_op is not None and prior_op.status not in TERMINAL_STATUSES:
-        raise HTTPException(
-            status_code=409,
-            detail=f"Project already has an active operation {prior_op.operation_id}",
-        )
-    extra_scan_ids = [prior_op.scan_id] if prior_op is not None else []
-
-    if body.action == "remediate":
-        from apme_gateway.proposals.draft import (  # noqa: PLC0415
-            abandon_project_drafts,
-            project_has_draft_proposals,
-        )
-
-        async with get_session() as db:
-            has_draft = await project_has_draft_proposals(db, proj.id, extra_scan_ids=extra_scan_ids)
-            if has_draft and not body.abandon_working_set:
-                raise HTTPException(
-                    status_code=409,
-                    detail={
-                        "code": "working_set_in_progress",
-                        "message": "Project has an interactive draft working set; "
-                        "retry with abandon_working_set=true to discard it.",
-                    },
-                )
-            if has_draft and body.abandon_working_set:
-                await abandon_project_drafts(db, proj.id, extra_scan_ids=extra_scan_ids)
-                await db.commit()
-
     operation_id = uuid.uuid4().hex
     scan_id = uuid.uuid4().hex
     scan_type = body.action
 
-    try:
-        state = registry.create(
-            operation_id=operation_id,
-            project_id=proj.id,
-            scan_id=scan_id,
-            scan_type=scan_type,
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    # Hold the per-project lock across active-check → abandon → create so a
+    # concurrent remediate cannot interleave and wipe another op's drafts.
+    async with registry.project_lock(proj.id):
+        prior_op = registry.get_by_project(proj.id)
+        if prior_op is not None and prior_op.status not in TERMINAL_STATUSES:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Project already has an active operation {prior_op.operation_id}",
+            )
+        extra_scan_ids = [prior_op.scan_id] if prior_op is not None else []
+
+        if body.action == "remediate":
+            from apme_gateway.proposals.draft import (  # noqa: PLC0415
+                abandon_project_drafts,
+                project_has_draft_proposals,
+            )
+
+            async with get_session() as db:
+                has_draft = await project_has_draft_proposals(db, proj.id, extra_scan_ids=extra_scan_ids)
+                if has_draft and not body.abandon_working_set:
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "code": "working_set_in_progress",
+                            "message": "Project has an interactive draft working set; "
+                            "retry with abandon_working_set=true to discard it.",
+                        },
+                    )
+                if has_draft and body.abandon_working_set:
+                    await abandon_project_drafts(db, proj.id, extra_scan_ids=extra_scan_ids)
+                    await db.commit()
+
+        try:
+            state = registry.create(
+                operation_id=operation_id,
+                project_id=proj.id,
+                scan_id=scan_id,
+                scan_type=scan_type,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     cfg = load_config()
     galaxy_servers = await load_galaxy_server_defs()
@@ -259,17 +260,24 @@ async def approve_proposals(project_id: str, body: ApproveRequest) -> dict[str, 
     from apme_gateway.proposals.draft import commit_gate_decisions  # noqa: PLC0415
 
     offered = [p.id for p in (state.proposals or [])]
+    offered_set = set(offered)
+    approved_set = {str(i) for i in body.approved_ids}
+    unknown = sorted(approved_set - offered_set)
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unknown proposal ids: {unknown}")
+    # Preserve offered order; only ids that were actually presented this round.
+    approved = [pid for pid in offered if pid in approved_set]
     async with get_session() as db:
         await commit_gate_decisions(
             db,
             scan_id=state.scan_id,
             project_id=project_id,
-            approved_engine_ids=body.approved_ids,
+            approved_engine_ids=approved,
             offered_engine_ids=offered,
         )
         await db.commit()
 
-    state.approval_future.set_result(body.approved_ids)
+    state.approval_future.set_result(approved)
     return {"status": "approved"}
 
 

--- a/src/apme_gateway/api/schemas.py
+++ b/src/apme_gateway/api/schemas.py
@@ -125,6 +125,8 @@ class ProposalDetail(BaseModel):  # type: ignore[misc]
         diff_hunk: Unified diff when available (optional additive).
         explanation: AI explanation when available (optional additive).
         suggestion: Manual suggestion when available (optional additive).
+        engine_proposal_id: Live engine proposal id when bridged (optional).
+        draft: True while optimistic UI edits are not yet gate-committed.
     """
 
     id: int
@@ -143,6 +145,8 @@ class ProposalDetail(BaseModel):  # type: ignore[misc]
     diff_hunk: str = ""
     explanation: str = ""
     suggestion: str = ""
+    engine_proposal_id: str | None = None
+    draft: bool = False
 
 
 class LogEntry(BaseModel):  # type: ignore[misc]

--- a/src/apme_gateway/db/__init__.py
+++ b/src/apme_gateway/db/__init__.py
@@ -123,6 +123,12 @@ def _migrate_proposals_table(conn: object) -> None:
         migrations.append("ALTER TABLE proposals ADD COLUMN suggestion TEXT NOT NULL DEFAULT ''")
     if "analytics_flushed" not in existing:
         migrations.append("ALTER TABLE proposals ADD COLUMN analytics_flushed INTEGER NOT NULL DEFAULT 0")
+    if "engine_proposal_id" not in existing:
+        migrations.append("ALTER TABLE proposals ADD COLUMN engine_proposal_id TEXT DEFAULT NULL")
+    if "draft" not in existing:
+        migrations.append("ALTER TABLE proposals ADD COLUMN draft INTEGER NOT NULL DEFAULT 0")
+    if "stamp_rule_ids_json" not in existing:
+        migrations.append("ALTER TABLE proposals ADD COLUMN stamp_rule_ids_json TEXT NOT NULL DEFAULT '[]'")
 
     for stmt in migrations:
         conn.execute(text(stmt))

--- a/src/apme_gateway/db/models.py
+++ b/src/apme_gateway/db/models.py
@@ -216,6 +216,11 @@ class Proposal(Base):
         explanation: AI explanation while actionable (ephemeral).
         suggestion: Manual suggestion text.
         analytics_flushed: 1 after counts were rolled into analytics, else 0.
+        engine_proposal_id: Live FixSession / OperationRegistry proposal id
+            when known (ADR-062 Phase 2 id bridge); null for archival-only.
+        draft: 1 while UI has optimistic edits not yet gate-committed.
+        stamp_rule_ids_json: JSON array of rule ids allowed to receive
+            ``review_status`` stamps (empty = use full ``rule_ids_json``).
         scan: Back-reference to owning Scan.
     """
 
@@ -239,6 +244,9 @@ class Proposal(Base):
     explanation: Mapped[str] = mapped_column(Text, nullable=False, default="")
     suggestion: Mapped[str] = mapped_column(Text, nullable=False, default="")
     analytics_flushed: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    engine_proposal_id: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    draft: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    stamp_rule_ids_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
 
     scan: Mapped[Scan] = relationship(back_populates="proposals")
 

--- a/src/apme_gateway/db/queries.py
+++ b/src/apme_gateway/db/queries.py
@@ -529,7 +529,9 @@ async def link_scan_to_project(
     if effective_type == "remediate":
         from apme_gateway.proposals.flush import flush_proposals_for_project  # noqa: PLC0415
 
-        await flush_proposals_for_project(db, project_id)
+        # Exclude the scan being linked so live stubs that already set
+        # project_id (ADR-062 Phase 2) are not deleted by flush-before-attach.
+        await flush_proposals_for_project(db, project_id, exclude_scan_id=scan_id)
     elif effective_type == "check":
         from apme_gateway.proposals.flush import discard_scan_proposals  # noqa: PLC0415
 

--- a/src/apme_gateway/grpc_reporting/servicer.py
+++ b/src/apme_gateway/grpc_reporting/servicer.py
@@ -397,7 +397,10 @@ async def _persist_grouped_proposals(
     # across replace_scan_proposals (and non-interactive Tier 1 promotions
     # written by replace) are applied once violation_ids exist.
     from apme_gateway.db.models import Proposal  # noqa: PLC0415
-    from apme_gateway.proposals.grouping import parse_json_list  # noqa: PLC0415
+    from apme_gateway.proposals.grouping import (  # noqa: PLC0415
+        parse_json_list,
+        stamp_rule_allowlist,
+    )
 
     by_id = {v.id: v for v in violations}
     persisted = list((await db.execute(sa_select(Proposal).where(Proposal.scan_id == scan_id))).scalars().all())
@@ -409,7 +412,10 @@ async def _persist_grouped_proposals(
         int_ids = [int(v) for v in v_ids if str(v).isdigit() or isinstance(v, int)]
         if not int_ids:
             continue
-        stamp_rules = set(parse_json_list(prop.stamp_rule_ids_json or "[]"))
+        stamp_rules = stamp_rule_allowlist(
+            stamp_rule_ids_json=prop.stamp_rule_ids_json,
+            rule_ids_json=prop.rule_ids_json,
+        )
         for vid in int_ids:
             violation = by_id.get(vid)
             if violation is None or violation.review_status is not None:

--- a/src/apme_gateway/grpc_reporting/servicer.py
+++ b/src/apme_gateway/grpc_reporting/servicer.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 
 import grpc
+from sqlalchemy import delete as sa_delete
 from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -127,6 +128,9 @@ class ReportingServicer(reporting_pb2_grpc.ReportingServicer):
                     scan.manual_review = request.summary.manual_review if request.summary else scan.manual_review
                     scan.fixed_count = request.report.fixed if request.report else scan.fixed_count
                     scan.diagnostics_json = _diagnostics_to_json(request.diagnostics)
+                    # Idempotent replay: clear append-only children before re-add.
+                    # Keep Proposal rows until replace_scan_proposals bridges them.
+                    await _clear_scan_children_for_replay(db, request.scan_id)
                 await db.flush()
                 _add_violations(db, request.scan_id, list(request.remaining_violations))
                 _add_violations(db, request.scan_id, list(request.fixed_violations))
@@ -252,6 +256,29 @@ async def _reconcile_rules(
         unchanged += 1
 
     return added, removed, unchanged
+
+
+async def _clear_scan_children_for_replay(db: AsyncSession, scan_id: str) -> None:
+    """Delete append-only scan children so ReportFixCompleted can re-insert.
+
+    Preserves ``Proposal`` rows so the live stub → archival bridge in
+    ``replace_scan_proposals`` still sees prior gate-commit state.
+
+    Args:
+        db: Active async session.
+        scan_id: Scan whose child rows to clear.
+    """
+    for model in (
+        Violation,
+        ScanLog,
+        ScanPatch,
+        PatchedFile,
+        ScanManifest,
+        ScanCollection,
+        ScanPythonPackage,
+        ScanGraph,
+    ):
+        await db.execute(sa_delete(model).where(model.scan_id == scan_id))
 
 
 async def _upsert_session(db: AsyncSession, session_id: str, project_path: str) -> None:

--- a/src/apme_gateway/grpc_reporting/servicer.py
+++ b/src/apme_gateway/grpc_reporting/servicer.py
@@ -93,23 +93,40 @@ class ReportingServicer(reporting_pb2_grpc.ReportingServicer):
         try:
             async with get_session() as db:
                 await _upsert_session(db, request.session_id, request.project_path)
-                scan = Scan(
-                    scan_id=request.scan_id,
-                    session_id=request.session_id,
-                    project_id=None,
-                    project_path=request.project_path,
-                    source=request.source or "cli",
-                    trigger="cli",
-                    created_at=_now_iso(),
-                    scan_type="remediate",
-                    total_violations=request.summary.total if request.summary else 0,
-                    auto_fixable=request.summary.auto_fixable if request.summary else 0,
-                    ai_candidate=request.summary.ai_candidate if request.summary else 0,
-                    manual_review=request.summary.manual_review if request.summary else 0,
-                    fixed_count=request.report.fixed if request.report else 0,
-                    diagnostics_json=_diagnostics_to_json(request.diagnostics),
-                )
-                db.add(scan)
+                existing = (
+                    await db.execute(sa_select(Scan).where(Scan.scan_id == request.scan_id))
+                ).scalar_one_or_none()
+                if existing is None:
+                    scan = Scan(
+                        scan_id=request.scan_id,
+                        session_id=request.session_id,
+                        project_id=None,
+                        project_path=request.project_path,
+                        source=request.source or "cli",
+                        trigger="cli",
+                        created_at=_now_iso(),
+                        scan_type="remediate",
+                        total_violations=request.summary.total if request.summary else 0,
+                        auto_fixable=request.summary.auto_fixable if request.summary else 0,
+                        ai_candidate=request.summary.ai_candidate if request.summary else 0,
+                        manual_review=request.summary.manual_review if request.summary else 0,
+                        fixed_count=request.report.fixed if request.report else 0,
+                        diagnostics_json=_diagnostics_to_json(request.diagnostics),
+                    )
+                    db.add(scan)
+                else:
+                    # Live ProposalsReady may have created a stub scan (ADR-062 Phase 2).
+                    scan = existing
+                    scan.session_id = request.session_id
+                    scan.project_path = request.project_path
+                    if not scan.source or scan.source == "gateway":
+                        scan.source = request.source or scan.source or "cli"
+                    scan.total_violations = request.summary.total if request.summary else scan.total_violations
+                    scan.auto_fixable = request.summary.auto_fixable if request.summary else scan.auto_fixable
+                    scan.ai_candidate = request.summary.ai_candidate if request.summary else scan.ai_candidate
+                    scan.manual_review = request.summary.manual_review if request.summary else scan.manual_review
+                    scan.fixed_count = request.report.fixed if request.report else scan.fixed_count
+                    scan.diagnostics_json = _diagnostics_to_json(request.diagnostics)
                 await db.flush()
                 _add_violations(db, request.scan_id, list(request.remaining_violations))
                 _add_violations(db, request.scan_id, list(request.fixed_violations))
@@ -349,19 +366,24 @@ async def _persist_grouped_proposals(
 
     await replace_scan_proposals(db, scan_id=scan_id, proposals=list(merged))
 
-    # Stamp review_status for terminal decisions (e.g. auto-approved Tier 1).
+    # Stamp review_status from persisted rows so gate-commit decisions bridged
+    # across replace_scan_proposals (and non-interactive Tier 1 promotions
+    # written by replace) are applied once violation_ids exist.
+    from apme_gateway.db.models import Proposal  # noqa: PLC0415
+    from apme_gateway.proposals.grouping import parse_json_list  # noqa: PLC0415
+
     by_id = {v.id: v for v in violations}
-    for prop in merged:
-        status = prop.status
-        if status == "pending" and prop.source == "deterministic" and prop.fixed_yaml:
-            # Non-interactive Tier 1: engine applied a fix without a human
-            # gate — treat as accepted for analytics / durable review.
-            status = "approved"
-        review = review_status_for_proposal(prop.source, status)
-        if not review or not prop.violation_ids:
+    persisted = list((await db.execute(sa_select(Proposal).where(Proposal.scan_id == scan_id))).scalars().all())
+    for prop in persisted:
+        review = review_status_for_proposal(prop.source, prop.status)
+        if not review:
             continue
-        stamp_rules = set(prop.stamp_rule_ids or ())
-        for vid in prop.violation_ids:
+        v_ids = parse_json_list(prop.violation_ids_json)
+        int_ids = [int(v) for v in v_ids if str(v).isdigit() or isinstance(v, int)]
+        if not int_ids:
+            continue
+        stamp_rules = set(parse_json_list(prop.stamp_rule_ids_json or "[]"))
+        for vid in int_ids:
             violation = by_id.get(vid)
             if violation is None or violation.review_status is not None:
                 continue
@@ -369,7 +391,7 @@ async def _persist_grouped_proposals(
                 v_rule = str(getattr(violation, "rule_id", "") or "")
                 if v_rule not in stamp_rules:
                     continue
-            if not violation_accepts_review_status(prop.source, violation, decision=status):
+            if not violation_accepts_review_status(prop.source, violation, decision=prop.status):
                 continue
             violation.review_status = review
 

--- a/src/apme_gateway/operation_registry.py
+++ b/src/apme_gateway/operation_registry.py
@@ -272,6 +272,18 @@ class OperationRegistry:
             },
         )
 
+    def broadcast_proposal_updated(self, operation_id: str, proposals: list[dict[str, Any]]) -> None:
+        """Broadcast optimistic draft updates (ADR-062 Phase 2).
+
+        Args:
+            operation_id: The operation to notify.
+            proposals: Updated proposal detail dicts.
+        """
+        op = self._ops.get(operation_id)
+        if op is None:
+            return
+        self._broadcast(op, SSEEventType.PROPOSAL_UPDATED, {"proposals": proposals})
+
     def set_result(self, operation_id: str, result: OperationResult) -> None:
         """Store the operation result and transition to COMPLETED.
 

--- a/src/apme_gateway/operation_registry.py
+++ b/src/apme_gateway/operation_registry.py
@@ -180,6 +180,11 @@ class OperationRegistry:
         self._terminal_times.pop(operation_id, None)
         if self._by_project.get(op.project_id) == operation_id:
             del self._by_project[op.project_id]
+            # Drop idle lock so long-lived gateways do not retain one entry
+            # per historical project_id (Copilot: unbounded _project_locks).
+            lock = self._project_locks.get(op.project_id)
+            if lock is not None and not lock.locked():
+                self._project_locks.pop(op.project_id, None)
         for q in op.sse_subscribers:
             with contextlib.suppress(asyncio.QueueFull):
                 q.put_nowait({"_close": True})

--- a/src/apme_gateway/operation_registry.py
+++ b/src/apme_gateway/operation_registry.py
@@ -50,6 +50,22 @@ class OperationRegistry:
         self._terminal_times: dict[str, float] = {}
         self._terminal_ttl = terminal_ttl
         self._reaper_task: asyncio.Task[None] | None = None
+        self._project_locks: dict[str, asyncio.Lock] = {}
+
+    def project_lock(self, project_id: str) -> asyncio.Lock:
+        """Return a per-project lock for operate/abandon critical sections.
+
+        Args:
+            project_id: Project UUID.
+
+        Returns:
+            Lock shared by all callers for this project.
+        """
+        lock = self._project_locks.get(project_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._project_locks[project_id] = lock
+        return lock
 
     # ── lifecycle ──────────────────────────────────────────────────────
 
@@ -74,6 +90,7 @@ class OperationRegistry:
         self._ops.clear()
         self._by_project.clear()
         self._terminal_times.clear()
+        self._project_locks.clear()
 
     # ── CRUD ──────────────────────────────────────────────────────────
 

--- a/src/apme_gateway/operation_types.py
+++ b/src/apme_gateway/operation_types.py
@@ -244,6 +244,7 @@ class SSEEventType(str, Enum):
         STATUS_CHANGED: Status transition delta.
         PROGRESS: New progress log entry.
         PROPOSALS: AI proposals delivered.
+        PROPOSAL_UPDATED: Optimistic draft status change (ADR-062 Phase 2).
         RESULT: Operation completed with results.
         APPROVAL_ACK: Approval acknowledged.
         PR_CREATED: Pull request URL available.
@@ -254,6 +255,7 @@ class SSEEventType(str, Enum):
     STATUS_CHANGED = "status_changed"
     PROGRESS = "progress"
     PROPOSALS = "proposals"
+    PROPOSAL_UPDATED = "proposal_updated"
     RESULT = "result"
     APPROVAL_ACK = "approval_ack"
     PR_CREATED = "pr_created"

--- a/src/apme_gateway/proposals/__init__.py
+++ b/src/apme_gateway/proposals/__init__.py
@@ -1,5 +1,12 @@
 """Proposal working-set package (ADR-062)."""
 
+from apme_gateway.proposals.draft import (
+    abandon_project_drafts,
+    apply_draft_updates,
+    commit_gate_decisions,
+    project_has_draft_proposals,
+    upsert_live_proposal_stubs,
+)
 from apme_gateway.proposals.flush import (
     discard_scan_proposals,
     flush_proposals_for_project,
@@ -9,10 +16,15 @@ from apme_gateway.proposals.flush import (
 from apme_gateway.proposals.grouping import group_violations, merge_outcomes
 
 __all__ = [
+    "abandon_project_drafts",
+    "apply_draft_updates",
+    "commit_gate_decisions",
     "discard_scan_proposals",
     "flush_proposals_for_project",
     "flush_proposals_for_scan",
     "group_violations",
     "merge_outcomes",
+    "project_has_draft_proposals",
     "replace_scan_proposals",
+    "upsert_live_proposal_stubs",
 ]

--- a/src/apme_gateway/proposals/draft.py
+++ b/src/apme_gateway/proposals/draft.py
@@ -147,11 +147,26 @@ async def abandon_project_drafts(
     )
     cleared = int(result.rowcount or 0)
 
-    linked_set = set((await db.execute(linked_scans)).scalars().all())
-    orphan_scans = [s for s in extra_scan_ids if s and s not in linked_set]
-    for sid in orphan_scans:
-        result = await db.execute(delete(Proposal).where(Proposal.scan_id == sid))
-        cleared += int(result.rowcount or 0)
+    # Only probe the tiny extra_scan_ids set — do not materialize all project scans.
+    candidates = [s for s in extra_scan_ids if s]
+    if candidates:
+        linked_extras = set(
+            (
+                await db.execute(
+                    select(Scan.scan_id).where(
+                        Scan.project_id == project_id,
+                        Scan.scan_id.in_(list(candidates)),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for sid in candidates:
+            if sid in linked_extras:
+                continue
+            result = await db.execute(delete(Proposal).where(Proposal.scan_id == sid))
+            cleared += int(result.rowcount or 0)
     return cleared
 
 

--- a/src/apme_gateway/proposals/draft.py
+++ b/src/apme_gateway/proposals/draft.py
@@ -1,0 +1,485 @@
+"""Optimistic draft updates and gate-commit stamps (ADR-062 Phase 2)."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from sqlalchemy import or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apme_gateway.db.models import Proposal, Scan, Violation
+from apme_gateway.proposals.flush import upsert_analytics_increment
+from apme_gateway.proposals.grouping import (
+    GATE_AI,
+    GATE_TIER1,
+    SOURCE_AI,
+    SOURCE_AI_CANDIDATE,
+    SOURCE_DETERMINISTIC,
+    analytics_increments,
+    parse_json_list,
+    review_status_for_proposal,
+    serialize_rule_ids,
+    violation_accepts_review_status,
+)
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_DRAFT_STATUSES = frozenset({"pending", "approved", "declined", "proposed", "rejected"})
+
+
+def _gate_for_source(source: str, tier: int) -> str:
+    """Return archival gate label for a live proposal source/tier.
+
+    Args:
+        source: Proposal source string.
+        tier: Numeric remediation tier.
+
+    Returns:
+        Gate label (``tier1``, ``ai``, or empty).
+    """
+    if source in {SOURCE_AI, SOURCE_AI_CANDIDATE} or tier >= 2:
+        return GATE_AI
+    if source == SOURCE_DETERMINISTIC or tier == 1:
+        return GATE_TIER1
+    return ""
+
+
+def _archival_proposal_id(*, file: str, path: str, gate: str, rule_id: str, engine_id: str) -> str:
+    """Stable Gateway proposal_id for a live stub (path hash or engine id).
+
+    Args:
+        file: Target file path.
+        path: Node identity path when known.
+        gate: Archival gate label.
+        rule_id: Primary rule id.
+        engine_id: Live engine proposal id.
+
+    Returns:
+        ``prop-{gate}-{digest}`` identifier.
+    """
+    material = path or f"{file}:{rule_id}:{engine_id}"
+    digest = hashlib.sha1(material.encode("utf-8")).hexdigest()[:12]  # noqa: S324
+    gate_part = gate or "na"
+    return f"prop-{gate_part}-{digest}"
+
+
+def _normalize_status(status: str) -> str:
+    """Map engine proposed/rejected onto Gateway pending/declined.
+
+    Args:
+        status: Raw status string from engine or UI.
+
+    Returns:
+        Normalized Gateway status.
+    """
+    lowered = status.lower().strip()
+    if lowered == "proposed":
+        return "pending"
+    if lowered == "rejected":
+        return "declined"
+    return lowered
+
+
+async def project_has_draft_proposals(
+    db: AsyncSession,
+    project_id: str,
+    *,
+    extra_scan_ids: Sequence[str] = (),
+) -> bool:
+    """Return True when the project has any proposal with ``draft=1``.
+
+    Live ProposalsReady stubs may sit on a Scan with ``project_id`` still
+    NULL (flush-before-attach); pass that operation's ``scan_id`` via
+    ``extra_scan_ids``.
+
+    Args:
+        db: Active async session.
+        project_id: Project UUID.
+        extra_scan_ids: Additional scan ids (e.g. active/terminal op stub).
+
+    Returns:
+        Whether an interactive draft working set exists.
+    """
+    scan_ids = list((await db.execute(select(Scan.scan_id).where(Scan.project_id == project_id))).scalars().all())
+    for sid in extra_scan_ids:
+        if sid and sid not in scan_ids:
+            scan_ids.append(sid)
+    if not scan_ids:
+        return False
+    stmt = select(Proposal.id).where(Proposal.scan_id.in_(scan_ids), Proposal.draft == 1).limit(1)
+    return (await db.execute(stmt)).scalar_one_or_none() is not None
+
+
+async def abandon_project_drafts(
+    db: AsyncSession,
+    project_id: str,
+    *,
+    extra_scan_ids: Sequence[str] = (),
+) -> int:
+    """Clear interactive drafts so a new remediate can start (opt-in abandon).
+
+    Clears ``draft=1`` and resets ``status`` to ``pending`` on project-linked
+    scans so abandoned optimistic decisions cannot later flush into analytics
+    or ``review_status``. For unlinked stub scans in ``extra_scan_ids``,
+    deletes proposal rows so orphan working sets do not linger.
+
+    Args:
+        db: Active async session.
+        project_id: Project UUID.
+        extra_scan_ids: Operation scan ids that may not yet be project-linked.
+
+    Returns:
+        Number of proposal rows cleared or deleted.
+    """
+    from sqlalchemy import delete  # noqa: PLC0415
+
+    linked = list((await db.execute(select(Scan.scan_id).where(Scan.project_id == project_id))).scalars().all())
+    cleared = 0
+    if linked:
+        result = await db.execute(
+            update(Proposal).where(Proposal.scan_id.in_(linked), Proposal.draft == 1).values(draft=0, status="pending")
+        )
+        cleared += int(result.rowcount or 0)
+
+    orphan_scans = [s for s in extra_scan_ids if s and s not in linked]
+    for sid in orphan_scans:
+        result = await db.execute(delete(Proposal).where(Proposal.scan_id == sid))
+        cleared += int(result.rowcount or 0)
+    return cleared
+
+
+async def ensure_scan_row(
+    db: AsyncSession,
+    *,
+    scan_id: str,
+    project_id: str | None = None,
+    scan_type: str = "remediate",
+) -> Scan:
+    """Ensure a Scan row exists so live proposal stubs can FK to it.
+
+    Creates a placeholder session when needed. ``ReportFixCompleted`` later
+    upserts the real session_id and scan counters onto the same row.
+
+    Args:
+        db: Active async session.
+        scan_id: Engine/operation scan UUID.
+        project_id: Optional owning project.
+        scan_type: check or remediate.
+
+    Returns:
+        Existing or newly created Scan.
+    """
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    from apme_gateway.db.models import Session  # noqa: PLC0415
+
+    existing = (await db.execute(select(Scan).where(Scan.scan_id == scan_id))).scalar_one_or_none()
+    if existing is not None:
+        # Attach project when known so draft detection survives registry reaper.
+        # link_scan_to_project excludes this scan_id from flush-before-attach.
+        if project_id and not existing.project_id:
+            existing.project_id = project_id
+            await db.flush()
+        return existing  # type: ignore[no-any-return]
+
+    now = datetime.now(tz=timezone.utc).isoformat()
+    # Full scan_id — truncated prefixes can collide across distinct UUIDs.
+    placeholder_session = f"op-{scan_id}"
+    sess = (await db.execute(select(Session).where(Session.session_id == placeholder_session))).scalar_one_or_none()
+    if sess is None:
+        db.add(
+            Session(
+                session_id=placeholder_session,
+                project_path="",
+                first_seen=now,
+                last_seen=now,
+            )
+        )
+        await db.flush()
+
+    # Attach project_id when known so abandon/draft detection works without
+    # relying solely on in-memory OperationRegistry. flush-before-attach
+    # excludes this scan_id when linking (ADR-062 Phase 2).
+    scan = Scan(
+        scan_id=scan_id,
+        session_id=placeholder_session,
+        project_id=project_id,
+        project_path="",
+        source="gateway",
+        trigger="ui",
+        created_at=now,
+        scan_type=scan_type,
+        total_violations=0,
+        auto_fixable=0,
+        ai_candidate=0,
+        manual_review=0,
+        fixed_count=0,
+        diagnostics_json="{}",
+    )
+    db.add(scan)
+    await db.flush()
+    return scan
+
+
+async def upsert_live_proposal_stubs(
+    db: AsyncSession,
+    *,
+    scan_id: str,
+    project_id: str | None,
+    proposals: Sequence[Mapping[str, Any]],
+) -> list[Proposal]:
+    """Upsert Gateway proposal rows for live ProposalsReady items.
+
+    Matches existing rows by ``engine_proposal_id`` first, then by
+    ``proposal_id``. Creates archival-style ids when inserting.
+
+    Args:
+        db: Active async session.
+        scan_id: Operation scan UUID.
+        project_id: Owning project when known.
+        proposals: Mappings with id/file/rule_id/tier/status/source/….
+
+    Returns:
+        Upserted ORM Proposal rows.
+    """
+    await ensure_scan_row(db, scan_id=scan_id, project_id=project_id, scan_type="remediate")
+    out: list[Proposal] = []
+    for raw in proposals:
+        engine_id = str(raw.get("id") or raw.get("engine_proposal_id") or "").strip()
+        if not engine_id:
+            continue
+        file_ = str(raw.get("file") or "")
+        rule_id = str(raw.get("rule_id") or "")
+        path = str(raw.get("path") or "")
+        tier = int(raw.get("tier") or 0)
+        source = str(raw.get("source") or (SOURCE_AI if tier >= 2 else SOURCE_DETERMINISTIC))
+        gate = str(raw.get("gate") or "") or _gate_for_source(source, tier)
+        status = _normalize_status(str(raw.get("status") or "pending"))
+        rule_parts = tuple(p.strip() for p in rule_id.split(",") if p.strip()) or ((rule_id,) if rule_id else ())
+        stamp_rules = rule_parts
+        archival_id = _archival_proposal_id(file=file_, path=path, gate=gate, rule_id=rule_id, engine_id=engine_id)
+
+        existing = (
+            await db.execute(
+                select(Proposal).where(
+                    Proposal.scan_id == scan_id,
+                    or_(Proposal.engine_proposal_id == engine_id, Proposal.proposal_id == archival_id),
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is None:
+            existing = Proposal(
+                scan_id=scan_id,
+                proposal_id=archival_id,
+                rule_id=rule_id or (rule_parts[0] if rule_parts else ""),
+                file=file_,
+                tier=tier,
+                confidence=float(raw.get("confidence") or 0.0),
+                status=status,
+                path=path,
+                source=source,
+                gate=gate,
+                rule_ids_json=serialize_rule_ids(rule_parts),
+                violation_ids_json="[]",
+                line_start=int(raw.get("line_start") or 0),
+                diff_hunk=str(raw.get("diff_hunk") or ""),
+                explanation=str(raw.get("explanation") or ""),
+                suggestion=str(raw.get("suggestion") or ""),
+                analytics_flushed=0,
+                engine_proposal_id=engine_id,
+                draft=0,
+                stamp_rule_ids_json=serialize_rule_ids(stamp_rules),
+            )
+            db.add(existing)
+        else:
+            existing.engine_proposal_id = engine_id
+            existing.file = file_ or existing.file
+            existing.rule_id = rule_id or existing.rule_id
+            existing.tier = tier or existing.tier
+            existing.path = path or existing.path
+            existing.source = source or existing.source
+            existing.gate = gate or existing.gate
+            existing.diff_hunk = str(raw.get("diff_hunk") or existing.diff_hunk)
+            existing.explanation = str(raw.get("explanation") or existing.explanation)
+            existing.suggestion = str(raw.get("suggestion") or existing.suggestion)
+            existing.line_start = int(raw.get("line_start") or existing.line_start)
+            existing.confidence = float(raw.get("confidence") or existing.confidence)
+            if "tier" in raw and raw.get("tier") is not None:
+                existing.tier = int(raw["tier"])
+            if rule_parts:
+                existing.rule_ids_json = serialize_rule_ids(rule_parts)
+                existing.stamp_rule_ids_json = serialize_rule_ids(stamp_rules)
+            # Do not clobber an in-progress draft status from a re-emit.
+            if not existing.draft:
+                existing.status = status
+        out.append(existing)
+    await db.flush()
+    return out
+
+
+async def apply_draft_updates(
+    db: AsyncSession,
+    *,
+    scan_id: str,
+    updates: Sequence[Mapping[str, str]],
+) -> list[Proposal]:
+    """Apply optimistic checkbox status updates without stamping review.
+
+    Args:
+        db: Active async session.
+        scan_id: Operation scan UUID.
+        updates: Mappings with proposal_id (gateway or engine) and status.
+
+    Returns:
+        Updated Proposal rows.
+
+    Raises:
+        ValueError: Unknown id or illegal status.
+    """
+    updated: list[Proposal] = []
+    for item in updates:
+        key = str(item.get("proposal_id") or item.get("id") or "").strip()
+        status = _normalize_status(str(item.get("status") or ""))
+        if not key:
+            raise ValueError("proposal_id is required")
+        if status not in _ALLOWED_DRAFT_STATUSES:
+            raise ValueError(f"invalid draft status: {status}")
+        prop = (
+            await db.execute(
+                select(Proposal).where(
+                    Proposal.scan_id == scan_id,
+                    or_(Proposal.proposal_id == key, Proposal.engine_proposal_id == key),
+                )
+            )
+        ).scalar_one_or_none()
+        if prop is None:
+            raise ValueError(f"proposal not found: {key}")
+        prop.status = status
+        prop.draft = 1
+        updated.append(prop)
+    await db.flush()
+    return updated
+
+
+async def commit_gate_decisions(
+    db: AsyncSession,
+    *,
+    scan_id: str,
+    project_id: str,
+    approved_engine_ids: Sequence[str],
+    offered_engine_ids: Sequence[str] | None = None,
+) -> int:
+    """Mirror omit=reject onto Gateway rows and roll analytics when claimable.
+
+    Does **not** delete proposal rows (publish / new remediate still flush).
+    Only rows whose ``engine_proposal_id`` is in ``offered_engine_ids`` (this
+    approval round) are updated — prior gate decisions on the same scan are
+    left alone. When ``offered_engine_ids`` is omitted, all live-bridged rows
+    on the scan are treated as offered (single-gate callers).
+
+    ``review_status`` is stamped only when ``violation_ids_json`` already
+    lists violation PKs. Live stubs usually have ``[]`` until
+    ``ReportFixCompleted`` rebuilds groups; that path stamps from the
+    bridged terminal status (see ``_persist_grouped_proposals``).
+
+    Args:
+        db: Active async session.
+        scan_id: Operation scan UUID.
+        project_id: Project UUID for analytics.
+        approved_engine_ids: Engine proposal ids accepted at the gate.
+        offered_engine_ids: Engine ids presented in this approval round.
+
+    Returns:
+        Number of proposals updated.
+    """
+    approved = {str(i) for i in approved_engine_ids}
+    offered = {str(i) for i in offered_engine_ids} if offered_engine_ids is not None else None
+    props = list((await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalars().all())
+    if not props:
+        return 0
+
+    count = 0
+    for prop in props:
+        engine_id = (prop.engine_proposal_id or "").strip()
+        # Only gate-commit rows offered in this round (have an engine id).
+        if not engine_id:
+            continue
+        if offered is not None and engine_id not in offered:
+            continue
+        if engine_id in approved:
+            prop.status = "approved"
+        else:
+            prop.status = "declined"
+        prop.draft = 0
+        count += 1
+
+        if prop.analytics_flushed:
+            continue
+        claim = await db.execute(
+            update(Proposal).where(Proposal.id == prop.id, Proposal.analytics_flushed == 0).values(analytics_flushed=1)
+        )
+        if not claim.rowcount:
+            continue
+
+        rule_ids = parse_json_list(prop.rule_ids_json)
+        increments = analytics_increments(
+            {
+                "status": prop.status,
+                "rule_id": prop.rule_id,
+                "rule_ids": rule_ids,
+                "source": prop.source,
+                "gate": prop.gate,
+                "tier": prop.tier,
+                "coupled": len(rule_ids) > 1,
+            }
+        )
+        for inc in increments:
+            await upsert_analytics_increment(
+                db,
+                project_id=project_id,
+                rule_id=str(inc["rule_id"]),
+                source=str(inc["source"]),
+                gate=str(inc["gate"]),
+                tier=int(inc["tier"]),
+                coupled=int(inc["coupled"]),
+                is_group=int(inc["is_group"]),
+                accepted_delta=int(inc["accepted_delta"]),
+                declined_delta=int(inc["declined_delta"]),
+            )
+
+        review = review_status_for_proposal(prop.source, prop.status)
+        if not review:
+            continue
+        stamp_rules = set(parse_json_list(prop.stamp_rule_ids_json))
+        v_ids = parse_json_list(prop.violation_ids_json)
+        int_ids = [int(v) for v in v_ids if str(v).isdigit() or isinstance(v, int)]
+        if not int_ids:
+            continue
+        v_stmt = select(Violation).where(Violation.id.in_(int_ids))
+        for violation in (await db.execute(v_stmt)).scalars().all():
+            if violation.review_status is not None:
+                continue
+            if stamp_rules:
+                v_rule = str(getattr(violation, "rule_id", "") or "")
+                if v_rule not in stamp_rules:
+                    continue
+            if not violation_accepts_review_status(prop.source, violation, decision=prop.status):
+                continue
+            violation.review_status = review
+
+    await db.flush()
+    logger.info("Gate-committed %s proposals for scan %s", count, scan_id[:12])
+    return count
+
+
+__all__ = [
+    "abandon_project_drafts",
+    "apply_draft_updates",
+    "commit_gate_decisions",
+    "ensure_scan_row",
+    "project_has_draft_proposals",
+    "upsert_live_proposal_stubs",
+]

--- a/src/apme_gateway/proposals/draft.py
+++ b/src/apme_gateway/proposals/draft.py
@@ -60,7 +60,9 @@ def _archival_proposal_id(*, file: str, path: str, gate: str, rule_id: str, engi
     Returns:
         ``prop-{gate}-{digest}`` identifier.
     """
-    material = path or f"{file}:{rule_id}:{engine_id}"
+    # Always include rule_id + engine_id so two live proposals that share a
+    # node path (different rules / engine ids) do not collapse to one row.
+    material = f"{file}:{path}:{rule_id}:{engine_id}" if path else f"{file}:{rule_id}:{engine_id}"
     digest = hashlib.sha1(material.encode("utf-8")).hexdigest()[:12]  # noqa: S324
     gate_part = gate or "na"
     return f"prop-{gate_part}-{digest}"

--- a/src/apme_gateway/proposals/draft.py
+++ b/src/apme_gateway/proposals/draft.py
@@ -10,8 +10,8 @@ from typing import Any
 from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from apme_gateway.db.models import Proposal, Scan, Violation
-from apme_gateway.proposals.flush import upsert_analytics_increment
+from apme_gateway.db.models import Proposal, Scan
+from apme_gateway.proposals.flush import fetch_violations_by_ids, upsert_analytics_increment
 from apme_gateway.proposals.grouping import (
     GATE_AI,
     GATE_TIER1,
@@ -460,8 +460,7 @@ async def commit_gate_decisions(
         int_ids = [int(v) for v in v_ids if str(v).isdigit() or isinstance(v, int)]
         if not int_ids:
             continue
-        v_stmt = select(Violation).where(Violation.id.in_(int_ids))
-        for violation in (await db.execute(v_stmt)).scalars().all():
+        for violation in await fetch_violations_by_ids(db, int_ids):
             if violation.review_status is not None:
                 continue
             if stamp_rules:

--- a/src/apme_gateway/proposals/draft.py
+++ b/src/apme_gateway/proposals/draft.py
@@ -22,6 +22,7 @@ from apme_gateway.proposals.grouping import (
     parse_json_list,
     review_status_for_proposal,
     serialize_rule_ids,
+    stamp_rule_allowlist,
     violation_accepts_review_status,
 )
 
@@ -261,8 +262,12 @@ async def upsert_live_proposal_stubs(
         gate = str(raw.get("gate") or "") or _gate_for_source(source, tier)
         status = _normalize_status(str(raw.get("status") or "pending"))
         rule_parts = tuple(p.strip() for p in rule_id.split(",") if p.strip()) or ((rule_id,) if rule_id else ())
+        # Proposal.rule_id is the primary/display rule — never the coupled CSV.
+        primary_rule = rule_parts[0] if rule_parts else ""
         stamp_rules = rule_parts
-        archival_id = _archival_proposal_id(file=file_, path=path, gate=gate, rule_id=rule_id, engine_id=engine_id)
+        archival_id = _archival_proposal_id(
+            file=file_, path=path, gate=gate, rule_id=primary_rule or rule_id, engine_id=engine_id
+        )
 
         existing = (
             await db.execute(
@@ -276,7 +281,7 @@ async def upsert_live_proposal_stubs(
             existing = Proposal(
                 scan_id=scan_id,
                 proposal_id=archival_id,
-                rule_id=rule_id or (rule_parts[0] if rule_parts else ""),
+                rule_id=primary_rule,
                 file=file_,
                 tier=tier,
                 confidence=float(raw.get("confidence") or 0.0),
@@ -299,7 +304,8 @@ async def upsert_live_proposal_stubs(
         else:
             existing.engine_proposal_id = engine_id
             existing.file = file_ or existing.file
-            existing.rule_id = rule_id or existing.rule_id
+            if primary_rule:
+                existing.rule_id = primary_rule
             existing.tier = tier or existing.tier
             existing.path = path or existing.path
             existing.source = source or existing.source
@@ -455,7 +461,10 @@ async def commit_gate_decisions(
         review = review_status_for_proposal(prop.source, prop.status)
         if not review:
             continue
-        stamp_rules = set(parse_json_list(prop.stamp_rule_ids_json))
+        stamp_rules = stamp_rule_allowlist(
+            stamp_rule_ids_json=prop.stamp_rule_ids_json,
+            rule_ids_json=prop.rule_ids_json,
+        )
         v_ids = parse_json_list(prop.violation_ids_json)
         int_ids = [int(v) for v in v_ids if str(v).isdigit() or isinstance(v, int)]
         if not int_ids:

--- a/src/apme_gateway/proposals/draft.py
+++ b/src/apme_gateway/proposals/draft.py
@@ -106,13 +106,13 @@ async def project_has_draft_proposals(
     Returns:
         Whether an interactive draft working set exists.
     """
-    scan_ids = list((await db.execute(select(Scan.scan_id).where(Scan.project_id == project_id))).scalars().all())
-    for sid in extra_scan_ids:
-        if sid and sid not in scan_ids:
-            scan_ids.append(sid)
-    if not scan_ids:
-        return False
-    stmt = select(Proposal.id).where(Proposal.scan_id.in_(scan_ids), Proposal.draft == 1).limit(1)
+    linked_scans = select(Scan.scan_id).where(Scan.project_id == project_id)
+    extras = [s for s in extra_scan_ids if s]
+    if extras:
+        scope = or_(Proposal.scan_id.in_(linked_scans), Proposal.scan_id.in_(list(extras)))
+    else:
+        scope = Proposal.scan_id.in_(linked_scans)
+    stmt = select(Proposal.id).where(scope, Proposal.draft == 1).limit(1)
     return (await db.execute(stmt)).scalar_one_or_none() is not None
 
 
@@ -139,15 +139,16 @@ async def abandon_project_drafts(
     """
     from sqlalchemy import delete  # noqa: PLC0415
 
-    linked = list((await db.execute(select(Scan.scan_id).where(Scan.project_id == project_id))).scalars().all())
-    cleared = 0
-    if linked:
-        result = await db.execute(
-            update(Proposal).where(Proposal.scan_id.in_(linked), Proposal.draft == 1).values(draft=0, status="pending")
-        )
-        cleared += int(result.rowcount or 0)
+    linked_scans = select(Scan.scan_id).where(Scan.project_id == project_id)
+    result = await db.execute(
+        update(Proposal)
+        .where(Proposal.scan_id.in_(linked_scans), Proposal.draft == 1)
+        .values(draft=0, status="pending")
+    )
+    cleared = int(result.rowcount or 0)
 
-    orphan_scans = [s for s in extra_scan_ids if s and s not in linked]
+    linked_set = set((await db.execute(linked_scans)).scalars().all())
+    orphan_scans = [s for s in extra_scan_ids if s and s not in linked_set]
     for sid in orphan_scans:
         result = await db.execute(delete(Proposal).where(Proposal.scan_id == sid))
         cleared += int(result.rowcount or 0)

--- a/src/apme_gateway/proposals/flush.py
+++ b/src/apme_gateway/proposals/flush.py
@@ -87,7 +87,12 @@ async def upsert_analytics_increment(
     await db.execute(stmt)
 
 
-async def flush_proposals_for_project(db: AsyncSession, project_id: str) -> int:
+async def flush_proposals_for_project(
+    db: AsyncSession,
+    project_id: str,
+    *,
+    exclude_scan_id: str | None = None,
+) -> int:
     """Roll unflushed project proposals into analytics and delete them.
 
     Idempotent: proposals with ``analytics_flushed=1`` are deleted without
@@ -105,11 +110,16 @@ async def flush_proposals_for_project(db: AsyncSession, project_id: str) -> int:
     Args:
         db: Active async session.
         project_id: Project UUID.
+        exclude_scan_id: When linking a remediate that already has
+            ``project_id`` (live stubs), skip flushing that scan's own
+            proposals (flush-before-attach).
 
     Returns:
         Number of proposal rows deleted.
     """
     scan_ids_stmt = select(Scan.scan_id).where(Scan.project_id == project_id)
+    if exclude_scan_id:
+        scan_ids_stmt = scan_ids_stmt.where(Scan.scan_id != exclude_scan_id)
     return await _flush_proposals(
         db,
         project_id=project_id,
@@ -205,9 +215,14 @@ async def _flush_proposals(
             int_ids = [int(v) for v in v_ids if str(v).isdigit() or isinstance(v, int)]
             if int_ids:
                 v_stmt = select(Violation).where(Violation.id.in_(int_ids))
+                stamp_rules = set(parse_json_list(getattr(prop, "stamp_rule_ids_json", None) or "[]"))
                 for violation in (await db.execute(v_stmt)).scalars().all():
                     if violation.review_status is not None:
                         continue
+                    if stamp_rules:
+                        v_rule = str(getattr(violation, "rule_id", "") or "")
+                        if v_rule not in stamp_rules:
+                            continue
                     if not violation_accepts_review_status(prop.source, violation, decision=prop.status):
                         continue
                     violation.review_status = review
@@ -275,12 +290,50 @@ async def replace_scan_proposals(
         )
         return
 
+    prior_rows = list((await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalars().all())
     await db.execute(delete(Proposal).where(Proposal.scan_id == scan_id))
+    # Bridge live stubs → archival groups. Key by file+source+primary_rule+line
+    # because primary.Proposal has no path field — stubs always have path="".
+    # Normalize: coupled stubs may store "L007,L013" while groups use "L007";
+    # ai-candidate groups must match stub source "ai".
+    # Carry analytics_flushed / terminal status / stamp_rule_ids so gate-commit
+    # survives FixCompleted rebuild without double-counting analytics.
+
+    def _bridge_key(file_: str, source: str, rule_id: str, line_start: int) -> tuple[str, str, str, int]:
+        primary_rule = (rule_id or "").split(",")[0].strip()
+        src = source or ""
+        if src == "ai-candidate":
+            src = "ai"
+        return (file_ or "", src, primary_rule, int(line_start or 0))
+
+    prior: dict[tuple[str, str, str, int], tuple[str | None, int, int, str, str]] = {}
+    for r in prior_rows:
+        if not (r.engine_proposal_id or r.draft or r.analytics_flushed):
+            continue
+        key = _bridge_key(str(r.file or ""), str(r.source or ""), str(r.rule_id or ""), int(r.line_start or 0))
+        prior[key] = (
+            r.engine_proposal_id,
+            int(r.draft or 0),
+            int(r.analytics_flushed or 0),
+            str(r.status or ""),
+            str(r.stamp_rule_ids_json or "[]"),
+        )
     for prop in typed:
         # Non-interactive deterministic with fixed yaml → approved for analytics.
         status = prop.status
         if status == "pending" and prop.source == "deterministic" and prop.fixed_yaml:
             status = "approved"
+        key = _bridge_key(prop.file or "", prop.source, prop.rule_id or "", int(prop.line_start or 0))
+        bridge = prior.get(key, (None, 0, 0, "", "[]"))
+        engine_id = getattr(prop, "engine_proposal_id", None) or bridge[0]
+        draft_flag = int(getattr(prop, "draft", 0) or bridge[1] or 0)
+        flushed = int(bridge[2] or 0)
+        bridged_status = str(bridge[3] or "")
+        if bridged_status in {"approved", "declined"} and status in {"pending", "proposed", ""}:
+            status = bridged_status
+        stamp_json = serialize_rule_ids(getattr(prop, "stamp_rule_ids", ()) or ())
+        if stamp_json == "[]" and bridge[4] and bridge[4] != "[]":
+            stamp_json = bridge[4]
         db.add(
             Proposal(
                 scan_id=scan_id,
@@ -299,7 +352,10 @@ async def replace_scan_proposals(
                 diff_hunk=prop.diff_hunk,
                 explanation=prop.explanation,
                 suggestion=prop.suggestion,
-                analytics_flushed=0,
+                analytics_flushed=flushed,
+                engine_proposal_id=engine_id,
+                draft=draft_flag,
+                stamp_rule_ids_json=stamp_json,
             )
         )
 
@@ -333,6 +389,8 @@ def proposal_to_detail_dict(prop: Proposal | object) -> dict[str, object]:
             "diff_hunk": prop.diff_hunk,
             "explanation": prop.explanation,
             "suggestion": prop.suggestion,
+            "engine_proposal_id": prop.engine_proposal_id,
+            "draft": bool(prop.draft),
         }
     # GroupedProposal / duck-typed
     rule_ids = list(getattr(prop, "rule_ids", ()) or ())
@@ -354,6 +412,8 @@ def proposal_to_detail_dict(prop: Proposal | object) -> dict[str, object]:
         "diff_hunk": getattr(prop, "diff_hunk", "") or "",
         "explanation": getattr(prop, "explanation", "") or "",
         "suggestion": getattr(prop, "suggestion", "") or "",
+        "engine_proposal_id": getattr(prop, "engine_proposal_id", None),
+        "draft": bool(getattr(prop, "draft", False)),
     }
 
 

--- a/src/apme_gateway/proposals/flush.py
+++ b/src/apme_gateway/proposals/flush.py
@@ -307,10 +307,19 @@ async def replace_scan_proposals(
         return (file_ or "", src, primary_rule, int(line_start or 0))
 
     prior: dict[tuple[str, str, str, int], tuple[str | None, int, int, str, str]] = {}
+    ambiguous: set[tuple[str, str, str, int]] = set()
     for r in prior_rows:
         if not (r.engine_proposal_id or r.draft or r.analytics_flushed):
             continue
         key = _bridge_key(str(r.file or ""), str(r.source or ""), str(r.rule_id or ""), int(r.line_start or 0))
+        if key in ambiguous:
+            continue
+        if key in prior:
+            # Duplicate key — refuse to guess which stub owns the archival row.
+            ambiguous.add(key)
+            prior.pop(key, None)
+            logger.warning("Ambiguous proposal bridge key for scan %s: %s", scan_id[:12], key)
+            continue
         prior[key] = (
             r.engine_proposal_id,
             int(r.draft or 0),

--- a/src/apme_gateway/proposals/flush.py
+++ b/src/apme_gateway/proposals/flush.py
@@ -20,9 +20,32 @@ from apme_gateway.proposals.grouping import (
 
 logger = logging.getLogger(__name__)
 
+# Stay under SQLite's default SQLITE_MAX_VARIABLE_NUMBER (999).
+_SQLITE_BIND_LIMIT = 900
+
 
 def _now_iso() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
+
+
+async def fetch_violations_by_ids(db: AsyncSession, int_ids: Sequence[int]) -> list[Violation]:
+    """Load violations by PK, chunking IN clauses for SQLite bind limits.
+
+    Args:
+        db: Active async session.
+        int_ids: Violation primary keys.
+
+    Returns:
+        Matching Violation rows (order not guaranteed).
+    """
+    if not int_ids:
+        return []
+    out: list[Violation] = []
+    for i in range(0, len(int_ids), _SQLITE_BIND_LIMIT):
+        chunk = list(int_ids[i : i + _SQLITE_BIND_LIMIT])
+        result = await db.execute(select(Violation).where(Violation.id.in_(chunk)))
+        out.extend(result.scalars().all())
+    return out
 
 
 async def upsert_analytics_increment(
@@ -214,9 +237,8 @@ async def _flush_proposals(
             v_ids = parse_json_list(prop.violation_ids_json)
             int_ids = [int(v) for v in v_ids if str(v).isdigit() or isinstance(v, int)]
             if int_ids:
-                v_stmt = select(Violation).where(Violation.id.in_(int_ids))
                 stamp_rules = set(parse_json_list(getattr(prop, "stamp_rule_ids_json", None) or "[]"))
-                for violation in (await db.execute(v_stmt)).scalars().all():
+                for violation in await fetch_violations_by_ids(db, int_ids):
                     if violation.review_status is not None:
                         continue
                     if stamp_rules:
@@ -429,6 +451,7 @@ def proposal_to_detail_dict(prop: Proposal | object) -> dict[str, object]:
 # Re-export for tests / callers.
 __all__ = [
     "discard_scan_proposals",
+    "fetch_violations_by_ids",
     "flush_proposals_for_project",
     "flush_proposals_for_scan",
     "proposal_to_detail_dict",

--- a/src/apme_gateway/proposals/flush.py
+++ b/src/apme_gateway/proposals/flush.py
@@ -15,6 +15,7 @@ from apme_gateway.proposals.grouping import (
     analytics_increments,
     parse_json_list,
     review_status_for_proposal,
+    stamp_rule_allowlist,
     violation_accepts_review_status,
 )
 
@@ -237,7 +238,10 @@ async def _flush_proposals(
             v_ids = parse_json_list(prop.violation_ids_json)
             int_ids = [int(v) for v in v_ids if str(v).isdigit() or isinstance(v, int)]
             if int_ids:
-                stamp_rules = set(parse_json_list(getattr(prop, "stamp_rule_ids_json", None) or "[]"))
+                stamp_rules = stamp_rule_allowlist(
+                    stamp_rule_ids_json=getattr(prop, "stamp_rule_ids_json", None),
+                    rule_ids_json=getattr(prop, "rule_ids_json", None),
+                )
                 for violation in await fetch_violations_by_ids(db, int_ids):
                     if violation.review_status is not None:
                         continue

--- a/src/apme_gateway/proposals/grouping.py
+++ b/src/apme_gateway/proposals/grouping.py
@@ -663,3 +663,23 @@ def parse_json_list(raw: str) -> list[Any]:
     except json.JSONDecodeError:
         return []
     return value if isinstance(value, list) else []
+
+
+def stamp_rule_allowlist(*, stamp_rule_ids_json: str | None, rule_ids_json: str | None) -> set[str]:
+    """Rules allowed to receive ``review_status`` stamps.
+
+    Empty ``stamp_rule_ids_json`` falls back to the proposal's full
+    ``rule_ids_json`` (``Proposal.stamp_rule_ids_json`` contract). When both
+    are empty, returns an empty set (callers treat that as no rule filter).
+
+    Args:
+        stamp_rule_ids_json: Optional stamp-scope JSON array.
+        rule_ids_json: Full proposal rule-id JSON array.
+
+    Returns:
+        Set of rule id strings to allow when non-empty.
+    """
+    stamp = {str(r) for r in parse_json_list(stamp_rule_ids_json or "[]") if r}
+    if stamp:
+        return stamp
+    return {str(r) for r in parse_json_list(rule_ids_json or "[]") if r}

--- a/tests/test_proposal_draft.py
+++ b/tests/test_proposal_draft.py
@@ -1,0 +1,575 @@
+"""Unit tests for ADR-062 Phase 2 draft PATCH, gate commit, and abandon."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from apme_gateway.app import create_app
+from apme_gateway.db import close_db, get_session, init_db
+from apme_gateway.db.models import Project, Proposal, ProposalRuleAnalytics, Scan, Session, Violation
+from apme_gateway.proposals.draft import (
+    abandon_project_drafts,
+    apply_draft_updates,
+    commit_gate_decisions,
+    project_has_draft_proposals,
+    upsert_live_proposal_stubs,
+)
+from apme_gateway.proposals.flush import flush_proposals_for_project, replace_scan_proposals
+from apme_gateway.proposals.grouping import GroupedProposal
+
+
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
+async def _db(tmp_path: Path) -> AsyncIterator[None]:
+    """Initialise a fresh DB per test.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Yields:
+        None: Test runs between setup and teardown.
+    """
+    await init_db(str(tmp_path / "test.db"))
+    yield
+    await close_db()
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+async def client() -> AsyncIterator[AsyncClient]:
+    """Build an async test client for the gateway app.
+
+    Yields:
+        AsyncClient: Client bound to the ASGI app.
+    """
+    transport = ASGITransport(app=create_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def _seed_project_scan(*, with_draft: bool = False) -> tuple[str, str]:
+    """Create project + scan + one proposal stub.
+
+    Args:
+        with_draft: When True, mark the proposal as an interactive draft.
+
+    Returns:
+        ``(project_id, scan_id)``.
+    """
+    project_id = "proj-draft-1"
+    scan_id = "scan-draft-1"
+    async with get_session() as db:
+        db.add(
+            Project(
+                id=project_id,
+                name="Draft Proj",
+                repo_url="https://example.com/r.git",
+                branch="main",
+                created_at="2026-01-01T00:00:00+00:00",
+            )
+        )
+        db.add(
+            Session(
+                session_id="sess-draft",
+                project_path="/tmp/p",
+                first_seen="2026-01-01T00:00:00+00:00",
+                last_seen="2026-01-01T00:00:00+00:00",
+            )
+        )
+        db.add(
+            Scan(
+                scan_id=scan_id,
+                session_id="sess-draft",
+                project_id=project_id,
+                project_path="/tmp/p",
+                source="gateway",
+                trigger="ui",
+                created_at="2026-01-01T00:00:00+00:00",
+                scan_type="remediate",
+            )
+        )
+        await db.flush()
+        db.add(
+            Proposal(
+                scan_id=scan_id,
+                proposal_id="prop-ai-abc",
+                rule_id="L007",
+                file="a.yml",
+                tier=2,
+                confidence=0.9,
+                status="pending",
+                path="a.yml::t[0]",
+                source="ai",
+                gate="ai",
+                rule_ids_json='["L007"]',
+                violation_ids_json="[]",
+                engine_proposal_id="ai-0001",
+                draft=1 if with_draft else 0,
+                stamp_rule_ids_json='["L007"]',
+            )
+        )
+        await db.commit()
+    return project_id, scan_id
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_upsert_live_stubs_sets_engine_proposal_id() -> None:
+    """ProposalsReady stubs persist engine_proposal_id for the id bridge."""
+    async with get_session() as db:
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id="scan-live-1",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "ai-0007",
+                    "rule_id": "L007",
+                    "file": "play.yml",
+                    "tier": 2,
+                    "status": "proposed",
+                    "source": "ai",
+                    "confidence": 0.8,
+                    "diff_hunk": "@@ -1 +1 @@",
+                }
+            ],
+        )
+        await db.commit()
+        assert len(rows) == 1
+        assert rows[0].engine_proposal_id == "ai-0007"
+        assert rows[0].proposal_id.startswith("prop-ai-")
+        assert rows[0].status == "pending"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_draft_update_does_not_stamp_review_or_analytics() -> None:
+    """PATCH draft changes status + draft flag only."""
+    _project_id, scan_id = await _seed_project_scan()
+    async with get_session() as db:
+        v = Violation(
+            scan_id=scan_id,
+            rule_id="L007",
+            level="warning",
+            message="x",
+            file="a.yml",
+            line=1,
+            path="a.yml::t[0]",
+            remediation_class=2,
+            remediation_resolution=0,
+            scope=0,
+        )
+        db.add(v)
+        await db.flush()
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        prop.violation_ids_json = f"[{v.id}]"
+        await db.commit()
+
+    async with get_session() as db:
+        updated = await apply_draft_updates(
+            db,
+            scan_id=scan_id,
+            updates=[{"proposal_id": "ai-0001", "status": "approved"}],
+        )
+        await db.commit()
+        assert updated[0].status == "approved"
+        assert updated[0].draft == 1
+
+    async with get_session() as db:
+        v = (await db.execute(select(Violation).where(Violation.scan_id == scan_id))).scalar_one()
+        assert v.review_status is None
+        analytics = list((await db.execute(select(ProposalRuleAnalytics))).scalars().all())
+        assert analytics == []
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_gate_commit_stamps_and_clears_draft() -> None:
+    """Approve gate mirrors omit=reject, stamps review_status, clears draft."""
+    project_id, scan_id = await _seed_project_scan(with_draft=True)
+    async with get_session() as db:
+        v = Violation(
+            scan_id=scan_id,
+            rule_id="L007",
+            level="warning",
+            message="x",
+            file="a.yml",
+            line=1,
+            path="a.yml::t[0]",
+            remediation_class=2,
+            remediation_resolution=0,
+            scope=0,
+            fixed_yaml="",
+        )
+        db.add(v)
+        await db.flush()
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        prop.violation_ids_json = f"[{v.id}]"
+        prop.status = "pending"
+        await db.commit()
+
+    async with get_session() as db:
+        n = await commit_gate_decisions(
+            db,
+            scan_id=scan_id,
+            project_id=project_id,
+            approved_engine_ids=["ai-0001"],
+        )
+        await db.commit()
+        assert n == 1
+
+    async with get_session() as db:
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        assert prop.status == "approved"
+        assert prop.draft == 0
+        assert prop.analytics_flushed == 1
+        v = (await db.execute(select(Violation).where(Violation.scan_id == scan_id))).scalar_one()
+        assert v.review_status == "ai_approved"
+        analytics = list((await db.execute(select(ProposalRuleAnalytics))).scalars().all())
+        assert len(analytics) == 1
+        assert analytics[0].accepted_count == 1
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_gate_commit_omitted_ids_declined() -> None:
+    """Engine omit=reject declines Gateway rows not in approved_ids."""
+    project_id, scan_id = await _seed_project_scan()
+    async with get_session() as db:
+        n = await commit_gate_decisions(
+            db,
+            scan_id=scan_id,
+            project_id=project_id,
+            approved_engine_ids=[],
+        )
+        await db.commit()
+        assert n == 1
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        assert prop.status == "declined"
+        assert prop.draft == 0
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_abandon_detects_draft_only() -> None:
+    """Abandon safeguard keys on draft=1, not mere approved status."""
+    project_id, scan_id = await _seed_project_scan(with_draft=False)
+    async with get_session() as db:
+        assert await project_has_draft_proposals(db, project_id) is False
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        prop.draft = 1
+        prop.status = "approved"
+        await db.commit()
+        assert await project_has_draft_proposals(db, project_id) is True
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_operate_remediate_409_when_draft(client: AsyncClient) -> None:
+    """POST operate remediate returns 409 working_set_in_progress with draft.
+
+    Args:
+        client: Async HTTP test client.
+    """
+    project_id, _ = await _seed_project_scan(with_draft=True)
+    resp = await client.post(
+        f"/api/v1/projects/{project_id}/operation",
+        json={"action": "remediate", "options": {}},
+    )
+    assert resp.status_code == 409
+    body = resp.json()["detail"]
+    assert body["code"] == "working_set_in_progress"
+
+    resp2 = await client.post(
+        f"/api/v1/projects/{project_id}/operation",
+        json={"action": "remediate", "options": {}, "abandon_working_set": True},
+    )
+    # Abandon check passed — operation is created (background task may fail later).
+    assert resp2.status_code == 201
+    assert "operation_id" in resp2.json()
+
+    async with get_session() as db:
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == "scan-draft-1"))).scalar_one()
+        assert prop.draft == 0
+        assert prop.status == "pending"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_live_stub_attaches_project_and_abandon_resets_status() -> None:
+    """Live stubs set project_id; abandon resets status so flush cannot invent review."""
+    project_id = "proj-orphan"
+    scan_id = "scan-orphan"
+    async with get_session() as db:
+        db.add(
+            Project(
+                id=project_id,
+                name="Orphan",
+                repo_url="https://example.com/o.git",
+                branch="main",
+                created_at="2026-01-01T00:00:00+00:00",
+            )
+        )
+        await db.commit()
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id=scan_id,
+            project_id=project_id,
+            proposals=[
+                {
+                    "id": "ai-orphan",
+                    "rule_id": "L007",
+                    "file": "o.yml",
+                    "tier": 2,
+                    "status": "pending",
+                    "source": "ai",
+                    "line_start": 3,
+                }
+            ],
+        )
+        rows[0].draft = 1
+        rows[0].status = "approved"
+        await db.commit()
+        scan = (await db.execute(select(Scan).where(Scan.scan_id == scan_id))).scalar_one()
+        assert scan.project_id == project_id
+        assert await project_has_draft_proposals(db, project_id) is True
+        n = await abandon_project_drafts(db, project_id)
+        await db.commit()
+        assert n >= 1
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        assert prop.draft == 0
+        assert prop.status == "pending"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_gate_commit_preserves_analytics_across_replace() -> None:
+    """analytics_flushed survives replace_scan_proposals (no double-count)."""
+    project_id, scan_id = await _seed_project_scan()
+    async with get_session() as db:
+        await commit_gate_decisions(
+            db,
+            scan_id=scan_id,
+            project_id=project_id,
+            approved_engine_ids=["ai-0001"],
+            offered_engine_ids=["ai-0001"],
+        )
+        await db.commit()
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        assert prop.analytics_flushed == 1
+        assert prop.status == "approved"
+
+        # Seeded stub has line_start=0; archival group must match that key
+        # (primary.Proposal has no path — bridge is file+rule+line_start).
+        await replace_scan_proposals(
+            db,
+            scan_id=scan_id,
+            proposals=[
+                GroupedProposal(
+                    proposal_id="prop-ai-abc",
+                    rule_id="L007",
+                    rule_ids=("L007",),
+                    violation_ids=(),
+                    file="a.yml",
+                    path="a.yml::t[0]",
+                    line_start=0,
+                    tier=2,
+                    source="ai",
+                    gate="ai",
+                    status="pending",
+                )
+            ],
+        )
+        await db.commit()
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        assert prop.analytics_flushed == 1
+        assert prop.engine_proposal_id == "ai-0001"
+        assert prop.status == "approved"
+
+        await flush_proposals_for_project(db, project_id)
+        await db.commit()
+        analytics = list((await db.execute(select(ProposalRuleAnalytics))).scalars().all())
+        assert len(analytics) == 1
+        assert analytics[0].accepted_count == 1
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_gate_commit_scopes_to_offered_engine_ids() -> None:
+    """A later gate must not rewrite prior decisions on the same scan."""
+    project_id, scan_id = await _seed_project_scan()
+    async with get_session() as db:
+        db.add(
+            Proposal(
+                scan_id=scan_id,
+                proposal_id="prop-ai-def",
+                rule_id="L008",
+                file="b.yml",
+                tier=2,
+                confidence=0.5,
+                status="pending",
+                path="b.yml::t[0]",
+                source="ai",
+                gate="ai",
+                rule_ids_json='["L008"]',
+                violation_ids_json="[]",
+                engine_proposal_id="ai-0002",
+                draft=0,
+                stamp_rule_ids_json='["L008"]',
+            )
+        )
+        await db.commit()
+
+        await commit_gate_decisions(
+            db,
+            scan_id=scan_id,
+            project_id=project_id,
+            approved_engine_ids=["ai-0001"],
+            offered_engine_ids=["ai-0001"],
+        )
+        await db.commit()
+        by_eng = {
+            p.engine_proposal_id: p
+            for p in (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalars().all()
+        }
+        assert by_eng["ai-0001"].status == "approved"
+        assert by_eng["ai-0002"].status == "pending"
+
+        await commit_gate_decisions(
+            db,
+            scan_id=scan_id,
+            project_id=project_id,
+            approved_engine_ids=[],
+            offered_engine_ids=["ai-0002"],
+        )
+        await db.commit()
+        by_eng = {
+            p.engine_proposal_id: p
+            for p in (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalars().all()
+        }
+        assert by_eng["ai-0001"].status == "approved"
+        assert by_eng["ai-0002"].status == "declined"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_bridge_normalizes_coupled_rule_id() -> None:
+    """Coupled stub rule_id 'L007,L013' bridges to grouped primary 'L007'."""
+    scan_id = "scan-coupled"
+    async with get_session() as db:
+        await upsert_live_proposal_stubs(
+            db,
+            scan_id=scan_id,
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-coupled",
+                    "rule_id": "L007,L013",
+                    "file": "c.yml",
+                    "tier": 2,
+                    "status": "approved",
+                    "source": "ai",
+                    "line_start": 5,
+                }
+            ],
+        )
+        await db.commit()
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        prop.analytics_flushed = 1
+        await db.commit()
+
+        await replace_scan_proposals(
+            db,
+            scan_id=scan_id,
+            proposals=[
+                GroupedProposal(
+                    proposal_id="prop-ai-c",
+                    rule_id="L007",
+                    rule_ids=("L007", "L013"),
+                    violation_ids=(1, 2),
+                    file="c.yml",
+                    path="c.yml::t[0]",
+                    line_start=5,
+                    tier=2,
+                    source="ai-candidate",
+                    gate="ai",
+                    status="pending",
+                )
+            ],
+        )
+        await db.commit()
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        assert prop.engine_proposal_id == "eng-coupled"
+        assert prop.status == "approved"
+        assert prop.analytics_flushed == 1
+
+
+async def test_bridge_uses_file_rule_line_start() -> None:
+    """Bridge matches stubs to archival groups by file+rule+line_start."""
+    scan_id = "scan-bridge-multi"
+    async with get_session() as db:
+        await upsert_live_proposal_stubs(
+            db,
+            scan_id=scan_id,
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-a",
+                    "rule_id": "L001",
+                    "file": "same.yml",
+                    "tier": 2,
+                    "status": "approved",
+                    "source": "ai",
+                    "line_start": 1,
+                },
+                {
+                    "id": "eng-b",
+                    "rule_id": "L001",
+                    "file": "same.yml",
+                    "tier": 2,
+                    "status": "declined",
+                    "source": "ai",
+                    "line_start": 2,
+                },
+            ],
+        )
+        await db.commit()
+        for prop in (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalars().all():
+            prop.analytics_flushed = 1 if prop.engine_proposal_id == "eng-a" else 0
+        await db.commit()
+
+        await replace_scan_proposals(
+            db,
+            scan_id=scan_id,
+            proposals=[
+                GroupedProposal(
+                    proposal_id="prop-ai-a",
+                    rule_id="L001",
+                    rule_ids=("L001",),
+                    violation_ids=(1,),
+                    file="same.yml",
+                    path="same.yml::t[0]",
+                    line_start=1,
+                    tier=2,
+                    source="ai",
+                    gate="ai",
+                    status="pending",
+                ),
+                GroupedProposal(
+                    proposal_id="prop-ai-b",
+                    rule_id="L001",
+                    rule_ids=("L001",),
+                    violation_ids=(2,),
+                    file="same.yml",
+                    path="same.yml::t[1]",
+                    line_start=2,
+                    tier=2,
+                    source="ai",
+                    gate="ai",
+                    status="pending",
+                ),
+            ],
+        )
+        await db.commit()
+        by_line = {
+            p.line_start: p
+            for p in (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalars().all()
+        }
+        assert by_line[1].engine_proposal_id == "eng-a"
+        assert by_line[1].status == "approved"
+        assert by_line[1].analytics_flushed == 1
+        assert by_line[2].engine_proposal_id == "eng-b"
+        assert by_line[2].status == "declined"

--- a/tests/test_proposal_draft.py
+++ b/tests/test_proposal_draft.py
@@ -116,6 +116,31 @@ async def _seed_project_scan(*, with_draft: bool = False) -> tuple[str, str]:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_upsert_stores_primary_rule_id_for_coupled() -> None:
+    """Coupled engine rule_id CSV must not land in Proposal.rule_id."""
+    async with get_session() as db:
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id="scan-coupled-primary",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-c",
+                    "rule_id": "L007,L013",
+                    "file": "c.yml",
+                    "tier": 2,
+                    "status": "pending",
+                    "source": "ai",
+                    "line_start": 1,
+                }
+            ],
+        )
+        await db.commit()
+        assert rows[0].rule_id == "L007"
+        assert "L013" in rows[0].rule_ids_json
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_upsert_live_stubs_sets_engine_proposal_id() -> None:
     """ProposalsReady stubs persist engine_proposal_id for the id bridge."""
     async with get_session() as db:

--- a/tests/test_proposal_draft.py
+++ b/tests/test_proposal_draft.py
@@ -446,6 +446,101 @@ async def test_gate_commit_scopes_to_offered_engine_ids() -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_archival_id_includes_engine_id_when_path_set() -> None:
+    """Two same-path live stubs must not collapse to one proposal_id."""
+    scan_id = "scan-path-collide"
+    async with get_session() as db:
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id=scan_id,
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-1",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "path": "a.yml::t[0]",
+                    "tier": 2,
+                    "status": "pending",
+                    "source": "ai",
+                    "line_start": 1,
+                },
+                {
+                    "id": "eng-2",
+                    "rule_id": "L013",
+                    "file": "a.yml",
+                    "path": "a.yml::t[0]",
+                    "tier": 2,
+                    "status": "pending",
+                    "source": "ai",
+                    "line_start": 1,
+                },
+            ],
+        )
+        await db.commit()
+        assert len(rows) == 2
+        assert rows[0].proposal_id != rows[1].proposal_id
+        assert {r.engine_proposal_id for r in rows} == {"eng-1", "eng-2"}
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_bridge_skips_ambiguous_duplicate_keys() -> None:
+    """Duplicate bridge keys must not last-wins overwrite engine ids."""
+    scan_id = "scan-ambiguous"
+    async with get_session() as db:
+        await upsert_live_proposal_stubs(
+            db,
+            scan_id=scan_id,
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-a",
+                    "rule_id": "L001",
+                    "file": "same.yml",
+                    "tier": 2,
+                    "status": "approved",
+                    "source": "ai",
+                    "line_start": 0,
+                },
+                {
+                    "id": "eng-b",
+                    "rule_id": "L001",
+                    "file": "same.yml",
+                    "tier": 2,
+                    "status": "declined",
+                    "source": "ai",
+                    "line_start": 0,
+                },
+            ],
+        )
+        await db.commit()
+        await replace_scan_proposals(
+            db,
+            scan_id=scan_id,
+            proposals=[
+                GroupedProposal(
+                    proposal_id="prop-ai-x",
+                    rule_id="L001",
+                    rule_ids=("L001",),
+                    violation_ids=(1,),
+                    file="same.yml",
+                    path="",
+                    line_start=0,
+                    tier=2,
+                    source="ai",
+                    gate="ai",
+                    status="pending",
+                )
+            ],
+        )
+        await db.commit()
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        # Ambiguous — do not attach either stub's engine id / status.
+        assert prop.engine_proposal_id is None
+        assert prop.status == "pending"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_bridge_normalizes_coupled_rule_id() -> None:
     """Coupled stub rule_id 'L007,L013' bridges to grouped primary 'L007'."""
     scan_id = "scan-coupled"
@@ -497,6 +592,7 @@ async def test_bridge_normalizes_coupled_rule_id() -> None:
         assert prop.analytics_flushed == 1
 
 
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_bridge_uses_file_rule_line_start() -> None:
     """Bridge matches stubs to archival groups by file+rule+line_start."""
     scan_id = "scan-bridge-multi"


### PR DESCRIPTION
## Why this exists

Interactive remediation ([#379](https://github.com/ansible/apme/issues/379)) needs a **two-gate approval workflow** (Option C):

1. **Gate 1 — Tier 1 / deterministic fixes** — user reviews auto-fixable proposals and approves or declines before they are applied.
2. **Gate 2 — AI proposals** — after Tier 1 settles, the engine offers AI candidates; the user reviews those separately and approves or declines.

Today the live checkbox UI talks to the engine via in-memory `OperationRegistry` / WebSocket approve (ADR-052). That works for a single approval round, but it does **not** give Gateway a durable working set: optimistic checkbox edits, per-gate decisions, and analytics/`review_status` have nowhere stable to live between `ProposalsReady` and `ReportFixCompleted`.

Without that durability:

- Checkbox state disappears if the page refreshes or the operation ends.
- Starting a new remediate can silently wipe an in-progress review.
- Gate decisions cannot be stamped onto violations or rolled into rule-efficacy analytics once the engine finishes.
- Live engine proposal ids (`ai-0001`, …) and Gateway archival ids (`prop-ai-…`) are different namespaces — the UI and history cannot share one approval unit.

**This PR is Gateway Phase 2 of ADR-062.** It builds the persistence and REST surface the two-gate UX needs, without changing the engine yet. Phase 3 will add Option C in Primary (`FixOptions.interactive` and the second gate). Phase 1 (#391) already shipped archival grouping, `review_status`, and analytics tables.

## How this contributes to two-stage approval

| Stage | What the user does | What this PR enables |
|-------|--------------------|----------------------|
| During a gate | Toggle checkboxes before submitting | `PATCH .../operation/proposals` stores optimistic drafts (`draft=1`) without waking Primary or writing analytics |
| At gate submit | Approve / omit=decline | Existing `POST .../approve` (unchanged shape) now **gate-commits** Gateway rows for that round’s offered engine ids, rolls analytics, and stamps `review_status` when violation ids are linked |
| Between gates / after FixCompleted | Engine rebuilds archival proposals | `engine_proposal_id` bridge carries draft/status/`analytics_flushed` across rebuild so Gate 1 decisions are not lost or double-counted when Gate 2 runs |
| Starting over | New remediate while drafts exist | `409 working_set_in_progress` unless `abandon_working_set=true` (abandon resets status to pending — discarded drafts cannot invent review later) |

In short: **Phase 2 makes each approval gate a durable Gateway working set** that survives the engine’s FixCompleted rebuild, so Phase 3 can add a second engine gate without inventing a new persistence model.

## Summary
- Gateway-only ADR-062 Phase 2 for interactive remediation (#379): optimistic draft PATCH, gate-commit analytics, and `engine_proposal_id` bridging so live checkbox decisions survive `ReportFixCompleted` without double-counting analytics.
- Additive `/api/v1` only (ADR-060): new `PATCH .../operation/proposals`, optional `abandon_working_set` on operate, SSE `proposal_updated`; existing approve request/response shape unchanged (unknown approve ids are logged and ignored, not 400).
- Engine Option C / `FixOptions.interactive` remains Phase 3; UI wiring of PATCH/`proposal_updated` is a follow-up (TS types only here).

## Changes
- New `proposals/draft.py`: live stub upsert, draft updates, gate-commit (scoped to offered engine ids), abandon (resets `status` to `pending`).
- Schema: `engine_proposal_id`, `draft`, `stamp_rule_ids_json` + SQLite migrate.
- Coupled stubs store **primary** `rule_id` (first of CSV); full list in `rule_ids_json`.
- Empty `stamp_rule_ids_json` falls back to `rule_ids_json` via `stamp_rule_allowlist` (flush / gate-commit / FixCompleted).
- Bridge key `(file, source, primary_rule, line_start)` with coupled-rule / `ai-candidate` normalization; ambiguous duplicate keys are skipped (not last-wins).
- Archival stub ids include `rule_id` + `engine_id` even when `path` is set.
- Live stubs attach `project_id` early; `link_scan_to_project` excludes the linking scan from flush-before-attach.
- Operate holds a per-project lock across active-check → abandon → create; idle locks pruned on reaper remove.
- Approve intersects with offered set (log+ignore unknown); same list for gate-commit and Primary.
- `DraftProposalUpdate.status` schema-validated (`pending|approved|declined|proposed|rejected`).
- `ReportFixCompleted` clears append-only scan children on existing-scan replay (keeps proposals for the bridge).
- Violation stamp queries chunked for SQLite bind limits.
- ADR-062 Phase 2 notes updated; regression tests in `tests/test_proposal_draft.py`.

## Quality of life
- `pr-new` / `pr-address-feedback` skills: Rule of Five cold multi-agent review; ship-blockers include single-pass **major**; Pass 2 notes ADR-060 semantic hardening and stamp-allowlist fallback contracts.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (targeted + prior full suite)
- [x] ADR-062 Phase 2 notes updated
- [ ] Manual: remediate → PATCH drafts → approve → confirm analytics not double-counted after FixCompleted
- [ ] Follow-up: frontend PATCH client + `proposal_updated` SSE handler
- [ ] Follow-up (Phase 3): Option C engine + optional `path` on `primary.Proposal`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draft-based proposal editing, including live updates, abandonment, and final gate confirmation.
  * Proposal updates now appear in real time and can be reviewed before being committed.
  * Improved handling of proposal identity so repeated updates stay linked correctly.

* **Bug Fixes**
  * Prevented proposal work from being overwritten when a draft is already in progress.
  * Improved scan and proposal synchronization to avoid duplicate or lost updates.
  * Refined review-status stamping so only eligible items are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->