### PR TITLE
fix(ui): fetch-stream SSE for authenticated Portal hosts

### DIFF
--- a/frontend/packages/ui-workflow/src/api/sseFetch.ts
+++ b/frontend/packages/ui-workflow/src/api/sseFetch.ts
@@ -77,7 +77,8 @@ export async function readSseStream(
       }
     }
     // Flush any final frame that ended without a trailing blank line.
-    if (buffer.trim()) {
+    // Skip on abort — cleanup/unmount must not emit post-cancel events.
+    if (!signal?.aborted && buffer.trim()) {
       const { events } = parseSseChunk(`${buffer}\n\n`);
       for (const ev of events) {
         onEvent(ev);

--- a/frontend/packages/ui-workflow/src/api/sseFetch.ts
+++ b/frontend/packages/ui-workflow/src/api/sseFetch.ts
@@ -76,9 +76,21 @@ export async function readSseStream(
         onEvent(ev);
       }
     }
+    // Skip remaining decode/flush on abort — cleanup/unmount must not emit.
+    if (signal?.aborted) return;
+
+    // Flush TextDecoder so a multi-byte UTF-8 sequence split across the
+    // last chunk boundary is not dropped (stream:true holds it until EOS).
+    buffer += decoder.decode();
+    {
+      const { events, rest } = parseSseChunk(buffer);
+      buffer = rest;
+      for (const ev of events) {
+        onEvent(ev);
+      }
+    }
     // Flush any final frame that ended without a trailing blank line.
-    // Skip on abort — cleanup/unmount must not emit post-cancel events.
-    if (!signal?.aborted && buffer.trim()) {
+    if (buffer.trim()) {
       const { events } = parseSseChunk(`${buffer}\n\n`);
       for (const ev of events) {
         onEvent(ev);

--- a/frontend/packages/ui-workflow/src/api/sseFetch.ts
+++ b/frontend/packages/ui-workflow/src/api/sseFetch.ts
@@ -1,0 +1,90 @@
+/**
+ * Authenticated SSE over fetch (ReadableStream).
+ *
+ * Browser EventSource cannot set Authorization headers, so Portal hosts that
+ * authenticate via Backstage fetchApi get 401 on /operation/events. This
+ * client uses the host adapter's fetch so Bearer (and cookies) work the same
+ * as REST — native Vite proxy hosts keep working with plain fetch.
+ */
+
+export interface SseEvent {
+  event: string;
+  data: string;
+}
+
+/**
+ * Parse SSE frames from a buffer. Returns complete events and unparsed remainder
+ * (incomplete trailing frame).
+ */
+export function parseSseChunk(buffer: string): {
+  events: SseEvent[];
+  rest: string;
+} {
+  const events: SseEvent[] = [];
+  // SSE frames are separated by a blank line (\n\n or \r\n\r\n).
+  const parts = buffer.split(/\r?\n\r?\n/);
+  const rest = parts.pop() ?? '';
+
+  for (const part of parts) {
+    if (!part.trim()) continue;
+    let event = 'message';
+    const dataLines: string[] = [];
+    for (const line of part.split(/\r?\n/)) {
+      if (line.startsWith('event:')) {
+        event = line.slice(6).trim();
+      } else if (line.startsWith('data:')) {
+        // Spec: optional single leading space after the colon.
+        const raw = line.slice(5);
+        dataLines.push(raw.startsWith(' ') ? raw.slice(1) : raw);
+      }
+      // ignore id:, retry:, comments (:)
+    }
+    if (dataLines.length === 0) continue;
+    events.push({ event, data: dataLines.join('\n') });
+  }
+
+  return { events, rest };
+}
+
+/**
+ * Read an SSE response body, invoking onEvent for each complete frame.
+ * Resolves when the stream ends; rejects on read errors (not abort).
+ */
+export async function readSseStream(
+  body: ReadableStream<Uint8Array>,
+  onEvent: (event: SseEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const onAbort = () => {
+    void reader.cancel().catch(() => undefined);
+  };
+  signal?.addEventListener('abort', onAbort, { once: true });
+
+  try {
+    for (;;) {
+      if (signal?.aborted) break;
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const { events, rest } = parseSseChunk(buffer);
+      buffer = rest;
+      for (const ev of events) {
+        onEvent(ev);
+      }
+    }
+    // Flush any final frame that ended without a trailing blank line.
+    if (buffer.trim()) {
+      const { events } = parseSseChunk(`${buffer}\n\n`);
+      for (const ev of events) {
+        onEvent(ev);
+      }
+    }
+  } finally {
+    signal?.removeEventListener('abort', onAbort);
+    reader.releaseLock();
+  }
+}

--- a/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
@@ -1,18 +1,16 @@
 /**
  * SSE hook for real-time project operation state (ADR-052).
  *
- * Connects to GET /api/v1/projects/{id}/operation/events and returns
- * the current OperationState.  On initial connect receives a full
- * snapshot, then applies delta events.  Automatically reconnects on
- * disconnect.  Returns null when no operation is active.
+ * Connects to GET …/projects/{id}/operation/events via **fetch + stream**
+ * (adapter.fetch) so authenticated hosts (Portal Bearer) work. On connect
+ * receives a full snapshot, then applies delta events. Automatically
+ * reconnects on disconnect. Returns null when no operation is active.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  apmeApiUrl,
-  apmeSseUrl,
-  getApmeApiAdapter,
-} from "../api/apmeApiAdapter";
+import type { Dispatch, SetStateAction } from "react";
+import { apmeApiUrl, getApmeApiAdapter } from "../api/apmeApiAdapter";
+import { readSseStream, type SseEvent } from "../api/sseFetch";
 
 export type ProjectOperationStatus =
   | "queued"
@@ -321,52 +319,22 @@ export interface UseProjectOperationStateOptions {
   enabled?: boolean;
 }
 
-export function useProjectOperationState(
-  projectId: string,
-  options: UseProjectOperationStateOptions = {},
-) {
-  const enabled = options.enabled ?? true;
-  const [state, setState] = useState<ProjectOperationState | null>(null);
-  const [connected, setConnected] = useState(false);
-  const esRef = useRef<EventSource | null>(null);
-  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const mountedRef = useRef(true);
-
-  const cleanup = useCallback(() => {
-    if (esRef.current) {
-      esRef.current.close();
-      esRef.current = null;
-    }
-    if (reconnectTimer.current) {
-      clearTimeout(reconnectTimer.current);
-      reconnectTimer.current = null;
-    }
-    setConnected(false);
-  }, []);
-
-  const connect = useCallback(() => {
-    cleanup();
-
-    const es = new EventSource(
-      apmeSseUrl(`/projects/${projectId}/operation/events`),
-    );
-    esRef.current = es;
-
-    es.addEventListener("snapshot", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
-        const data = JSON.parse(e.data) as ProjectOperationState;
+/** Apply one Gateway operation SSE event to React state (exported for tests). */
+export function applyOperationSseEvent(
+  setState: Dispatch<SetStateAction<ProjectOperationState | null>>,
+  setConnected: Dispatch<SetStateAction<boolean>>,
+  ev: SseEvent,
+): void {
+  try {
+    switch (ev.event) {
+      case "snapshot": {
+        const data = JSON.parse(ev.data) as ProjectOperationState;
         setState(data);
         setConnected(true);
-      } catch {
-        /* ignore parse errors */
+        break;
       }
-    });
-
-    es.addEventListener("status_changed", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
-        const data = JSON.parse(e.data) as {
+      case "status_changed": {
+        const data = JSON.parse(ev.data) as {
           status: string;
           previous: string;
           error?: string;
@@ -380,41 +348,26 @@ export function useProjectOperationState(
               }
             : prev,
         );
-      } catch {
-        /* ignore */
+        break;
       }
-    });
-
-    es.addEventListener("progress", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
-        const entry = JSON.parse(e.data) as ProgressEntry;
+      case "progress": {
+        const entry = JSON.parse(ev.data) as ProgressEntry;
         setState((prev) =>
           prev
             ? { ...prev, progress: [...(prev.progress ?? []), entry] }
             : prev,
         );
-      } catch {
-        /* ignore */
+        break;
       }
-    });
-
-    es.addEventListener("proposals", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
-        const data = JSON.parse(e.data) as { proposals: Proposal[] };
+      case "proposals": {
+        const data = JSON.parse(ev.data) as { proposals: Proposal[] };
         setState((prev) =>
           prev ? { ...prev, proposals: data.proposals } : prev,
         );
-      } catch {
-        /* ignore */
+        break;
       }
-    });
-
-    es.addEventListener("findings", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
-        const data = JSON.parse(e.data) as { findings: AssessFinding[] };
+      case "findings": {
+        const data = JSON.parse(ev.data) as { findings: AssessFinding[] };
         setState((prev) =>
           prev
             ? {
@@ -424,17 +377,12 @@ export function useProjectOperationState(
               }
             : prev,
         );
-      } catch {
-        /* ignore */
+        break;
       }
-    });
-
-    // Gateway broadcasts status_changed(awaiting_ai_triage) then ai_triage
-    // with {candidates}. Without this handler the Session triage UI stays empty.
-    es.addEventListener("ai_triage", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
-        const data = JSON.parse(e.data) as { candidates?: AssessFinding[] };
+      // Gateway broadcasts status_changed(awaiting_ai_triage) then ai_triage
+      // with {candidates}. Without this handler the Session triage UI stays empty.
+      case "ai_triage": {
+        const data = JSON.parse(ev.data) as { candidates?: AssessFinding[] };
         setState((prev) =>
           prev
             ? {
@@ -444,15 +392,10 @@ export function useProjectOperationState(
               }
             : prev,
         );
-      } catch {
-        /* ignore */
+        break;
       }
-    });
-
-    es.addEventListener("proposal_updated", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
-        const data = JSON.parse(e.data) as {
+      case "proposal_updated": {
+        const data = JSON.parse(ev.data) as {
           proposals?: Array<Record<string, unknown>>;
         };
         const updates = data.proposals ?? [];
@@ -461,43 +404,30 @@ export function useProjectOperationState(
           if (!prev?.proposals) return prev;
           const byId = new Map(prev.proposals.map((p) => [p.id, p]));
           for (const item of updates) {
-            const eng = String(
-              item.engine_proposal_id || item.id || "",
-            );
+            const eng = String(item.engine_proposal_id || item.id || "");
             if (!eng || !byId.has(eng)) continue;
             const cur = byId.get(eng)!;
             byId.set(eng, {
               ...cur,
-              status: (String(item.status || cur.status) as Proposal["status"]),
-              path:
-                typeof item.path === "string" ? item.path : cur.path,
+              status: String(item.status || cur.status) as Proposal["status"],
+              path: typeof item.path === "string" ? item.path : cur.path,
               source:
                 typeof item.source === "string" ? item.source : cur.source,
             });
           }
           return { ...prev, proposals: Array.from(byId.values()) };
         });
-      } catch {
-        /* ignore */
+        break;
       }
-    });
-
-    es.addEventListener("result", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
-        const result = JSON.parse(e.data) as OperationResultData;
+      case "result": {
+        const result = JSON.parse(ev.data) as OperationResultData;
         setState((prev) => (prev ? { ...prev, result } : prev));
-      } catch {
-        /* ignore */
+        break;
       }
-    });
-
-    es.addEventListener("approval_ack", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
+      case "approval_ack": {
         // Do not force status to "applying" — two-gate interactive flow may
         // return to awaiting_approval; status_changed owns transitions.
-        const data = JSON.parse(e.data) as { applied_count: number };
+        const data = JSON.parse(ev.data) as { applied_count: number };
         setState((prev) =>
           prev
             ? {
@@ -508,63 +438,133 @@ export function useProjectOperationState(
               }
             : prev,
         );
-      } catch {
-        /* ignore */
+        break;
       }
-    });
-
-    es.addEventListener("pr_created", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
-        const data = JSON.parse(e.data) as { pr_url: string };
+      case "pr_created": {
+        const data = JSON.parse(ev.data) as { pr_url: string };
         setState((prev) => (prev ? { ...prev, pr_url: data.pr_url } : prev));
-      } catch {
-        /* ignore */
+        break;
       }
-    });
-
-    es.addEventListener("error_event", (e: MessageEvent) => {
-      if (!mountedRef.current) return;
-      try {
-        const data = JSON.parse(e.data) as { error: string };
+      case "error_event": {
+        const data = JSON.parse(ev.data) as { error: string };
         setState((prev) => (prev ? { ...prev, error: data.error } : prev));
-      } catch {
-        /* ignore */
+        break;
       }
-    });
+      default:
+        break;
+    }
+  } catch {
+    /* ignore parse errors */
+  }
+}
 
