### PR TITLE
build(deps): batch Dependabot updates

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       services: ${{ steps.matrix.outputs.services }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - id: matrix
         run: |
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - id: owner
         run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
@@ -91,7 +91,7 @@ jobs:
     runs-on: ${{ matrix.arch.runner }}
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - id: owner
         run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - id: owner
         run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deprecation-scrape.yml
+++ b/.github/workflows/deprecation-scrape.yml
@@ -33,11 +33,11 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v7
 
       - run: uv sync --extra dev
 
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload gap report artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deprecation-gap-report
           path: /tmp/gaps.json

--- a/.github/workflows/helm-charts.yml
+++ b/.github/workflows/helm-charts.yml
@@ -38,9 +38,9 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v7
 
       - name: Lint and package chart
         run: uvx --with tox-uv tox -e helm
@@ -55,11 +55,11 @@ jobs:
       group: helm-charts-release-main
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v7
 
       - name: Configure Git user.name
         run: git config user.name "$GITHUB_ACTOR"

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -20,8 +20,8 @@ jobs:
   prek:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
       - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
       # Explicit tox gate (same command as docs / prek openapi-check entry).
       - run: uvx --with tox-uv tox -e openapi -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
       - run: uvx --with tox-uv tox -e unit
       - name: Fail if git reports dirty
         run: |
@@ -34,8 +34,8 @@ jobs:
   integration:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
       - name: Install OPA binary
         run: |
           curl -fsSL -o /usr/local/bin/opa \
@@ -54,8 +54,8 @@ jobs:
   ui:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
@@ -87,6 +87,6 @@ jobs:
   test-ai-extra:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
       - run: uvx --with tox-uv tox -e ai

--- a/.github/workflows/ui-workflow-release.yml
+++ b/.github/workflows/ui-workflow-release.yml
@@ -18,7 +18,7 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           # Privileged job + npm ci — do not leave GITHUB_TOKEN in .git/config.
           persist-credentials: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+    rev: v0.15.20
     hooks:
       - id: ruff
         args: [--fix]
@@ -17,11 +17,11 @@ repos:
           - types-PyYAML
           - grpc-stubs
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.21
+    rev: 0.11.25
     hooks:
       - id: uv-lock
   - repo: https://github.com/jsh9/pydoclint
-    rev: 0.8.3
+    rev: 0.8.7
     hooks:
       - id: pydoclint
         args: [--exclude=src/apme/v1/, src/, tests/, scripts/]

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
   steps:
     # ── Install CLI ───────────────────────────────────────────────────
     - name: Set up uv
-      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
 
     - name: Install APME CLI
       shell: bash
@@ -193,7 +193,7 @@ runs:
     # ── Upload results ────────────────────────────────────────────────
     - name: Upload SARIF to Code Scanning
       if: inputs.sarif == 'true' && steps.scan.outputs.sarif-path != ''
-      uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
       with:
         sarif_file: ${{ steps.scan.outputs.sarif-path }}
         category: apme
@@ -201,7 +201,7 @@ runs:
 
     - name: Upload JSON artifact
       if: inputs.upload-artifact == 'true' && hashFiles('apme-results.json') != ''
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: apme-results
         path: apme-results.json

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,10 +14,10 @@
         "@ansible/ansible-ui-framework": "file:./vendor/ansible-ui-framework",
         "@apme/ui-workflow": "workspace:*",
         "@patternfly/patternfly": "6.3.1",
-        "@patternfly/react-charts": "8.3.1",
+        "@patternfly/react-charts": "8.5.1",
         "@patternfly/react-core": "6.3.1",
-        "@patternfly/react-icons": "6.3.1",
-        "@patternfly/react-table": "6.3.1",
+        "@patternfly/react-icons": "6.5.1",
+        "@patternfly/react-table": "6.5.1",
         "@react-hook/resize-observer": "^2.0.2",
         "d3": "^7.9.0",
         "dagre": "^0.8.5",
@@ -26,7 +26,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^15.1.0",
-        "react-router-dom": "^6.30.4",
+        "react-router-dom": "^7.18.0",
         "react-syntax-highlighter": "^16.1.1",
         "styled-components": "^6.1.13",
         "swr": "^2.2.5",
@@ -1313,18 +1313,19 @@
       "integrity": "sha512-O/lTo5EHKzer/HNzqMQOQEAMG7izDDkEHpAeJ5+sGaeQ/maB3RK7sQsOPS4DjrnMxt4/cC6LogK2mowlbf1j5Q=="
     },
     "node_modules/@patternfly/react-charts": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-8.3.1.tgz",
