### PR TITLE
ci(helm): publish chart repo for OpenShift via chart-releaser

### DIFF
--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -52,6 +52,7 @@ environment that developers run locally.
 | `tox -e ai` | AI extra tests (abbenay) | `test.yml` |
 | `tox -e ui` | Playwright UI tests | `test.yml` |
 | `tox -e grpc` | Regenerate gRPC stubs | manual |
+| `tox -e helm` | Lint + package Helm chart | `helm-charts.yml` |
 | `tox -e build` | Build container images | `container-images.yml` (GHCR) |
 | `tox -e up` | Start the APME pod | manual |
 | `tox -e down` | Stop the APME pod | manual |
@@ -61,7 +62,7 @@ Install: `uv tool install tox --with tox-uv`
 
 ## Workflow structure
 
-CI has five workflows in `.github/workflows/`:
+CI has six workflows in `.github/workflows/`:
 
 - **prek.yml**: Runs `prek` (ruff lint, ruff format, mypy strict, pydoclint,
   uv-lock). Quality gate for code style and type safety.
@@ -70,6 +71,9 @@ CI has five workflows in `.github/workflows/`:
   is enforced via `--cov-fail-under` in `tox.ini`.
 - **container-images.yml**: Builds and pushes container images to GHCR on push
   to `main`.
+- **helm-charts.yml**: Lints/packages the Helm chart (`tox -e helm`) and
+  publishes to GitHub Pages via chart-releaser when `deploy/helm/apme/**`
+  changes on `main`.
 - **deprecation-scrape.yml**: Monthly cron scraping ansible-core for deprecation
   gaps.
 - **pr-feedback.yml**: Labels PRs with failing checks or merge conflicts.

--- a/.agents/skills/tox/SKILL.md
+++ b/.agents/skills/tox/SKILL.md
@@ -65,6 +65,12 @@ directly. Every task maps to a `tox -e <env>` command.
 |-------------|-------------|-------------|
 | `tox -e grpc` | `scripts/gen_grpc.sh` | After modifying any `.proto` file. |
 
+### Helm
+
+| Environment | What it runs | When to use |
+|-------------|-------------|-------------|
+| `tox -e helm` | `scripts/helm_chart.sh` (`helm lint` + `helm package`) | After changing `deploy/helm/apme/**`. Writes `dist/charts/*.tgz`. |
+
 ### Developer tools
 
 | Environment | What it runs | When to use |

--- a/.github/workflows/helm-charts.yml
+++ b/.github/workflows/helm-charts.yml
@@ -1,0 +1,71 @@
+# Publish the Helm chart to a classic HTTP chart repository (GitHub Pages).
+# OpenShift Developer Catalog / HelmChartRepository consume index.yaml from
+# https://ansible.github.io/apme (requires Pages enabled on the gh-pages branch).
+name: Helm Charts
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "deploy/helm/apme/**"
+      - ".github/workflows/helm-charts.yml"
+      - "scripts/helm_chart.sh"
+      - "tox.ini"
+  pull_request:
+    paths:
+      - "deploy/helm/apme/**"
+      - ".github/workflows/helm-charts.yml"
+      - "scripts/helm_chart.sh"
+      - "tox.ini"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: helm-charts-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 1
+  PY_COLORS: 1
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+
+      - name: Lint and package chart
+        run: uvx --with tox-uv tox -e helm
+
+  release:
+    if: github.event_name != 'pull_request'
+    needs: lint
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    concurrency:
+      group: helm-charts-release-main
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git user.name
+        run: git config user.name "$GITHUB_ACTOR"
+
+      - name: Configure Git user.email
+        run: git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
+        with:
+          charts_dir: deploy/helm
+          skip_existing: "true"
+          mark_as_latest: "false"
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.sdlc/adrs/ADR-054-production-deployment.md
+++ b/.sdlc/adrs/ADR-054-production-deployment.md
@@ -92,6 +92,19 @@ Secrets. The chart currently supports native Kubernetes `Secret` resources
 and inline values rendered into those secrets. Support for
 external-secrets-operator `ExternalSecret` resources is not yet implemented.
 
