### PR TITLE
fix(gateway): accept inline scm_token and skip non-FQCN collection sources

### DIFF
--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -14,6 +14,7 @@ import difflib
 import json
 import logging
 import os
+import re
 import tempfile
 import time
 import uuid
@@ -364,12 +365,31 @@ async def _call_validator(
 
 _REQUIREMENTS_PATHS = {"requirements.yml", "collections/requirements.yml"}
 
+# Galaxy requirements.yml allows git/url/file sources; pip install only accepts FQCNs.
+_NON_FQCN_COLLECTION_TYPES = frozenset({"git", "url", "file", "dir", "subdirs"})
+_FQCN_COLLECTION_RE = re.compile(r"^[A-Za-z0-9_]+\.[A-Za-z0-9_]+$")
+
+
+def _is_pip_installable_collection_spec(name: str, entry_type: object | None = None) -> bool:
+    """Return True when *name* is a Galaxy FQCN suitable for pip install.
+
+    Git/URL/file sources (``type: git`` with a GitHub URL, etc.) are valid in
+    ``requirements.yml`` but cannot be converted by ``_spec_to_pip``.
+    """
+    if isinstance(entry_type, str) and entry_type.strip().lower() in _NON_FQCN_COLLECTION_TYPES:
+        return False
+    bare = name.split(":", 1)[0].strip()
+    if not bare or "://" in bare or bare.startswith(("git@", "git+", "/", ".")):
+        return False
+    return bool(_FQCN_COLLECTION_RE.match(bare))
+
 
 def _discover_collection_specs(files: Sequence[File]) -> tuple[list[str], list[str]]:
     """Extract collection specs from requirements.yml files in the uploaded file set.
 
     Looks for ``requirements.yml`` and ``collections/requirements.yml``.
     Parses the ``collections`` key and returns ``name[:version]`` strings.
+    Skips git/url/file sources that are not Galaxy FQCNs.
 
     Args:
         files: Uploaded File protos (or duck-typed objects with ``path``/``content``).
@@ -397,9 +417,21 @@ def _discover_collection_specs(files: Sequence[File]) -> tuple[list[str], list[s
             continue
         for entry in collections:
             if isinstance(entry, str):
+                if not _is_pip_installable_collection_spec(entry):
+                    logger.info("Skipping non-FQCN collection entry from %s: %s", norm, entry[:120])
+                    continue
                 specs.setdefault(entry, entry)
             elif isinstance(entry, dict) and entry.get("name"):
                 name = str(entry["name"])
+                entry_type = entry.get("type")
+                if not _is_pip_installable_collection_spec(name, entry_type):
+                    logger.info(
+                        "Skipping non-FQCN collection entry from %s: %s (type=%s)",
+                        norm,
+                        name[:120],
+                        entry_type,
+                    )
+                    continue
                 version = entry.get("version")
                 spec = (
                     f"{name}:{version}"

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -375,6 +375,13 @@ def _is_pip_installable_collection_spec(name: str, entry_type: object | None = N
 
     Git/URL/file sources (``type: git`` with a GitHub URL, etc.) are valid in
     ``requirements.yml`` but cannot be converted by ``_spec_to_pip``.
+
+    Args:
+        name: Collection name or URL from requirements.yml.
+        entry_type: Optional Galaxy source type (``git``, ``url``, etc.).
+
+    Returns:
+        True when the entry can be passed to pip install as an FQCN spec.
     """
     if isinstance(entry_type, str) and entry_type.strip().lower() in _NON_FQCN_COLLECTION_TYPES:
         return False

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -51,11 +51,14 @@ class OperateRequest(BaseModel):  # type: ignore[misc]
         options: Additional operation options.
         abandon_working_set: When True, allow a new remediate to flush an
             interactive draft working set (ADR-062 Phase 2).
+        scm_token: Optional one-time SCM token for private-repo clone
+            (overrides project/global token when present).
     """
 
     action: str = Field(..., pattern="^(check|remediate)$")
     options: dict[str, Any] = Field(default_factory=dict)
     abandon_working_set: bool = False
+    scm_token: str | None = None
 
 
 class OperateResponse(BaseModel):  # type: ignore[misc]
@@ -181,6 +184,9 @@ async def initiate_operation(project_id: str, body: OperateRequest) -> OperateRe
     cfg = load_config()
     galaxy_servers = await load_galaxy_server_defs()
 
+    inline_token = body.scm_token.strip() if body.scm_token else None
+    effective_scm_token = inline_token or proj.scm_token or cfg.scm_token
+
     task = asyncio.create_task(
         _drive_operation(
             operation_id=operation_id,
@@ -192,7 +198,7 @@ async def initiate_operation(project_id: str, body: OperateRequest) -> OperateRe
             options=body.options,
             scan_id=scan_id,
             galaxy_servers=galaxy_servers,
-            scm_token=proj.scm_token or cfg.scm_token,
+            scm_token=effective_scm_token,
         )
     )
     state.grpc_task = task

--- a/tests/test_operation_scm_token.py
+++ b/tests/test_operation_scm_token.py
@@ -86,7 +86,15 @@ async def test_operate_scm_token_resolution(
     global_token: str,
     expected: str,
 ) -> None:
-    """Inline body scm_token overrides project and global tokens."""
+    """Inline body scm_token overrides project and global tokens.
+
+    Args:
+        client: Async HTTP test client.
+        body_token: Optional inline scm_token from request body.
+        project_token: Optional per-project scm_token.
+        global_token: Global config scm_token fallback.
+        expected: Expected token passed to ``_drive_operation``.
+    """
     project_id = await _seed_project(scm_token=project_token)
     captured: dict[str, object] = {}
 
@@ -119,7 +127,11 @@ async def test_operate_scm_token_resolution(
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_operate_scm_token_strips_whitespace(client: AsyncClient) -> None:
-    """Whitespace around inline scm_token is trimmed before use."""
+    """Whitespace around inline scm_token is trimmed before use.
+
+    Args:
+        client: Async HTTP test client.
+    """
     project_id = await _seed_project()
     captured: dict[str, object] = {}
 

--- a/tests/test_operation_scm_token.py
+++ b/tests/test_operation_scm_token.py
@@ -70,7 +70,7 @@ async def _seed_project(scm_token: str | None = None) -> str:
     return project_id
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("body_token", "project_token", "global_token", "expected"),
     [
         ("inline-token", "project-token", "global-token", "inline-token"),

--- a/tests/test_operation_scm_token.py
+++ b/tests/test_operation_scm_token.py
@@ -1,0 +1,149 @@
+"""Tests for inline scm_token on POST /operation."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from apme_gateway.app import create_app
+from apme_gateway.db import close_db, get_session, init_db
+from apme_gateway.db.models import Project
+from apme_gateway.operation_registry import get_operation_registry
+
+
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
+async def _db(tmp_path: Path) -> AsyncIterator[None]:
+    """Initialise a fresh DB and clear operation registry per test.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Yields:
+        None: Test runs between setup and teardown.
+    """
+    await init_db(str(tmp_path / "test.db"))
+    yield
+    registry = get_operation_registry()
+    await registry.shutdown()
+    await close_db()
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+async def client() -> AsyncIterator[AsyncClient]:
+    """Build an async test client for the gateway app.
+
+    Yields:
+        AsyncClient: Client bound to the ASGI app.
+    """
+    transport = ASGITransport(app=create_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def _seed_project(scm_token: str | None = None) -> str:
+    """Insert a project row for operation tests.
+
+    Args:
+        scm_token: Optional per-project SCM token.
+
+    Returns:
+        The new project id.
+    """
+    project_id = "proj-scm-op"
+    async with get_session() as db:
+        db.add(
+            Project(
+                id=project_id,
+                name="SCM Op",
+                repo_url="https://github.com/org/repo.git",
+                branch="main",
+                created_at="2026-01-01T00:00:00+00:00",
+                scm_token=scm_token,
+            )
+        )
+        await db.commit()
+    return project_id
+
+
+@pytest.mark.parametrize(
+    ("body_token", "project_token", "global_token", "expected"),
+    [
+        ("inline-token", "project-token", "global-token", "inline-token"),
+        (None, "project-token", "global-token", "project-token"),
+        (None, None, "global-token", "global-token"),
+    ],
+)
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_operate_scm_token_resolution(
+    client: AsyncClient,
+    body_token: str | None,
+    project_token: str | None,
+    global_token: str,
+    expected: str,
+) -> None:
+    """Inline body scm_token overrides project and global tokens."""
+    project_id = await _seed_project(scm_token=project_token)
+    captured: dict[str, object] = {}
+
+    async def capture_drive(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    body: dict[str, object] = {"action": "check", "options": {}}
+    if body_token is not None:
+        body["scm_token"] = body_token
+
+    mock_cfg = MagicMock()
+    mock_cfg.scm_token = global_token
+    mock_cfg.primary_address = "127.0.0.1:50051"
+
+    with (
+        patch("apme_gateway.api.operation_router._drive_operation", side_effect=capture_drive),
+        patch("apme_gateway.config.load_config", return_value=mock_cfg),
+        patch(
+            "apme_gateway._galaxy_inject.load_galaxy_server_defs",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        resp = await client.post(f"/api/v1/projects/{project_id}/operation", json=body)
+        await asyncio.sleep(0.05)
+
+    assert resp.status_code == 201
+    assert captured.get("scm_token") == expected
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_operate_scm_token_strips_whitespace(client: AsyncClient) -> None:
+    """Whitespace around inline scm_token is trimmed before use."""
+    project_id = await _seed_project()
+    captured: dict[str, object] = {}
+
+    async def capture_drive(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    mock_cfg = MagicMock()
+    mock_cfg.scm_token = ""
+    mock_cfg.primary_address = "127.0.0.1:50051"
+
+    with (
+        patch("apme_gateway.api.operation_router._drive_operation", side_effect=capture_drive),
+        patch("apme_gateway.config.load_config", return_value=mock_cfg),
+        patch(
+            "apme_gateway._galaxy_inject.load_galaxy_server_defs",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        resp = await client.post(
+            f"/api/v1/projects/{project_id}/operation",
+            json={"action": "check", "options": {}, "scm_token": "  ghp_inline  "},
+        )
+        await asyncio.sleep(0.05)
+
+    assert resp.status_code == 201
+    assert captured.get("scm_token") == "ghp_inline"

--- a/tests/test_scanner_hierarchy.py
+++ b/tests/test_scanner_hierarchy.py
@@ -245,12 +245,19 @@ class TestDiscoverCollectionSpecs:
         assert specs == []
         assert paths == []
 
-    def test_paths_reported_even_without_collections_key(self) -> None:
-        """File path is reported even if YAML has no collections key."""
-        files = [self._file("requirements.yml", "roles:\n  - some.role\n")]
+    def test_skips_git_url_collection_entries(self) -> None:
+        """Git/URL collection sources are skipped; FQCNs are kept."""
+        content = (
+            "collections:\n"
+            "  - name: ansible.posix\n"
+            "    version: 1.4.0\n"
+            "  - name: https://github.com/redhat-cop/network.backup\n"
+            "    type: git\n"
+        )
+        files = [self._file("collections/requirements.yml", content)]
         specs, paths = _discover_collection_specs(files)
-        assert specs == []
-        assert paths == ["requirements.yml"]
+        assert specs == ["ansible.posix:1.4.0"]
+        assert paths == ["collections/requirements.yml"]
 
 
 class TestBuildManifest:


### PR DESCRIPTION
## Summary

- **Portal private-repo scans:** `POST /api/v1/projects/{id}/operation` now accepts an optional `scm_token` in the request body. Token resolution order is inline body token → per-project token → global config token. Enables the portal to pass a one-time SCM credential for check/remediate without persisting it on the project.
- **Collection requirements parsing:** `_discover_collection_specs` skips git/url/file collection entries in `requirements.yml` that are not Galaxy FQCNs, avoiding pip install failures when repos declare GitHub-sourced collections alongside standard FQCNs.

## Related

Companion portal changes (SCM token forwarding from Backstage router/client) are in `ansible-backstage-plugins` `prototype/apme` — separate PR #434.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for providing a one-time SCM token when starting an operation.
  - Inline tokens take precedence over project and default credentials, with surrounding whitespace removed.

- **Bug Fixes**
  - Collection discovery now ignores Git, URL, file, and directory-based sources that cannot be installed as Galaxy collections.
  - Valid Galaxy collection entries continue to be detected from requirements files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->