-    es.onerror = () => {
-      if (!mountedRef.current) return;
-      es.close();
-      esRef.current = null;
-      setConnected(false);
-      reconnectTimer.current = setTimeout(() => {
-        if (mountedRef.current) connect();
-      }, 3000);
-    };
+export function useProjectOperationState(
+  projectId: string,
+  options: UseProjectOperationStateOptions = {},
+) {
+  const enabled = options.enabled ?? true;
+  const [state, setState] = useState<ProjectOperationState | null>(null);
+  const [connected, setConnected] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+  const connectGenRef = useRef(0);
+
+  const cleanup = useCallback(() => {
+    connectGenRef.current += 1;
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+    if (reconnectTimer.current) {
+      clearTimeout(reconnectTimer.current);
+      reconnectTimer.current = null;
+    }
+    setConnected(false);
+  }, []);
+
+  const connect = useCallback(() => {
+    cleanup();
+    const gen = connectGenRef.current;
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    const { fetch: doFetch } = getApmeApiAdapter();
+    // Use apmeApiUrl (not EventSource-only helper) so absolute discovery
+    // bases and adapter.fetch auth both apply.
+    const url = apmeApiUrl(`/projects/${projectId}/operation/events`);
+
+    void (async () => {
+      try {
+        const res = await doFetch(url, {
+          method: "GET",
+          headers: { Accept: "text/event-stream" },
+          signal: ac.signal,
+        });
+        if (!mountedRef.current || gen !== connectGenRef.current) return;
+        if (!res.ok) {
+          throw new Error(
+            `SSE connect failed (${res.status} ${res.statusText})`,
+          );
+        }
+        if (!res.body) {
+          throw new Error("SSE connect failed: empty response body");
+        }
+        await readSseStream(
+          res.body,
+          (ev) => {
+            if (!mountedRef.current || gen !== connectGenRef.current) return;
+            applyOperationSseEvent(setState, setConnected, ev);
+          },
+          ac.signal,
+        );
+        // Stream ended — reconnect unless torn down.
+        if (!mountedRef.current || gen !== connectGenRef.current) return;
+        setConnected(false);
+        reconnectTimer.current = setTimeout(() => {
+          if (mountedRef.current && gen === connectGenRef.current) {
+            connect();
+          }
+        }, 3000);
+      } catch (err) {
+        if (ac.signal.aborted) return;
+        if (!mountedRef.current || gen !== connectGenRef.current) return;
+        setConnected(false);
+        reconnectTimer.current = setTimeout(() => {
+          if (mountedRef.current && gen === connectGenRef.current) {
+            connect();
+          }
+        }, 3000);
+        void err;
+      }
+    })();
   }, [projectId, cleanup]);
 
-  const poll = useCallback(async () => {
-    if (!enabled || !projectId) {
-      setState(null);
-      return;
-    }
-    try {
-      const s = await fetchProjectOperationState(projectId);
-      if (!mountedRef.current) return;
-      if (!s) {
-        setState(null);
+  const poll = useCallback(
+    async (opts?: { force?: boolean }) => {
+      const force = opts?.force === true;
+      if ((!enabled && !force) || !projectId) {
+        if (!force) setState(null);
         return;
       }
-      setState(s);
-      if (!TERMINAL_STATUSES.has(s.status)) {
-        connect();
+      try {
+        const s = await fetchProjectOperationState(projectId);
+        if (!mountedRef.current && !force) return;
+        if (!s) {
+          setState(null);
+          return;
+        }
+        setState(s);
+        if (!TERMINAL_STATUSES.has(s.status)) {
+          connect();
+        }
+      } catch {
+        // Transient Gateway/network error — keep prior state; SSE reconnect
+        // or a later refresh can recover.
       }
-    } catch {
-      // Transient Gateway/network error — keep prior state; SSE reconnect
-      // or a later refresh can recover.
-    }
-  }, [projectId, connect, enabled]);
+    },
+    [projectId, connect, enabled],
+  );
 
   useEffect(() => {
     mountedRef.current = true;
@@ -576,16 +576,18 @@ export function useProjectOperationState(
         cleanup();
       };
     }
-    poll();
+    void poll();
     return () => {
       mountedRef.current = false;
       cleanup();
     };
   }, [poll, cleanup, enabled, projectId]);
 
+  // Explicit refresh must not depend on ``enabled``: startScan calls
+  // refreshOp from a closure where attachOp was still false (no-op).
   const refresh = useCallback(() => {
-    if (enabled) poll();
-  }, [poll, enabled]);
+    void poll({ force: true });
+  }, [poll]);
 
   const clear = useCallback(() => {
     cleanup();

--- a/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
@@ -3,8 +3,9 @@
  *
  * Connects to GET …/projects/{id}/operation/events via **fetch + stream**
  * (adapter.fetch) so authenticated hosts (Portal Bearer) work. On connect
- * receives a full snapshot, then applies delta events. Automatically
- * reconnects on disconnect. Returns null when no operation is active.
+ * receives a full snapshot, then applies delta events. Reconnects on
+ * disconnect while the operation is non-terminal (Gateway closes the
+ * stream after terminal statuses). Returns null when no operation is active.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -469,6 +470,21 @@ export function useProjectOperationState(
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
   const connectGenRef = useRef(0);
+  /** Latest operation status for reconnect gating (SSE ends on terminal). */
+  const statusRef = useRef<ProjectOperationStatus | null>(null);
+  const errorBackoffRef = useRef(0);
+  const connectRef = useRef<() => void>(() => {});
+
+  const setStateTracked = useCallback(
+    (next: SetStateAction<ProjectOperationState | null>) => {
+      setState((prev) => {
+        const resolved = typeof next === "function" ? next(prev) : next;
+        statusRef.current = resolved?.status ?? null;
+        return resolved;
+      });
+    },
+    [],
+  );
 
   const cleanup = useCallback(() => {
     connectGenRef.current += 1;
@@ -481,6 +497,31 @@ export function useProjectOperationState(
       reconnectTimer.current = null;
     }
     setConnected(false);
+  }, []);
+
+  const scheduleReconnect = useCallback((gen: number, kind: "end" | "error") => {
+    if (!mountedRef.current || gen !== connectGenRef.current) return;
+    setConnected(false);
+    // Gateway closes the SSE after a terminal snapshot/status — do not loop.
+    const status = statusRef.current;
+    if (status && TERMINAL_STATUSES.has(status)) {
+      errorBackoffRef.current = 0;
+      return;
+    }
+    const delayMs =
+      kind === "error"
+        ? Math.min(30_000, 1_000 * 2 ** Math.min(errorBackoffRef.current, 4))
+        : 3_000;
+    if (kind === "error") {
+      errorBackoffRef.current += 1;
+    } else {
+      errorBackoffRef.current = 0;
+    }
+    reconnectTimer.current = setTimeout(() => {
+      if (mountedRef.current && gen === connectGenRef.current) {
+        connectRef.current();
+      }
+    }, delayMs);
   }, []);
 
   const connect = useCallback(() => {
@@ -510,51 +551,43 @@ export function useProjectOperationState(
         if (!res.body) {
           throw new Error("SSE connect failed: empty response body");
         }
+        errorBackoffRef.current = 0;
         await readSseStream(
           res.body,
           (ev) => {
             if (!mountedRef.current || gen !== connectGenRef.current) return;
-            applyOperationSseEvent(setState, setConnected, ev);
+            applyOperationSseEvent(setStateTracked, setConnected, ev);
           },
           ac.signal,
         );
-        // Stream ended — reconnect unless torn down.
-        if (!mountedRef.current || gen !== connectGenRef.current) return;
-        setConnected(false);
-        reconnectTimer.current = setTimeout(() => {
-          if (mountedRef.current && gen === connectGenRef.current) {
-            connect();
-          }
-        }, 3000);
-      } catch (err) {
+        scheduleReconnect(gen, "end");
+      } catch {
         if (ac.signal.aborted) return;
-        if (!mountedRef.current || gen !== connectGenRef.current) return;
-        setConnected(false);
-        reconnectTimer.current = setTimeout(() => {
-          if (mountedRef.current && gen === connectGenRef.current) {
-            connect();
-          }
-        }, 3000);
-        void err;
+        scheduleReconnect(gen, "error");
       }
     })();
-  }, [projectId, cleanup]);
+  }, [projectId, cleanup, scheduleReconnect, setStateTracked]);
+
+  connectRef.current = connect;
 
   const poll = useCallback(
     async (opts?: { force?: boolean }) => {
       const force = opts?.force === true;
       if ((!enabled && !force) || !projectId) {
-        if (!force) setState(null);
+        if (!force) {
+          setStateTracked(null);
+        }
         return;
       }
       try {
         const s = await fetchProjectOperationState(projectId);
-        if (!mountedRef.current && !force) return;
+        // Never update React state after unmount — force only bypasses enabled.
+        if (!mountedRef.current) return;
         if (!s) {
-          setState(null);
+          setStateTracked(null);
           return;
         }
-        setState(s);
+        setStateTracked(s);
         if (!TERMINAL_STATUSES.has(s.status)) {
           connect();
         }
@@ -563,14 +596,14 @@ export function useProjectOperationState(
         // or a later refresh can recover.
       }
     },
-    [projectId, connect, enabled],
+    [projectId, connect, enabled, setStateTracked],
   );
 
   useEffect(() => {
     mountedRef.current = true;
     if (!enabled || !projectId) {
       cleanup();
-      setState(null);
+      setStateTracked(null);
       return () => {
         mountedRef.current = false;
         cleanup();
@@ -581,7 +614,7 @@ export function useProjectOperationState(
       mountedRef.current = false;
       cleanup();
     };
-  }, [poll, cleanup, enabled, projectId]);
+  }, [poll, cleanup, enabled, projectId, setStateTracked]);
 
   // Explicit refresh must not depend on ``enabled``: startScan calls
   // refreshOp from a closure where attachOp was still false (no-op).
@@ -591,8 +624,8 @@ export function useProjectOperationState(
 
   const clear = useCallback(() => {
     cleanup();
-    setState(null);
-  }, [cleanup]);
+    setStateTracked(null);
+  }, [cleanup, setStateTracked]);
 
   return { state, connected, refresh, clear };
 }