+#### Chart distribution (HTTP repository)
+
+Chart **source** lives in-repo at `deploy/helm/apme/`. Packaged releases are
+published to a classic Helm HTTP repository on GitHub Pages
+(`https://ansible.github.io/apme`) via chart-releaser
+(`.github/workflows/helm-charts.yml`). That URL is what OpenShift
+`HelmChartRepository` / Developer Catalog and `helm repo add` consume.
+OCI chart refs are out of scope for the OpenShift console path.
+
+On release tags `vYYYY.M.P` (CalVer), container CI publishes matching image
+tags (without the leading `v`). `Chart.appVersion` must stay aligned with
+that tag so Catalog installs with an empty `image.tag` pull real images.
+
 ### 2. bootc VM Image (`deploy/bootc/`)
 
 A bootc Containerfile builds an OCI image that can be converted to qcow2, raw,
@@ -174,8 +187,10 @@ not the default.
 
 ### Positive
 
-- **Standard K8s deployment**: `helm install apme ./deploy/helm/apme` gives a
-  production-ready deployment with proper Services, PVCs, and Ingress.
+- **Standard K8s deployment**: `helm repo add apme https://ansible.github.io/apme`
+  then `helm install apme apme/apme` (or path install from `deploy/helm/apme`)
+  gives a production-ready deployment with proper Services, PVCs, and Ingress.
+  OpenShift can add the same URL as a Helm chart repository for Developer Catalog.
 - **Preserves architecture**: Sidecar model keeps ADR-005 (localhost) and
   ADR-012 (scale pods) intact — no service discovery changes needed.
 - **Reproducible VMs**: bootc images are atomic and reproducible. `bootc switch`

