### PR TITLE
feat(observability): P0 OTLP metrics for scans, venv, and Galaxy

### DIFF
--- a/.sdlc/adrs/ADR-013-structured-diagnostics.md
+++ b/.sdlc/adrs/ADR-013-structured-diagnostics.md
@@ -129,3 +129,5 @@ apme check -vv playbook.yml
 
 - ADR-001: gRPC communication (diagnostics in response)
 - ADR-007: Async gRPC servers (timing collection)
+- ADR-067: OpenTelemetry operational metrics with in-pod collector
+  (complementary continuous series; does not replace this ADR)

--- a/.sdlc/adrs/ADR-067-otel-metrics-in-pod-collector.md
+++ b/.sdlc/adrs/ADR-067-otel-metrics-in-pod-collector.md
@@ -168,6 +168,44 @@ strictly simpler and safer than fan-out from every container.
   stack (ADR-054); do not require Gateway/UI Deployments to emit unless
   they gain independent metrics needs.
 
+## Acceptance Criteria
+
+- [x] Instrumented services (Primary, Gateway, Galaxy Proxy) emit OTLP/HTTP
+      only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set; otherwise metrics are
+      no-op and startup never fails on OTel misconfiguration.
+- [x] Reference pod includes an `otel-collector` sidecar; apps target
+      `http://127.0.0.1:4318`; Prometheus scrape is available on `:8889`.
+- [x] Metric attributes avoid high-cardinality and secret leakage (coarse
+      buckets; hostname-only server labels — no URL userinfo).
+- [x] ADR-013 structured diagnostics remain on the gRPC path; this ADR does
+      not replace them.
+- [x] Local companion stack (`containers/observability/`) is documented as
+      optional and binds to loopback only.
+- [ ] Optional OTLP forward-out from the collector to a platform/BYO
+      endpoint (https://github.com/ansible/apme/issues/457).
+
+## Phase Assignment
+
+Not assigned to PHASE-001–004. Operational metrics are a **cross-cutting
+platform** concern (engine pod + Gateway), not a feature slice of the CLI
+scanner, rewrite engine, dashboard, or AI remediation phases in
+`.sdlc/phases/README.md`. Delivery tracks with PR #456 / follow-up #457.
+
+## Verification
+
+```bash
+# Lint / ADR index / typecheck (tox only)
+tox -e lint
+
+# Unit coverage for OTel setup, instruments, and Galaxy metric labels
+tox -e unit -- tests/test_observability_metrics.py tests/test_galaxy_proxy_server.py --no-cov
+
+# Optional live stack (requires built images)
+tox -e up
+curl -sf http://127.0.0.1:8889/metrics | head
+./containers/observability/up.sh
+```
+
 ## Related Decisions
 
 - ADR-004: Podman pod as deployment unit (collector is a sibling container)
@@ -189,3 +227,4 @@ strictly simpler and safer than fan-out from every container.
 | Date | Change |
 |------|--------|
 | 2026-07-29 | Initial — OTel metrics standard + in-pod collector aggregation |
+| 2026-07-29 | Add acceptance criteria, phase assignment, tox verification |

--- a/.sdlc/adrs/ADR-067-otel-metrics-in-pod-collector.md
+++ b/.sdlc/adrs/ADR-067-otel-metrics-in-pod-collector.md
@@ -1,0 +1,191 @@
+# ADR-067: OpenTelemetry Metrics with In-Pod Collector
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-29
+
+## Context
+
+APME needs **operational metrics** (scan duration, phase timings, venv acquire
+outcomes, Galaxy fetch/wheel cache, HTTP server latency) that survive beyond a
+single request and can be scraped, alerted on, and charted. ADR-013 already
+delivers **per-scan structured diagnostics** on the gRPC response path for
+CLI/UI display. Those concerns are complementary, not interchangeable:
+
+| Concern | Consumer | Lifetime |
+|---------|----------|----------|
+| ADR-013 diagnostics | CLI, UI, FixSession response | One scan |
+| Operational metrics | Prometheus/Grafana, platform collectors | Continuous |
+
+Constraints and drivers:
+
+- Reference deployment is a multi-container Podman pod sharing localhost
+  (ADR-004, ADR-005). Primary, Gateway, and Galaxy Proxy all emit metrics.
+- Align with the AAP direction for OTEL-based observability (emit OTLP;
+  BYO/platform collector; do not bundle a logging product).
+- Apps must stay **emitter-only**. They must not embed Prometheus scrape
+  servers, vendor-specific agents, or customer collector credentials.
+- Prefer **one controlled egress** per pod over N containers each unicasting
+  OTLP to an external endpoint (auth, TLS, retry, and failure isolation).
+- Local development still needs a scrape target and dashboards without
+  requiring a customer OpenShift stack.
+
+## Decision
+
+**1. OpenTelemetry is the standard for APME operational metrics.**  
+Instrumented services export OTLP/HTTP. Metric names use the `apme.*`
+namespace. Export is opt-in via `OTEL_EXPORTER_OTLP_ENDPOINT` (no-op when
+unset). Misconfiguration must never crash the service.
+
+**2. An in-pod OpenTelemetry Collector aggregates emission.**  
+App containers send OTLP/HTTP to `http://127.0.0.1:4318`. The collector
+sidecar exposes Prometheus scrape on `:8889` for local/dev and is the
+future attachment point for optional OTLP forward-out to a customer or
+platform collector (tracked separately).
+
+**3. Companion Prometheus/Grafana is local-dev only.**  
+`containers/observability/` scrapes the collector hostPort; it is not a
+product dependency and must not ship as the production observability stack.
+
+This ADR **does not supersede ADR-013**. Structured diagnostics remain the
+source of truth for per-scan timing embedded in the gRPC contract.
+
+This ADR **amends** the practical HTTP surface under architectural
+invariant 2 (gRPC between backend services): business traffic stays gRPC;
+the in-pod OTel Collector may expose OTLP (`:4318`) and Prometheus scrape
+(`:8889`) as observability endpoints.
+
+## Alternatives Considered
+
+### Alternative 1: Prometheus client libraries in each process
+
+**Description**: Each service exposes `/metrics` with `prometheus_client`
+(or equivalent) and is scraped independently.
+
+**Pros**:
+- Familiar scrape model
+- No collector sidecar
+
+**Cons**:
+- Multiplies scrape endpoints and auth surface
+- Couples apps to Prometheus wire format
+- Poor fit for AAP “emit OTLP, BYO collector” direction
+- Harder to add traces/logs later under one pipeline
+
+**Why not chosen**: Violates emitter-only posture and fragments the scrape
+topology across every container.
+
+### Alternative 2: Every container unicasts OTLP to an external collector
+
+**Description**: Each instrumented process sets
+`OTEL_EXPORTER_OTLP_ENDPOINT` to a customer/platform collector URL.
+
+**Pros**:
+- No in-pod aggregator
+- Matches single-process microservice diagrams
+
+**Cons**:
+- N copies of egress config, retries, and TLS
+- Partial failure when one container is misconfigured
+- Breaks the “one pod, one observability egress” model for localhost pods
+- Harder to offer a stable local Prom scrape during development
+
+**Why not chosen**: APME’s co-located pod makes a single in-pod aggregator
+strictly simpler and safer than fan-out from every container.
+
+### Alternative 3: Metrics only via ADR-013 diagnostics / log scraping
+
+**Description**: Rely on ScanDiagnostics and/or log aggregation for timing.
+
+**Pros**:
+- No new infrastructure
+
+**Cons**:
+- Diagnostics die with the response; no continuous series
+- Log scraping is brittle for histograms/counters
+- Cannot express venv/Galaxy cache hit rates across scans cleanly
+
+**Why not chosen**: Insufficient for operational SLIs and dashboards.
+
+### Alternative 4: Vendor agent / bundled observability product in-pod
+
+**Description**: Ship a commercial or productized agent as the aggregator.
+
+**Pros**:
+- Turnkey UI in some environments
+
+**Cons**:
+- Contradicts BYO/platform collector direction
+- License and supply-chain weight for a reference pod
+
+**Why not chosen**: Collector stays vendor-neutral OpenTelemetry Collector.
+
+## Consequences
+
+### Positive
+
+- One instrumentation API (OTel) across Primary, Gateway, and Galaxy Proxy.
+- Apps remain dumb emitters to localhost; collector owns export policy.
+- Local Prom scrape (`:8889`) works without external dependencies.
+- Forward-out to platform/BYO collectors can be added on the sidecar without
+  rewiring every app.
+- Coexists cleanly with ADR-013 per-scan diagnostics.
+
+### Negative
+
+- One more container in the reference pod and (eventually) Helm engine
+  Deployment.
+- Operators must understand OTLP vs Prometheus scrape roles.
+- Label cardinality discipline is mandatory (bucket coarse attributes;
+  never put secrets or raw userinfo into attributes).
+
+### Neutral
+
+- gRPC OTLP (`:4317`) may be enabled on the collector later; P0 uses
+  OTLP/HTTP (`:4318`) only.
+- Traces and logs over OTLP are out of scope for this ADR; metrics land
+  first.
+- Companion Grafana password and loopback binds are local-dev security
+  hygiene, not production IAM.
+
+## Implementation Notes
+
+- Setup: `apme_engine.observability.otel_setup.setup_otel` — no-op unless
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is set; never raises to callers.
+- Instruments: `apme_engine.observability.metrics` (`apme.scan.*`,
+  `apme.venv.acquire.*`, `apme.galaxy.fetch.*`, `apme.galaxy.wheel.serve.*`,
+  `apme.http.server.*`).
+- Pod: `otel-collector` in `containers/podman/pod.yaml`; config under
+  `containers/observability/` / collector config in-tree.
+- Local dashboards: `containers/observability/up.sh` (Prometheus + Grafana
+  on loopback).
+- OTLP forward-out from the sidecar: https://github.com/ansible/apme/issues/457
+- Helm: engine Deployment should co-locate the collector with the engine
+  stack (ADR-054); do not require Gateway/UI Deployments to emit unless
+  they gain independent metrics needs.
+
+## Related Decisions
+
+- ADR-004: Podman pod as deployment unit (collector is a sibling container)
+- ADR-005: No service discovery / localhost addressing (OTLP to `127.0.0.1`)
+- ADR-012: Scale pods, not services (collector scales with the engine unit)
+- ADR-013: Structured diagnostics in gRPC (complementary; not superseded)
+- ADR-033: Centralized log bridge (logs path; metrics use OTel instead)
+- ADR-054: Production Helm/bootc deployment (collector belongs with engine)
+
+## References
+
+- PR: https://github.com/ansible/apme/pull/456
+- Follow-up: https://github.com/ansible/apme/issues/457 (OTLP forward-out)
+- AAP Decision Record — Log Forwarding OTEL Backend (ANSTRAT-1730): emit
+  OTLP; BYO/platform collector; do not bundle a logging product
+
+## Revision History
+
+| Date | Change |
+|------|--------|
+| 2026-07-29 | Initial — OTel metrics standard + in-pod collector aggregation |

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -75,6 +75,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-064](ADR-064-assess-pause-session-continue.md) | Assess-Pause and Session-Continue Scan → Remediate | 2026-07-18 |
 | [ADR-065](ADR-065-spa-gateway-live-state-ownership.md) | SPA vs Gateway Live-Operation State Ownership | 2026-07-20 |
 | [ADR-066](ADR-066-ui-workflow-github-release-artifacts.md) | Publish `@apme/ui-workflow` via GitHub Release Artifacts | 2026-07-23 |
+| [ADR-067](ADR-067-otel-metrics-in-pod-collector.md) | OpenTelemetry Metrics with In-Pod Collector | 2026-07-29 |
 
 ## Proposed
 
@@ -101,7 +102,7 @@ Decisions replaced by newer ADRs.
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-067)
+2. Use the next available number (currently ADR-068)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,11 @@ one needs to change, write an ADR first.
 
 2. **gRPC everywhere between backend services** (ADR-001). No REST, no message
    queues, no direct function calls between services. The only HTTP endpoints
-   are Galaxy Proxy (PEP 503), Gateway REST (:8080 for external consumers),
-   and the UI (:8081, nginx-served SPA).
+   for product traffic are Galaxy Proxy (PEP 503), Gateway REST (:8080 for
+   external consumers), and the UI (:8081, nginx-served SPA). Observability
+   may add an in-pod OpenTelemetry Collector (OTLP/HTTP :4318, Prometheus
+   scrape :8889) per ADR-067 — apps emit OTLP to localhost; business traffic
+   between APME services remains gRPC.
 
 3. **Async servers with executor discipline** (ADR-007). All gRPC servers use
    `grpc.aio`. Blocking work (engine scan, subprocess calls, venv builds) goes

--- a/containers/observability/README.md
+++ b/containers/observability/README.md
@@ -16,10 +16,13 @@ Scrapes the in-pod OpenTelemetry Collector Prometheus exporter
 
 | UI | URL |
 |----|-----|
-| Grafana | http://127.0.0.1:3002 (`admin` / `$APME_GRAFANA_ADMIN_PASSWORD`, default `apme-local`) |
+| Grafana | http://127.0.0.1:3002 (`admin` / `$APME_GRAFANA_ADMIN_PASSWORD`) |
 | Prometheus | http://127.0.0.1:9091 |
 
 Ports bind to loopback only. Anonymous Grafana access is disabled.
