### PR TITLE
feat(helm): add portal and standalone values profiles

### DIFF
--- a/.sdlc/adrs/ADR-054-production-deployment.md
+++ b/.sdlc/adrs/ADR-054-production-deployment.md
@@ -197,6 +197,9 @@ not the default.
   enables zero-downtime upgrades.
 - **Separated concerns**: Engine, Gateway, and UI scale independently in K8s.
   In the VM (single node), all services run in one pod as today.
+- **Helm install profiles**: One chart; portal vs standalone expressed as named
+  values files (`values-portal.yaml`, `values-standalone.yaml`) rather than a
+  second chart or a breaking default flip (ADR-030 Options A and B).
 
 ### Negative
 

--- a/.sdlc/context/deployment.md
+++ b/.sdlc/context/deployment.md
@@ -21,7 +21,9 @@
 **Key rule:** If the target has `kubectl` / `oc` access to a cluster, **always
 use the Helm chart** (`https://ansible.github.io/apme` or
 `deploy/helm/apme/`). Podman pods are for local development and
-non-Kubernetes Linux servers only.
+non-Kubernetes Linux servers only. Helm chart defaults keep the standalone UI
+on; portal / backend-only installs use `-f values-portal.yaml` (see
+[deploy/helm/apme/README.md](/deploy/helm/apme/README.md)).
 
 ## Podman Pod
 

--- a/deploy/helm/apme/Chart.yaml
+++ b/deploy/helm/apme/Chart.yaml
@@ -3,7 +3,7 @@ name: apme
 description: Ansible Policy & Modernization Engine — policy enforcement and modernization for Ansible content
 type: application
 # Chart semver — bump whenever the packaged chart changes (templates, values, deps).
-version: 0.1.2
+version: 0.1.3
 # Must match image.tag in values.yaml (CalVer release tag without leading "v",
 # e.g. git tag v2026.7.3 → image tag 2026.7.3). Empty image.tag falls back to
 # this field via the apme.image helper.

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -80,19 +80,52 @@ spec:
 
 ## Quick start
 