--- a/.sdlc/context/deployment.md
+++ b/.sdlc/context/deployment.md
@@ -15,12 +15,13 @@
 |--------------------|-------------------|------|-------|
 | Developer laptop / workstation | Podman pod | `tox -e up` | [Below](#podman-pod) |
 | Linux server **without** Kubernetes | Podman pod or bootc VM | `tox -e up` or bootc | [Below](#podman-pod), [deploy/bootc/README.md](/deploy/bootc/README.md) |
-| **Kubernetes / OpenShift** | **Helm chart** | `helm install` | [deploy/helm/apme/README.md](/deploy/helm/apme/README.md) |
+| **Kubernetes / OpenShift** | **Helm chart** | `helm repo add` / `helm install` | [deploy/helm/apme/README.md](/deploy/helm/apme/README.md) |
 | Quick evaluation / CI | CLI daemon | `apme daemon start` | [CLI Guide](/docs/guides/CLI.md) |
 
 **Key rule:** If the target has `kubectl` / `oc` access to a cluster, **always
-use the Helm chart** at `deploy/helm/apme/`. Podman pods are for local
-development and non-Kubernetes Linux servers only.
+use the Helm chart** (`https://ansible.github.io/apme` or
+`deploy/helm/apme/`). Podman pods are for local development and
+non-Kubernetes Linux servers only.
 
 ## Podman Pod
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Validator fan-out uses gRPC; Galaxy Proxy is HTTP (PEP 503). The engine parses c
 | **CLI** (`pip install`) | Quick evaluation, CI pipelines, single-user | [CLI Guide](docs/guides/CLI.md) |
 | **Podman pod** | Development, full feature set (UI, AI, persistence) | [Deployment Guide](docs/guides/DEPLOYMENT.md) |
 | **bootc VM** | Production single-node, atomic upgrades, systemd lifecycle | [bootc Guide](deploy/bootc/README.md) |
-| **Helm chart** | Kubernetes / OpenShift production | [Helm Guide](deploy/helm/apme/README.md) |
+| **Helm chart** | Kubernetes / OpenShift production | [Helm Guide](deploy/helm/apme/README.md) (`helm repo add apme https://ansible.github.io/apme`) |
 
 ### Try it now
 

--- a/deploy/helm/apme/.helmignore
+++ b/deploy/helm/apme/.helmignore
@@ -1,0 +1,13 @@
+# Patterns to ignore when packaging (helm package).
+.DS_Store
+.git/
+.gitignore
+*.tgz
+.helmignore
+dist/
+*.swp
+*~
+.idea/
+.vscode/
+__pycache__/
+*.pyc

--- a/deploy/helm/apme/Chart.yaml
+++ b/deploy/helm/apme/Chart.yaml
@@ -2,12 +2,14 @@ apiVersion: v2
 name: apme
 description: Ansible Policy & Modernization Engine — policy enforcement and modernization for Ansible content
 type: application
-# Bump whenever chart templates, values defaults, or packaged metadata change.
-version: 0.1.1
-# Tracks the default APME image tag (release tag without leading "v").
-# Keep in sync with image.tag in values.yaml. Override image.tag for SHA builds.
+# Chart semver — bump whenever the packaged chart changes (templates, values, deps).
+version: 0.1.2
+# Must match image.tag in values.yaml (CalVer release tag without leading "v",
+# e.g. git tag v2026.7.3 → image tag 2026.7.3). Empty image.tag falls back to
+# this field via the apme.image helper.
 appVersion: "2026.7.3"
 home: https://github.com/ansible/apme
+icon: https://raw.githubusercontent.com/ansible/apme/main/docs/images/apme.png
 sources:
   - https://github.com/ansible/apme
 maintainers:
@@ -18,3 +20,8 @@ keywords:
   - modernization
   - static-analysis
   - grpc
+annotations:
+  # OpenShift / Artifact Hub friendly metadata
+  charts.openshift.io/name: APME
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: integration-delivery

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -5,6 +5,66 @@ as defined in [ADR-054](../../../.sdlc/adrs/ADR-054-production-deployment.md):
 the engine stack runs as sidecar containers in a single pod (preserving
 localhost networking per ADR-005 and pod-level scaling per ADR-012).
 
+## Chart repository (OpenShift / `helm repo add`)
+
+Packaged chart releases are published to a classic HTTP Helm repository on
+GitHub Pages:
+
+| | |
+|--|--|
+| **Repo URL** | `https://ansible.github.io/apme` |
+| **Index** | `https://ansible.github.io/apme/index.yaml` |
+
+> **Ops:** Enable GitHub Pages on the `ansible/apme` repository with source
+> **Deploy from a branch → `gh-pages` / root**. Chart releases are created by
+> `.github/workflows/helm-charts.yml` (chart-releaser) when
+> `deploy/helm/apme/**` changes on `main`.
+
+### CLI
+
+```bash
+helm repo add apme https://ansible.github.io/apme
+helm repo update
+helm install apme apme/apme \
+  --namespace apme --create-namespace \
+  --set route.enabled=true   # OpenShift
+```
+
+Defaults pull from `quay.io/ansible` with image tag `2026.7.3` (`Chart.appVersion`).
+For unreleased SHA builds, set `--set image.tag=sha-<commit>`.
+
+### OpenShift Developer Catalog
+
+1. **UI:** Developer perspective → **Helm** → **Create** → add chart repository
+   with URL `https://ansible.github.io/apme`, then install **apme** from the
+   catalog (enable Route / set values as needed).
+2. **Cluster-scoped CR** (admin):
+
+```yaml
+apiVersion: helm.openshift.io/v1beta1
+kind: HelmChartRepository
+metadata:
+  name: apme
+spec:
+  name: APME
+  connectionConfig:
+    url: https://ansible.github.io/apme
+```
+
+3. **Namespace-scoped CR** (project member with RBAC):
+
+```yaml
+apiVersion: helm.openshift.io/v1beta1
+kind: ProjectHelmChartRepository
+metadata:
+  name: apme
+  namespace: my-project
+spec:
+  name: APME
+  connectionConfig:
+    url: https://ansible.github.io/apme
+```
+
 ## Prerequisites
 
 - Kubernetes 1.26+ or OpenShift 4.14+
@@ -17,6 +77,16 @@ localhost networking per ADR-005 and pod-level scaling per ADR-012).
 
 ## Quick start
 
+### From the chart repository (recommended)
+
+```bash
+helm repo add apme https://ansible.github.io/apme
+helm repo update
+helm install apme apme/apme --namespace apme --create-namespace
+```
+
+### From a local clone (contributors)
+
 ```bash
 # From the repository root (uses quay.io/ansible + tag 2026.7.3 by default)
 helm install apme ./deploy/helm/apme/
@@ -27,6 +97,8 @@ helm install apme ./deploy/helm/apme/ \
   --set abbenay.token=$APME_ABBENAY_TOKEN \
   --set-json 'abbenay.providers={"openrouter":{"engine":"openrouter","apiKey":"'$OPENROUTER_API_KEY'","models":{"anthropic/claude-sonnet-4-6":{}}}}'
 ```
+
+Lint and package locally with `tox -e helm` (writes `dist/charts/*.tgz`).
 
 ## Architecture
 

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -64,5 +64,5 @@ Access the Gateway API directly via port-forward:
 
 WARNING: image.tag is not set. Falling back to Chart.appVersion
 ({{ .Chart.AppVersion }}). Confirm that tag exists in the configured
-registry (or set --set image.tag=<sha-…> for unreleased builds).
+registry (or set --set image.tag=sha-<commit> for unreleased builds).
 {{- end }}

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -62,7 +62,7 @@ Access the Gateway API directly via port-forward:
 
 {{- if not .Values.image.tag }}
 
-NOTE: image.tag is unset; using Chart.appVersion ({{ .Chart.AppVersion }}),
-which tracks this chart's default release image tag. Override with
---set image.tag=<tag> for SHA builds (e.g. sha-b7d1683).
+WARNING: image.tag is not set. Falling back to Chart.appVersion
+({{ .Chart.AppVersion }}). Confirm that tag exists in the configured
+registry (or set --set image.tag=<sha-…> for unreleased builds).
 {{- end }}

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -293,10 +293,14 @@ for different SDKs and will be ignored.
 ## Install / Upgrade
 
 ```bash
-helm upgrade --install apme deploy/helm/apme/ \
+helm repo add apme https://ansible.github.io/apme
+helm repo update
+helm upgrade --install apme apme/apme \
   -n apme --create-namespace \
   -f values.yaml
 ```
+
+From a local clone: `helm upgrade --install apme deploy/helm/apme/ …`.
 
 ## Verify
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -9,7 +9,8 @@ APME supports multiple deployment methods depending on your environment and need
 | Production single-node VM | **bootc VM** | [bootc section](#bootc-vm) / [full guide](../../deploy/bootc/README.md) |
 | Quick evaluation / CI | **CLI daemon** | [CLI Guide](CLI.md) |
 
-> **Deploying on Kubernetes or OpenShift?** Use the Helm chart at
+> **Deploying on Kubernetes or OpenShift?** Use the published Helm chart
+> (`helm repo add apme https://ansible.github.io/apme`) or the source chart at
 > `deploy/helm/apme/`. Do not use Podman on K8s/OCP.
 
 Full deployment methods (Podman, bootc, Helm) run the complete engine stack
@@ -380,7 +381,8 @@ configuration, service management, and troubleshooting.
 
 ## Helm / Kubernetes
 
-Deploy APME on Kubernetes or OpenShift using the Helm chart at
+Deploy APME on Kubernetes or OpenShift using the published Helm chart
+repository (`https://ansible.github.io/apme`) or the source chart at
 `deploy/helm/apme/`. The chart models the engine stack as sidecar containers
 in a single pod (preserving localhost networking per ADR-005 and pod scaling
 per ADR-012).
@@ -393,10 +395,19 @@ per ADR-012).
 - Ingress/Route support (OpenShift Routes included)
 - NetworkPolicy for pod isolation
 - PVC for Gateway persistence; PVC for session venvs (single replica), emptyDir when scaling to multiple replicas
+- OpenShift Developer Catalog via `HelmChartRepository` pointing at the Pages URL
 
 ### Quick start
 
 ```bash
+# Recommended: install from the published chart repo
+helm repo add apme https://ansible.github.io/apme
+helm repo update
+helm install apme apme/apme \
+  --namespace apme --create-namespace \
+  --set route.enabled=true
+
+# From a local clone (contributors / unreleased SHA builds)
 helm install apme ./deploy/helm/apme/ \
   --set image.tag=sha-7cb2464 \
   --set abbenay.enabled=true \
@@ -404,11 +415,17 @@ helm install apme ./deploy/helm/apme/ \
   --set-json 'abbenay.providers={"openrouter":{"engine":"openrouter","apiKey":"'$OPENROUTER_API_KEY'","models":{"anthropic/claude-sonnet-4-6":{}}}}'
 ```
 
+### OpenShift UI
+
+Add chart repository URL `https://ansible.github.io/apme` (Developer → Helm),
+or apply a `HelmChartRepository` / `ProjectHelmChartRepository` CR — see
+[deploy/helm/apme/README.md](../../deploy/helm/apme/README.md).
+
 ### Key values
 
 | Value | Description |
 |-------|-------------|
-| `image.tag` | Image tag for all containers (required — no default) |
+| `image.tag` | Image tag (empty → `Chart.appVersion` CalVer; or SHA like `sha-7cb2464`) |
 | `engine.replicas` | Engine pod replicas (default: 1) |
 | `abbenay.enabled` | Enable AI provider (default: false) |
 | `abbenay.token` | Abbenay service token (required when `abbenay.enabled=true`) |

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -425,7 +425,7 @@ or apply a `HelmChartRepository` / `ProjectHelmChartRepository` CR — see
 
 | Value | Description |
 |-------|-------------|
-| `image.tag` | Image tag (empty → `Chart.appVersion` CalVer; or SHA like `sha-7cb2464`) |
+| `image.tag` | Image tag (default `2026.7.3` / `Chart.appVersion`; override with SHA like `sha-b7d1683`) |
 | `engine.replicas` | Engine pod replicas (default: 1) |
 | `abbenay.enabled` | Enable AI provider (default: false) |
 | `abbenay.token` | Abbenay service token (required when `abbenay.enabled=true`) |

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -53,6 +53,7 @@ tox is the single entry point for all developer tasks. Every CI check has a corr
 | `tox -e ai` | `pytest` with AI extras (abbenay) | Test |
 | `tox -e ui` | `pytest -m ui` (Playwright, requires running gateway + UI) | Test |
 | `tox -e grpc` | `scripts/gen_grpc.sh` | Code generation |
+| `tox -e helm` | `scripts/helm_chart.sh` (`helm lint` + `helm package`) | Helm chart |
 | `tox -e graph` | `tools/visualize_graph.py` (interactive HTML graph) | Developer tool |
 | `tox -e build` | `containers/podman/build.sh` | Pod lifecycle |
 | `tox -e up` | `build.sh` + `up.sh` | Pod lifecycle |

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Lint and package the APME Helm chart.
+# Invoked via: tox -e helm
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHART_DIR="${ROOT}/deploy/helm/apme"
+OUT_DIR="${ROOT}/dist/charts"
+HELM_VERSION="${HELM_VERSION:-v3.16.4}"
+CACHE_DIR="${ROOT}/.tox/helm-tools"
+HELM_BIN="${CACHE_DIR}/helm"
+
+ensure_helm() {
+  # Prefer a cached binary matching HELM_VERSION so CI/local stay aligned.
+  if [[ -x "${HELM_BIN}" ]] \
+    && "${HELM_BIN}" version --short 2>/dev/null | grep -Fq "${HELM_VERSION#v}"; then
+    return
+  fi
+  if command -v helm >/dev/null 2>&1; then
+    local found
+    found="$(command -v helm)"
+    if "${found}" version --short 2>/dev/null | grep -Fq "${HELM_VERSION#v}"; then
+      HELM_BIN="${found}"
+      return
+    fi
+  fi
+  mkdir -p "${CACHE_DIR}"
+  local os arch tarball sumfile
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+  case "${arch}" in
+    x86_64) arch="amd64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    *)
+      echo "Unsupported architecture: ${arch}" >&2
+      exit 1
+      ;;
+  esac
+  tarball="helm-${HELM_VERSION}-${os}-${arch}.tar.gz"
+  sumfile="${tarball}.sha256sum"
+  echo "Downloading Helm ${HELM_VERSION}..."
+  curl -fsSL "https://get.helm.sh/${tarball}" -o "${CACHE_DIR}/${tarball}"
+  curl -fsSL "https://get.helm.sh/${sumfile}" -o "${CACHE_DIR}/${sumfile}"
+  (
+    cd "${CACHE_DIR}"
+    sha256sum -c "${sumfile}"
+  )
+  tar -xzf "${CACHE_DIR}/${tarball}" -C "${CACHE_DIR}" "${os}-${arch}/helm"
+  mv "${CACHE_DIR}/${os}-${arch}/helm" "${HELM_BIN}"
+  rm -rf "${CACHE_DIR}/${os}-${arch}" "${CACHE_DIR}/${tarball}" "${CACHE_DIR}/${sumfile}"
+  chmod +x "${HELM_BIN}"
+}
+
+ensure_helm
+
+echo "==> helm lint ${CHART_DIR}"
+"${HELM_BIN}" lint "${CHART_DIR}"
+
+mkdir -p "${OUT_DIR}"
+echo "==> helm package ${CHART_DIR} -> ${OUT_DIR}"
+"${HELM_BIN}" package "${CHART_DIR}" -d "${OUT_DIR}"
+
+echo "OK: packaged chart(s) in ${OUT_DIR}"
+ls -la "${OUT_DIR}"

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -6,9 +6,21 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CHART_DIR="${ROOT}/deploy/helm/apme"
 OUT_DIR="${ROOT}/dist/charts"