+If `APME_GRAFANA_ADMIN_PASSWORD` is unset, `up.sh` generates a high-entropy
+password and stores it at
+`${XDG_CACHE_HOME:-$HOME/.cache}/apme/grafana-admin.password` (mode `0600`).
 
 Prometheus TSDB persists under
 `${XDG_CACHE_HOME:-$HOME/.cache}/apme/prometheus-tsdb` (override with

--- a/containers/observability/README.md
+++ b/containers/observability/README.md
@@ -1,0 +1,68 @@
+# APME observability companion (Prometheus + Grafana)
+
+Scrapes the in-pod OpenTelemetry Collector Prometheus exporter
+(`localhost:8889`) and ships a pre-provisioned **APME Scan Times** dashboard.
+
+## Prerequisites
+
+1. APME pod running (`tox -e up`) with the `otel-collector` container.
+2. Metrics visible: `curl -s http://localhost:8889/metrics | head`
+
+## Start
+
+```bash
+./containers/observability/up.sh
+```
+
+| UI | URL |
+|----|-----|
+| Grafana | http://localhost:3002 (admin/admin, anonymous Viewer) |
+| Prometheus | http://localhost:9091 |
+
+Prometheus TSDB persists under
+`${XDG_CACHE_HOME:-$HOME/.cache}/apme/prometheus-tsdb` (override with
+`APME_PROM_DATA`). Retention is 15 days. `down.sh` keeps the data;
+`down.sh --wipe` deletes it.
+
+Dashboard **mean** panels use instant `_sum/_count` so they stay populated
+between scans. Percentile panels use `rate()` and may go blank until new
+samples arrive.
+
+## Stop
+
+```bash
+./containers/observability/down.sh          # keep history
+./containers/observability/down.sh --wipe   # also delete TSDB
+```
+
+## Metrics (P0)
+
+| OTel name | Prometheus (typical) | Source |
+|-----------|----------------------|--------|
+| `apme.scan.duration` | `apme_scan_duration_seconds` | Primary |
+| `apme.scan.phase.duration` | `apme_scan_phase_duration_seconds` | Primary |
+| `apme.validator.duration` | `apme_validator_duration_seconds` | Primary (from ADR-013) |
+| `apme.scan.completed` | `apme_scan_completed_total` | Primary |
+| `apme.http.server.duration` | `apme_http_server_duration_seconds` | Gateway, Galaxy Proxy |
+| `apme.venv.acquire.duration` | `apme_venv_acquire_duration_seconds` | Primary (`outcome=warm|incremental|create`) |
+| `apme.venv.acquire.completed` | `apme_venv_acquire_completed_total` | Primary |
+| `apme.galaxy.fetch.duration` | `apme_galaxy_fetch_duration_seconds` | Galaxy Proxy (`operation=download` or `version_lookup`) |
+| `apme.galaxy.fetch.completed` | `apme_galaxy_fetch_completed_total` | Galaxy Proxy |
+| `apme.galaxy.wheel.serve.duration` | `apme_galaxy_wheel_serve_duration_seconds` | Galaxy Proxy (`outcome=hit` or `miss`) |
+| `apme.galaxy.wheel.serve.completed` | `apme_galaxy_wheel_serve_completed_total` | Galaxy Proxy |
+
+Histogram boundaries are explicit (see `apme_engine/observability/buckets.py`):
+HTTP uses OTel semantic-convention buckets; scan/validator/phase use
+APME-tuned boundaries so `histogram_quantile` is meaningful. SDK defaults
+(`0, 5, 10, …`) are intentionally not used.
+
+Apps export OTLP only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set (pod.yaml sets
+`http://127.0.0.1:4318`). Set `OTEL_SDK_DISABLED=true` to force off.
+
+## Helm note
+
+The Podman pod co-locates Gateway with the engine. Helm splits Gateway / Abbenay /
+UI into separate Deployments, so an in-pod collector on the **engine** Deployment
+only sees Primary + validators + galaxy-proxy. Gateway/UI need their own
+collector sidecar (or a cluster Collector) when that topology is used.
+

--- a/containers/observability/README.md
+++ b/containers/observability/README.md
@@ -16,8 +16,10 @@ Scrapes the in-pod OpenTelemetry Collector Prometheus exporter
 
 | UI | URL |
 |----|-----|
-| Grafana | http://localhost:3002 (admin/admin, anonymous Viewer) |
-| Prometheus | http://localhost:9091 |
+| Grafana | http://127.0.0.1:3002 (`admin` / `$APME_GRAFANA_ADMIN_PASSWORD`, default `apme-local`) |
+| Prometheus | http://127.0.0.1:9091 |
+
+Ports bind to loopback only. Anonymous Grafana access is disabled.
 
 Prometheus TSDB persists under
 `${XDG_CACHE_HOME:-$HOME/.cache}/apme/prometheus-tsdb` (override with
@@ -44,7 +46,7 @@ samples arrive.
 | `apme.validator.duration` | `apme_validator_duration_seconds` | Primary (from ADR-013) |
 | `apme.scan.completed` | `apme_scan_completed_total` | Primary |
 | `apme.http.server.duration` | `apme_http_server_duration_seconds` | Gateway, Galaxy Proxy |
-| `apme.venv.acquire.duration` | `apme_venv_acquire_duration_seconds` | Primary (`outcome=warm|incremental|create`) |
+| `apme.venv.acquire.duration` | `apme_venv_acquire_duration_seconds` | Primary (`outcome=warm`, `incremental`, or `create`) |
 | `apme.venv.acquire.completed` | `apme_venv_acquire_completed_total` | Primary |
 | `apme.galaxy.fetch.duration` | `apme_galaxy_fetch_duration_seconds` | Galaxy Proxy (`operation=download` or `version_lookup`) |
 | `apme.galaxy.fetch.completed` | `apme_galaxy_fetch_completed_total` | Galaxy Proxy |

--- a/containers/observability/README.md
+++ b/containers/observability/README.md
@@ -3,6 +3,9 @@
 Scrapes the in-pod OpenTelemetry Collector Prometheus exporter
 (`localhost:8889`) and ships a pre-provisioned **APME Scan Times** dashboard.
 
+Architecture: [ADR-067](../../.sdlc/adrs/ADR-067-otel-metrics-in-pod-collector.md)
+(OTel as the metrics standard; in-pod collector aggregates localhost OTLP).
+
 ## Prerequisites
 
 1. APME pod running (`tox -e up`) with the `otel-collector` container.

--- a/containers/observability/down.sh
+++ b/containers/observability/down.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Stop the Prometheus + Grafana companion stack.
+# Usage: ./down.sh [--wipe]   # --wipe also deletes persisted TSDB
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WIPE=0
+for arg in "$@"; do
+  case "$arg" in
+    --wipe) WIPE=1 ;;
+    *) echo "Unknown arg: $arg (expected --wipe)" >&2; exit 1 ;;
+  esac
+done
+
+if podman pod exists apme-observability 2>/dev/null; then
+  podman pod stop apme-observability 2>/dev/null || true
+  podman pod rm -f apme-observability
+  echo "apme-observability stopped."
+else
+  echo "apme-observability not running."
+fi
+
+if [[ "$WIPE" -eq 1 ]]; then
+  PROM_DATA="${APME_PROM_DATA:-${XDG_CACHE_HOME:-$HOME/.cache}/apme/prometheus-tsdb}"
+  if [[ -d "$PROM_DATA" ]]; then
+    rm -rf "$PROM_DATA"
+    echo "Wiped Prometheus TSDB: $PROM_DATA"
+  else
+    echo "No TSDB dir to wipe at $PROM_DATA"
+  fi
+fi

