### PR TITLE
fix(helm): default image.registry to quay.io/ansible

### DIFF
--- a/deploy/helm/apme/Chart.yaml
+++ b/deploy/helm/apme/Chart.yaml
@@ -3,10 +3,9 @@ name: apme
 description: Ansible Policy & Modernization Engine — policy enforcement and modernization for Ansible content
 type: application
 version: 0.1.0
-# appVersion is informational only.  CI publishes images tagged by git SHA
-# (e.g. "sha-7cb2464"), NOT by this semver string.  Always set image.tag in
-# your values override to a real published tag.
-appVersion: "0.2.10"
+# Tracks the default APME image tag (Quay / GitHub release without leading "v").
+# Override with image.tag for SHA builds (e.g. "sha-b7d1683").
+appVersion: "2026.7.3"
 home: https://github.com/ansible/apme
 sources:
   - https://github.com/ansible/apme

--- a/deploy/helm/apme/Chart.yaml
+++ b/deploy/helm/apme/Chart.yaml
@@ -2,9 +2,10 @@ apiVersion: v2
 name: apme
 description: Ansible Policy & Modernization Engine — policy enforcement and modernization for Ansible content
 type: application
-version: 0.1.0
-# Tracks the default APME image tag (Quay / GitHub release without leading "v").
-# Override with image.tag for SHA builds (e.g. "sha-b7d1683").
+# Bump whenever chart templates, values defaults, or packaged metadata change.
+version: 0.1.1
+# Tracks the default APME image tag (release tag without leading "v").
+# Keep in sync with image.tag in values.yaml. Override image.tag for SHA builds.
 appVersion: "2026.7.3"
 home: https://github.com/ansible/apme
 sources:

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -9,10 +9,11 @@ localhost networking per ADR-005 and pod-level scaling per ADR-012).
 
 - Kubernetes 1.26+ or OpenShift 4.14+
 - Helm 3.x
-- Access to `quay.io/ansible` container registry (or mirror images locally;
-  CI also publishes to `ghcr.io/ansible`)
-- Default image tag is `2026.7.3` (GitHub release `v2026.7.3`). Override with
-  `--set image.tag=…` for another release or a SHA build (e.g. `sha-b7d1683`)
+- Access to `quay.io/ansible` (default pull registry) or a mirror. CI always
+  publishes to `ghcr.io/ansible` and publishes to Quay when credentials are set
+- Default image tag is pinned to `2026.7.3` (GitHub release `v2026.7.3`; must
+  match Chart.appVersion). Override with `--set image.tag=…` for another
+  release or a SHA build (e.g. `sha-b7d1683`)
 
 ## Quick start
 

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -9,7 +9,8 @@ localhost networking per ADR-005 and pod-level scaling per ADR-012).
 
 - Kubernetes 1.26+ or OpenShift 4.14+
 - Helm 3.x
-- Access to `ghcr.io/ansible` container registry (or mirror images locally)
+- Access to `quay.io/ansible` container registry (or mirror images locally;
+  CI also publishes to `ghcr.io/ansible`)
 - A published image tag (CI tags images by git SHA, e.g. `sha-7cb2464`)
 
 ## Quick start
@@ -54,7 +55,7 @@ helm install apme ./deploy/helm/apme/ \
 
 | Value | Default | Description |
 |-------|---------|-------------|
-| `image.registry` | `ghcr.io/ansible` | Container registry |
+| `image.registry` | `quay.io/ansible` | Container registry |
 | `image.tag` | `""` | Image tag (required — set explicitly) |
 | `engine.replicas` | `1` | Engine pod replicas |
 | `gitleaks.enabled` | `true` | Enable Gitleaks validator |
@@ -126,8 +127,7 @@ ui:
   enabled: false
 
 image:
-  registry: quay.io/your-org
-  tag: sha-7cb2464
+  tag: sha-7cb2464   # pulls from quay.io/ansible by default
 
 route:
   enabled: true

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -11,18 +11,17 @@ localhost networking per ADR-005 and pod-level scaling per ADR-012).
 - Helm 3.x
 - Access to `quay.io/ansible` container registry (or mirror images locally;
   CI also publishes to `ghcr.io/ansible`)
