### PR TITLE
fix(engine): skip roles/requirements.yml file and serialize YAML dates

### DIFF
--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -805,7 +805,8 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                 content_graph = cg
                 loop = asyncio.get_event_loop()
                 content_graph_data = await loop.run_in_executor(
-                    None, lambda: json.dumps(cg.to_dict(slim=True)).encode()
+                    None,
+                    lambda: json.dumps(cg.to_dict(slim=True), default=str).encode(),
                 )
                 logger.debug(
                     "ContentGraph serialized: %d bytes (req=%s)",
@@ -1583,7 +1584,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             if native_addr:
                 graph_data = await asyncio.get_event_loop().run_in_executor(
                     None,
-                    lambda: json.dumps(g.to_dict(slim=True)).encode(),
+                    lambda: json.dumps(g.to_dict(slim=True), default=str).encode(),
                 )
                 ext_coros.append(
                     _call_validator(

--- a/src/apme_engine/engine/model_loader.py
+++ b/src/apme_engine/engine/model_loader.py
@@ -451,7 +451,7 @@ def load_file(
 
         try:
             data = yaml.safe_load(body)
-            data_str = json.dumps(data, separators=(",", ":"))
+            data_str = json.dumps(data, separators=(",", ":"), default=str)
         except Exception:
             # ignore exception if any
             # because possibly this file is not a YAML file
@@ -1505,6 +1505,9 @@ def load_roles(
         dirs = sorted(os.listdir(roles_dir_path))
         for dir_name in dirs:
             candidate = os.path.join(roles_dir_path, dir_name)
+            # Skip non-directories (e.g. roles/requirements.yml as a file)
+            if not os.path.isdir(candidate):
+                continue
             dirs_in_cand = os.listdir(candidate)
             if is_role_dir(dirs_in_cand):
                 role_dirs.append(candidate)
@@ -1523,6 +1526,9 @@ def load_roles(
                     test_sub_role_names = os.listdir(test_sub_roles_dir)
                     for test_sub_role_name in test_sub_role_names:
                         test_sub_role_dir = os.path.join(test_sub_roles_dir, test_sub_role_name)
+                        # Skip non-directories (e.g. requirements.yml as a file)
+                        if not os.path.isdir(test_sub_role_dir):
+                            continue
                         role_dirs.append(test_sub_role_dir)
 
     # add role dirs if yaml_label_list is given

--- a/tests/test_engine_model_loader.py
+++ b/tests/test_engine_model_loader.py
@@ -15,6 +15,7 @@ from apme_engine.engine.model_loader import (
     load_playbooks,
     load_requirements,
     load_roleinplay,
+    load_roles,
     load_task,
     load_taskfile,
 )
@@ -462,6 +463,14 @@ class TestLoadFile:
         assert isinstance(f, File)
         assert "key: value" in f.body
 
+    def test_load_yaml_date_tag_is_json_serializable(self) -> None:
+        """YAML date tags must not break File.data JSON serialization."""
+        import json
+
+        f = load_file(path="vars/main.yml", body="released: 2024-01-15\n", read=False)
+        assert isinstance(f.data, str)
+        json.loads(f.data)
+
 
 class TestLoadRequirements:
     """Tests for load_requirements."""
@@ -822,3 +831,55 @@ class TestLoadPlaybooksNestedDirectories:
         assert len(playbooks) == 1
         assert "site.yml" in str(playbooks[0])
         assert not any("tasks" in str(p) for p in playbooks)
+
+
+class TestLoadRoles:
+    """Tests for load_roles directory discovery."""
+
+    def test_skips_requirements_yml_file_under_roles(self, tmp_path: Path) -> None:
+        """roles/requirements.yml as a file must not raise NotADirectoryError.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        roles_dir = tmp_path / "roles"
+        roles_dir.mkdir()
+        (roles_dir / "requirements.yml").write_text("---\ncollections: []\n")
+
+        real_role_tasks = roles_dir / "web" / "tasks"
+        real_role_tasks.mkdir(parents=True)
+        (real_role_tasks / "main.yml").write_text("---\n- name: Hello\n  ansible.builtin.debug:\n    msg: hi\n")
+
+        roles = load_roles(str(tmp_path), basedir=str(tmp_path), load_children=False)
+
+        assert len(roles) == 1
+        assert "web" in str(roles[0])
+
+    def test_skips_non_directory_under_test_sub_roles(self, tmp_path: Path) -> None:
+        """Files under tests/.../roles/ must not be treated as role dirs.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        # Anchor top-level roles/ so discovery does not latch onto tests/.../roles.
+        (tmp_path / "roles").mkdir()
+
+        # Target has roles/ but no top-level tasks/ (hits the elif branch).
+        sub_roles = tmp_path / "tests" / "integration" / "targets" / "demo" / "roles"
+        sub_roles.mkdir(parents=True)
+        (sub_roles / "requirements.yml").write_text("---\ncollections: []\n")
+
+        real_role_tasks = sub_roles / "helper" / "tasks"
+        real_role_tasks.mkdir(parents=True)
+        (real_role_tasks / "main.yml").write_text("---\n- name: Hello\n  ansible.builtin.debug:\n    msg: hi\n")
+
+        roles = load_roles(
+            str(tmp_path),
+            basedir=str(tmp_path),
+            include_test_contents=True,
+            load_children=False,
+        )
+
+        assert len(roles) == 1
+        assert "helper" in str(roles[0])
+        assert not any("requirements.yml" in str(r) for r in roles)


### PR DESCRIPTION
## Summary

Fixes two scan/remediate failures seen when loading Ansible content:

1. **`NotADirectoryError` under `roles/`** — Repos that keep Galaxy deps as a *file* at `roles/requirements.yml` (instead of only role directories) crashed `load_roles`, which assumed every entry under `roles/` was a directory and called `os.listdir` on it.
2. **`TypeError: Object of type datetime is not JSON serializable`** — YAML date tags (e.g. `released: 2024-01-15`) become `datetime` via `yaml.safe_load`. Serializing that with plain `json.dumps` failed during file load and content-graph encoding, aborting scan/remediate.

Also applies the same non-directory skip under `tests/integration/targets/*/roles/` (closes #416).

## Changes

- `model_loader.load_roles`: skip non-directory entries before listing role contents (top-level `roles/` and test sub-roles)
- `model_loader.load_file`: `json.dumps(..., default=str)` after YAML parse
- `primary_server`: `default=str` when encoding slim content graphs for validators
- Tests covering both cases in `test_engine_model_loader.py`

## Why

These show up on real customer-style repos (e.g. tower/devsecops layouts with `roles/requirements.yml`, and collections/vars with date fields). Without the guards, portal Quality scan/remediate fails even when rules otherwise run fine.

## Test plan

- [x] Unit: `TestLoadRoles::test_skips_requirements_yml_file_under_roles`
- [x] Unit: `TestLoadRoles::test_skips_non_directory_under_test_sub_roles`
- [x] Unit: `TestLoadFile::test_load_yaml_date_tag_is_json_serializable`
- [x] CI: prek, test, integration, ui, test-ai-extra
- [ ] Manual (optional): scan a repo with `roles/requirements.yml` as a file and YAML dates in vars; confirm scan completes without `NotADirectoryError` / datetime JSON errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of date-like and other non-standard values in imported configuration data.
  * Prevented files from being incorrectly detected as roles during role discovery.
  * Increased resilience when processing content graphs containing values that cannot be serialized in the usual format.

* **Tests**
  * Added regression coverage for configuration loading and role discovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->