--- a/containers/observability/grafana/dashboards/apme-scan-times.json
+++ b/containers/observability/grafana/dashboards/apme-scan-times.json
@@ -1,0 +1,423 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Scan duration p50 / p95 / p99",
+      "description": "Needs recent samples in the rate window; blank between scans is expected",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 10, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "spanNulls": true }
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(apme_scan_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(apme_scan_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(apme_scan_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "title": "Scan duration mean (lifetime)",
+      "description": "Instant _sum/_count — stays populated between scans (cumulative mean since app process start)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 10, "x": 10, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "spanNulls": true }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(apme_scan_duration_seconds_sum) / clamp_min(sum(apme_scan_duration_seconds_count), 1)",
+          "legendFormat": "mean",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Scans total",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(apme_scan_completed_total) or vector(0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Scan errors total",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(apme_scan_completed_total{status=\"error\"}) or vector(0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Phase duration p95",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(apme_scan_phase_duration_seconds_bucket[5m])) by (le, phase))",
+          "legendFormat": "{{phase}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Phase duration mean (lifetime)",
+      "description": "Instant _sum/_count by phase — populated even with no recent scans",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "sum by (phase) (apme_scan_phase_duration_seconds_sum) / clamp_min(sum by (phase) (apme_scan_phase_duration_seconds_count), 1)",
+          "legendFormat": "{{phase}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Validator duration p95",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(apme_validator_duration_seconds_bucket[5m])) by (le, validator))",
+          "legendFormat": "{{validator}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Validator duration mean (lifetime)",
+      "description": "Instant _sum/_count by validator — use this between scans; not bucket-estimated",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "sum by (validator) (apme_validator_duration_seconds_sum) / clamp_min(sum by (validator) (apme_validator_duration_seconds_count), 1)",
+          "legendFormat": "{{validator}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Gateway HTTP duration p95",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(apme_http_server_duration_seconds_bucket{service=\"gateway\"}[5m])) by (le, http_request_method))",
+          "legendFormat": "{{http_request_method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Gateway HTTP duration mean (lifetime)",
+      "description": "Instant _sum/_count by method",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "sum by (http_request_method) (apme_http_server_duration_seconds_sum{service=\"gateway\"}) / clamp_min(sum by (http_request_method) (apme_http_server_duration_seconds_count{service=\"gateway\"}), 1)",
+          "legendFormat": "{{http_request_method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy Proxy HTTP duration p95",
+      "description": "PEP 503 / collection wheel traffic — split from Gateway for proxy internals",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(apme_http_server_duration_seconds_bucket{service=\"galaxy-proxy\"}[5m])) by (le, http_request_method))",
+          "legendFormat": "{{http_request_method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy Proxy HTTP duration mean (lifetime)",
+      "description": "Instant _sum/_count by method — populated between scans",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "sum by (http_request_method) (apme_http_server_duration_seconds_sum{service=\"galaxy-proxy\"}) / clamp_min(sum by (http_request_method) (apme_http_server_duration_seconds_count{service=\"galaxy-proxy\"}), 1)",
+          "legendFormat": "{{http_request_method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy Proxy request count (lifetime)",
+      "description": "Cumulative request counts by method/status — not rate-based",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 40 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "sum by (http_request_method, http_response_status_code) (apme_http_server_duration_seconds_count{service=\"galaxy-proxy\"})",
+          "legendFormat": "{{http_request_method}} {{http_response_status_code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Venv acquire duration mean (lifetime)",
+      "description": "Session venv warm / incremental / create — exact _sum/_count",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (apme_venv_acquire_duration_seconds_sum) / clamp_min(sum by (outcome) (apme_venv_acquire_duration_seconds_count), 1)",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Venv acquire p95",
+      "description": "Needs recent acquires in the rate window",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(apme_venv_acquire_duration_seconds_bucket[5m])) by (le, outcome))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Venv acquires total",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 56 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (apme_venv_acquire_completed_total) or vector(0)",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Venv acquire errors total",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 56 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(apme_venv_acquire_completed_total{status=\"error\"}) or vector(0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy fetch duration mean (lifetime)",
+      "description": "Outbound Ansible Galaxy: ansible-galaxy download vs API version lookup",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 60 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "sum by (operation) (apme_galaxy_fetch_duration_seconds_sum) / clamp_min(sum by (operation) (apme_galaxy_fetch_duration_seconds_count), 1)",
+          "legendFormat": "{{operation}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy fetch p95",
+      "description": "Needs recent Galaxy fetches in the rate window",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 60 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(apme_galaxy_fetch_duration_seconds_bucket[5m])) by (le, operation))",
+          "legendFormat": "{{operation}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy fetches total",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 68 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (operation, status) (apme_galaxy_fetch_completed_total) or vector(0)",
+          "legendFormat": "{{operation}} {{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy fetch errors/timeouts",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 68 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(apme_galaxy_fetch_completed_total{status=~\"error|timeout\"}) or vector(0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy wheel serve mean (lifetime)",
+      "description": "GET /wheels cache hit vs miss (miss includes ansible-galaxy download)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 72 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (apme_galaxy_wheel_serve_duration_seconds_sum) / clamp_min(sum by (outcome) (apme_galaxy_wheel_serve_duration_seconds_count), 1)",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy wheel serve p95",
+      "description": "Needs recent wheel serves in the rate window",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 72 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(apme_galaxy_wheel_serve_duration_seconds_bucket[5m])) by (le, outcome))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy wheel serves total",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 80 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (outcome, status) (apme_galaxy_wheel_serve_completed_total) or vector(0)",
+          "legendFormat": "{{outcome}} {{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Galaxy wheel cache hit ratio",
+      "description": "hits / (hits + misses) from completed counters",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 80 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "max": 1 }
+      },
+      "targets": [
+        {
+          "expr": "sum(apme_galaxy_wheel_serve_completed_total{outcome=\"hit\"}) / clamp_min(sum(apme_galaxy_wheel_serve_completed_total), 1)",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["apme", "otel"],
+  "templating": { "list": [] },
+  "time": { "from": "now-30m", "to": "now" },
+  "timezone": "browser",
+  "title": "APME Scan Times",
+  "uid": "apme-scan-times",
+  "version": 7
+}

--- a/containers/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/containers/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: apme
+    orgId: 1
+    folder: APME
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/containers/observability/grafana/provisioning/datasources/datasource.yml
+++ b/containers/observability/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://127.0.0.1:9090
+    isDefault: true
+    editable: false

--- a/containers/observability/pod.yaml
+++ b/containers/observability/pod.yaml
@@ -1,0 +1,81 @@
+# Companion observability stack: Prometheus + Grafana outside apme-pod.
+#
+# Prerequisites: apme-pod running with otel-collector hostPort 8889.
+# Start: ./containers/observability/up.sh
+# Stop:  ./containers/observability/down.sh
+#
+# Grafana: http://localhost:3002 (admin/admin)
+# Prometheus: http://localhost:9091
+# TSDB persists on the host under APME_PROM_DATA (see up.sh).
+apiVersion: v1
+kind: Pod
+metadata:
+  name: apme-observability
+  labels:
+    app: apme-observability
+spec:
+  hostname: apme-observability
+  containers:
+    - name: prometheus
+      image: docker.io/prom/prometheus:v3.2.1
+      args:
+        - --config.file=/etc/prometheus/prometheus.yml
+        - --storage.tsdb.path=/prometheus
+        - --storage.tsdb.retention.time=15d
+        - --web.enable-lifecycle
+      ports:
+        - containerPort: 9090
+          hostPort: 9091
+      volumeMounts:
+        - name: prometheus-config
+          mountPath: /etc/prometheus/prometheus.yml
+          readOnly: true
+        - name: prometheus-data
+          mountPath: /prometheus
+    - name: grafana
+      image: docker.io/grafana/grafana:11.5.2
+      env:
+        - name: GF_SECURITY_ADMIN_USER
+          value: admin
+        - name: GF_SECURITY_ADMIN_PASSWORD
+          value: admin
+        - name: GF_USERS_DEFAULT_THEME
+          value: dark
+        - name: GF_AUTH_ANONYMOUS_ENABLED
+          value: "true"
+        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+          value: Viewer
+      ports:
+        - containerPort: 3000
+          hostPort: 3002
+      volumeMounts:
+        - name: grafana-datasources
+          mountPath: /etc/grafana/provisioning/datasources
+          readOnly: true
+        - name: grafana-dashboards-prov
+          mountPath: /etc/grafana/provisioning/dashboards
+          readOnly: true
+        - name: grafana-dashboards
+          mountPath: /var/lib/grafana/dashboards
+          readOnly: true
+  volumes:
+    - name: prometheus-config
+      hostPath:
+        path: ${APME_ROOT}/containers/observability/prometheus.yml
+        type: File
+    - name: prometheus-data
+      hostPath:
+        path: ${APME_PROM_DATA}
+        type: DirectoryOrCreate
+    - name: grafana-datasources
+      hostPath:
+        path: ${APME_ROOT}/containers/observability/grafana/provisioning/datasources
+        type: Directory
+    - name: grafana-dashboards-prov
+      hostPath:
+        path: ${APME_ROOT}/containers/observability/grafana/provisioning/dashboards
+        type: Directory
+    - name: grafana-dashboards
+      hostPath:
+        path: ${APME_ROOT}/containers/observability/grafana/dashboards
+        type: Directory

--- a/containers/observability/pod.yaml
+++ b/containers/observability/pod.yaml
@@ -4,8 +4,9 @@
 # Start: ./containers/observability/up.sh
 # Stop:  ./containers/observability/down.sh
 #
-# Grafana: http://localhost:3002 (admin/admin)
-# Prometheus: http://localhost:9091
+# Ports bind to 127.0.0.1 only (see hostIP on hostPort entries).
+# Grafana: http://127.0.0.1:3002 (admin / $APME_GRAFANA_ADMIN_PASSWORD)
+# Prometheus: http://127.0.0.1:9091
 # TSDB persists on the host under APME_PROM_DATA (see up.sh).
 apiVersion: v1
 kind: Pod
@@ -18,6 +19,9 @@ spec:
   containers:
     - name: prometheus
       image: docker.io/prom/prometheus:v3.2.1
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
       args:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/prometheus
@@ -26,6 +30,7 @@ spec:
       ports:
         - containerPort: 9090
           hostPort: 9091
+          hostIP: 127.0.0.1
       volumeMounts:
         - name: prometheus-config
           mountPath: /etc/prometheus/prometheus.yml
@@ -34,20 +39,22 @@ spec:
           mountPath: /prometheus
     - name: grafana
       image: docker.io/grafana/grafana:11.5.2
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
       env:
         - name: GF_SECURITY_ADMIN_USER
           value: admin
         - name: GF_SECURITY_ADMIN_PASSWORD
-          value: admin
+          value: ${APME_GRAFANA_ADMIN_PASSWORD}
         - name: GF_USERS_DEFAULT_THEME
           value: dark
         - name: GF_AUTH_ANONYMOUS_ENABLED
-          value: "true"
-        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
-          value: Viewer
+          value: "false"
       ports:
         - containerPort: 3000
           hostPort: 3002
+          hostIP: 127.0.0.1
       volumeMounts:
         - name: grafana-datasources
           mountPath: /etc/grafana/provisioning/datasources

--- a/containers/observability/prometheus.yml
+++ b/containers/observability/prometheus.yml
@@ -1,0 +1,11 @@
+# Scrape the in-pod OTel Collector Prometheus exporter (hostPort 8889).
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: apme-otel-collector
+    static_configs:
+      - targets: ["host.containers.internal:8889"]
+        labels:
+          stack: apme

--- a/containers/observability/up.sh
+++ b/containers/observability/up.sh
@@ -8,7 +8,8 @@ cd "$ROOT"
 _relabel() {
   local host_path="$1"
   if command -v chcon >/dev/null 2>&1 && [[ "$(getenforce 2>/dev/null)" == "Enforcing" ]]; then
-    chcon -t container_file_t "$host_path" 2>/dev/null || \
+    # Recursive: YAML/dashboard files under the path must be labeled too.
+    chcon -Rt container_file_t "$host_path" 2>/dev/null || \
       echo "WARNING: could not relabel $host_path for SELinux" >&2
   fi
 }
@@ -22,11 +23,13 @@ fi
 # Persist TSDB across restarts (override with APME_PROM_DATA).
 PROM_DATA="${APME_PROM_DATA:-${XDG_CACHE_HOME:-$HOME/.cache}/apme/prometheus-tsdb}"
 mkdir -p "$PROM_DATA"
-# Official prometheus image runs as UID 65534 (nobody).
-if command -v podman >/dev/null 2>&1; then
-  podman unshare chown -R 65534:65534 "$PROM_DATA" 2>/dev/null || chmod -R a+rwX "$PROM_DATA"
-else
-  chmod -R a+rwX "$PROM_DATA"
+# Official prometheus image runs as UID 65534 (nobody). Prefer podman unshare;
+# never fall back to world-writable permissions.
+if ! podman unshare chown -R 65534:65534 "$PROM_DATA" 2>/dev/null; then
+  echo "ERROR: cannot chown $PROM_DATA to UID 65534 for Prometheus." >&2
+  echo "  Fix ownership (e.g. podman unshare chown -R 65534:65534 \"$PROM_DATA\")" >&2
+  echo "  or point APME_PROM_DATA at a writable directory you control." >&2
+  exit 1
 fi
 
 _relabel "$ROOT/containers/observability/prometheus.yml"
@@ -35,14 +38,16 @@ _relabel "$ROOT/containers/observability/grafana/provisioning/dashboards"
 _relabel "$ROOT/containers/observability/grafana/dashboards"
 _relabel "$PROM_DATA"
 
+# Local-dev Grafana password (loopback-only UI). Override via env.
+export APME_GRAFANA_ADMIN_PASSWORD="${APME_GRAFANA_ADMIN_PASSWORD:-apme-local}"
 export APME_ROOT="$ROOT"
 export APME_PROM_DATA="$PROM_DATA"
-POD_YAML=$(envsubst '$APME_ROOT $APME_PROM_DATA' < containers/observability/pod.yaml)
+POD_YAML=$(envsubst '$APME_ROOT $APME_PROM_DATA $APME_GRAFANA_ADMIN_PASSWORD' < containers/observability/pod.yaml)
 echo "$POD_YAML" | podman play kube -
 
-echo "Observability stack started."
-echo "  Prometheus: http://localhost:9091"
-echo "  Grafana:    http://localhost:3002  (admin/admin)"
+echo "Observability stack started (ports bound to 127.0.0.1)."
+echo "  Prometheus: http://127.0.0.1:9091"
+echo "  Grafana:    http://127.0.0.1:3002  (admin / \$APME_GRAFANA_ADMIN_PASSWORD)"
 echo "  Dashboard:  APME Scan Times"
 echo "  Scrape target: host.containers.internal:8889 (otel-collector hostPort)"
 echo "  TSDB data:  $PROM_DATA  (15d retention; survives down/up)"

--- a/containers/observability/up.sh
+++ b/containers/observability/up.sh
@@ -38,8 +38,20 @@ _relabel "$ROOT/containers/observability/grafana/provisioning/dashboards"
 _relabel "$ROOT/containers/observability/grafana/dashboards"
 _relabel "$PROM_DATA"
 
-# Local-dev Grafana password (loopback-only UI). Override via env.
-export APME_GRAFANA_ADMIN_PASSWORD="${APME_GRAFANA_ADMIN_PASSWORD:-apme-local}"
+# Grafana admin password: require explicit env, or generate+persist a
+# high-entropy secret (never a known default like admin/admin).
+PASS_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/apme/grafana-admin.password"
+if [[ -z "${APME_GRAFANA_ADMIN_PASSWORD:-}" ]]; then
+  if [[ -f "$PASS_FILE" ]]; then
+    APME_GRAFANA_ADMIN_PASSWORD="$(tr -d '\n' <"$PASS_FILE")"
+  else
+    mkdir -p "$(dirname "$PASS_FILE")"
+    APME_GRAFANA_ADMIN_PASSWORD="$(openssl rand -base64 32 | tr -d '/+=\n' | head -c 32)"
+    (umask 077; printf '%s\n' "$APME_GRAFANA_ADMIN_PASSWORD" >"$PASS_FILE")
+    echo "Generated Grafana admin password → $PASS_FILE"
+  fi
+fi
+export APME_GRAFANA_ADMIN_PASSWORD
 export APME_ROOT="$ROOT"
 export APME_PROM_DATA="$PROM_DATA"
 POD_YAML=$(envsubst '$APME_ROOT $APME_PROM_DATA $APME_GRAFANA_ADMIN_PASSWORD' < containers/observability/pod.yaml)
@@ -47,7 +59,8 @@ echo "$POD_YAML" | podman play kube -
 
 echo "Observability stack started (ports bound to 127.0.0.1)."
 echo "  Prometheus: http://127.0.0.1:9091"
-echo "  Grafana:    http://127.0.0.1:3002  (admin / \$APME_GRAFANA_ADMIN_PASSWORD)"
+echo "  Grafana:    http://127.0.0.1:3002  (user: admin)"
+echo "  Password:   \$APME_GRAFANA_ADMIN_PASSWORD (or $PASS_FILE)"
 echo "  Dashboard:  APME Scan Times"
 echo "  Scrape target: host.containers.internal:8889 (otel-collector hostPort)"
 echo "  TSDB data:  $PROM_DATA  (15d retention; survives down/up)"

--- a/containers/observability/up.sh
+++ b/containers/observability/up.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Start Prometheus + Grafana companion stack for APME OTel metrics.
+# Prometheus TSDB persists on the host (survives down/up).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+_relabel() {
+  local host_path="$1"
+  if command -v chcon >/dev/null 2>&1 && [[ "$(getenforce 2>/dev/null)" == "Enforcing" ]]; then
+    chcon -t container_file_t "$host_path" 2>/dev/null || \
+      echo "WARNING: could not relabel $host_path for SELinux" >&2
+  fi
+}
+
+if podman pod exists apme-observability 2>/dev/null; then
+  echo "Stopping existing apme-observability..."
+  podman pod stop apme-observability 2>/dev/null || true
+  podman pod rm -f apme-observability 2>/dev/null || true
+fi
+
+# Persist TSDB across restarts (override with APME_PROM_DATA).
+PROM_DATA="${APME_PROM_DATA:-${XDG_CACHE_HOME:-$HOME/.cache}/apme/prometheus-tsdb}"
+mkdir -p "$PROM_DATA"
+# Official prometheus image runs as UID 65534 (nobody).
+if command -v podman >/dev/null 2>&1; then
+  podman unshare chown -R 65534:65534 "$PROM_DATA" 2>/dev/null || chmod -R a+rwX "$PROM_DATA"
+else
+  chmod -R a+rwX "$PROM_DATA"
+fi
+
+_relabel "$ROOT/containers/observability/prometheus.yml"
+_relabel "$ROOT/containers/observability/grafana/provisioning/datasources"
+_relabel "$ROOT/containers/observability/grafana/provisioning/dashboards"
+_relabel "$ROOT/containers/observability/grafana/dashboards"
+_relabel "$PROM_DATA"
+
+export APME_ROOT="$ROOT"
+export APME_PROM_DATA="$PROM_DATA"
+POD_YAML=$(envsubst '$APME_ROOT $APME_PROM_DATA' < containers/observability/pod.yaml)
+echo "$POD_YAML" | podman play kube -
+
+echo "Observability stack started."
+echo "  Prometheus: http://localhost:9091"
+echo "  Grafana:    http://localhost:3002  (admin/admin)"
+echo "  Dashboard:  APME Scan Times"
+echo "  Scrape target: host.containers.internal:8889 (otel-collector hostPort)"
+echo "  TSDB data:  $PROM_DATA  (15d retention; survives down/up)"
+echo "  Wipe TSDB:  ./containers/observability/down.sh --wipe"

--- a/containers/otel-collector/config.yaml
+++ b/containers/otel-collector/config.yaml
@@ -1,0 +1,37 @@
+# OpenTelemetry Collector — receives OTLP from APME sidecars, exposes Prometheus.
+#
+# Apps push metrics to http://127.0.0.1:4318 (OTLP/HTTP).
+# Prometheus scrapes http://127.0.0.1:8889/metrics (hostPort when using podman).
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+  resource:
+    attributes:
+      - key: service.namespace
+        value: apme
+        action: upsert
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: ""
+    resource_to_telemetry_conversion:
+      enabled: true
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch, resource]
+      exporters: [prometheus, debug]

--- a/containers/podman/README.md
+++ b/containers/podman/README.md
@@ -1,6 +1,8 @@
-# Podman pod (6 app containers + 1 infra; CLI on-the-fly)
+# Podman pod (app containers + infra + OTel collector; CLI on-the-fly)
 
-Backend services run in a single **pod** so they share a network (localhost). Podman creates one extra **infra** container per pod to hold the pod's shared network namespace, so `podman pod list` shows **7** containers (primary, native, ansible, opa, gitleaks, galaxy-proxy, plus the infra container). That's expected. The **CLI is not part of the pod** and is run on-the-fly with your current directory mounted so you can scan any project without baking a path into the pod.
+Backend services run in a single **pod** so they share a network (localhost). Podman creates one extra **infra** container per pod to hold the pod's shared network namespace. The **CLI is not part of the pod** and is run on-the-fly with your current directory mounted so you can scan any project without baking a path into the pod.
+
+The pod includes an **otel-collector** sidecar that receives OTLP metrics from Primary, Gateway, and Galaxy Proxy and exposes Prometheus scrape on **http://localhost:8889/metrics**. Optional Grafana/Prometheus companion: [`containers/observability/README.md`](../observability/README.md).
 
 ## Prerequisites
 

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -1,9 +1,11 @@
 # Podman pod: Primary, Native, OPA, Ansible, Gitleaks, Collection Health,
-# Dep Audit, Galaxy Proxy.
+# Dep Audit, Galaxy Proxy, Gateway, UI, Abbenay, OTel Collector.
 # All validators implement the unified Validator gRPC service (validate.proto).
 # Galaxy Proxy serves collections as Python wheels via PEP 503 (ADR-031).
 # Session venvs are built by Primary (read-write) and shared with validators
 # (read-only) via the sessions volume.
+# OTel Collector receives OTLP from sibling containers and exposes Prometheus
+# metrics on :8889 for an external Prometheus scrape.
 # CLI is run on-the-fly with: ./run-cli.sh [args]
 # Start from repo root: podman play kube pod.yaml
 # Requires: images built first (./build.sh). PVCs are created from pvc.yaml on start.
@@ -43,6 +45,14 @@ spec:
           value: "apme-dev-token"
         - name: APME_AI_MODEL
           value: "${APME_AI_MODEL}"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://127.0.0.1:4318"
+        - name: OTEL_SERVICE_NAME
+          value: "apme-primary"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.namespace=apme,service.instance.id=apme-pod"
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: "10000"
       ports:
         - containerPort: 50051
           hostPort: 50051
@@ -132,6 +142,14 @@ spec:
           value: "${APME_FEEDBACK_GITHUB_REPO}"
         - name: APME_FEEDBACK_GITHUB_TOKEN
           value: "${APME_FEEDBACK_GITHUB_TOKEN}"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://127.0.0.1:4318"
+        - name: OTEL_SERVICE_NAME
+          value: "apme-gateway"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.namespace=apme,service.instance.id=apme-pod"
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: "10000"
       ports:
         - containerPort: 50060
           hostPort: 50060
@@ -166,12 +184,33 @@ spec:
           readOnly: true
     - name: galaxy-proxy
       image: apme-galaxy-proxy:latest
+      env:
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://127.0.0.1:4318"
+        - name: OTEL_SERVICE_NAME
+          value: "apme-galaxy-proxy"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.namespace=apme,service.instance.id=apme-pod"
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: "10000"
       ports:
         - containerPort: 8765
           hostPort: 8765
       volumeMounts:
         - name: proxy-cache
           mountPath: /cache
+    - name: otel-collector
+      image: docker.io/otel/opentelemetry-collector-contrib:0.120.0
+      args: ["--config=/etc/otelcol/config.yaml"]
+      ports:
+        - containerPort: 4317
+        - containerPort: 4318
+        - containerPort: 8889
+          hostPort: 8889
+      volumeMounts:
+        - name: otel-config
+          mountPath: /etc/otelcol/config.yaml
+          readOnly: true
   volumes:
     - name: gateway-data
       persistentVolumeClaim:
@@ -185,4 +224,8 @@ spec:
     - name: abbenay-config
       hostPath:
         path: ${APME_ROOT}/containers/abbenay/config.yaml
+        type: File
+    - name: otel-config
+      hostPath:
+        path: ${APME_ROOT}/containers/otel-collector/config.yaml
         type: File

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -270,6 +270,7 @@ print(yaml)
 fi
 
 _relabel_host_path_for_podman "$ROOT/containers/abbenay/config.yaml"
+_relabel_host_path_for_podman "$ROOT/containers/otel-collector/config.yaml"
 if [[ -n "$ABBENAY_CA_BUNDLE" ]]; then
   _relabel_host_path_for_podman "$ABBENAY_CA_BUNDLE"
 fi