-      "integrity": "sha512-5EPc4Bl7ZhZiDnFZzgyRhCkFcC0Km3fbC8PLjAxAf/prcWNCKXNHc6dtP38rYfrwP8R8Y831gF2bYg1uTbpKHQ==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-8.5.1.tgz",
+      "integrity": "sha512-3PUeicoG1dAcAP0TW425H0rPML3MP3DHkWH4WkguOLQgmpgRfDdRWa+ePKc2K7U1cOLl8hpQm1CVMhyamePBQw==",
+      "license": "MIT",
       "dependencies": {
-        "@patternfly/react-styles": "^6.3.1",
-        "@patternfly/react-tokens": "^6.3.1",
+        "@patternfly/react-styles": "^6.5.1",
+        "@patternfly/react-tokens": "^6.5.1",
         "hoist-non-react-statics": "^3.3.2",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
-        "echarts": "^5.6.0",
+        "echarts": "^5.6.0 || ^6.0.0",
         "react": "^17 || ^18 || ^19",
         "react-dom": "^17 || ^18 || ^19",
         "victory-area": "^37.3.6",
@@ -1420,29 +1421,32 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.3.1.tgz",
-      "integrity": "sha512-uiMounSIww1iZLM4pq+X8c3upzwl9iowXRPjR5CA8entb70lwgAXg3PqvypnuTAcilTq1Y3k5sFTqkhz7rgKcQ==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.5.1.tgz",
+      "integrity": "sha512-CnuPvTTs4MMWx8CAUkmnY690ouN1bbHjunsyXu3QxvGOmzbztP+wS4BdiLS8TIXOIH80Yb7KPhnF8VkA+CduOA==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^17 || ^18 || ^19",
         "react-dom": "^17 || ^18 || ^19"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.4.0.tgz",
-      "integrity": "sha512-EXmHA67s5sy+Wy/0uxWoUQ52jr9lsH2wV3QcgtvVc5zxpyBX89gShpqv4jfVqaowznHGDoL6fVBBrSe9BYOliQ=="
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.6.0.tgz",
+      "integrity": "sha512-u/HzJ48Cg6Nb12dIVbj4g31lMDVHPHVKRXkRuPBcuK6MQyAsxSfcyWVivW7Lga8TsNhFW26JWB5ay+IW5xpZ8A==",
+      "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.3.1.tgz",
-      "integrity": "sha512-ZndBbPcMr/vInP5eELRe9m7MWzRoejRAhWx+25xOdjVAd31/CmMK1nBgZk4QAXaWjH1P+uZaZYsTgr/FMTte2g==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.5.1.tgz",
+      "integrity": "sha512-JpX66ctLsg5snRRheDhuF2fHvXDG4UDKYfP5403kCAQ4Dz2dPu3PhlHi4AJol+egEBD2HfS/U37j7noQ1Y7mpA==",
+      "license": "MIT",
       "dependencies": {
-        "@patternfly/react-core": "^6.3.1",
-        "@patternfly/react-icons": "^6.3.1",
-        "@patternfly/react-styles": "^6.3.1",
-        "@patternfly/react-tokens": "^6.3.1",
-        "lodash": "^4.17.21",
+        "@patternfly/react-core": "^6.5.1",
+        "@patternfly/react-icons": "^6.5.1",
+        "@patternfly/react-styles": "^6.5.1",
+        "@patternfly/react-tokens": "^6.5.1",
+        "lodash": "^4.18.1",
         "tslib": "^2.8.1"
       },
       "peerDependencies": {
@@ -1450,10 +1454,51 @@
         "react-dom": "^17 || ^18 || ^19"
       }
     },
+    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-core": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.6.0.tgz",
+      "integrity": "sha512-MLYPcJvdDWHZqWcvEH2QhKtCg6APRfrDJ4o192/wc2LUaf4ViGVsVLKDMbaKCamhbGauv7KpffNCSy3fjRy4Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@patternfly/react-icons": "^6.6.0",
+        "@patternfly/react-styles": "^6.6.0",
+        "@patternfly/react-tokens": "^6.6.0",
+        "focus-trap": "7.6.6",
+        "react-dropzone": "^14.3.5",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-icons": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.6.0.tgz",
+      "integrity": "sha512-cDDUm4PFxqeBo4PS08xO1eFd6CMTOppn5RS4fs2hAgu/vRFkPXuL0zZCkxgRg5asd/W4olEN7WrIAbvjKbHKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@patternfly/react-table/node_modules/focus-trap": {
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.6.tgz",
+      "integrity": "sha512-v/Z8bvMCajtx4mEXmOo7QEsIzlIOqRXTIwgUfsFOF9gEsespdbD0AkPIka1bSXZ8Y8oZ+2IVDQZePkTfEHZl7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.3.0"
+      }
+    },
     "node_modules/@patternfly/react-tokens": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.4.0.tgz",
