### PR TITLE
fix(ui): expand AI escalation locations by default

### DIFF
--- a/frontend/packages/ui-workflow/src/components/AiEscalationPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AiEscalationPanel.tsx
@@ -462,7 +462,7 @@ export function AiEscalationPanel({
                 decisionMode: true,
                 decisions,
                 onDecisionChange: handleDecisionChange,
-                defaultExpanded: false,
+                defaultExpanded: true,
                 showExpandControls: true,
                 resetKey: `ai-esc-${pathKey}-${filteredFindings.length}-${sevFilters.size}-${nodeTypeFilters.size}-${decisionFilters.size}`,
                 onAcceptRemaining: includeRemaining,


### PR DESCRIPTION
## Summary
- Set `AiEscalationPanel` list `defaultExpanded: true` so Include/Skip location rows open expanded when the AI escalation triage step mounts.
- Matches Review findings and Quick-fix / AI proposal gates (those already default to expanded).

## Test plan
- [x] `tox -e lint`
- [x] `tox -e unit`
- [ ] Native or Portal Quality: enable AI → reach AI escalation → locations show expanded detail (YAML) without clicking Expand all
- [ ] Collapse / Expand controls still work; decided rows still collapse as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UX Improvements**
  * Location details in the AI escalation panel are now expanded by default for quicker access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->