+# Accept HELM_VERSION with or without a leading "v" (tarball names use "v…").
 HELM_VERSION="${HELM_VERSION:-v3.16.4}"
+HELM_VERSION="v${HELM_VERSION#v}"
 CACHE_DIR="${ROOT}/.tox/helm-tools"
 HELM_BIN="${CACHE_DIR}/helm"
+
+download() {
+  local url="$1" dest="$2"
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required to download Helm (not found on PATH)" >&2
+    exit 1
+  fi
+  curl -fsSL --retry 3 --retry-delay 2 \
+    -o "${dest}" "${url}"
+}
 
 verify_sha256() {
   # Portable checksum check: GNU coreutils on Linux, shasum on macOS.
@@ -71,8 +83,8 @@ ensure_helm() {
   tarball="helm-${HELM_VERSION}-${os}-${arch}.tar.gz"
   sumfile="${tarball}.sha256sum"
   echo "Downloading Helm ${HELM_VERSION}..."
-  curl -fsSL "https://get.helm.sh/${tarball}" -o "${CACHE_DIR}/${tarball}"
-  curl -fsSL "https://get.helm.sh/${sumfile}" -o "${CACHE_DIR}/${sumfile}"
+  download "https://get.helm.sh/${tarball}" "${CACHE_DIR}/${tarball}"
+  download "https://get.helm.sh/${sumfile}" "${CACHE_DIR}/${sumfile}"
   (
     cd "${CACHE_DIR}"
     verify_sha256 "${sumfile}"

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -10,6 +10,35 @@ HELM_VERSION="${HELM_VERSION:-v3.16.4}"
 CACHE_DIR="${ROOT}/.tox/helm-tools"
 HELM_BIN="${CACHE_DIR}/helm"
 
+verify_sha256() {
+  # Portable checksum check: GNU coreutils on Linux, shasum on macOS.
+  local sumfile="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "${sumfile}"
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    local expected actual filename
+    # Helm publishes "<hash>  <filename>" (two spaces) or "<hash> <filename>".
+    read -r expected _ filename <"${sumfile}"
+    if [[ -z "${filename}" ]]; then
+      echo "Unable to parse checksum file: ${sumfile}" >&2
+      exit 1
+    fi
+    actual="$(shasum -a 256 "${filename}" | awk '{print $1}')"
+    if [[ "${actual}" != "${expected}" ]]; then
+      echo "Checksum mismatch for ${filename}" >&2
+      echo "  expected: ${expected}" >&2
+      echo "  actual:   ${actual}" >&2
+      exit 1
+    fi
+    echo "${filename}: OK"
+    return
+  fi
+  echo "Neither sha256sum nor shasum found; cannot verify Helm download" >&2
+  exit 1
+}
+
 ensure_helm() {
   # Prefer a cached binary matching HELM_VERSION so CI/local stay aligned.
   if [[ -x "${HELM_BIN}" ]] \
@@ -43,7 +72,7 @@ ensure_helm() {
   curl -fsSL "https://get.helm.sh/${sumfile}" -o "${CACHE_DIR}/${sumfile}"
   (
     cd "${CACHE_DIR}"
-    sha256sum -c "${sumfile}"
+    verify_sha256 "${sumfile}"
   )
   tar -xzf "${CACHE_DIR}/${tarball}" -C "${CACHE_DIR}" "${os}-${arch}/helm"
   mv "${CACHE_DIR}/${os}-${arch}/helm" "${HELM_BIN}"

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -19,9 +19,12 @@ verify_sha256() {
   fi
   if command -v shasum >/dev/null 2>&1; then
     local expected actual filename
-    # Helm publishes "<hash>  <filename>" (two spaces) or "<hash> <filename>".
-    read -r expected _ filename <"${sumfile}"
-    if [[ -z "${filename}" ]]; then
+    # Helm publishes "<hash>  <filename>" (two spaces) or "<hash> *<filename>".
+    # Use field splitting so consecutive whitespace does not drop the filename.
+    expected="$(awk '{print $1; exit}' "${sumfile}")"
+    filename="$(awk '{print $2; exit}' "${sumfile}")"
+    filename="${filename#\*}"
+    if [[ -z "${expected}" || -z "${filename}" ]]; then
       echo "Unable to parse checksum file: ${sumfile}" >&2
       exit 1
     fi

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ pass_env =
     HELM_VERSION
     HOME
     PATH
-commands = bash scripts/helm_chart.sh {posargs}
+commands = bash scripts/helm_chart.sh
 
 # ── Developer tools ──────────────────────────────────────────────────
 

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,16 @@ skip_install = true
 allowlist_externals = bash
 commands = bash scripts/gen_grpc.sh
 
+[testenv:helm]
+description = Lint and package the Helm chart (OpenShift / helm repo)
+skip_install = true
+allowlist_externals = bash
+pass_env =
+    HELM_VERSION
+    HOME
+    PATH
+commands = bash scripts/helm_chart.sh {posargs}
+
 # ── Developer tools ──────────────────────────────────────────────────
 
 [testenv:graph]


### PR DESCRIPTION
## Summary
- Publish the APME Helm chart as a classic HTTP chart repository (GitHub Pages + chart-releaser) so OpenShift Developer Catalog / `HelmChartRepository` can add `https://ansible.github.io/apme`
- Add `tox -e helm` for local lint/package; PR-gated CI lint; release job on `main` with `skip_existing` and `mark_as_latest: false`
- Rebased onto main after #396 (quay.io defaults + pinned `2026.7.3` tag); chart `version` bumped to `0.1.2` for packaging metadata changes

## Changes
- `.github/workflows/helm-charts.yml` — lint on PR; chart-releaser → `gh-pages` on main; `FORCE_COLOR`/`PY_COLORS`; single-line git config steps
- `scripts/helm_chart.sh` + `tox -e helm` — checksum-verified Helm download (GNU `sha256sum` or macOS `shasum`), lint, package to `dist/charts/`
- Chart metadata (`.helmignore`, annotations, icon, `version: 0.1.2`) and docs for `helm repo add` / OpenShift UI / CR
- ADR-054 distribution note for Pages HTTP repo

## Quality of life
- Documented `tox -e helm` in tox/lean-ci skills and `DEVELOPMENT.md`

## Ops (manual, required after merge)
Enable GitHub Pages on `ansible/apme`: **Settings → Pages → Deploy from a branch → `gh-pages` / root**. Until then `https://ansible.github.io/apme/index.yaml` will 404.

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes
- [x] `tox -e helm` passes (lint + package `apme-0.1.2.tgz`)
- [ ] After merge + Pages enable: `curl -fsSL https://ansible.github.io/apme/index.yaml`
- [ ] `helm repo add apme https://ansible.github.io/apme && helm search repo apme`
- [ ] OpenShift: add `HelmChartRepository` with that URL; chart appears in Developer Catalog