-      "integrity": "sha512-iZthBoXSGQ/+PfGTdPFJVulaJZI3rwE+7A/whOXPGp3Jyq3k6X52pr1+5nlO6WHasbZ9FyeZGqXf4fazUZNjbw=="
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.6.0.tgz",
+      "integrity": "sha512-oRUFYJAM9LKYTM9YRnd7rz3wB6ZoaBWit/Eu+EK22J4o5AhZRjLt0+ewXQ7I99dBP4c8BbnPEUFnxQYAroqNLg==",
+      "license": "MIT"
     },
     "node_modules/@react-hook/latest": {
       "version": "1.0.3",
@@ -1482,15 +1527,6 @@
       },
       "peerDependencies": {
         "react": ">=18"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2729,6 +2765,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -4189,35 +4238,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
+      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-syntax-highlighter": {
@@ -4392,6 +4447,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,11 +13,12 @@
   },
   "dependencies": {
     "@ansible/ansible-ui-framework": "file:./vendor/ansible-ui-framework",
+    "@apme/ui-workflow": "workspace:*",
     "@patternfly/patternfly": "6.3.1",
-    "@patternfly/react-charts": "8.3.1",
+    "@patternfly/react-charts": "8.5.1",
     "@patternfly/react-core": "6.3.1",
-    "@patternfly/react-icons": "6.3.1",
-    "@patternfly/react-table": "6.3.1",
+    "@patternfly/react-icons": "6.5.1",
+    "@patternfly/react-table": "6.5.1",
     "@react-hook/resize-observer": "^2.0.2",
     "d3": "^7.9.0",
     "dagre": "^0.8.5",
@@ -26,12 +27,11 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^15.1.0",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.0",
     "react-syntax-highlighter": "^16.1.1",
     "styled-components": "^6.1.13",
     "swr": "^2.2.5",
-    "undici": "7.28.0",
-    "@apme/ui-workflow": "workspace:*"
+    "undici": "7.28.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/apme_engine/engine/yaml_utils.py
+++ b/src/apme_engine/engine/yaml_utils.py
@@ -44,7 +44,7 @@ def _nested_items_path(
         parent_path: Accumulated path of keys/indices from the root.
 
     Yields:
-        (object, object, list[str | int]): Tuples of (key_or_index, value, parent_path).
+        tuple[object, object, list[str | int]]: Tuples of (key_or_index, value, parent_path).
     """
     if data_collection is None:
         return


### PR DESCRIPTION
## Summary

Consolidates all 11 open Dependabot PRs into a single reviewable changeset:

- **GitHub Actions:** `actions/checkout` v7, `astral-sh/setup-uv` v8, `actions/upload-artifact` v7, `github/codeql-action/upload-sarif` v4
- **pre-commit:** `ruff-pre-commit` v0.15.20, `uv-pre-commit` 0.11.25, `pydoclint` 0.8.7
- **frontend npm:** `@patternfly/react-charts` 8.5.1, `@patternfly/react-icons` 6.5.1, `@patternfly/react-table` 6.5.1, `react-router-dom` 7.18.0

Also fixes a pydoclint 0.8.7 yield-type docstring in `yaml_utils.py` required by the hook upgrade.

Closes #428
Closes #429
Closes #430
Closes #431
Closes #432
Closes #433
Closes #434
Closes #435
Closes #443
Closes #444
Closes #445

## Test plan

- [x] `tox -e lint`
- [x] `tox -e unit`
- [ ] CI green on PR (prek, test, container-images, helm-charts)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Upgraded PatternFly React libraries and moved routing to `react-router-dom` v7 for improved compatibility.
* **Tooling & CI**
  * Refreshed pinned GitHub Actions across build, test, UI release, container image, Helm chart, deprecation scraping, and workflow automation pipelines.
  * Updated action versions used for code scanning artifacts and artifact uploads.
  * Bumped pre-commit hook versions for formatting/linting/documentation checks.
* **Documentation**
  * Modernized a type annotation in a YAML utilities docstring (no runtime behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->