--- a/frontend/packages/ui-workflow/src/index.ts
+++ b/frontend/packages/ui-workflow/src/index.ts
@@ -17,6 +17,12 @@ export {
 } from './api/apmeApiAdapter';
 
 export {
+  parseSseChunk,
+  readSseStream,
+  type SseEvent,
+} from './api/sseFetch';
+
+export {
   useProjectWorkflow,
   type ProjectWorkflowCheckOptions,
   type ProjectWorkflowController,

--- a/frontend/src/test/sseFetch.test.ts
+++ b/frontend/src/test/sseFetch.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseSseChunk, readSseStream } from '@apme/ui-workflow';
+import { applyOperationSseEvent } from '../../packages/ui-workflow/src/hooks/useProjectOperationState';
+
+describe('parseSseChunk', () => {
+  it('parses event and data frames', () => {
+    const { events, rest } = parseSseChunk(
+      'event: snapshot\ndata: {"status":"cloning"}\n\n' +
+        'event: progress\ndata: {"phase":"clone","message":"Cloning"}\n\n',
+    );
+    expect(rest).toBe('');
+    expect(events).toEqual([
+      { event: 'snapshot', data: '{"status":"cloning"}' },
+      {
+        event: 'progress',
+        data: '{"phase":"clone","message":"Cloning"}',
+      },
+    ]);
+  });
+
+  it('keeps incomplete trailing frame in rest', () => {
+    const { events, rest } = parseSseChunk(
+      'event: snapshot\ndata: {"a":1}\n\nevent: progress\ndata: {"partial',
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event).toBe('snapshot');
+    expect(rest).toContain('partial');
+  });
+
+  it('joins multi-line data', () => {
+    const { events } = parseSseChunk('event: x\ndata: line1\ndata: line2\n\n');
+    expect(events[0]?.data).toBe('line1\nline2');
+  });
+});
+
+describe('readSseStream', () => {
+  it('delivers events from a streamed body', async () => {
+    const text =
+      'event: snapshot\ndata: {"status":"assessed"}\n\n' +
+      'event: progress\ndata: {"phase":"scan","message":"done"}\n\n';
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(text.slice(0, 20)));
+        controller.enqueue(new TextEncoder().encode(text.slice(20)));
+        controller.close();
+      },
+    });
+    const seen: Array<{ event: string; data: string }> = [];
+    await readSseStream(stream, (ev) => seen.push(ev));
+    expect(seen.map((e) => e.event)).toEqual(['snapshot', 'progress']);
+  });
+});
+
+describe('applyOperationSseEvent', () => {
+  it('applies snapshot and marks connected', () => {
+    const setState = vi.fn();
+    const setConnected = vi.fn();
+    applyOperationSseEvent(setState, setConnected, {
+      event: 'snapshot',
+      data: JSON.stringify({
+        operation_id: 'op-1',
+        project_id: 'p-1',
+        scan_id: 's-1',
+        status: 'cloning',
+        scan_type: 'check',
+        started_at: '2026-01-01T00:00:00Z',
+        progress: [],
+      }),
+    });
+    expect(setConnected).toHaveBeenCalledWith(true);
+    expect(setState).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'cloning', operation_id: 'op-1' }),
+    );
+  });
+});