-### From the chart repository (recommended)
+Install flavors are **named values files** shipped with the chart (one chart;
+ADR-030 Options A and B). Chart `values.yaml` keeps the standalone UI on by
+default so a bare `helm install` is not a footgun for SPA evaluators.
+
+| Profile | File | UI | Use when |
+|---------|------|----|----------|
+| Standalone SPA | [`values-standalone.yaml`](values-standalone.yaml) | on | Bundled PatternFly UI (default) |
+| Portal / backend | [`values-portal.yaml`](values-portal.yaml) | off | Automation portal / Backstage / Gateway API only |
+
+### Standalone UI (default)
 
 ```bash
 helm repo add apme https://ansible.github.io/apme
 helm repo update
-helm install apme apme/apme --namespace apme --create-namespace
+helm install apme apme/apme \
+  --namespace apme --create-namespace \
+  -f https://raw.githubusercontent.com/ansible/apme/main/deploy/helm/apme/values-standalone.yaml \
+  --set route.enabled=true   # OpenShift
+```
+
+Omit `-f values-standalone.yaml` if you want the same UI-on default without an
+explicit profile (the file is equivalent to chart defaults).
+
+### Portal / backend-only
+
+No standalone UI Deployment — suitable for automation portal and other
+Backstage integrations that consume the Gateway API (ADR-030 Option B).
+
+```bash
+helm repo add apme https://ansible.github.io/apme
+helm repo update
+helm install apme apme/apme \
+  --namespace apme --create-namespace \
+  -f https://raw.githubusercontent.com/ansible/apme/main/deploy/helm/apme/values-portal.yaml \
+  --set route.enabled=true   # OpenShift
 ```
 
 ### From a local clone (contributors)
 
 ```bash
-# From the repository root (uses quay.io/ansible + tag 2026.7.3 by default)
+# Standalone (chart default)
 helm install apme ./deploy/helm/apme/
+
+# Portal / backend-only
+helm install apme ./deploy/helm/apme/ \
+  -f ./deploy/helm/apme/values-portal.yaml
 
 # With AI enabled (OpenRouter provider)
 helm install apme ./deploy/helm/apme/ \
@@ -121,9 +154,10 @@ Lint and package locally with `tox -e helm` (writes `dist/charts/*.tgz`).
 - **Engine Deployment**: All validators run as sidecars in one pod. HPA scales
   the entire engine stack together.
 - **Gateway Deployment**: REST API + gRPC Reporting + SQLite persistence.
-- **UI Deployment** (optional): nginx-served React SPA, proxies `/api/` to Gateway.
-  Disable with `ui.enabled: false` when an external UI (e.g. automation portal)
-  consumes the Gateway API.
+- **UI Deployment** (optional): nginx-served React SPA, proxies `/api/` to
+  Gateway. Enabled by default (`ui.enabled: true`). For portal / Backstage
+  (ADR-030 Option B), install with `-f values-portal.yaml` (or
+  `--set ui.enabled=false`) so only the Gateway API is exposed.
 - **Abbenay Deployment** (optional): AI provider for Tier 2 remediation.
 
 ## Key values
@@ -137,7 +171,7 @@ Lint and package locally with `tox -e helm` (writes `dist/charts/*.tgz`).
 | `collectionHealth.enabled` | `true` | Enable Collection Health validator |
 | `depAudit.enabled` | `true` | Enable Dependency Audit validator |
 | `gateway.replicas` | `1` | Gateway replicas |
-| `ui.enabled` | `true` | Deploy standalone UI (set `false` for portal-only) |
+| `ui.enabled` | `true` | Deploy standalone UI (`false` via `values-portal.yaml`) |
 | `ui.replicas` | `1` | UI replicas (when `ui.enabled`) |
 | `abbenay.enabled` | `false` | Enable AI provider |
 | `abbenay.token` | `""` | Abbenay service token (required when `abbenay.enabled=true`) |
@@ -195,13 +229,21 @@ When `host` is empty, OpenShift auto-assigns separate hosts per Route.
 ### Portal / external UI (backend only)
 
 When automation portal or another Backstage instance is the presentation
-layer, deploy APME without the standalone UI and expose only the Gateway:
+layer, install with the portal values profile (or the equivalent override)
+and expose only the Gateway:
+
+```bash
+helm install apme apme/apme \
+  -f https://raw.githubusercontent.com/ansible/apme/main/deploy/helm/apme/values-portal.yaml \
+  --set route.enabled=true \
+  --set route.host=apme-api.apps.ocp.example.com
+```
+
+Equivalent values fragment (already in [`values-portal.yaml`](values-portal.yaml)):
 
 ```yaml
 ui:
   enabled: false
-
-# image.tag defaults to 2026.7.3 on quay.io/ansible
 
 route:
   enabled: true
@@ -211,6 +253,23 @@ route:
 With `ui.enabled: false`, the API Route serves the Gateway at `/` (no `/api`
 path prefix). Portal plugins should reach the Gateway via in-cluster DNS,
 e.g. `http://<release>-gateway:8080`.
+
+### Standalone UI
+
+The chart default (and [`values-standalone.yaml`](values-standalone.yaml))
+deploys the bundled React SPA:
+
+```yaml
+ui:
+  enabled: true
+
+route:
+  enabled: true
+  host: apme.apps.ocp.example.com
+```
+
+With `ui.enabled: true`, OpenShift Routes expose the UI at `/` and the
+Gateway API at `/api`.
 
 ## Scaling
 

--- a/deploy/helm/apme/values-portal.yaml
+++ b/deploy/helm/apme/values-portal.yaml
@@ -1,0 +1,12 @@
+# Portal / backend-only install profile (ADR-030 Option B).
+#
+# Use when automation portal, RHDH/Backstage, or another external UI consumes
+# the Gateway API. Does not deploy the standalone nginx SPA.
+#
+#   helm install apme apme/apme -f values-portal.yaml
+#   helm install apme ./deploy/helm/apme/ -f ./deploy/helm/apme/values-portal.yaml
+#
+# Chart defaults remain standalone-friendly (ui.enabled: true in values.yaml).
+
+ui:
+  enabled: false

--- a/deploy/helm/apme/values-standalone.yaml
+++ b/deploy/helm/apme/values-standalone.yaml
@@ -1,0 +1,11 @@
+# Standalone SPA install profile (ADR-030 Option A).
+#
+# Deploys the nginx-served React UI alongside the Gateway. Equivalent to the
+# chart default in values.yaml; use this file for an explicit, documented
+# install flavor (or as a base to layer further overrides).
+#
+#   helm install apme apme/apme -f values-standalone.yaml
+#   helm install apme ./deploy/helm/apme/ -f ./deploy/helm/apme/values-standalone.yaml
+
+ui:
+  enabled: true

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -134,8 +134,10 @@ gateway:
     githubToken: ""
 
 # -- UI (nginx-served React SPA)
-# Set enabled: false when an external presentation layer (e.g. Ansible
-# automation portal / Backstage) consumes the Gateway API instead.
+# Default: standalone SPA (ADR-030 Option A). For portal / backend-only
+# installs (ADR-030 Option B), use the named profile:
+#   -f values-portal.yaml
+# or --set ui.enabled=false. See also values-standalone.yaml.
 # The stock nginx image requires writable /var/run, /var/cache/nginx, and
 # /etc/nginx/conf.d.  The chart mounts emptyDir volumes for these paths so
 # the container works under OCP restricted-v2 SCC (arbitrary non-root UID).

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -399,15 +399,40 @@ per ADR-012).
 
 ### Quick start
 
+Install flavors use named values files under `deploy/helm/apme/`
+(`values-standalone.yaml`, `values-portal.yaml`). Chart defaults keep the
+standalone UI enabled; portal installs pass `-f values-portal.yaml`.
+
+#### Standalone UI (default)
+
 ```bash
-# Recommended: install from the published chart repo
 helm repo add apme https://ansible.github.io/apme
 helm repo update
 helm install apme apme/apme \
   --namespace apme --create-namespace \
   --set route.enabled=true
+```
 
-# From a local clone (contributors / unreleased SHA builds)
+#### Portal / backend-only
+
+```bash
+helm repo add apme https://ansible.github.io/apme
+helm repo update
+helm install apme apme/apme \
+  --namespace apme --create-namespace \
+  -f https://raw.githubusercontent.com/ansible/apme/main/deploy/helm/apme/values-portal.yaml \
+  --set route.enabled=true
+```
+
+#### From a local clone (contributors / unreleased SHA builds)
+
+```bash
+# Portal profile from the clone
+helm install apme ./deploy/helm/apme/ \
+  -f ./deploy/helm/apme/values-portal.yaml \
+  --set image.tag=sha-7cb2464
+
+# Standalone + AI (OpenRouter)
 helm install apme ./deploy/helm/apme/ \
   --set image.tag=sha-7cb2464 \
   --set abbenay.enabled=true \
@@ -437,6 +462,7 @@ SHA or release tag (and Quay only when that publish included Quay credentials).
 | `abbenay.enabled` | Enable AI provider (default: false) |
 | `abbenay.token` | Abbenay service token (required when `abbenay.enabled=true`) |
 | `abbenay.providers` | LLM provider map (see [ABBENAY_AI.md](ABBENAY_AI.md)) |
+| `ui.enabled` | Deploy standalone UI (default: `true`; use `values-portal.yaml` for portal) |
 | `ingress.enabled` | Create Ingress resource (default: false) |
 | `route.enabled` | Create OpenShift Route (default: false) |
 


### PR DESCRIPTION
## Summary

- Add named Helm values profiles for install flavors on **one chart** (ADR-030 Options A/B; ADR-054):
  - [`values-portal.yaml`](deploy/helm/apme/values-portal.yaml) — UI off (automation portal / Backstage / Gateway API)
  - [`values-standalone.yaml`](deploy/helm/apme/values-standalone.yaml) — UI on (explicit SPA profile; matches chart default)
- Keep chart default `ui.enabled: true` so bare `helm install` stays standalone-friendly (no breaking default flip)
- Document `-f values-….yaml` in chart README, deployment guide, ADR-054, and deployment context
- Bump chart version to `0.1.3` for the packaged values-file addition

## Changes

| Area | Change |
|------|--------|
| `deploy/helm/apme/values-portal.yaml` | New portal/backend-only profile |
| `deploy/helm/apme/values-standalone.yaml` | New standalone SPA profile |
| `deploy/helm/apme/values.yaml` | Comment points at profiles; default remains `ui.enabled: true` |
| `deploy/helm/apme/README.md` | Quick start + portal/standalone docs use `-f` profiles |
| `docs/guides/DEPLOYMENT.md` | Same profile guidance |
| ADR-054 / deployment context | Named values profiles, not a second chart or default flip |
| `Chart.yaml` | `0.1.2` → `0.1.3` |

## Related

- ADR-030: Frontend Deployment Model (Option A SPA + Option B portal)
- ADR-054: Production Deployment — Helm Chart
- Review feedback on this PR: prefer named values profiles over flipping the chart default

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation

## Test plan

- [x] `tox -e lint`
- [x] `tox -e unit`
- [x] `tox -e helm` (lint + package; package includes both values profiles)
- [x] `helm template` default → 5 `component: ui` matches
- [x] `helm template -f values-portal.yaml` → 0 `component: ui` matches
- [x] `helm template -f values-standalone.yaml` → 5 `component: ui` matches

## Security Checklist

- [x] No secrets in code
- [x] No input validation changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm deployments now support standalone (UI enabled by default) and portal/backend-only installation profiles.
  * Route configuration guidance clarifies UI and API access patterns.

* **Documentation**
  * Updated Helm chart and deployment guides to document installation profiles and UI configuration.

* **Chores**
  * Bumped the Helm chart version to 0.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->