### PR TITLE
ci: publish multi-arch amd64/arm64 images (ADR-063)

### DIFF
--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -69,8 +69,10 @@ CI has six workflows in `.github/workflows/`:
 - **test.yml**: Runs `tox -e unit`, `tox -e integration`, `tox -e ui`, and
   `tox -e ai` as separate jobs. Quality gate for correctness. Coverage threshold
   is enforced via `--cov-fail-under` in `tox.ini`.
-- **container-images.yml**: Builds and pushes container images to GHCR on push
-  to `main`.
+- **container-images.yml**: Builds and pushes multi-arch container images
+  (`linux/amd64` + `linux/arm64`, ADR-063) to GHCR on `main`, version tags, and
+  `workflow_dispatch`, then merges manifests via
+  `containers/ci/merge-manifests.sh` (image list: `containers/ci/images.txt`).
 - **helm-charts.yml**: Lints/packages the Helm chart (`tox -e helm`) and
   publishes to GitHub Pages via chart-releaser when `deploy/helm/apme/**`
   changes on `main`.

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -1,3 +1,6 @@
+# Multi-platform publish (ADR-063): native amd64 + arm64 builds, then
+# imagetools merge into consumer tags on GHCR (and optional Quay).
+# Image inventory: containers/ci/images.txt (single source of truth).
 name: Container Images
 
 on:
@@ -16,10 +19,38 @@ env:
   QUAY_REGISTRY: quay.io
 
 jobs:
-  build-base:
-    runs-on: ubuntu-latest
+  prepare:
+    runs-on: ubuntu-24.04
     outputs:
-      base-image: ${{ steps.base-ref.outputs.image }}
+      services: ${{ steps.matrix.outputs.services }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - id: matrix
+        run: |
+          services="$(
+            grep -vE '^[[:space:]]*(#|$)' containers/ci/images.txt \
+              | grep -vx 'base' \
+              | jq -R -s -c '
+                  split("\n")
+                  | map(select(length > 0))
+                  | map({name: ., file: ("containers/" + . + "/Dockerfile")})
+                '
+          )"
+          echo "services=${services}" >> "$GITHUB_OUTPUT"
+          echo "Service matrix: ${services}"
+
+  build-base:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -34,59 +65,63 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
-        with:
-          images: ${{ env.GHCR_REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-base
-          tags: |
-            type=sha
-            type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
-            type=semver,pattern={{major}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
-
-      - id: base-ref
-        run: echo "image=${{ env.GHCR_REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-base:${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
-
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: containers/base/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=base
-          cache-to: type=gha,scope=base,mode=max
+          platforms: linux/${{ matrix.arch }}
+          provenance: false
+          sbom: false
+          tags: ${{ env.GHCR_REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-base:${{ github.sha }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=base-${{ matrix.arch }}
+          cache-to: type=gha,scope=base-${{ matrix.arch }},mode=max
 
   build-images:
-    needs: build-base
-    runs-on: ubuntu-latest
+    needs: [prepare, build-base]
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - name: primary
-            file: containers/primary/Dockerfile
-          - name: native
-            file: containers/native/Dockerfile
-          - name: opa
-            file: containers/opa/Dockerfile
-          - name: ansible
-            file: containers/ansible/Dockerfile
-          - name: galaxy-proxy
-            file: containers/galaxy-proxy/Dockerfile
-          - name: gitleaks
-            file: containers/gitleaks/Dockerfile
-          - name: gateway
-            file: containers/gateway/Dockerfile
-          - name: cli
-            file: containers/cli/Dockerfile
-          - name: ui
-            file: containers/ui/Dockerfile
-          - name: collection-health
-            file: containers/collection-health/Dockerfile
-          - name: dep-audit
-            file: containers/dep-audit/Dockerfile
+        arch:
+          - name: amd64
+            runner: ubuntu-24.04
+          - name: arm64
+            runner: ubuntu-24.04-arm
+        image: ${{ fromJson(needs.prepare.outputs.services) }}
+    runs-on: ${{ matrix.arch.runner }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - id: owner
+        run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: ${{ matrix.image.file }}
+          push: true
+          platforms: linux/${{ matrix.arch.name }}
+          provenance: false
+          sbom: false
+          tags: ${{ env.GHCR_REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-${{ matrix.image.name }}:${{ github.sha }}-${{ matrix.arch.name }}
+          build-args: |
+            BASE_IMAGE=${{ env.GHCR_REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-base:${{ github.sha }}-${{ matrix.arch.name }}
+          cache-from: type=gha,scope=${{ matrix.image.name }}-${{ matrix.arch.name }}
+          cache-to: type=gha,scope=${{ matrix.image.name }}-${{ matrix.arch.name }},mode=max
+
+  merge-manifests:
+    needs: build-images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -95,7 +130,7 @@ jobs:
 
       - id: quay-check
         run: |
-          if [ -n "$QUAY_USER" ]; then
+          if [ -n "$QUAY_USER" ] && [ -n "$QUAY_PASS" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
             echo "ns=${QUAY_ORG:-${{ steps.owner.outputs.lc }}}" >> "$GITHUB_OUTPUT"
           else
@@ -103,6 +138,7 @@ jobs:
           fi
         env:
           QUAY_USER: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASS: ${{ secrets.QUAY_PASSWORD }}
           QUAY_ORG: ${{ secrets.QUAY_NAMESPACE }}
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
@@ -120,12 +156,11 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
+      # Tag list only — image name is a placeholder; merge script applies tags per image.
       - id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
-          images: |
-            ${{ env.GHCR_REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-${{ matrix.image.name }}
-            ${{ steps.quay-check.outputs.enabled == 'true' && format('{0}/{1}/apme-{2}', env.QUAY_REGISTRY, steps.quay-check.outputs.ns, matrix.image.name) || '' }}
+          images: ${{ env.GHCR_REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-gateway
           tags: |
             type=sha
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
@@ -133,14 +168,28 @@ jobs:
             type=semver,pattern={{major}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
 
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: .
-          file: ${{ matrix.image.file }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BASE_IMAGE=${{ needs.build-base.outputs.base-image }}
-          cache-from: type=gha,scope=${{ matrix.image.name }}
-          cache-to: type=gha,scope=${{ matrix.image.name }},mode=max
+      - id: tags
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          jq -r '.tags[]' <<<"$DOCKER_METADATA_OUTPUT_JSON" \
+            | awk -F: '{print $NF}' \
+            | sort -u \
+            > /tmp/consumer-tags.txt
+          echo "Consumer tags:"
+          cat /tmp/consumer-tags.txt
+
+      - name: Merge multi-arch manifests
+        env:
+          GHCR_REGISTRY: ${{ env.GHCR_REGISTRY }}
+          QUAY_REGISTRY: ${{ env.QUAY_REGISTRY }}
+        run: |
+          args=(
+            --owner "${{ steps.owner.outputs.lc }}"
+            --sha "${{ github.sha }}"
+            --tags-file /tmp/consumer-tags.txt
+          )
+          if [ "${{ steps.quay-check.outputs.enabled }}" = "true" ]; then
+            args+=(--quay-ns "${{ steps.quay-check.outputs.ns }}")
+          fi
+          ./containers/ci/merge-manifests.sh "${args[@]}"

--- a/.sdlc/adrs/ADR-054-production-deployment.md
+++ b/.sdlc/adrs/ADR-054-production-deployment.md
@@ -222,3 +222,4 @@ not the default.
 - ADR-029: Web Gateway architecture (independent Gateway scaling)
 - ADR-034: Multi-pod health registration (Gateway aggregation)
 - ADR-035: Secret externalization (token management)
+- ADR-063: Multi-platform container image publish (amd64 + arm64)

--- a/.sdlc/adrs/ADR-061-ubi-container-bases.md
+++ b/.sdlc/adrs/ADR-061-ubi-container-bases.md
@@ -160,7 +160,8 @@ implementation (ADR → Python stack → UI/bootc).
 - APME-built images are UBI10/RHEL-ecosystem compliant after full rollout.
 - Gateway uses `microdnf` consistent with UBI minimal images.
 - CI and local builds continue via existing `BASE_IMAGE` build-arg pattern.
-- Multi-arch (amd64 + arm64) supported by UBI10 App Stream manifests.
+- Multi-arch (amd64 + arm64) supported by UBI10 App Stream manifests
+  (publish contract completed by [ADR-063](ADR-063-multi-platform-container-images.md)).
 
 ### Negative
 
@@ -176,8 +177,9 @@ implementation (ADR → Python stack → UI/bootc).
 - OPA/Gitleaks final images change OS base but retain upstream binary copy
   pattern.
 - Helm chart values unchanged; same image names and tags published to GHCR/Quay.
-- Container CI workflow (`.github/workflows/container-images.yml`) needs no
-  structural change.
+- Container CI later gained a structural multi-arch publish path
+  ([ADR-063](ADR-063-multi-platform-container-images.md)); the UBI migration
+  itself did not require that reshape.
 
 ## Implementation Notes
 
@@ -241,6 +243,7 @@ FROM ${BOOTC_BASE_IMAGE}
 - [ADR-010](ADR-010-gitleaks-validator.md): Gitleaks multi-stage binary copy
 - [ADR-037](ADR-037-project-centric-ui-model.md): Gateway requires `git`
 - [ADR-054](ADR-054-production-deployment.md): Helm and bootc production paths
+- [ADR-063](ADR-063-multi-platform-container-images.md): Multi-platform image publish
 
 ## References
 

--- a/.sdlc/adrs/ADR-063-multi-platform-container-images.md
+++ b/.sdlc/adrs/ADR-063-multi-platform-container-images.md
@@ -1,0 +1,185 @@
+# ADR-063: Multi-Platform Container Image Publish
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-15
+
+## Context
+
+APME publishes container images to GHCR (and optionally Quay) for Helm,
+bootc, and external consumers. CI historically built on a single
+`ubuntu-latest` (amd64) runner with Docker Buildx and **no** `platforms`
+matrix, so published tags were effectively **linux/amd64 only**.
+
+Early-access and demo users frequently run on **Apple Silicon** laptops and
+**arm64** Kubernetes/OpenShift nodes. Requiring those users to rebuild all
+images locally is a high-friction mismatch with "meet users where they are."
+
+[ADR-061](ADR-061-ubi-container-bases.md) already selected UBI10 Application
+Stream bases partly because they publish amd64 and arm64 manifests. That made
+the **bases** multi-arch ready; it did **not** make APME's **publish pipeline**
+a contract. Without an explicit decision, multi-arch support can regress when
+CI is "simplified."
+
+Abbenay (`ghcr.io/redhat-developer/abbenay`) already ships multi-arch images.
+OPA and Gitleaks upstream images used in multi-stage `COPY --from` builds are
+also multi-arch. The gap is APME-built images only.
+
+### Decision Drivers
+
+- **Meet users where they are**: amd64 servers and arm64 developer/demo clusters
+  must pull the same Helm tags.
+- **Stable consumer contract**: same image names and tags; nodes select the
+  matching platform from a manifest list (no chart or values change).
+- **Reliable CI**: prefer native per-arch builds over QEMU cross-compilation for
+  heavy images (`apme-base` `uv sync`, `apme-ansible` prewarm).
+- **Org precedent**: [ansible-dev-tools](https://github.com/ansible/ansible-dev-tools)
+  builds amd64 and arm64 on native runners, then merges manifests.
+- **Lock the requirement**: document the platforms so "drop arm to save CI
+  minutes" requires a superseding ADR.
+
+### Constraints
+
+- **Registries stay the same**: `ghcr.io/<owner>/apme-*` and optional
+  `quay.io/<ns>/apme-*`.
+- **Helm remains tag-based** (ADR-054); no digest pinning required for this ADR.
+- **Local `tox -e build`** builds the host architecture only (developer laptop
+  path). CI is the multi-arch guarantee.
+- **bootc VM images** are out of scope (separate host/arch concern).
+- **Lean CI** (ADR-047): merge/publish logic lives in a repo script callable
+  from the workflow, not only in opaque YAML.
+
+## Decision
+
+**Published APME application images MUST be multi-platform manifest lists for
+`linux/amd64` and `linux/arm64` under the existing GHCR/Quay image names and
+consumer tags.**
+
+Build method:
+
+1. **Native per-arch CI builds** on GitHub-hosted runners (`ubuntu-24.04` for
+   amd64, `ubuntu-24.04-arm` for arm64).
+2. Push **arch-suffixed intermediate tags** into the **same** final image
+   repositories (e.g. `apme-gateway:<git-sha>-amd64` /
+   `apme-gateway:<git-sha>-arm64`) so GHCR blob mounting works when merging.
+3. A **merge job** creates consumer tags (`sha-*`, semver, `latest` per existing
+   metadata rules) via `docker buildx imagetools create`, with a **preflight**
+   that all per-arch sources exist, **phase-1 immutable `sha-*` tags** for the
+   full image set, then **phase-2 floating tags**, and a **hard assert** that
+   each published consumer tag lists both `linux/amd64` and `linux/arm64`.
+4. Optional Quay publish receives the **final** multi-arch tags from the merge
+   job (sources may remain on GHCR). Quay is enabled only when both username
+   and password secrets are set.
+5. Image inventory is **`containers/ci/images.txt`** — single source of truth
+   for the workflow service matrix and the merge script.
+
+Removing either platform from published images requires a superseding ADR.
+
+## Alternatives Considered
+
+### Alternative 1: QEMU / single-runner `platforms: linux/amd64,linux/arm64`
+
+**Description**: Keep one `ubuntu-latest` job and ask Buildx to cross-build
+arm64 under QEMU.
+
+**Pros**:
+- Smaller workflow matrix
+- Familiar Buildx one-liner
+
+**Cons**:
+- Slow and flaky for `apme-base` and `apme-ansible`
+- Harder to debug arch-specific failures
+
+**Why not chosen**: ansible-dev-tools and our own arm rebuild experience favor
+native builds for reliability.
+
+### Alternative 2: Separate `-arm64` image names or a second chart
+
+**Description**: Publish `apme-gateway-arm64` (or a second Helm chart) instead
+of multi-arch tags.
+
+**Pros**:
+- Simple single-arch tags per name
+
+**Cons**:
+- Shifts arch selection onto every consumer
+- Helm values / docs fork forever
+- Violates "same tags, meet users where they are"
+
+**Why not chosen**: Manifest lists keep the Helm contract unchanged.
+
+### Alternative 3: amd64-only publish; document local rebuild for arm
+
+**Description**: Keep current CI; tell arm users to `tox -e build`.
+
+**Pros**:
+- Lowest CI cost
+
+**Cons**:
+- Blocks Helm-from-registry demos on arm64
+- High friction for EAP / Apple Silicon users
+
+**Why not chosen**: Unacceptable for the supported deployment story.
+
+## Consequences
+
+### Positive
+
+- `helm install` with a published tag works on amd64 and arm64 nodes.
+- Apple Silicon and arm64 cluster demos no longer require a full local rebuild.
+- ADR-061's multi-arch base choice is completed by a publish contract.
+- Intentional removal of a platform requires an explicit ADR change.
+
+### Negative
+
+- CI cost and wall-clock time increase (roughly ~2× image build capacity;
+  arm runners may queue).
+- Merge job adds a failure mode if one arch leg fails.
+- Intermediate arch-suffixed tags accumulate in the registry (acceptable;
+  GC/package retention can age them out).
+
+### Neutral
+
+- Local `tox -e build` / Podman remains single-arch (host native).
+- Abbenay and bootc unchanged by this ADR.
+- Chart `values.yaml` image names and tag semantics unchanged.
+
+## Implementation Notes
+
+- Workflow: [`.github/workflows/container-images.yml`](../../.github/workflows/container-images.yml)
+- Merge script: [`containers/ci/merge-manifests.sh`](../../containers/ci/merge-manifests.sh)
+- Service builds for a given arch must `FROM` that arch's `apme-base:<sha>-<arch>`
+  tag (never an unfinished multi-arch `latest` mid-pipeline).
+- Prefer `docker buildx imagetools create` over raw `docker manifest create`
+  (matches ansible-dev-tools `merge-release` action).
+- Verification: merge CI fails unless each published consumer tag lists both
+  `linux/amd64` and `linux/arm64`. After the first post-merge release, confirm
+  with `docker buildx imagetools inspect` on arm and amd64 pull/smoke.
+- Tags published **before** this ADR remain single-arch until rebuilt; chart
+  defaults and older release tags are not retroactively multi-arch.
+- Pin Actions to commit SHAs with `# vN` comments (ADR-015).
+
+## Related Decisions
+
+- [ADR-015](ADR-015-github-actions-prek.md): Action pinning / CI hygiene
+- [ADR-047](ADR-047-tox-developer-orchestration.md): tox / lean CI orchestration
+- [ADR-054](ADR-054-production-deployment.md): Helm / bootc production paths
+- [ADR-061](ADR-061-ubi-container-bases.md): UBI10 bases (multi-arch capable)
+
+## References
+
+- [ansible-dev-tools `tools/ee.sh`](https://github.com/ansible/ansible-dev-tools/blob/main/tools/ee.sh) — native per-arch build + manifest merge
+- [ansible-dev-tools merge-release action](https://github.com/ansible/ansible-dev-tools/blob/main/.github/actions/merge-release/action.yml) — `imagetools create`
+- [Docker Buildx imagetools](https://docs.docker.com/reference/cli/docker/buildx/imagetools/)
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-07-15 | APME Team | Initial acceptance — multi-platform publish contract |

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -71,6 +71,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-060](ADR-060-rest-api-versioning-contract.md) | REST API Versioning Contract | 2026-07-08 |
 | [ADR-061](ADR-061-ubi-container-bases.md) | UBI10 Container Base Images | 2026-07-08 |
 | [ADR-062](ADR-062-ephemeral-proposal-working-set.md) | Ephemeral Proposal Working Set and Review Analytics | 2026-07-09 |
+| [ADR-063](ADR-063-multi-platform-container-images.md) | Multi-Platform Container Image Publish | 2026-07-15 |
 
 ## Proposed
 
@@ -97,7 +98,7 @@ Decisions replaced by newer ADRs.
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-063)
+2. Use the next available number (currently ADR-064)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/.sdlc/context/deployment.md
+++ b/.sdlc/context/deployment.md
@@ -59,6 +59,11 @@ This builds eleven images:
 
 The Abbenay AI image (`ghcr.io/redhat-developer/abbenay`) is pulled from the registry.
 
+CI publishes multi-arch images (`linux/amd64` + `linux/arm64`) per
+[ADR-063](/.sdlc/adrs/ADR-063-multi-platform-container-images.md) for tags built
+after that ADR; older release tags stay amd64-only until rebuilt. Local
+`tox -e build` remains host-native.
+
 ### Start the Pod
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Full details: [architecture.md](/.sdlc/context/architecture.md) | [deployment.md
 | [ADR-009](/.sdlc/adrs/ADR-009-remediation-engine.md) | Validators are read-only; remediation is separate |
 | [ADR-054](/.sdlc/adrs/ADR-054-production-deployment.md) | **Helm chart for K8s/OCP**, bootc for VM |
 | [ADR-060](/.sdlc/adrs/ADR-060-rest-api-versioning-contract.md) | REST API is a versioned public contract — no breaking changes without version bump |
+| [ADR-063](/.sdlc/adrs/ADR-063-multi-platform-container-images.md) | Published images are multi-arch (`linux/amd64` + `linux/arm64`) |
 
 Full list: `.sdlc/adrs/README.md`
 

--- a/containers/ci/images.txt
+++ b/containers/ci/images.txt
@@ -1,0 +1,16 @@
+# APME images published by container-images.yml (ADR-063).
+# One name per line. Dockerfile path: containers/<name>/Dockerfile
+# Keep this file as the single source of truth for the merge script and
+# the workflow prepare job (do not duplicate the list in YAML).
+base
+primary
+native
+opa
+ansible
+galaxy-proxy
+gitleaks
+gateway
+cli
+ui
+collection-health
+dep-audit

--- a/containers/ci/merge-manifests.sh
+++ b/containers/ci/merge-manifests.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Merge per-arch APME image tags into multi-arch consumer tags (ADR-063).
+#
+# Expects arch-specific images already pushed to GHCR:
+#   ghcr.io/<owner>/apme-<name>:<git-sha>-amd64
+#   ghcr.io/<owner>/apme-<name>:<git-sha>-arm64
+#
+# Image names are read from containers/ci/images.txt (single source of truth).
+#
+# Usage:
+#   merge-manifests.sh --owner ansible --sha "$GITHUB_SHA" --tags "sha-abc1234,latest"
+#   merge-manifests.sh --owner ansible --sha "$GITHUB_SHA" --tags-file /tmp/tags.txt
+#   merge-manifests.sh ... --quay-ns ansible   # also push final tags to quay.io
+#
+# Locally runnable (lean CI): logic lives here, not only in workflow YAML.
+set -euo pipefail
+
+OWNER=""
+SHA=""
+TAGS_CSV=""
+TAGS_FILE=""
+QUAY_NS=""
+GHCR_REGISTRY="${GHCR_REGISTRY:-ghcr.io}"
+QUAY_REGISTRY="${QUAY_REGISTRY:-quay.io}"
+ENGINE="${CONTAINER_ENGINE:-docker}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGES_FILE="${IMAGES_FILE:-${SCRIPT_DIR}/images.txt}"
+
+usage() {
+  sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+load_images() {
+  local line
+  IMAGES=()
+  if [[ ! -f "$IMAGES_FILE" ]]; then
+    echo "Images file not found: $IMAGES_FILE" >&2
+    exit 1
+  fi
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line//$'\r'/}"
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    IMAGES+=("$line")
+  done <"$IMAGES_FILE"
+  if [[ ${#IMAGES[@]} -eq 0 ]]; then
+    echo "No images listed in ${IMAGES_FILE}" >&2
+    exit 1
+  fi
+}
+
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+assert_multiarch() {
+  local ref="$1"
+  local raw arches
+  raw="$("${ENGINE}" buildx imagetools inspect --raw "${ref}")"
+  arches="$(printf '%s' "$raw" | jq -r '
+    if .manifests then
+      [.manifests[] | select(.platform.os == "linux") | .platform.architecture] | unique | .[]
+    elif .architecture then
+      .architecture
+    else
+      empty
+    end
+  ')"
+  if ! grep -qx 'amd64' <<<"$arches"; then
+    echo "ERROR: ${ref} missing linux/amd64 (arches: ${arches//$'\n'/ })" >&2
+    exit 1
+  fi
+  if ! grep -qx 'arm64' <<<"$arches"; then
+    echo "ERROR: ${ref} missing linux/arm64 (arches: ${arches//$'\n'/ })" >&2
+    exit 1
+  fi
+  echo "OK multi-arch: ${ref}"
+}
+
+preflight_sources() {
+  local name src_amd src_arm
+  echo "==> Preflight: verifying per-arch sources exist"
+  for name in "${IMAGES[@]}"; do
+    src_amd="${GHCR_REGISTRY}/${OWNER}/apme-${name}:${SHA}-amd64"
+    src_arm="${GHCR_REGISTRY}/${OWNER}/apme-${name}:${SHA}-arm64"
+    "${ENGINE}" buildx imagetools inspect "${src_amd}" >/dev/null
+    "${ENGINE}" buildx imagetools inspect "${src_arm}" >/dev/null
+    echo "OK sources: apme-${name}"
+  done
+}
+
+merge_tags_for_all_images() {
+  local -a tags=("$@")
+  local name tag src_amd src_arm
+  local -a tag_args
+  local dest
+
+  for name in "${IMAGES[@]}"; do
+    src_amd="${GHCR_REGISTRY}/${OWNER}/apme-${name}:${SHA}-amd64"
+    src_arm="${GHCR_REGISTRY}/${OWNER}/apme-${name}:${SHA}-arm64"
+    tag_args=()
+    for tag in "${tags[@]}"; do
+      tag="$(trim "$tag")"
+      [[ -z "$tag" ]] && continue
+      tag_args+=(-t "${GHCR_REGISTRY}/${OWNER}/apme-${name}:${tag}")
+      if [[ -n "$QUAY_NS" ]]; then
+        tag_args+=(-t "${QUAY_REGISTRY}/${QUAY_NS}/apme-${name}:${tag}")
+      fi
+    done
+    if [[ ${#tag_args[@]} -eq 0 ]]; then
+      echo "No tags left after trimming for ${name}" >&2
+      exit 1
+    fi
+    echo "==> imagetools create apme-${name} tags=${tags[*]}"
+    "${ENGINE}" buildx imagetools create "${tag_args[@]}" "${src_amd}" "${src_arm}"
+    # Assert GHCR consumer tag (first tag in this batch).
+    dest="${GHCR_REGISTRY}/${OWNER}/apme-${name}:$(trim "${tags[0]}")"
+    assert_multiarch "${dest}"
+  done
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --owner)
+      OWNER="${2:-}"
+      shift 2
+      ;;
+    --sha)
+      SHA="${2:-}"
+      shift 2
+      ;;
+    --tags)
+      TAGS_CSV="${2:-}"
+      shift 2
+      ;;
+    --tags-file)
+      TAGS_FILE="${2:-}"
+      shift 2
+      ;;
+    --quay-ns)
+      QUAY_NS="${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [[ -z "$OWNER" || -z "$SHA" ]]; then
+  echo "--owner and --sha are required" >&2
+  usage
+fi
+
+TAGS=()
+if [[ -n "$TAGS_FILE" ]]; then
+  if [[ ! -f "$TAGS_FILE" ]]; then
+    echo "Tags file not found: $TAGS_FILE" >&2
+    exit 1
+  fi
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line//$'\r'/}"
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    TAGS+=("$(trim "$line")")
+  done <"$TAGS_FILE"
+elif [[ -n "$TAGS_CSV" ]]; then
+  IFS=',' read -r -a TAGS <<<"$TAGS_CSV"
+else
+  echo "Provide --tags or --tags-file" >&2
+  usage
+fi
+
+# Drop empties after trim.
+_filtered=()
+for tag in "${TAGS[@]}"; do
+  tag="$(trim "$tag")"
+  [[ -n "$tag" ]] && _filtered+=("$tag")
+done
+TAGS=("${_filtered[@]}")
+
+if [[ ${#TAGS[@]} -eq 0 ]]; then
+  echo "No consumer tags to publish" >&2
+  exit 1
+fi
+
+load_images
+
+echo "==> Merging multi-arch manifests for owner=${OWNER} sha=${SHA}"
+echo "==> Images (${#IMAGES[@]}): ${IMAGES[*]}"
+echo "==> Consumer tags: ${TAGS[*]}"
+if [[ -n "$QUAY_NS" ]]; then
+  echo "==> Also publishing to ${QUAY_REGISTRY}/${QUAY_NS}"
+fi
+
+preflight_sources
+
+# Phase 1: immutable sha-* tags for every image (consistent set before floating tags).
+SHA_TAGS=()
+FLOAT_TAGS=()
+for tag in "${TAGS[@]}"; do
+  if [[ "$tag" == sha-* ]]; then
+    SHA_TAGS+=("$tag")
+  else
+    FLOAT_TAGS+=("$tag")
+  fi
+done
+
+if [[ ${#SHA_TAGS[@]} -eq 0 ]]; then
+  echo "ERROR: expected at least one sha-* consumer tag in: ${TAGS[*]}" >&2
+  exit 1
+fi
+
+echo "==> Phase 1: immutable tags (${SHA_TAGS[*]})"
+merge_tags_for_all_images "${SHA_TAGS[@]}"
+
+if [[ ${#FLOAT_TAGS[@]} -gt 0 ]]; then
+  echo "==> Phase 2: floating tags (${FLOAT_TAGS[*]})"
+  merge_tags_for_all_images "${FLOAT_TAGS[@]}"
+fi
+
+echo "==> Multi-arch merge complete"

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -74,6 +74,9 @@ spec:
 - Default image tag is pinned to `2026.7.3` (GitHub release `v2026.7.3`; must
   match Chart.appVersion). Override with `--set image.tag=…` for another
   release or a SHA build (e.g. `sha-b7d1683`)
+- Cluster nodes on `linux/amd64` or `linux/arm64`. Tags published by CI after
+  [ADR-063](../../../.sdlc/adrs/ADR-063-multi-platform-container-images.md) are
+  multi-arch manifest lists (older release tags remain amd64-only until rebuilt)
 
 ## Quick start
 
@@ -236,7 +239,9 @@ engine:
 
 The chart works under OpenShift's `restricted-v2` SCC without modification.
 APME application container images are built on **UBI10** Application Stream
-bases (ADR-061).
+bases (ADR-061). CI publishes **multi-arch** (`linux/amd64` + `linux/arm64`)
+manifest lists under the same tags after ADR-063 (rebuild release tags to pick
+that up).
 
 - `podSecurityContext` and `securityContext` default to empty (OCP injects UID/GID)
 - The UI container mounts emptyDir volumes for nginx writable paths

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -421,6 +421,13 @@ Add chart repository URL `https://ansible.github.io/apme` (Developer → Helm),
 or apply a `HelmChartRepository` / `ProjectHelmChartRepository` CR — see
 [deploy/helm/apme/README.md](../../deploy/helm/apme/README.md).
 
+Application images published by CI after
+[ADR-063](../../.sdlc/adrs/ADR-063-multi-platform-container-images.md) are
+**multi-arch** (`linux/amd64` and `linux/arm64`) under the same registry tags.
+Older release tags remain amd64-only until rebuilt. Helm does not need
+arch-specific values; the node pulls the matching platform. Prefer a post-ADR
+SHA or release tag (and Quay only when that publish included Quay credentials).
+
 ### Key values
 
 | Value | Description |


### PR DESCRIPTION
## Summary
- Lock multi-platform publish (`linux/amd64` + `linux/arm64`) in **ADR-063** so arm support cannot be silently dropped
- Reshape `container-images.yml` on the ansible-dev-tools pattern: native per-arch builds → arch-suffixed GHCR tags → `imagetools` merge into the same consumer tags Helm already uses
- Same GHCR/Quay image names; chart values unchanged

## Changes
- Add [ADR-063](.sdlc/adrs/ADR-063-multi-platform-container-images.md) and index/cross-links (ADR-054/061, CLAUDE.md)
- `containers/ci/images.txt` as single image inventory; prepare job builds the service matrix from it
- `containers/ci/merge-manifests.sh`: preflight sources, phase-1 `sha-*` then phase-2 floating tags, hard assert both platforms on every image
- Disable Buildx provenance/SBOM on per-arch pushes to keep merges reliable
- Quay mirror only when both username and password secrets are set
- Docs note that tags published **before** ADR-063 remain amd64-only until rebuilt

## Quality of life
- Update lean-ci skill for multi-arch lifecycle (`main`, tags, `workflow_dispatch`) and `images.txt`

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (full suite earlier; hygiene re-checked after RoF fixes)
- [ ] After merge (or `workflow_dispatch`): `docker buildx imagetools inspect ghcr.io/ansible/apme-gateway:sha-<short>` shows amd64 + arm64
- [ ] Pull/smoke on an arm64 node with a post-ADR tag
- [ ] Confirm Quay multi-arch only when Quay secrets are configured

## Rule of Five
Ship-blockers from cold review (≥2 passes) addressed before push: dual-arch assert, single image list, merge preflight + sha-then-floating phases, provenance off, docs honesty for pre-existing tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Container images are now published as multi-architecture images for `linux/amd64` and `linux/arm64`.
  - Images are built consistently across services and verified before publication.
  - Optional Quay publishing now requires complete credentials.

- **Documentation**
  - Updated deployment guidance to explain multi-architecture image availability, tag behavior, rebuild requirements, and platform selection.
  - Added documentation for the multi-platform publishing contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->