-- A published image tag (CI tags images by git SHA, e.g. `sha-7cb2464`)
+- Default image tag is `2026.7.3` (GitHub release `v2026.7.3`). Override with
+  `--set image.tag=…` for another release or a SHA build (e.g. `sha-b7d1683`)
 
 ## Quick start
 
 ```bash
-# From the repository root
-helm install apme ./deploy/helm/apme/ \
-  --set image.tag=sha-7cb2464
+# From the repository root (uses quay.io/ansible + tag 2026.7.3 by default)
+helm install apme ./deploy/helm/apme/
 
 # With AI enabled (OpenRouter provider)
 helm install apme ./deploy/helm/apme/ \
-  --set image.tag=sha-7cb2464 \
   --set abbenay.enabled=true \
   --set abbenay.token=$APME_ABBENAY_TOKEN \
   --set-json 'abbenay.providers={"openrouter":{"engine":"openrouter","apiKey":"'$OPENROUTER_API_KEY'","models":{"anthropic/claude-sonnet-4-6":{}}}}'
@@ -56,7 +55,7 @@ helm install apme ./deploy/helm/apme/ \
 | Value | Default | Description |
 |-------|---------|-------------|
 | `image.registry` | `quay.io/ansible` | Container registry |
-| `image.tag` | `""` | Image tag (required — set explicitly) |
+| `image.tag` | `2026.7.3` | Image tag (GitHub release `v2026.7.3`; Quay omits the `v`) |
 | `engine.replicas` | `1` | Engine pod replicas |
 | `gitleaks.enabled` | `true` | Enable Gitleaks validator |
 | `collectionHealth.enabled` | `true` | Enable Collection Health validator |
@@ -126,8 +125,7 @@ layer, deploy APME without the standalone UI and expose only the Gateway:
 ui:
   enabled: false
 
-image:
-  tag: sha-7cb2464   # pulls from quay.io/ansible by default
+# image.tag defaults to 2026.7.3 on quay.io/ansible
 
 route:
   enabled: true

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -62,7 +62,7 @@ Access the Gateway API directly via port-forward:
 
 {{- if not .Values.image.tag }}
 
-WARNING: image.tag is not set. The chart falls back to appVersion
-({{ .Chart.AppVersion }}) which may not match a published image tag.
-Set image.tag to a valid tag (e.g. "2026.7.3" or a git SHA like "sha-b7d1683").
+NOTE: image.tag is unset; using Chart.appVersion ({{ .Chart.AppVersion }}),
+which tracks this chart's default release image tag. Override with
+--set image.tag=<tag> for SHA builds (e.g. sha-b7d1683).
 {{- end }}

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -64,5 +64,5 @@ Access the Gateway API directly via port-forward:
 
 WARNING: image.tag is not set. The chart falls back to appVersion
 ({{ .Chart.AppVersion }}) which may not match a published image tag.
-Set image.tag to a valid tag (e.g. a git SHA like "sha-7cb2464").
+Set image.tag to a valid tag (e.g. "2026.7.3" or a git SHA like "sha-b7d1683").
 {{- end }}

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -4,7 +4,9 @@
 # a single pod, preserving ADR-005 localhost networking and ADR-012 pod scaling.
 
 image:
-  registry: ghcr.io/ansible
+  # Primary publish target (also mirrored to ghcr.io/ansible). Override for
+  # private mirrors / air-gapped registries.
+  registry: quay.io/ansible
   # -- Image tag for all APME containers.
   # CI publishes images with git SHA tags (e.g. "sha-7cb2464").
   # Set this explicitly; the fallback is Chart.yaml appVersion which is

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -4,12 +4,15 @@
 # a single pod, preserving ADR-005 localhost networking and ADR-012 pod scaling.
 
 image:
-  # Primary publish target (also mirrored to ghcr.io/ansible). Override for
-  # private mirrors / air-gapped registries.
+  # Default registry to *pull* APME images from. CI always publishes to
+  # ghcr.io/ansible and also publishes to quay.io/ansible when Quay
+  # credentials are configured (see .github/workflows/container-images.yml).
+  # Override for private mirrors / air-gapped registries.
   registry: quay.io/ansible
   # -- Image tag for all APME containers.
-  # Defaults to the Quay tag for the latest GitHub release (v2026.7.3 →
-  # 2026.7.3; CI strips the leading "v"). Override with a SHA tag
+  # Pinned default shipped with this chart (must match Chart.yaml
+  # appVersion). Corresponds to GitHub release v2026.7.3; Quay/GHCR
+  # release tags omit the leading "v". Override with a SHA tag
   # (e.g. "sha-b7d1683") for unreleased builds.
   tag: "2026.7.3"
   pullPolicy: IfNotPresent

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -8,10 +8,10 @@ image:
   # private mirrors / air-gapped registries.
   registry: quay.io/ansible
   # -- Image tag for all APME containers.
-  # CI publishes images with git SHA tags (e.g. "sha-7cb2464").
-  # Set this explicitly; the fallback is Chart.yaml appVersion which is
-  # informational and may not correspond to a published image tag.
-  tag: ""
+  # Defaults to the Quay tag for the latest GitHub release (v2026.7.3 →
+  # 2026.7.3; CI strips the leading "v"). Override with a SHA tag
+  # (e.g. "sha-b7d1683") for unreleased builds.
+  tag: "2026.7.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Default Helm `image.registry` to `quay.io/ansible` (pull registry; CI always publishes GHCR and Quay when credentials are set).
- Pin default `image.tag` / `appVersion` to `2026.7.3` (GitHub release `v2026.7.3`; registry tags omit the `v`).
- Leave `abbenay.image` on `ghcr.io/redhat-developer/abbenay`.
- Bump chart `version` to `0.1.1` for the default change.
- Clarify values/NOTES/README wording from Copilot review.

## Test plan
- [x] `tox -e lint`
- [x] `tox -e unit` (earlier on branch)
- [ ] `helm template apme ./deploy/helm/apme` resolves `quay.io/ansible/apme-*:2026.7.3`
- [ ] Confirm Quay has `ansible/apme-primary:2026.7.3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Helm deployment defaults to use the `quay.io/ansible` image registry and version `2026.7.3`.
  * Added clearer guidance for overriding the image tag, including SHA-based builds.

* **Documentation**
  * Updated installation instructions, configuration examples, and deployment notes to reflect the new image source and pinned default version.
  * Bumped the Helm chart version to `0.1.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->