### PR TITLE
fix(ui): copy workspace package before npm ci in container build

### DIFF
--- a/containers/ui/Dockerfile
+++ b/containers/ui/Dockerfile
@@ -10,7 +10,12 @@ FROM ${UBI_NODEJS_IMAGE} AS build
 
 USER root
 WORKDIR /app
+# npm workspaces + file: deps must exist before ``npm ci`` (``workspace:*`` is
+# not a registry URL; without packages/*/package.json npm fails with
+# EUNSUPPORTEDPROTOCOL).
 COPY frontend/package.json frontend/package-lock.json* ./
+COPY frontend/packages/ui-workflow/package.json ./packages/ui-workflow/
+COPY frontend/vendor ./vendor
 RUN npm ci
 COPY frontend/ .
 RUN npm run build


### PR DESCRIPTION
## Summary
- UI Dockerfile ran `npm ci` with only the root `package.json`, but `@apme/ui-workflow` is `workspace:*` (ADR-066 / dual-shell extract).
- That fails with `EUNSUPPORTEDPROTOCOL` / `Unsupported URL Type "workspace:"`.
- Copy `packages/ui-workflow/package.json` and `vendor/` (existing `file:` dep) before `npm ci`.

## Test plan
- [x] `podman build -t apme-ui:latest -f containers/ui/Dockerfile .` succeeds (`npm ci` + Vite build)
- [ ] `tox -e build` / `tox -e up` on a clean machine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UI container builds by ensuring all required workspace dependencies and bundled vendor files are available during installation.
  - Prevented dependency installation failures in environments using workspace packages.

- **Chores**
  - Updated the container build setup to support more reliable, consistent application deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->