--- a/frontend/src/test/sseFetch.test.ts
+++ b/frontend/src/test/sseFetch.test.ts
@@ -50,6 +50,23 @@ describe('readSseStream', () => {
     expect(seen.map((e) => e.event)).toEqual(['snapshot', 'progress']);
   });
 
+  it('flushes TextDecoder at end-of-stream', async () => {
+    // Leading byte of "é" (C3 A9) held by stream:true; without decoder.decode()
+    // at EOS the pending byte is dropped (data would be "caf", not "caf�").
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode('event: message\ndata: caf'),
+        );
+        controller.enqueue(new Uint8Array([0xc3]));
+        controller.close();
+      },
+    });
+    const seen: Array<{ event: string; data: string }> = [];
+    await readSseStream(stream, (ev) => seen.push(ev));
+    expect(seen).toEqual([{ event: 'message', data: 'caf\uFFFD' }]);
+  });
+
   it('does not flush a partial frame after abort', async () => {
     const ac = new AbortController();
     // Incomplete frame (no trailing blank line) — would flush on clean end.

--- a/frontend/src/test/sseFetch.test.ts
+++ b/frontend/src/test/sseFetch.test.ts
@@ -49,6 +49,27 @@ describe('readSseStream', () => {
     await readSseStream(stream, (ev) => seen.push(ev));
     expect(seen.map((e) => e.event)).toEqual(['snapshot', 'progress']);
   });
+
+  it('does not flush a partial frame after abort', async () => {
+    const ac = new AbortController();
+    // Incomplete frame (no trailing blank line) — would flush on clean end.
+    const partial = new TextEncoder().encode(
+      'event: snapshot\ndata: {"status":"cloning"}',
+    );
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(partial);
+        // Leave open until abort cancels the reader.
+      },
+    });
+    const seen: Array<{ event: string; data: string }> = [];
+    const reading = readSseStream(stream, (ev) => seen.push(ev), ac.signal);
+    // Let the first chunk land in the internal buffer, then abort.
+    await new Promise((r) => setTimeout(r, 0));
+    ac.abort();
+    await reading;
+    expect(seen).toEqual([]);
+  });
 });
 
 describe('applyOperationSseEvent', () => {


### PR DESCRIPTION
## Summary
- Replace `EventSource` in `@apme/ui-workflow` with **fetch + ReadableStream** SSE via `adapter.fetch`, so hosts that authenticate with Backstage Bearer (Portal catalog proxy) receive live operation updates.
- Extract `parseSseChunk` / `readSseStream` and shared `applyOperationSseEvent` handlers; add vitest coverage.
- Force-enable `refresh()` after `startScan` so a stale `attachOp=false` closure cannot no-op the post-start poll (related Portal stuck spinner).

**Why:** Portal `/operation/events` was 401ing under `EventSource` (no `Authorization` header). The UI kept the first “Cloning repository…” snapshot while the Gateway had already reached `assessed`.

Native SPA keeps working: its adapter `fetch` is still plain `fetch` through the Vite `/api/v1` proxy.

## Test plan
- [x] `npm test` in `frontend/` (115 tests, including new `sseFetch` cases)
- [x] `npm run typecheck` in `frontend/`
- [x] `tox -e lint`
- [x] `tox -e unit`
- [ ] Local Portal smoke: Quality → Scan → progress advances past Cloning without poll workaround
- [ ] Native SPA: project Session still streams progress via Vite proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated Server-Sent Events streaming for real-time project operation updates.
  * Live events now update project state including status, progress, proposals/findings, AI triage candidates, results/approvals, pull request links, and errors.
  * Introduced SSE parsing and stream-reading utilities, now available via the package’s public API.
* **Bug Fixes**
  * Improved the operation-state update lifecycle with safer abort handling and more reliable reconnection behavior.
* **Tests**
  * Added automated coverage for SSE chunk parsing, ordered streaming delivery, decoder flush behavior, abort edge cases, and state updates from events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->