@@ -278,6 +279,7 @@ podman kube play containers/podman/pvc.yaml
 echo "$POD_YAML" | podman play kube -
 
 echo "Pod apme-pod started (volumes: apme-sessions, apme-gateway-data, apme-proxy-cache). Run a scan: containers/podman/run-cli.sh"
+echo "OTel Prometheus metrics: http://localhost:8889/metrics (companion stack: containers/observability/up.sh)"
 
 if [[ -n "$APME_FEEDBACK_GITHUB_REPO" && -n "$APME_FEEDBACK_GITHUB_TOKEN" ]]; then
   echo "Issue reporting enabled (repo: $APME_FEEDBACK_GITHUB_REPO)"

--- a/docs/architecture/17-scaling-and-deployment.md
+++ b/docs/architecture/17-scaling-and-deployment.md
@@ -68,7 +68,7 @@ convention — there is no service discovery, no message queue.
 | 8080 | Gateway | HTTP | REST API for UI and external consumers |
 | 8081 | UI | HTTP | nginx-served React SPA (proxies `/api/` to Gateway) |
 | 8765 | Galaxy Proxy | HTTP | PEP 503 simple repository API for collection wheels |
-| 8889 | OTel Collector | HTTP | Prometheus metrics scrape (`/metrics`) |
+| 8889 | OTel Collector | HTTP | Prometheus metrics scrape (`/metrics`) — ADR-067 |
 
 ## Volume Mounts
 

--- a/docs/architecture/17-scaling-and-deployment.md
+++ b/docs/architecture/17-scaling-and-deployment.md
@@ -68,6 +68,7 @@ convention — there is no service discovery, no message queue.
 | 8080 | Gateway | HTTP | REST API for UI and external consumers |
 | 8081 | UI | HTTP | nginx-served React SPA (proxies `/api/` to Gateway) |
 | 8765 | Galaxy Proxy | HTTP | PEP 503 simple repository API for collection wheels |
+| 8889 | OTel Collector | HTTP | Prometheus metrics scrape (`/metrics`) |
 
 ## Volume Mounts
 

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -441,6 +441,17 @@ tox -e pm                            # build, start, wait, open browser
 
 The underlying scripts in `containers/podman/` remain directly callable for debugging and low-level troubleshooting, but tox is the expected interface for routine work. See `containers/podman/README.md` for troubleshooting details.
 
+### Observability (OTel → Prometheus → Grafana)
+
+The pod includes an `otel-collector` that scrapes as **http://localhost:8889/metrics**. Primary exports scan/phase/validator duration histograms; Gateway and Galaxy Proxy export HTTP request durations.
+
+```bash
+./containers/observability/up.sh     # Prometheus :9091, Grafana :3002
+./containers/observability/down.sh
+```
+
+See [`containers/observability/README.md`](../../containers/observability/README.md).
+
 ## YAML formatter
 
 The `format` subcommand normalizes YAML files to a consistent style before semantic analysis. This is Phase 1 of the remediation pipeline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
     "uvicorn[standard]>=0.20",
     "pip-audit>=2.7",
     "ansible-core>=2.20.7",
+    "opentelemetry-api>=1.44.0",
+    "opentelemetry-sdk>=1.44.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.44.0",
 ]
 
 [project.optional-dependencies]
@@ -162,8 +165,17 @@ module = [
     "pydantic.*",
     "playwright",
     "playwright.*",
+    "opentelemetry",
+    "opentelemetry.*",
+    "starlette",
+    "starlette.*",
 ]
 ignore_missing_imports = true
+
+# OTel instrument handles are SDK objects without usable public stubs.
+[[tool.mypy.overrides]]
+module = ["apme_engine.observability", "apme_engine.observability.*"]
+disallow_any_explicit = false
 
 # Deprecation scraper uses untyped JSON dicts extensively.
 [[tool.mypy.overrides]]

--- a/src/apme_engine/daemon/primary_main.py
+++ b/src/apme_engine/daemon/primary_main.py
@@ -30,8 +30,10 @@ def main() -> None:
     Uses APME_PRIMARY_LISTEN for bind address. Exits with code 1 on failure.
     """
     from apme_engine.log_bridge import install_handler
+    from apme_engine.observability import setup_otel, shutdown_otel
 
     install_handler()
+    setup_otel(service_name=os.environ.get("OTEL_SERVICE_NAME", "apme-primary"))
 
     listen = os.environ.get("APME_PRIMARY_LISTEN", "0.0.0.0:50051")
     try:
@@ -41,6 +43,8 @@ def main() -> None:
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
         sys.exit(1)
+    finally:
+        shutdown_otel()
 
 
 if __name__ == "__main__":

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -1084,6 +1084,9 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
         learned_fqcns = {str(c) for c in hierarchy_collections if isinstance(c, str)}
 
         logger.info("Scan: pipeline done (%.0fms, %d violations, req=%s)", total_ms, len(violations), scan_id)
+        from apme_engine.observability import record_scan_diagnostics
+
+        record_scan_diagnostics(diag, status="ok")
         return (
             violations,
             diag,

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -867,12 +867,15 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                 skip_validators=skip_validators,
             )
         except Exception:
-            from apme_engine.observability import record_scan_diagnostics
+            try:
+                from apme_engine.observability import record_scan_diagnostics
 
-            record_scan_diagnostics(
-                ScanDiagnostics(total_ms=(time.monotonic() - scan_t0) * 1000.0),
-                status="error",
-            )
+                record_scan_diagnostics(
+                    ScanDiagnostics(total_ms=(time.monotonic() - scan_t0) * 1000.0),
+                    status="error",
+                )
+            except Exception:  # noqa: BLE001 — metrics must never mask scan failures
+                logger.debug("Failed to record scan error metrics", exc_info=True)
             raise
 
     async def _execute_scan_pipeline(
@@ -1171,9 +1174,12 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
         learned_fqcns = {str(c) for c in hierarchy_collections if isinstance(c, str)}
 
         logger.info("Scan: pipeline done (%.0fms, %d violations, req=%s)", total_ms, len(violations), scan_id)
-        from apme_engine.observability import record_scan_diagnostics
+        try:
+            from apme_engine.observability import record_scan_diagnostics
 
-        record_scan_diagnostics(diag, status="ok")
+            record_scan_diagnostics(diag, status="ok")
+        except Exception:  # noqa: BLE001 — metrics must never break the scan pipeline
+            logger.debug("Failed to record scan metrics", exc_info=True)
         return (
             violations,
             diag,

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -839,9 +839,9 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
                 request-scoped control over optional validators (ADR-051).
 
         Raises:
-            ValueError: If ``rule_configs_complete`` is ``True`` and either
-                direction of the bidirectional audit fails (unknown IDs the
-                Primary cannot execute, or known IDs absent from the config).
+            Exception: Pipeline failures (including ``ValueError`` from
+                bidirectional rule-catalog audit when complete). Failures are
+                recorded as ``status=error`` metrics before re-raise.
 
         Returns:
             Tuple of (violations, ScanDiagnostics or None, resolved session_id,
@@ -849,6 +849,93 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             VenvSession or None, requirements file paths found,
             specified collection FQCNs, learned collection FQCNs,
             ContentGraph or None).
+        """
+        scan_t0 = time.monotonic()
+        try:
+            return await self._execute_scan_pipeline(
+                temp_dir,
+                files,
+                scan_id,
+                ansible_core_version=ansible_core_version,
+                collection_specs=collection_specs,
+                include_scandata=include_scandata,
+                session_id=session_id,
+                progress_callback=progress_callback,
+                galaxy_cfg_path=galaxy_cfg_path,
+                rule_configs=rule_configs,
+                rule_configs_complete=rule_configs_complete,
+                skip_validators=skip_validators,
+            )
+        except Exception:
+            from apme_engine.observability import record_scan_diagnostics
+
+            record_scan_diagnostics(
+                ScanDiagnostics(total_ms=(time.monotonic() - scan_t0) * 1000.0),
+                status="error",
+            )
+            raise
+
+    async def _execute_scan_pipeline(
+        self,
+        temp_dir: Path,
+        files: list[File],
+        scan_id: str,
+        *,
+        ansible_core_version: str = "",
+        collection_specs: list[str] | None = None,
+        include_scandata: bool = True,
+        session_id: str = "",
+        progress_callback: Callable[[str, str, float, int], None] | None = None,
+        galaxy_cfg_path: Path | None = None,
+        rule_configs: list[object] | None = None,
+        rule_configs_complete: bool = False,
+        skip_validators: frozenset[str] = frozenset(),
+    ) -> tuple[
+        list[ViolationDict],
+        ScanDiagnostics | None,
+        str,
+        list[list[ProgressUpdate]],
+        Mapping[str, object] | None,
+        VenvSession | None,
+        list[str],
+        set[str],
+        set[str],
+        object | None,
+    ]:
+        """Run the scan pipeline body (see ``_scan_pipeline``).
+
+        Args:
+            temp_dir: Directory containing the materialized files.
+            files: Original File protos (for ValidateRequest).
+            scan_id: Request ID for correlation.
+            ansible_core_version: Ansible core version constraint.
+            collection_specs: Collection specifiers (may be extended by discovery).
+            include_scandata: Whether to include scandata in engine call.
+            session_id: Client-provided session ID for venv reuse.
+            progress_callback: Optional callback ``(phase, message, fraction)``
+                for streaming per-validator progress to callers.
+            galaxy_cfg_path: Session-scoped ``ansible.cfg`` for Galaxy auth
+                (ADR-045). In daemon mode this is temporarily exposed to the
+                in-process Galaxy Proxy during venv acquisition.
+            rule_configs: Per-rule overrides from ``ScanOptions`` (ADR-041).
+                When provided, disabled rules are filtered and severity is
+                overridden after validator fan-out.
+            rule_configs_complete: When ``True`` the incoming ``rule_configs``
+                represents the full catalog (Gateway path).  The Primary
+                performs bidirectional audit and hard-fails on unknown **or**
+                missing rule IDs.  When ``False`` (CLI path), unknown IDs
+                produce a warning only.
+            skip_validators: Validator names to exclude from fan-out
+                (e.g. ``{"collection_health", "dep_audit"}``).  Allows
+                request-scoped control over optional validators (ADR-051).
+
+        Raises:
+            ValueError: If ``rule_configs_complete`` is ``True`` and either
+                direction of the bidirectional audit fails (unknown IDs the
+                Primary cannot execute, or known IDs absent from the config).
+
+        Returns:
+            Same tuple as ``_scan_pipeline``.
         """
         from apme_engine.validators.ansible._venv import DEFAULT_VERSION
         from apme_engine.venv_manager.session import _venv_site_packages

--- a/src/apme_engine/observability/__init__.py
+++ b/src/apme_engine/observability/__init__.py
@@ -1,0 +1,23 @@
+"""Operational observability (OpenTelemetry metrics).
+
+Product-facing per-scan diagnostics remain in ADR-013 gRPC messages.
+This package exports fleet/ops metrics via OTLP when configured.
+"""
+
+from apme_engine.observability.metrics import (
+    record_galaxy_fetch,
+    record_galaxy_wheel_serve,
+    record_scan_diagnostics,
+    record_venv_acquire,
+)
+from apme_engine.observability.otel_setup import get_meter, setup_otel, shutdown_otel
+
+__all__ = [
+    "get_meter",
+    "record_galaxy_fetch",
+    "record_galaxy_wheel_serve",
+    "record_scan_diagnostics",
+    "record_venv_acquire",
+    "setup_otel",
+    "shutdown_otel",
+]

--- a/src/apme_engine/observability/buckets.py
+++ b/src/apme_engine/observability/buckets.py
@@ -1,0 +1,101 @@
+"""Histogram bucket boundaries for APME OTel duration metrics.
+
+SDK defaults (0, 5, 10, …) dump most sub‑5s samples into one bucket and make
+``histogram_quantile`` lie (e.g. OPA p95 ≈ 4.75s). Boundaries below are tuned
+so typical APME latencies spread across mid buckets; HTTP follows the OTel
+HTTP semantic-convention set.
+"""
+
+from __future__ import annotations
+
+# https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
+# (http.server.request.duration explicit bucket boundaries)
+HTTP_DURATION_BUCKETS_S: tuple[float, ...] = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.075,
+    0.1,
+    0.25,
+    0.5,
+    0.75,
+    1.0,
+    2.5,
+    5.0,
+    7.5,
+    10.0,
+)
+
+# End-to-end scans: warm ~5–15s, cold often 30–60s+
+SCAN_DURATION_BUCKETS_S: tuple[float, ...] = (
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    7.5,
+    10.0,
+    15.0,
+    20.0,
+    30.0,
+    45.0,
+    60.0,
+    90.0,
+    120.0,
+)
+
+# Validator / phase: sub-second (native/opa/gitleaks) through tens of seconds
+# (collection_health / ansible / fan_out)
+VALIDATOR_DURATION_BUCKETS_S: tuple[float, ...] = (
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    0.75,
+    1.0,
+    2.5,
+    5.0,
+    7.5,
+    10.0,
+    15.0,
+    25.0,
+    45.0,
+    60.0,
+)
+
+# Session venv acquire: warm hits are ms; cold create + collection install can be minutes
+VENV_DURATION_BUCKETS_S: tuple[float, ...] = (
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    20.0,
+    30.0,
+    45.0,
+    60.0,
+    90.0,
+    120.0,
+    180.0,
+)
+
+# Outbound Galaxy: version lookup is sub-second–few seconds; tarball download can be minutes
+GALAXY_FETCH_DURATION_BUCKETS_S: tuple[float, ...] = (
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    20.0,
+    30.0,
+    60.0,
+    120.0,
+    180.0,
+    300.0,
+)

--- a/src/apme_engine/observability/http_middleware.py
+++ b/src/apme_engine/observability/http_middleware.py
@@ -1,0 +1,57 @@
+"""ASGI middleware that records HTTP request durations via OTel metrics."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class HttpMetricsMiddleware:
+    """Record ``apme.http.server.duration`` for HTTP requests."""
+
+    def __init__(self, app: ASGIApp, *, service: str) -> None:
+        """Wrap ``app`` and tag metrics with ``service``.
+
+        Args:
+            app: Downstream ASGI application.
+            service: Logical service label (``gateway`` or ``galaxy-proxy``).
+        """
+        self.app = app
+        self.service = service
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """ASGI entrypoint: time HTTP requests and record duration metrics.
+
+        Args:
+            scope: ASGI connection scope.
+            receive: ASGI receive callable.
+            send: ASGI send callable.
+        """
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope.get("method", "GET")
+        status_code = 500
+        started = time.perf_counter()
+
+        async def send_wrapper(message: dict) -> None:  # type: ignore[type-arg]
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = int(message.get("status", 500))
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            from apme_engine.observability.metrics import record_http_request
+
+            record_http_request(
+                time.perf_counter() - started,
+                method=str(method),
+                status_code=status_code,
+                service=self.service,
+            )

--- a/src/apme_engine/observability/http_middleware.py
+++ b/src/apme_engine/observability/http_middleware.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger("apme.observability.http")
 
 
 class HttpMetricsMiddleware:
@@ -47,11 +50,14 @@ class HttpMetricsMiddleware:
         try:
             await self.app(scope, receive, send_wrapper)
         finally:
-            from apme_engine.observability.metrics import record_http_request
+            try:
+                from apme_engine.observability.metrics import record_http_request
 
-            record_http_request(
-                time.perf_counter() - started,
-                method=str(method),
-                status_code=status_code,
-                service=self.service,
-            )
+                record_http_request(
+                    time.perf_counter() - started,
+                    method=str(method),
+                    status_code=status_code,
+                    service=self.service,
+                )
+            except Exception:  # noqa: BLE001 — metrics must never break HTTP responses
+                logger.debug("Failed to record HTTP metrics", exc_info=True)

--- a/src/apme_engine/observability/metrics.py
+++ b/src/apme_engine/observability/metrics.py
@@ -1,0 +1,283 @@
+"""APME scan/ops metric instruments.
+
+Metric names use OTel dotted form; the Collector Prometheus exporter maps
+them to Prometheus names such as ``apme_scan_duration_seconds``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from apme_engine.observability.buckets import (
+    GALAXY_FETCH_DURATION_BUCKETS_S,
+    HTTP_DURATION_BUCKETS_S,
+    SCAN_DURATION_BUCKETS_S,
+    VALIDATOR_DURATION_BUCKETS_S,
+    VENV_DURATION_BUCKETS_S,
+)
+from apme_engine.observability.otel_setup import get_meter
+
+if TYPE_CHECKING:
+    from apme.v1.primary_pb2 import ScanDiagnostics
+
+logger = logging.getLogger(__name__)
+
+_scan_duration: Any = None
+_phase_duration: Any = None
+_validator_duration: Any = None
+_scan_completed: Any = None
+_http_duration: Any = None
+_venv_duration: Any = None
+_venv_completed: Any = None
+_galaxy_fetch_duration: Any = None
+_galaxy_fetch_completed: Any = None
+_galaxy_wheel_duration: Any = None
+_galaxy_wheel_completed: Any = None
+_instruments_ready = False
+
+
+def _ensure_instruments() -> bool:
+    """Lazily create instruments once a meter is available.
+
+    Returns:
+        True when instruments exist and recording is safe.
+    """
+    global _scan_duration, _phase_duration, _validator_duration, _scan_completed
+    global _http_duration, _venv_duration, _venv_completed
+    global _galaxy_fetch_duration, _galaxy_fetch_completed
+    global _galaxy_wheel_duration, _galaxy_wheel_completed, _instruments_ready
+    if _instruments_ready:
+        return _scan_duration is not None
+
+    meter = get_meter()
+    _instruments_ready = True
+    if meter is None:
+        return False
+
+    _scan_duration = meter.create_histogram(
+        name="apme.scan.duration",
+        unit="s",
+        description="End-to-end APME scan pipeline duration",
+        explicit_bucket_boundaries_advisory=list(SCAN_DURATION_BUCKETS_S),
+    )
+    _phase_duration = meter.create_histogram(
+        name="apme.scan.phase.duration",
+        unit="s",
+        description="APME scan phase durations (parse, annotate, fan_out, engine)",
+        explicit_bucket_boundaries_advisory=list(VALIDATOR_DURATION_BUCKETS_S),
+    )
+    _validator_duration = meter.create_histogram(
+        name="apme.validator.duration",
+        unit="s",
+        description="Per-validator duration from ADR-013 diagnostics",
+        explicit_bucket_boundaries_advisory=list(VALIDATOR_DURATION_BUCKETS_S),
+    )
+    _http_duration = meter.create_histogram(
+        name="apme.http.server.duration",
+        unit="s",
+        description="HTTP server request duration",
+        explicit_bucket_boundaries_advisory=list(HTTP_DURATION_BUCKETS_S),
+    )
+    _venv_duration = meter.create_histogram(
+        name="apme.venv.acquire.duration",
+        unit="s",
+        description="Session venv acquire duration (warm hit, incremental install, or cold create)",
+        explicit_bucket_boundaries_advisory=list(VENV_DURATION_BUCKETS_S),
+    )
+    _venv_completed = meter.create_counter(
+        name="apme.venv.acquire.completed",
+        unit="{acquire}",
+        description="Completed session venv acquires by outcome",
+    )
+    _galaxy_fetch_duration = meter.create_histogram(
+        name="apme.galaxy.fetch.duration",
+        unit="s",
+        description="Outbound Ansible Galaxy fetch duration (collection download or version lookup)",
+        explicit_bucket_boundaries_advisory=list(GALAXY_FETCH_DURATION_BUCKETS_S),
+    )
+    _galaxy_fetch_completed = meter.create_counter(
+        name="apme.galaxy.fetch.completed",
+        unit="{fetch}",
+        description="Completed outbound Ansible Galaxy fetches by operation and status",
+    )
+    _galaxy_wheel_duration = meter.create_histogram(
+        name="apme.galaxy.wheel.serve.duration",
+        unit="s",
+        description="Galaxy Proxy wheel serve duration (cache hit or download miss)",
+        explicit_bucket_boundaries_advisory=list(GALAXY_FETCH_DURATION_BUCKETS_S),
+    )
+    _galaxy_wheel_completed = meter.create_counter(
+        name="apme.galaxy.wheel.serve.completed",
+        unit="{serve}",
+        description="Completed Galaxy Proxy wheel serves by cache outcome",
+    )
+    _scan_completed = meter.create_counter(
+        name="apme.scan.completed",
+        unit="{scan}",
+        description="Completed APME scans by status",
+    )
+    return True
+
+
+def record_scan_diagnostics(diag: ScanDiagnostics, *, status: str = "ok") -> None:
+    """Record histograms/counters from a completed ``ScanDiagnostics``.
+
+    Args:
+        diag: Aggregated scan diagnostics from the Primary pipeline.
+        status: Outcome label (``ok`` or ``error``).
+    """
+    if not _ensure_instruments():
+        return
+
+    try:
+        attrs = {"status": status}
+        _scan_duration.record(max(diag.total_ms, 0.0) / 1000.0, attrs)
+        _scan_completed.add(1, attrs)
+
+        phases = {
+            "parse": diag.engine_parse_ms,
+            "annotate": diag.engine_annotate_ms,
+            "engine": diag.engine_total_ms,
+            "fan_out": diag.fan_out_ms,
+        }
+        for phase, ms in phases.items():
+            _phase_duration.record(max(ms, 0.0) / 1000.0, {"phase": phase, "status": status})
+
+        for vdiag in diag.validators:
+            name = (vdiag.validator_name or "unknown").strip() or "unknown"
+            _validator_duration.record(
+                max(vdiag.total_ms, 0.0) / 1000.0,
+                {"validator": name, "status": status},
+            )
+    except Exception:  # noqa: BLE001 — never fail the scan path for metrics
+        logger.debug("Failed to record scan diagnostics metrics", exc_info=True)
+
+
+def record_venv_acquire(
+    duration_s: float,
+    *,
+    outcome: str,
+    status: str = "ok",
+    ansible_core_version: str = "",
+    collections_requested: int = 0,
+) -> None:
+    """Record a session venv acquire duration.
+
+    Args:
+        duration_s: Wall time for ``VenvSessionManager.acquire``.
+        outcome: ``warm``, ``incremental``, or ``create``.
+        status: ``ok`` or ``error``.
+        ansible_core_version: Normalised ansible-core version label.
+        collections_requested: Number of collection specs requested.
+    """
+    if not _ensure_instruments():
+        return
+    if _venv_duration is None or _venv_completed is None:
+        return
+    try:
+        attrs: dict[str, str] = {
+            "outcome": outcome or "unknown",
+            "status": status,
+            "collections_requested": str(max(collections_requested, 0)),
+        }
+        ver = (ansible_core_version or "").strip()
+        if ver:
+            attrs["ansible_core_version"] = ver
+        _venv_duration.record(max(duration_s, 0.0), attrs)
+        _venv_completed.add(1, attrs)
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to record venv acquire metrics", exc_info=True)
+
+
+def record_http_request(duration_s: float, *, method: str, status_code: int, service: str) -> None:
+    """Record an HTTP server request duration (Gateway / Galaxy Proxy).
+
+    Args:
+        duration_s: Request duration in seconds.
+        method: HTTP method.
+        status_code: Response status code.
+        service: Logical service name (``gateway`` or ``galaxy-proxy``).
+    """
+    if not _ensure_instruments():
+        return
+    if _http_duration is None:
+        return
+    try:
+        _http_duration.record(
+            max(duration_s, 0.0),
+            {
+                "http.request.method": method,
+                "http.response.status_code": str(status_code),
+                "service": service,
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to record HTTP metrics", exc_info=True)
+
+
+def record_galaxy_fetch(
+    duration_s: float,
+    *,
+    operation: str,
+    status: str = "ok",
+    collections_requested: int = 0,
+    server: str = "",
+) -> None:
+    """Record an outbound Ansible Galaxy fetch (download or version lookup).
+
+    Args:
+        duration_s: Wall time for the fetch attempt.
+        operation: ``download`` (``ansible-galaxy collection download``) or
+            ``version_lookup`` (Galaxy API versions HTTP).
+        status: ``ok``, ``error``, or ``timeout``.
+        collections_requested: Specs requested for ``download`` (0 otherwise).
+        server: Galaxy server host for ``version_lookup`` (omit for download).
+    """
+    if not _ensure_instruments():
+        return
+    if _galaxy_fetch_duration is None or _galaxy_fetch_completed is None:
+        return
+    try:
+        attrs: dict[str, str] = {
+            "operation": operation or "unknown",
+            "status": status,
+        }
+        if operation == "download":
+            attrs["collections_requested"] = str(max(collections_requested, 0))
+        host = (server or "").strip()
+        if host:
+            attrs["server"] = host
+        _galaxy_fetch_duration.record(max(duration_s, 0.0), attrs)
+        _galaxy_fetch_completed.add(1, attrs)
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to record Galaxy fetch metrics", exc_info=True)
+
+
+def record_galaxy_wheel_serve(
+    duration_s: float,
+    *,
+    outcome: str,
+    status: str = "ok",
+) -> None:
+    """Record a Galaxy Proxy ``GET /wheels/{filename}`` serve.
+
+    Args:
+        duration_s: Wall time to serve the wheel (includes download on miss).
+        outcome: ``hit`` (served from ``/cache/wheels``) or ``miss`` (download
+            + convert + cache).
+        status: ``ok`` or ``error``.
+    """
+    if not _ensure_instruments():
+        return
+    if _galaxy_wheel_duration is None or _galaxy_wheel_completed is None:
+        return
+    try:
+        attrs = {
+            "outcome": outcome or "unknown",
+            "status": status,
+        }
+        _galaxy_wheel_duration.record(max(duration_s, 0.0), attrs)
+        _galaxy_wheel_completed.add(1, attrs)
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to record Galaxy wheel serve metrics", exc_info=True)

--- a/src/apme_engine/observability/metrics.py
+++ b/src/apme_engine/observability/metrics.py
@@ -51,9 +51,11 @@ def _ensure_instruments() -> bool:
         return _scan_duration is not None
 
     meter = get_meter()
-    _instruments_ready = True
     if meter is None:
+        # Do not latch ready: setup_otel() may run later in this process.
         return False
+
+    _instruments_ready = True
 
     _scan_duration = meter.create_histogram(
         name="apme.scan.duration",
@@ -120,6 +122,45 @@ def _ensure_instruments() -> bool:
     return True
 
 
+def reset_instruments() -> None:
+    """Clear cached instruments so a later ``setup_otel`` can recreate them."""
+    global _scan_duration, _phase_duration, _validator_duration, _scan_completed
+    global _http_duration, _venv_duration, _venv_completed
+    global _galaxy_fetch_duration, _galaxy_fetch_completed
+    global _galaxy_wheel_duration, _galaxy_wheel_completed, _instruments_ready
+    _scan_duration = None
+    _phase_duration = None
+    _validator_duration = None
+    _scan_completed = None
+    _http_duration = None
+    _venv_duration = None
+    _venv_completed = None
+    _galaxy_fetch_duration = None
+    _galaxy_fetch_completed = None
+    _galaxy_wheel_duration = None
+    _galaxy_wheel_completed = None
+    _instruments_ready = False
+
+
+def _collections_requested_bucket(count: int) -> str:
+    """Coarse bucket for collection counts to avoid Prometheus cardinality blow-ups.
+
+    Args:
+        count: Number of collection specs requested.
+
+    Returns:
+        One of ``0``, ``1-5``, ``6-20``, or ``21+``.
+    """
+    n = max(count, 0)
+    if n == 0:
+        return "0"
+    if n <= 5:
+        return "1-5"
+    if n <= 20:
+        return "6-20"
+    return "21+"
+
+
 def record_scan_diagnostics(diag: ScanDiagnostics, *, status: str = "ok") -> None:
     """Record histograms/counters from a completed ``ScanDiagnostics``.
 
@@ -179,7 +220,7 @@ def record_venv_acquire(
         attrs: dict[str, str] = {
             "outcome": outcome or "unknown",
             "status": status,
-            "collections_requested": str(max(collections_requested, 0)),
+            "collections_requested": _collections_requested_bucket(collections_requested),
         }
         ver = (ansible_core_version or "").strip()
         if ver:
@@ -244,7 +285,7 @@ def record_galaxy_fetch(
             "status": status,
         }
         if operation == "download":
-            attrs["collections_requested"] = str(max(collections_requested, 0))
+            attrs["collections_requested"] = _collections_requested_bucket(collections_requested)
         host = (server or "").strip()
         if host:
             attrs["server"] = host

--- a/src/apme_engine/observability/otel_setup.py
+++ b/src/apme_engine/observability/otel_setup.py
@@ -17,13 +17,46 @@ _initialized = False
 _meter: Any = None
 _provider: Any = None
 
+_DEFAULT_EXPORT_INTERVAL_MS = 10000
+
 
 def _truthy(value: str | None) -> bool:
     return (value or "").strip().lower() in ("1", "true", "yes", "on")
 
 
+def _export_interval_ms() -> int:
+    """Parse ``OTEL_METRIC_EXPORT_INTERVAL`` with a safe default.
+
+    Returns:
+        Export interval in milliseconds (always positive).
+    """
+    raw = (os.environ.get("OTEL_METRIC_EXPORT_INTERVAL") or "").strip()
+    if not raw:
+        return _DEFAULT_EXPORT_INTERVAL_MS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid OTEL_METRIC_EXPORT_INTERVAL=%r; using default %d",
+            raw,
+            _DEFAULT_EXPORT_INTERVAL_MS,
+        )
+        return _DEFAULT_EXPORT_INTERVAL_MS
+    if value <= 0:
+        logger.warning(
+            "Non-positive OTEL_METRIC_EXPORT_INTERVAL=%r; using default %d",
+            raw,
+            _DEFAULT_EXPORT_INTERVAL_MS,
+        )
+        return _DEFAULT_EXPORT_INTERVAL_MS
+    return value
+
+
 def setup_otel(service_name: str | None = None) -> None:
     """Initialize the global MeterProvider with an OTLP HTTP exporter.
+
+    Misconfiguration or missing packages leave metrics disabled (no-op).
+    Failures never raise out of this function.
 
     Args:
         service_name: Overrides ``OTEL_SERVICE_NAME`` when provided.
@@ -33,16 +66,16 @@ def setup_otel(service_name: str | None = None) -> None:
         return
     _initialized = True
 
-    if _truthy(os.environ.get("OTEL_SDK_DISABLED")):
-        logger.info("OpenTelemetry disabled via OTEL_SDK_DISABLED")
-        return
-
-    endpoint = (os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or "").strip()
-    if not endpoint:
-        logger.debug("OpenTelemetry inactive: OTEL_EXPORTER_OTLP_ENDPOINT unset")
-        return
-
     try:
+        if _truthy(os.environ.get("OTEL_SDK_DISABLED")):
+            logger.info("OpenTelemetry disabled via OTEL_SDK_DISABLED")
+            return
+
+        endpoint = (os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or "").strip()
+        if not endpoint:
+            logger.debug("OpenTelemetry inactive: OTEL_EXPORTER_OTLP_ENDPOINT unset")
+            return
+
         from opentelemetry import metrics
         from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
         from opentelemetry.sdk.metrics import MeterProvider
@@ -57,74 +90,79 @@ def setup_otel(service_name: str | None = None) -> None:
             VALIDATOR_DURATION_BUCKETS_S,
             VENV_DURATION_BUCKETS_S,
         )
+
+        name = (service_name or os.environ.get("OTEL_SERVICE_NAME") or "apme").strip()
+        resource_attrs: dict[str, str] = {"service.name": name}
+        extra = (os.environ.get("OTEL_RESOURCE_ATTRIBUTES") or "").strip()
+        for part in extra.split(","):
+            if "=" in part:
+                key, value = part.split("=", 1)
+                key, value = key.strip(), value.strip()
+                if key and value:
+                    resource_attrs[key] = value
+
+        # Accept base endpoint (http://host:4318) or full metrics URL.
+        metrics_endpoint = endpoint
+        if not endpoint.rstrip("/").endswith("/v1/metrics"):
+            metrics_endpoint = endpoint.rstrip("/") + "/v1/metrics"
+
+        export_interval_ms = _export_interval_ms()
+        reader = PeriodicExportingMetricReader(
+            OTLPMetricExporter(endpoint=metrics_endpoint),
+            export_interval_millis=export_interval_ms,
+        )
+        # Enforce domain-tuned buckets (advisory alone is insufficient for quantile math).
+        views = [
+            View(
+                instrument_name="apme.scan.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(SCAN_DURATION_BUCKETS_S)),
+            ),
+            View(
+                instrument_name="apme.scan.phase.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
+            ),
+            View(
+                instrument_name="apme.validator.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
+            ),
+            View(
+                instrument_name="apme.http.server.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(HTTP_DURATION_BUCKETS_S)),
+            ),
+            View(
+                instrument_name="apme.venv.acquire.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VENV_DURATION_BUCKETS_S)),
+            ),
+            View(
+                instrument_name="apme.galaxy.fetch.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(GALAXY_FETCH_DURATION_BUCKETS_S)),
+            ),
+            View(
+                instrument_name="apme.galaxy.wheel.serve.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(GALAXY_FETCH_DURATION_BUCKETS_S)),
+            ),
+        ]
+        _provider = MeterProvider(
+            resource=Resource.create(resource_attrs),
+            metric_readers=[reader],
+            views=views,
+        )
+        metrics.set_meter_provider(_provider)
+        _meter = metrics.get_meter("apme", "0.1.0")
+        logger.info(
+            "OpenTelemetry metrics enabled service=%s endpoint=%s interval_ms=%d",
+            name,
+            metrics_endpoint,
+            export_interval_ms,
+        )
     except ImportError:
         logger.warning("OpenTelemetry packages missing; metrics export disabled")
-        return
-
-    name = (service_name or os.environ.get("OTEL_SERVICE_NAME") or "apme").strip()
-    resource_attrs: dict[str, str] = {"service.name": name}
-    extra = (os.environ.get("OTEL_RESOURCE_ATTRIBUTES") or "").strip()
-    for part in extra.split(","):
-        if "=" in part:
-            key, value = part.split("=", 1)
-            key, value = key.strip(), value.strip()
-            if key and value:
-                resource_attrs[key] = value
-
-    # Accept base endpoint (http://host:4318) or full metrics URL.
-    metrics_endpoint = endpoint
-    if not endpoint.rstrip("/").endswith("/v1/metrics"):
-        metrics_endpoint = endpoint.rstrip("/") + "/v1/metrics"
-
-    export_interval_ms = int(os.environ.get("OTEL_METRIC_EXPORT_INTERVAL", "10000"))
-    reader = PeriodicExportingMetricReader(
-        OTLPMetricExporter(endpoint=metrics_endpoint),
-        export_interval_millis=export_interval_ms,
-    )
-    # Enforce domain-tuned buckets (advisory alone is insufficient for quantile math).
-    views = [
-        View(
-            instrument_name="apme.scan.duration",
-            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(SCAN_DURATION_BUCKETS_S)),
-        ),
-        View(
-            instrument_name="apme.scan.phase.duration",
-            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
-        ),
-        View(
-            instrument_name="apme.validator.duration",
-            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
-        ),
-        View(
-            instrument_name="apme.http.server.duration",
-            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(HTTP_DURATION_BUCKETS_S)),
-        ),
-        View(
-            instrument_name="apme.venv.acquire.duration",
-            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VENV_DURATION_BUCKETS_S)),
-        ),
-        View(
-            instrument_name="apme.galaxy.fetch.duration",
-            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(GALAXY_FETCH_DURATION_BUCKETS_S)),
-        ),
-        View(
-            instrument_name="apme.galaxy.wheel.serve.duration",
-            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(GALAXY_FETCH_DURATION_BUCKETS_S)),
-        ),
-    ]
-    _provider = MeterProvider(
-        resource=Resource.create(resource_attrs),
-        metric_readers=[reader],
-        views=views,
-    )
-    metrics.set_meter_provider(_provider)
-    _meter = metrics.get_meter("apme", "0.1.0")
-    logger.info(
-        "OpenTelemetry metrics enabled service=%s endpoint=%s interval_ms=%d",
-        name,
-        metrics_endpoint,
-        export_interval_ms,
-    )
+        _meter = None
+        _provider = None
+    except Exception:  # noqa: BLE001 — never crash callers for metrics bootstrap
+        logger.warning("OpenTelemetry setup failed; metrics export disabled", exc_info=True)
+        _meter = None
+        _provider = None
 
 
 def get_meter() -> Any:
@@ -138,12 +176,18 @@ def get_meter() -> Any:
 
 def shutdown_otel() -> None:
     """Flush and shut down the MeterProvider if it was started."""
-    global _provider, _meter
-    if _provider is None:
-        return
-    try:
-        _provider.shutdown()
-    except Exception:  # noqa: BLE001 — best-effort teardown
-        logger.debug("OpenTelemetry shutdown failed", exc_info=True)
+    global _initialized, _provider, _meter
+    if _provider is not None:
+        try:
+            _provider.shutdown()
+        except Exception:  # noqa: BLE001 — best-effort teardown
+            logger.debug("OpenTelemetry shutdown failed", exc_info=True)
     _provider = None
     _meter = None
+    _initialized = False
+    try:
+        from apme_engine.observability.metrics import reset_instruments
+
+        reset_instruments()
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to reset metric instruments after shutdown", exc_info=True)

--- a/src/apme_engine/observability/otel_setup.py
+++ b/src/apme_engine/observability/otel_setup.py
@@ -1,0 +1,149 @@
+"""OpenTelemetry metrics bootstrap for APME services.
+
+Enabled when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set and ``OTEL_SDK_DISABLED``
+is not truthy. Otherwise this module is a no-op so local CLI/daemon runs
+stay light without a collector.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_initialized = False
+_meter: Any = None
+_provider: Any = None
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def setup_otel(service_name: str | None = None) -> None:
+    """Initialize the global MeterProvider with an OTLP HTTP exporter.
+
+    Args:
+        service_name: Overrides ``OTEL_SERVICE_NAME`` when provided.
+    """
+    global _initialized, _meter, _provider
+    if _initialized:
+        return
+    _initialized = True
+
+    if _truthy(os.environ.get("OTEL_SDK_DISABLED")):
+        logger.info("OpenTelemetry disabled via OTEL_SDK_DISABLED")
+        return
+
+    endpoint = (os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or "").strip()
+    if not endpoint:
+        logger.debug("OpenTelemetry inactive: OTEL_EXPORTER_OTLP_ENDPOINT unset")
+        return
+
+    try:
+        from opentelemetry import metrics
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, View
+        from opentelemetry.sdk.resources import Resource
+
+        from apme_engine.observability.buckets import (
+            GALAXY_FETCH_DURATION_BUCKETS_S,
+            HTTP_DURATION_BUCKETS_S,
+            SCAN_DURATION_BUCKETS_S,
+            VALIDATOR_DURATION_BUCKETS_S,
+            VENV_DURATION_BUCKETS_S,
+        )
+    except ImportError:
+        logger.warning("OpenTelemetry packages missing; metrics export disabled")
+        return
+
+    name = (service_name or os.environ.get("OTEL_SERVICE_NAME") or "apme").strip()
+    resource_attrs: dict[str, str] = {"service.name": name}
+    extra = (os.environ.get("OTEL_RESOURCE_ATTRIBUTES") or "").strip()
+    for part in extra.split(","):
+        if "=" in part:
+            key, value = part.split("=", 1)
+            key, value = key.strip(), value.strip()
+            if key and value:
+                resource_attrs[key] = value
+
+    # Accept base endpoint (http://host:4318) or full metrics URL.
+    metrics_endpoint = endpoint
+    if not endpoint.rstrip("/").endswith("/v1/metrics"):
+        metrics_endpoint = endpoint.rstrip("/") + "/v1/metrics"
+
+    export_interval_ms = int(os.environ.get("OTEL_METRIC_EXPORT_INTERVAL", "10000"))
+    reader = PeriodicExportingMetricReader(
+        OTLPMetricExporter(endpoint=metrics_endpoint),
+        export_interval_millis=export_interval_ms,
+    )
+    # Enforce domain-tuned buckets (advisory alone is insufficient for quantile math).
+    views = [
+        View(
+            instrument_name="apme.scan.duration",
+            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(SCAN_DURATION_BUCKETS_S)),
+        ),
+        View(
+            instrument_name="apme.scan.phase.duration",
+            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
+        ),
+        View(
+            instrument_name="apme.validator.duration",
+            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
+        ),
+        View(
+            instrument_name="apme.http.server.duration",
+            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(HTTP_DURATION_BUCKETS_S)),
+        ),
+        View(
+            instrument_name="apme.venv.acquire.duration",
+            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VENV_DURATION_BUCKETS_S)),
+        ),
+        View(
+            instrument_name="apme.galaxy.fetch.duration",
+            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(GALAXY_FETCH_DURATION_BUCKETS_S)),
+        ),
+        View(
+            instrument_name="apme.galaxy.wheel.serve.duration",
+            aggregation=ExplicitBucketHistogramAggregation(boundaries=list(GALAXY_FETCH_DURATION_BUCKETS_S)),
+        ),
+    ]
+    _provider = MeterProvider(
+        resource=Resource.create(resource_attrs),
+        metric_readers=[reader],
+        views=views,
+    )
+    metrics.set_meter_provider(_provider)
+    _meter = metrics.get_meter("apme", "0.1.0")
+    logger.info(
+        "OpenTelemetry metrics enabled service=%s endpoint=%s interval_ms=%d",
+        name,
+        metrics_endpoint,
+        export_interval_ms,
+    )
+
+
+def get_meter() -> Any:
+    """Return the APME meter, or ``None`` when OTel is inactive.
+
+    Returns:
+        The configured meter instance, or ``None`` when export is disabled.
+    """
+    return _meter
+
+
+def shutdown_otel() -> None:
+    """Flush and shut down the MeterProvider if it was started."""
+    global _provider, _meter
+    if _provider is None:
+        return
+    try:
+        _provider.shutdown()
+    except Exception:  # noqa: BLE001 — best-effort teardown
+        logger.debug("OpenTelemetry shutdown failed", exc_info=True)
+    _provider = None
+    _meter = None

--- a/src/apme_engine/venv_manager/session.py
+++ b/src/apme_engine/venv_manager/session.py
@@ -814,6 +814,10 @@ class VenvSessionManager:
 
         Returns:
             A ``VenvSession`` with a ready-to-use venv.
+
+        Raises:
+            Exception: Re-raises unexpected acquire failures after recording
+                error metrics.
         """
         session_id = _sanitize_session_id(session_id)
         specs = collection_specs or []
@@ -828,93 +832,152 @@ class VenvSessionManager:
 
         logger.info("Venv: acquiring session=%s core=%s", session_id, pip_version)
         t0 = time.monotonic()
+        outcome = "create"
+        try:
+            with open(lock_path, "w") as lock_fd:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                try:
+                    self._touch_session(session_dir)
 
-        with open(lock_path, "w") as lock_fd:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            try:
-                self._touch_session(session_dir)
+                    existing = self._read_version_meta(meta_path)
+                    if existing is not None and venv_dir.is_dir():
+                        installed = set(existing.installed_collections)
+                        missing = set(specs) - installed
 
-                existing = self._read_version_meta(meta_path)
-                if existing is not None and venv_dir.is_dir():
-                    installed = set(existing.installed_collections)
-                    missing = set(specs) - installed
+                        if not missing:
+                            existing.last_used_at = time.time()
+                            self._write_version_meta(meta_path, existing)
+                            dur = (time.monotonic() - t0) * 1000
+                            logger.info(
+                                "Venv: ready (%.0fms, warm hit, %d collections)",
+                                dur,
+                                len(existing.installed_collections),
+                            )
+                            outcome = "warm"
+                            self._record_acquire_metrics(
+                                t0,
+                                outcome=outcome,
+                                ansible_version=pip_version,
+                                collections_requested=len(specs),
+                            )
+                            return existing
 
-                    if not missing:
+                        logger.debug("Venv: installing %d missing collections", len(missing))
+                        failed = install_collections_incremental(venv_dir, sorted(missing))
+                        succeeded = set(specs) - set(failed)
+                        existing.installed_collections = sorted(installed | succeeded)
+                        existing.failed_collections = sorted(failed)
                         existing.last_used_at = time.time()
                         self._write_version_meta(meta_path, existing)
                         dur = (time.monotonic() - t0) * 1000
-                        logger.info(
-                            "Venv: ready (%.0fms, warm hit, %d collections)",
-                            dur,
-                            len(existing.installed_collections),
+                        if failed:
+                            logger.warning(
+                                "Venv: ready with warnings (%.0fms, %d collections installed, %d failed: %s)",
+                                dur,
+                                len(existing.installed_collections),
+                                len(failed),
+                                ", ".join(failed),
+                            )
+                        else:
+                            logger.info(
+                                "Venv: ready (%.0fms, incremental, %d collections)",
+                                dur,
+                                len(existing.installed_collections),
+                            )
+                        outcome = "incremental"
+                        self._record_acquire_metrics(
+                            t0,
+                            outcome=outcome,
+                            ansible_version=pip_version,
+                            collections_requested=len(specs),
                         )
                         return existing
 
-                    logger.debug("Venv: installing %d missing collections", len(missing))
-                    failed = install_collections_incremental(venv_dir, sorted(missing))
-                    succeeded = set(specs) - set(failed)
-                    existing.installed_collections = sorted(installed | succeeded)
-                    existing.failed_collections = sorted(failed)
-                    existing.last_used_at = time.time()
-                    self._write_version_meta(meta_path, existing)
+                    version_dir.mkdir(parents=True, exist_ok=True)
+                    if venv_dir.is_dir():
+                        shutil.rmtree(venv_dir)
+
+                    logger.info("Venv: cold start — creating venv core=%s", pip_version)
+                    create_base_venv(venv_dir, pip_version)
+                    failed = []
+                    if specs:
+                        logger.debug("Venv: installing %d collections", len(specs))
+                        failed = install_collections_incremental(venv_dir, specs)
+
+                    succeeded_specs = sorted(set(specs) - set(failed))
+                    now = time.time()
+                    session = VenvSession(
+                        session_id=session_id,
+                        venv_root=venv_dir,
+                        ansible_version=pip_version,
+                        installed_collections=succeeded_specs,
+                        failed_collections=sorted(failed),
+                        created_at=now,
+                        last_used_at=now,
+                    )
+                    self._write_version_meta(meta_path, session)
                     dur = (time.monotonic() - t0) * 1000
                     if failed:
                         logger.warning(
-                            "Venv: ready with warnings (%.0fms, %d collections installed, %d failed: %s)",
+                            "Venv: ready with warnings (%.0fms, cold start, %d collections installed, %d failed: %s)",
                             dur,
-                            len(existing.installed_collections),
+                            len(succeeded_specs),
                             len(failed),
                             ", ".join(failed),
                         )
                     else:
                         logger.info(
-                            "Venv: ready (%.0fms, incremental, %d collections)",
+                            "Venv: ready (%.0fms, cold start, %d collections)",
                             dur,
-                            len(existing.installed_collections),
+                            len(succeeded_specs),
                         )
-                    return existing
-
-                version_dir.mkdir(parents=True, exist_ok=True)
-                if venv_dir.is_dir():
-                    shutil.rmtree(venv_dir)
-
-                logger.info("Venv: cold start — creating venv core=%s", pip_version)
-                create_base_venv(venv_dir, pip_version)
-                failed = []
-                if specs:
-                    logger.debug("Venv: installing %d collections", len(specs))
-                    failed = install_collections_incremental(venv_dir, specs)
-
-                succeeded_specs = sorted(set(specs) - set(failed))
-                now = time.time()
-                session = VenvSession(
-                    session_id=session_id,
-                    venv_root=venv_dir,
-                    ansible_version=pip_version,
-                    installed_collections=succeeded_specs,
-                    failed_collections=sorted(failed),
-                    created_at=now,
-                    last_used_at=now,
-                )
-                self._write_version_meta(meta_path, session)
-                dur = (time.monotonic() - t0) * 1000
-                if failed:
-                    logger.warning(
-                        "Venv: ready with warnings (%.0fms, cold start, %d collections installed, %d failed: %s)",
-                        dur,
-                        len(succeeded_specs),
-                        len(failed),
-                        ", ".join(failed),
+                    outcome = "create"
+                    self._record_acquire_metrics(
+                        t0,
+                        outcome=outcome,
+                        ansible_version=pip_version,
+                        collections_requested=len(specs),
                     )
-                else:
-                    logger.info(
-                        "Venv: ready (%.0fms, cold start, %d collections)",
-                        dur,
-                        len(succeeded_specs),
-                    )
-                return session
-            finally:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    return session
+                finally:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        except Exception:
+            self._record_acquire_metrics(
+                t0,
+                outcome=outcome,
+                ansible_version=pip_version,
+                collections_requested=len(specs),
+                status="error",
+            )
+            raise
+
+    @staticmethod
+    def _record_acquire_metrics(
+        t0: float,
+        *,
+        outcome: str,
+        ansible_version: str,
+        collections_requested: int,
+        status: str = "ok",
+    ) -> None:
+        """Emit OTel metrics for a completed (or failed) acquire.
+
+        Args:
+            t0: Monotonic start time from ``time.monotonic()``.
+            outcome: ``warm``, ``incremental``, or ``create``.
+            ansible_version: Normalised ansible-core version.
+            collections_requested: Number of collection specs requested.
+            status: ``ok`` or ``error``.
+        """
+        from apme_engine.observability import record_venv_acquire
+
+        record_venv_acquire(
+            time.monotonic() - t0,
+            outcome=outcome,
+            status=status,
+            ansible_core_version=ansible_version,
+            collections_requested=collections_requested,
+        )
 
     def touch(self, session_id: str) -> bool:
         """Update ``last_used_at`` on all venvs in the session to prevent expiry.

--- a/src/apme_engine/venv_manager/session.py
+++ b/src/apme_engine/venv_manager/session.py
@@ -969,15 +969,18 @@ class VenvSessionManager:
             collections_requested: Number of collection specs requested.
             status: ``ok`` or ``error``.
         """
-        from apme_engine.observability import record_venv_acquire
+        try:
+            from apme_engine.observability import record_venv_acquire
 
-        record_venv_acquire(
-            time.monotonic() - t0,
-            outcome=outcome,
-            status=status,
-            ansible_core_version=ansible_version,
-            collections_requested=collections_requested,
-        )
+            record_venv_acquire(
+                time.monotonic() - t0,
+                outcome=outcome,
+                status=status,
+                ansible_core_version=ansible_version,
+                collections_requested=collections_requested,
+            )
+        except Exception:  # noqa: BLE001 — metrics must never break venv acquire
+            logger.debug("Failed to record venv acquire metrics", exc_info=True)
 
     def touch(self, session_id: str) -> bool:
         """Update ``last_used_at`` on all venvs in the session to prevent expiry.

--- a/src/apme_gateway/app.py
+++ b/src/apme_gateway/app.py
@@ -53,4 +53,7 @@ def create_app() -> FastAPI:
     app.include_router(router)
     app.include_router(feedback_router)
     app.include_router(operation_router)
+    from apme_engine.observability.http_middleware import HttpMetricsMiddleware
+
+    app.add_middleware(HttpMetricsMiddleware, service="gateway")
     return app

--- a/src/apme_gateway/main.py
+++ b/src/apme_gateway/main.py
@@ -127,7 +127,13 @@ def main() -> None:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
         stream=sys.stderr,
     )
-    asyncio.run(_run())
+    from apme_engine.observability import setup_otel, shutdown_otel
+
+    setup_otel(service_name=os.environ.get("OTEL_SERVICE_NAME", "apme-gateway"))
+    try:
+        asyncio.run(_run())
+    finally:
+        shutdown_otel()
 
 
 if __name__ == "__main__":

--- a/src/galaxy_proxy/cli.py
+++ b/src/galaxy_proxy/cli.py
@@ -120,6 +120,12 @@ def main(argv: list[str] | None = None) -> None:
         ansible_galaxy_bin=args.ansible_galaxy_bin,
     )
 
+    from apme_engine.observability import setup_otel, shutdown_otel
+    from apme_engine.observability.http_middleware import HttpMetricsMiddleware
+
+    setup_otel(service_name=os.environ.get("OTEL_SERVICE_NAME", "apme-galaxy-proxy"))
+    app.add_middleware(HttpMetricsMiddleware, service="galaxy-proxy")
+
     host, port = args.host, args.port
     sys.stderr.write(f"Starting Galaxy Proxy on {host}:{port}\n")
     if parsed_servers:
@@ -134,7 +140,10 @@ def main(argv: list[str] | None = None) -> None:
     sys.stderr.write(f"Cache: {args.cache_dir or '~/.cache/ansible-collection-proxy'}\n")
     sys.stderr.flush()
 
-    uvicorn.run(app, host=host, port=port, log_level="info" if args.verbose else "warning")
+    try:
+        uvicorn.run(app, host=host, port=port, log_level="info" if args.verbose else "warning")
+    finally:
+        shutdown_otel()
 
 
 if __name__ == "__main__":

--- a/src/galaxy_proxy/collection_downloader.py
+++ b/src/galaxy_proxy/collection_downloader.py
@@ -15,6 +15,7 @@ import re
 import shutil
 import sys
 import tempfile
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -256,6 +257,8 @@ async def download_collections(
     env = dict(os.environ)
     process: asyncio.subprocess.Process | None = None
     temp_cfg_dir: Path | None = None
+    started = time.perf_counter()
+    status = "error"
 
     try:
         if servers:
@@ -311,9 +314,11 @@ async def download_collections(
             len(tarballs),
             len(collection_specs),
         )
+        status = "ok"
         return DownloadResult(tarball_paths=tarballs, stderr=stderr_text)
 
     except TimeoutError:
+        status = "timeout"
         logger.error(
             "ansible-galaxy collection download timed out after %.0fs",
             timeout,
@@ -337,6 +342,17 @@ async def download_collections(
     finally:
         if temp_cfg_dir is not None:
             shutil.rmtree(temp_cfg_dir, ignore_errors=True)
+        try:
+            from apme_engine.observability import record_galaxy_fetch
+
+            record_galaxy_fetch(
+                time.perf_counter() - started,
+                operation="download",
+                status=status,
+                collections_requested=len(collection_specs),
+            )
+        except Exception:  # noqa: BLE001 — never fail downloads for metrics
+            logger.debug("Failed to record Galaxy download metrics", exc_info=True)
 
 
 def download_collections_sync(

--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -13,9 +13,11 @@ import logging
 import os
 import re
 import tempfile
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -339,9 +341,24 @@ def create_app(
         if not filename.endswith(".whl") or "/" in filename or "\\" in filename or ".." in filename:
             raise HTTPException(status_code=404, detail=f"Invalid wheel filename: {filename}")
 
+        started = time.perf_counter()
+
+        def _record_serve(outcome: str, status: str = "ok") -> None:
+            try:
+                from apme_engine.observability import record_galaxy_wheel_serve
+
+                record_galaxy_wheel_serve(
+                    time.perf_counter() - started,
+                    outcome=outcome,
+                    status=status,
+                )
+            except Exception:  # noqa: BLE001 — never fail serves for metrics
+                logger.debug("Failed to record Galaxy wheel serve metrics", exc_info=True)
+
         cached = cache.get_wheel(filename)
         if cached:
             logger.info("Cache hit: %s", filename)
+            _record_serve("hit")
             return Response(
                 content=cached,
                 media_type="application/octet-stream",
@@ -371,6 +388,7 @@ def create_app(
             cached = cache.get_wheel(filename)
             if cached:
                 logger.info("Cache hit after lock: %s", filename)
+                _record_serve("hit")
                 return Response(
                     content=cached,
                     media_type="application/octet-stream",
@@ -397,6 +415,7 @@ def create_app(
                 )
             except Exception as exc:
                 logger.exception("Failed to download/convert %s.%s %s", ns, coll_name, version)
+                _record_serve("miss", status="error")
                 raise HTTPException(
                     status_code=502,
                     detail=(
@@ -408,6 +427,7 @@ def create_app(
             cache.put_wheel(whl_name, whl_data)
             logger.info("Converted and cached: %s (%d bytes)", whl_name, len(whl_data))
 
+        _record_serve("miss")
         return Response(
             content=whl_data,
             media_type="application/octet-stream",
@@ -656,6 +676,9 @@ async def _fetch_versions_from(
     headers: dict[str, str] = {}
     if token:
         headers["Authorization"] = f"Token {token}"
+    server_host = urlsplit(normalized).netloc or base_url
+    started = time.perf_counter()
+    status = "error"
     try:
         async with httpx.AsyncClient(
             timeout=15.0,
@@ -671,6 +694,8 @@ async def _fetch_versions_from(
                 if not payload.get("links", {}).get("next"):
                     break
                 params["offset"] = int(params["offset"]) + int(params["limit"])
+        status = "ok"
+        return versions
     except (httpx.HTTPError, KeyError, ValueError) as exc:
         logger.debug(
             "Version fetch from %s failed for %s.%s: %s",
@@ -680,7 +705,18 @@ async def _fetch_versions_from(
             exc,
         )
         return None
-    return versions
+    finally:
+        try:
+            from apme_engine.observability import record_galaxy_fetch
+
+            record_galaxy_fetch(
+                time.perf_counter() - started,
+                operation="version_lookup",
+                status=status,
+                server=server_host,
+            )
+        except Exception:  # noqa: BLE001 — never fail lookups for metrics
+            logger.debug("Failed to record Galaxy version-lookup metrics", exc_info=True)
 
 
 def _list_cached_wheels(cache: ProxyCache, namespace: str, name: str) -> list[str]:

--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -676,7 +676,7 @@ async def _fetch_versions_from(
     headers: dict[str, str] = {}
     if token:
         headers["Authorization"] = f"Token {token}"
-    server_host = urlsplit(normalized).netloc or base_url
+    server_host = urlsplit(normalized).hostname or ""
     started = time.perf_counter()
     status = "error"
     try:

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -50,8 +50,11 @@ def test_setup_otel_invalid_export_interval_is_noop_safe(monkeypatch: pytest.Mon
     otel_setup._initialized = False
     otel_setup._meter = None
     otel_setup._provider = None
-    otel_setup.setup_otel("test-service")  # must not raise
-    assert otel_setup._export_interval_ms() == 10000
+    try:
+        otel_setup.setup_otel("test-service")  # must not raise
+        assert otel_setup._export_interval_ms() == 10000
+    finally:
+        otel_setup.shutdown_otel()
 
 
 def test_shutdown_otel_allows_reinit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -1,0 +1,366 @@
+"""Tests for OpenTelemetry metrics helpers (no collector required)."""
+
+from __future__ import annotations
+
+import pytest
+
+from apme.v1.common_pb2 import ValidatorDiagnostics
+from apme.v1.primary_pb2 import ScanDiagnostics
+from apme_engine.observability import metrics as metrics_mod
+from apme_engine.observability import otel_setup
+
+
+def test_setup_otel_noop_without_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OTel stays inactive when no OTLP endpoint is configured.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    otel_setup._initialized = False
+    otel_setup._meter = None
+    otel_setup._provider = None
+    otel_setup.setup_otel("test-service")
+    assert otel_setup.get_meter() is None
+
+
+def test_setup_otel_respects_sdk_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OTEL_SDK_DISABLED=true disables export even when an endpoint is set.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    otel_setup._initialized = False
+    otel_setup._meter = None
+    otel_setup._provider = None
+    otel_setup.setup_otel("test-service")
+    assert otel_setup.get_meter() is None
+
+
+def test_record_scan_diagnostics_noop_without_meter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Recording diagnostics is a no-op when the meter was never started.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(metrics_mod, "_instruments_ready", False)
+    monkeypatch.setattr(metrics_mod, "_scan_duration", None)
+    monkeypatch.setattr(otel_setup, "_meter", None)
+    diag = ScanDiagnostics(total_ms=1234.0, fan_out_ms=100.0, engine_parse_ms=10.0)
+    metrics_mod.record_scan_diagnostics(diag)  # must not raise
+
+
+def test_record_scan_diagnostics_with_inmemory_reader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scan diagnostics populate expected OTel metric names in-memory.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, View
+    from opentelemetry.sdk.resources import Resource
+
+    from apme_engine.observability.buckets import (
+        SCAN_DURATION_BUCKETS_S,
+        VALIDATOR_DURATION_BUCKETS_S,
+    )
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+        views=[
+            View(
+                instrument_name="apme.scan.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(SCAN_DURATION_BUCKETS_S)),
+            ),
+            View(
+                instrument_name="apme.scan.phase.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
+            ),
+            View(
+                instrument_name="apme.validator.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
+            ),
+        ],
+    )
+    meter = provider.get_meter("apme", "0.1.0")
+
+    monkeypatch.setattr(otel_setup, "_meter", meter)
+    monkeypatch.setattr(metrics_mod, "_instruments_ready", False)
+    monkeypatch.setattr(metrics_mod, "_scan_duration", None)
+    monkeypatch.setattr(metrics_mod, "_phase_duration", None)
+    monkeypatch.setattr(metrics_mod, "_validator_duration", None)
+    monkeypatch.setattr(metrics_mod, "_http_duration", None)
+    monkeypatch.setattr(metrics_mod, "_scan_completed", None)
+
+    diag = ScanDiagnostics(
+        total_ms=2500.0,
+        fan_out_ms=400.0,
+        engine_parse_ms=100.0,
+        engine_annotate_ms=50.0,
+        engine_total_ms=200.0,
+        validators=[
+            ValidatorDiagnostics(validator_name="native", total_ms=300.0),
+            ValidatorDiagnostics(validator_name="opa", total_ms=80.0),
+        ],
+    )
+    metrics_mod.record_scan_diagnostics(diag, status="ok")
+
+    data = reader.get_metrics_data()
+    assert data is not None
+    names = {metric.name for rm in data.resource_metrics for sm in rm.scope_metrics for metric in sm.metrics}
+    assert "apme.scan.duration" in names
+    assert "apme.scan.phase.duration" in names
+    assert "apme.validator.duration" in names
+    assert "apme.scan.completed" in names
+
+    bounds_by_name: dict[str, list[float]] = {}
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                for point in metric.data.data_points:
+                    if hasattr(point, "explicit_bounds"):
+                        bounds_by_name[metric.name] = list(point.explicit_bounds)
+    assert bounds_by_name["apme.scan.duration"] == list(SCAN_DURATION_BUCKETS_S)
+    assert bounds_by_name["apme.validator.duration"] == list(VALIDATOR_DURATION_BUCKETS_S)
+    provider.shutdown()
+
+
+def test_validator_buckets_spread_subsecond_samples() -> None:
+    """Sub-second validators must not all collapse into a single 5s bucket."""
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, View
+    from opentelemetry.sdk.resources import Resource
+
+    from apme_engine.observability.buckets import VALIDATOR_DURATION_BUCKETS_S
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+        views=[
+            View(
+                instrument_name="apme.validator.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
+            ),
+        ],
+    )
+    hist = provider.get_meter("apme").create_histogram(
+        "apme.validator.duration",
+        unit="s",
+        explicit_bucket_boundaries_advisory=list(VALIDATOR_DURATION_BUCKETS_S),
+    )
+    for value in (0.14, 0.30, 0.34, 1.67, 3.29, 8.53):
+        hist.record(value)
+
+    data = reader.get_metrics_data()
+    point = next(
+        p for rm in data.resource_metrics for sm in rm.scope_metrics for m in sm.metrics for p in m.data.data_points
+    )
+    # More than one non-empty bucket → quantile math has resolution.
+    assert sum(1 for c in point.bucket_counts if c) >= 4
+    provider.shutdown()
+
+
+def test_record_venv_acquire_with_inmemory_reader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Venv acquire metrics use tuned buckets and outcome labels.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, View
+    from opentelemetry.sdk.resources import Resource
+
+    from apme_engine.observability.buckets import VENV_DURATION_BUCKETS_S
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+        views=[
+            View(
+                instrument_name="apme.venv.acquire.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VENV_DURATION_BUCKETS_S)),
+            ),
+        ],
+    )
+    meter = provider.get_meter("apme", "0.1.0")
+    monkeypatch.setattr(otel_setup, "_meter", meter)
+    monkeypatch.setattr(metrics_mod, "_instruments_ready", False)
+    monkeypatch.setattr(metrics_mod, "_scan_duration", None)
+    monkeypatch.setattr(metrics_mod, "_phase_duration", None)
+    monkeypatch.setattr(metrics_mod, "_validator_duration", None)
+    monkeypatch.setattr(metrics_mod, "_http_duration", None)
+    monkeypatch.setattr(metrics_mod, "_venv_duration", None)
+    monkeypatch.setattr(metrics_mod, "_venv_completed", None)
+    monkeypatch.setattr(metrics_mod, "_galaxy_fetch_duration", None)
+    monkeypatch.setattr(metrics_mod, "_galaxy_fetch_completed", None)
+    monkeypatch.setattr(metrics_mod, "_scan_completed", None)
+
+    metrics_mod.record_venv_acquire(
+        0.02,
+        outcome="warm",
+        ansible_core_version="2.17",
+        collections_requested=3,
+    )
+    metrics_mod.record_venv_acquire(
+        12.5,
+        outcome="create",
+        ansible_core_version="2.17",
+        collections_requested=3,
+    )
+
+    data = reader.get_metrics_data()
+    names = {metric.name for rm in data.resource_metrics for sm in rm.scope_metrics for metric in sm.metrics}
+    assert "apme.venv.acquire.duration" in names
+    assert "apme.venv.acquire.completed" in names
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == "apme.venv.acquire.duration":
+                    for point in metric.data.data_points:
+                        assert list(point.explicit_bounds) == list(VENV_DURATION_BUCKETS_S)
+    provider.shutdown()
+
+
+def test_record_galaxy_fetch_with_inmemory_reader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Galaxy fetch metrics cover download and version_lookup operations.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, View
+    from opentelemetry.sdk.resources import Resource
+
+    from apme_engine.observability.buckets import GALAXY_FETCH_DURATION_BUCKETS_S
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+        views=[
+            View(
+                instrument_name="apme.galaxy.fetch.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(GALAXY_FETCH_DURATION_BUCKETS_S)),
+            ),
+        ],
+    )
+    meter = provider.get_meter("apme", "0.1.0")
+    monkeypatch.setattr(otel_setup, "_meter", meter)
+    monkeypatch.setattr(metrics_mod, "_instruments_ready", False)
+    monkeypatch.setattr(metrics_mod, "_scan_duration", None)
+    monkeypatch.setattr(metrics_mod, "_phase_duration", None)
+    monkeypatch.setattr(metrics_mod, "_validator_duration", None)
+    monkeypatch.setattr(metrics_mod, "_http_duration", None)
+    monkeypatch.setattr(metrics_mod, "_venv_duration", None)
+    monkeypatch.setattr(metrics_mod, "_venv_completed", None)
+    monkeypatch.setattr(metrics_mod, "_galaxy_fetch_duration", None)
+    monkeypatch.setattr(metrics_mod, "_galaxy_fetch_completed", None)
+    monkeypatch.setattr(metrics_mod, "_galaxy_wheel_duration", None)
+    monkeypatch.setattr(metrics_mod, "_galaxy_wheel_completed", None)
+    monkeypatch.setattr(metrics_mod, "_scan_completed", None)
+
+    metrics_mod.record_galaxy_fetch(
+        8.2,
+        operation="download",
+        status="ok",
+        collections_requested=2,
+    )
+    metrics_mod.record_galaxy_fetch(
+        0.35,
+        operation="version_lookup",
+        status="ok",
+        server="galaxy.ansible.com",
+    )
+    metrics_mod.record_galaxy_fetch(
+        15.0,
+        operation="download",
+        status="timeout",
+        collections_requested=1,
+    )
+
+    data = reader.get_metrics_data()
+    names = {metric.name for rm in data.resource_metrics for sm in rm.scope_metrics for metric in sm.metrics}
+    assert "apme.galaxy.fetch.duration" in names
+    assert "apme.galaxy.fetch.completed" in names
+
+    ops: set[str] = set()
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == "apme.galaxy.fetch.duration":
+                    for point in metric.data.data_points:
+                        assert list(point.explicit_bounds) == list(GALAXY_FETCH_DURATION_BUCKETS_S)
+                        ops.add(point.attributes["operation"])
+    assert ops == {"download", "version_lookup"}
+    provider.shutdown()
+
+
+def test_record_galaxy_wheel_serve_with_inmemory_reader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wheel serve metrics distinguish cache hit vs miss.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, View
+    from opentelemetry.sdk.resources import Resource
+
+    from apme_engine.observability.buckets import GALAXY_FETCH_DURATION_BUCKETS_S
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+        views=[
+            View(
+                instrument_name="apme.galaxy.wheel.serve.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(GALAXY_FETCH_DURATION_BUCKETS_S)),
+            ),
+        ],
+    )
+    meter = provider.get_meter("apme", "0.1.0")
+    monkeypatch.setattr(otel_setup, "_meter", meter)
+    monkeypatch.setattr(metrics_mod, "_instruments_ready", False)
+    monkeypatch.setattr(metrics_mod, "_scan_duration", None)
+    monkeypatch.setattr(metrics_mod, "_phase_duration", None)
+    monkeypatch.setattr(metrics_mod, "_validator_duration", None)
+    monkeypatch.setattr(metrics_mod, "_http_duration", None)
+    monkeypatch.setattr(metrics_mod, "_venv_duration", None)
+    monkeypatch.setattr(metrics_mod, "_venv_completed", None)
+    monkeypatch.setattr(metrics_mod, "_galaxy_fetch_duration", None)
+    monkeypatch.setattr(metrics_mod, "_galaxy_fetch_completed", None)
+    monkeypatch.setattr(metrics_mod, "_galaxy_wheel_duration", None)
+    monkeypatch.setattr(metrics_mod, "_galaxy_wheel_completed", None)
+    monkeypatch.setattr(metrics_mod, "_scan_completed", None)
+
+    metrics_mod.record_galaxy_wheel_serve(0.002, outcome="hit")
+    metrics_mod.record_galaxy_wheel_serve(11.0, outcome="miss")
+    metrics_mod.record_galaxy_wheel_serve(3.0, outcome="miss", status="error")
+
+    data = reader.get_metrics_data()
+    names = {metric.name for rm in data.resource_metrics for sm in rm.scope_metrics for metric in sm.metrics}
+    assert "apme.galaxy.wheel.serve.duration" in names
+    assert "apme.galaxy.wheel.serve.completed" in names
+
+    outcomes: set[str] = set()
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == "apme.galaxy.wheel.serve.duration":
+                    for point in metric.data.data_points:
+                        assert list(point.explicit_bounds) == list(GALAXY_FETCH_DURATION_BUCKETS_S)
+                        outcomes.add(point.attributes["outcome"])
+    assert outcomes == {"hit", "miss"}
+    provider.shutdown()

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -25,6 +25,52 @@ def test_setup_otel_noop_without_endpoint(monkeypatch: pytest.MonkeyPatch) -> No
     assert otel_setup.get_meter() is None
 
 
+def test_ensure_instruments_does_not_latch_before_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """record_* before setup_otel must not permanently disable instruments.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(otel_setup, "_meter", None)
+    monkeypatch.setattr(metrics_mod, "_instruments_ready", False)
+    monkeypatch.setattr(metrics_mod, "_scan_duration", None)
+    metrics_mod.record_scan_diagnostics(ScanDiagnostics(total_ms=1.0))
+    assert metrics_mod._instruments_ready is False
+
+
+def test_setup_otel_invalid_export_interval_is_noop_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed OTEL_METRIC_EXPORT_INTERVAL must not raise from setup_otel.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318")
+    monkeypatch.setenv("OTEL_METRIC_EXPORT_INTERVAL", "not-an-int")
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    otel_setup._initialized = False
+    otel_setup._meter = None
+    otel_setup._provider = None
+    otel_setup.setup_otel("test-service")  # must not raise
+    assert otel_setup._export_interval_ms() == 10000
+
+
+def test_shutdown_otel_allows_reinit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """shutdown_otel clears the initialized latch for a later setup_otel.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    otel_setup._initialized = True
+    otel_setup._meter = object()
+    otel_setup._provider = None
+    otel_setup.shutdown_otel()
+    assert otel_setup._initialized is False
+    assert otel_setup.get_meter() is None
+    otel_setup.setup_otel("again")
+    assert otel_setup._initialized is True
+
+
 def test_setup_otel_respects_sdk_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     """OTEL_SDK_DISABLED=true disables export even when an endpoint is set.
 

--- a/uv.lock
+++ b/uv.lock
@@ -267,6 +267,9 @@ dependencies = [
     { name = "joblib" },
     { name = "jsonpickle" },
     { name = "networkx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "pip-audit" },
     { name = "protobuf" },
@@ -323,6 +326,9 @@ requires-dist = [
     { name = "jsonpickle" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "networkx", specifier = ">=3.1" },
+    { name = "opentelemetry-api", specifier = ">=1.44.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.44.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.44.0" },
     { name = "packaging", specifier = ">=23" },
     { name = "pip-audit", specifier = ">=2.7" },
     { name = "protobuf", specifier = ">=7.35.1,<8" },
@@ -840,6 +846,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -1439,6 +1457,87 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/21/16/df7857783279384c910ac6c5272699a226fcec9dc8969b4fe230069d2f99/onigurumacffi-1.5.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d2e195b0255f88616af19021ebd6344a00d5a0df01a78c8c43729cf0b9c9fb9c", size = 605635, upload-time = "2026-01-25T23:12:46.256Z" },
     { url = "https://files.pythonhosted.org/packages/e2/7c/fda92bcc28c6ef05d6ce4cfd0f85e7a70e6fa9ea3a23fb7fe1b4cf6ef092/onigurumacffi-1.5.0-cp310-abi3-win32.whl", hash = "sha256:995a3a0d932df3995f6e9b081c4c5881ed6bc19c53d9c24d64a51eb21f46989c", size = 178808, upload-time = "2026-01-25T23:12:47.658Z" },
     { url = "https://files.pythonhosted.org/packages/a3/67/6461766dc7e7baea1b02df2c081ac7efcde3edf9cb74a80f570a7dc0566b/onigurumacffi-1.5.0-cp310-abi3-win_amd64.whl", hash = "sha256:862795245ac165913f146e81d18e5419c91f98f50a5eccba02e1ba6d781e8e26", size = 193354, upload-time = "2026-01-25T23:12:49.074Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add optional OpenTelemetry metrics (OTLP/HTTP) from Primary, Gateway, and Galaxy Proxy to an in-pod collector sidecar, with a local Prometheus/Grafana companion stack for development.
- Instrument scan/phase/validator durations, venv acquire outcomes (`warm`/`incremental`/`create`), outbound Galaxy fetch (`download`/`version_lookup`), and wheel serve cache hit/miss.
- Apps remain emitter-only toward `127.0.0.1:4318`; the sidecar aggregates for Prom scrape (`:8889`). OTLP forward-out tracked in https://github.com/ansible/apme/issues/457.
- **ADR-067** documents OTel as the metrics standard and why the in-pod collector is required (coexists with ADR-013); includes acceptance criteria and tox verification.
- Review hardening: safe OTel bootstrap/shutdown, bucketed labels, `status=error` on failed scans, loopback obs UI, generated Grafana password, hostname-only Galaxy `server` label, best-effort metrics guards at all call sites (`eefac58`).

## Test plan
- [x] `tox -e lint`
- [x] `tox -e unit -- tests/test_observability_metrics.py tests/test_galaxy_proxy_server.py --no-cov`
- [x] CI: prek / test / integration / ui
- [x] Local: cold Terrible Playbook scans + forced wheel miss/hit populate Grafana panels
- [ ] Optional: `containers/observability/up.sh` and confirm APME Scan Times dashboard