### PR TITLE
feat(observability): validator gRPC server OTel middleware

### DIFF
--- a/.sdlc/adrs/ADR-067-otel-metrics-in-pod-collector.md
+++ b/.sdlc/adrs/ADR-067-otel-metrics-in-pod-collector.md
@@ -158,7 +158,10 @@ strictly simpler and safer than fan-out from every container.
   `OTEL_EXPORTER_OTLP_ENDPOINT` is set; never raises to callers.
 - Instruments: `apme_engine.observability.metrics` (`apme.scan.*`,
   `apme.venv.acquire.*`, `apme.galaxy.fetch.*`, `apme.galaxy.wheel.serve.*`,
-  `apme.http.server.*`).
+  `apme.http.server.*`, `apme.grpc.server.*`).
+- Validator RPC middleware: `GrpcMetricsInterceptor` via
+  `apme_engine.daemon.validator_grpc.start_validator_server` (all six
+  validators). Distinct from Primary's `apme.validator.duration` (ADR-013).
 - Pod: `otel-collector` in `containers/podman/pod.yaml`; config under
   `containers/observability/` / collector config in-tree.
 - Local dashboards: `containers/observability/up.sh` (Prometheus + Grafana
@@ -228,3 +231,4 @@ curl -sf http://127.0.0.1:8889/metrics | head
 |------|--------|
 | 2026-07-29 | Initial — OTel metrics standard + in-pod collector aggregation |
 | 2026-07-29 | Add acceptance criteria, phase assignment, tox verification |
+| 2026-07-29 | Note validator gRPC server middleware (`apme.grpc.server.*`) |

--- a/.sdlc/adrs/ADR-067-otel-metrics-in-pod-collector.md
+++ b/.sdlc/adrs/ADR-067-otel-metrics-in-pod-collector.md
@@ -173,9 +173,10 @@ strictly simpler and safer than fan-out from every container.
 
 ## Acceptance Criteria
 
-- [x] Instrumented services (Primary, Gateway, Galaxy Proxy) emit OTLP/HTTP
-      only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set; otherwise metrics are
-      no-op and startup never fails on OTel misconfiguration.
+- [x] Instrumented services (Primary, Gateway, Galaxy Proxy, and the six
+      validators via `apme.grpc.server.*`) emit OTLP/HTTP only when
+      `OTEL_EXPORTER_OTLP_ENDPOINT` is set; otherwise metrics are no-op and
+      startup never fails on OTel misconfiguration.
 - [x] Reference pod includes an `otel-collector` sidecar; apps target
       `http://127.0.0.1:4318`; Prometheus scrape is available on `:8889`.
 - [x] Metric attributes avoid high-cardinality and secret leakage (coarse

--- a/containers/observability/README.md
+++ b/containers/observability/README.md
@@ -43,7 +43,7 @@ samples arrive.
 ./containers/observability/down.sh --wipe   # also delete TSDB
 ```
 
-## Metrics (P0)
+## Metrics
 
 | OTel name | Prometheus (typical) | Source |
 |-----------|----------------------|--------|
@@ -51,6 +51,8 @@ samples arrive.
 | `apme.scan.phase.duration` | `apme_scan_phase_duration_seconds` | Primary |
 | `apme.validator.duration` | `apme_validator_duration_seconds` | Primary (from ADR-013) |
 | `apme.scan.completed` | `apme_scan_completed_total` | Primary |
+| `apme.grpc.server.duration` | `apme_grpc_server_duration_seconds` | Validators (`Validate` / `Health`) |
+| `apme.grpc.server.completed` | `apme_grpc_server_completed_total` | Validators |
 | `apme.http.server.duration` | `apme_http_server_duration_seconds` | Gateway, Galaxy Proxy |
 | `apme.venv.acquire.duration` | `apme_venv_acquire_duration_seconds` | Primary (`outcome=warm`, `incremental`, or `create`) |
 | `apme.venv.acquire.completed` | `apme_venv_acquire_completed_total` | Primary |

--- a/containers/observability/grafana/dashboards/apme-scan-times.json
+++ b/containers/observability/grafana/dashboards/apme-scan-times.json
@@ -1,5 +1,7 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -10,12 +12,24 @@
       "title": "Scan duration p50 / p95 / p99",
       "description": "Needs recent samples in the rate window; blank between scans is expected",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 10, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "s",
-          "custom": { "drawStyle": "line", "fillOpacity": 10, "spanNulls": true }
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "spanNulls": true
+          }
         }
       },
       "targets": [
@@ -38,14 +52,26 @@
     },
     {
       "title": "Scan duration mean (lifetime)",
-      "description": "Instant _sum/_count — stays populated between scans (cumulative mean since app process start)",
+      "description": "Instant _sum/_count \u2014 stays populated between scans (cumulative mean since app process start)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 10, "x": 10, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 10,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "s",
-          "custom": { "drawStyle": "line", "fillOpacity": 10, "spanNulls": true }
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "spanNulls": true
+          }
         }
       },
       "targets": [
@@ -59,8 +85,16 @@
     {
       "title": "Scans total",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum(apme_scan_completed_total) or vector(0)",
@@ -71,8 +105,16 @@
     {
       "title": "Scan errors total",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 4 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum(apme_scan_completed_total{status=\"error\"}) or vector(0)",
@@ -83,10 +125,23 @@
     {
       "title": "Phase duration p95",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -98,12 +153,25 @@
     },
     {
       "title": "Phase duration mean (lifetime)",
-      "description": "Instant _sum/_count by phase — populated even with no recent scans",
+      "description": "Instant _sum/_count by phase \u2014 populated even with no recent scans",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -116,10 +184,23 @@
     {
       "title": "Validator duration p95",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -131,12 +212,25 @@
     },
     {
       "title": "Validator duration mean (lifetime)",
-      "description": "Instant _sum/_count by validator — use this between scans; not bucket-estimated",
+      "description": "Instant _sum/_count by validator \u2014 use this between scans; not bucket-estimated",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -147,12 +241,166 @@
       ]
     },
     {
+      "title": "Validator gRPC Validate p95",
+      "description": "Live Validate RPC latency per validator process (server middleware). Distinct from ADR-013 apme_validator_duration_* recorded by Primary after fan-out.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(apme_grpc_server_duration_seconds_bucket{rpc_method=\"Validate\"}[5m])) by (le, service))",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Validator gRPC Validate mean (lifetime)",
+      "description": "Instant _sum/_count by service for Validate RPCs \u2014 populated between scans",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (service) (apme_grpc_server_duration_seconds_sum{rpc_method=\"Validate\"}) / clamp_min(sum by (service) (apme_grpc_server_duration_seconds_count{rpc_method=\"Validate\"}), 1)",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Validator gRPC Health mean (lifetime)",
+      "description": "Health RPC latency by service \u2014 useful for hung-validator detection",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (service) (apme_grpc_server_duration_seconds_sum{rpc_method=\"Health\"}) / clamp_min(sum by (service) (apme_grpc_server_duration_seconds_count{rpc_method=\"Health\"}), 1)",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Validator gRPC RPCs total",
+      "description": "Cumulative completed RPCs by service, method, and status",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 12,
+        "y": 32
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "spanNulls": true
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (service, rpc_method, rpc_grpc_status_code) (apme_grpc_server_completed_total) or vector(0)",
+          "legendFormat": "{{service}} {{rpc_method}} {{rpc_grpc_status_code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Validator gRPC non-OK total",
+      "description": "Completed RPCs whose status is not OK",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 32
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum(apme_grpc_server_completed_total{rpc_grpc_status_code!=\"OK\"}) or vector(0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
       "title": "Gateway HTTP duration p95",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -166,10 +414,23 @@
       "title": "Gateway HTTP duration mean (lifetime)",
       "description": "Instant _sum/_count by method",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -181,12 +442,25 @@
     },
     {
       "title": "Galaxy Proxy HTTP duration p95",
-      "description": "PEP 503 / collection wheel traffic — split from Gateway for proxy internals",
+      "description": "PEP 503 / collection wheel traffic \u2014 split from Gateway for proxy internals",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -198,12 +472,25 @@
     },
     {
       "title": "Galaxy Proxy HTTP duration mean (lifetime)",
-      "description": "Instant _sum/_count by method — populated between scans",
+      "description": "Instant _sum/_count by method \u2014 populated between scans",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -215,12 +502,25 @@
     },
     {
       "title": "Galaxy Proxy request count (lifetime)",
-      "description": "Cumulative request counts by method/status — not rate-based",
+      "description": "Cumulative request counts by method/status \u2014 not rate-based",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 40 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "short", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -232,12 +532,25 @@
     },
     {
       "title": "Venv acquire duration mean (lifetime)",
-      "description": "Session venv warm / incremental / create — exact _sum/_count",
+      "description": "Session venv warm / incremental / create \u2014 exact _sum/_count",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 64
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -251,10 +564,23 @@
       "title": "Venv acquire p95",
       "description": "Needs recent acquires in the rate window",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 64
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -267,8 +593,16 @@
     {
       "title": "Venv acquires total",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 56 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 72
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum by (outcome) (apme_venv_acquire_completed_total) or vector(0)",
@@ -280,8 +614,16 @@
     {
       "title": "Venv acquire errors total",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 56 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 72
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum(apme_venv_acquire_completed_total{status=\"error\"}) or vector(0)",
@@ -293,10 +635,23 @@
       "title": "Galaxy fetch duration mean (lifetime)",
       "description": "Outbound Ansible Galaxy: ansible-galaxy download vs API version lookup",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 60 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -310,10 +665,23 @@
       "title": "Galaxy fetch p95",
       "description": "Needs recent Galaxy fetches in the rate window",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 60 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -326,8 +694,16 @@
     {
       "title": "Galaxy fetches total",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 68 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 84
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum by (operation, status) (apme_galaxy_fetch_completed_total) or vector(0)",
@@ -339,8 +715,16 @@
     {
       "title": "Galaxy fetch errors/timeouts",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 68 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 84
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum(apme_galaxy_fetch_completed_total{status=~\"error|timeout\"}) or vector(0)",
@@ -352,10 +736,23 @@
       "title": "Galaxy wheel serve mean (lifetime)",
       "description": "GET /wheels cache hit vs miss (miss includes ansible-galaxy download)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 72 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 88
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -369,10 +766,23 @@
       "title": "Galaxy wheel serve p95",
       "description": "Needs recent wheel serves in the rate window",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 72 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 88
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "custom": { "spanNulls": true } }
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "spanNulls": true
+          }
+        }
       },
       "targets": [
         {
@@ -385,8 +795,16 @@
     {
       "title": "Galaxy wheel serves total",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 80 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 96
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
         {
           "expr": "sum by (outcome, status) (apme_galaxy_wheel_serve_completed_total) or vector(0)",
@@ -399,10 +817,22 @@
       "title": "Galaxy wheel cache hit ratio",
       "description": "hits / (hits + misses) from completed counters",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 80 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 96
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "percentunit", "min": 0, "max": 1 }
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
       },
       "targets": [
         {
@@ -413,11 +843,20 @@
     }
   ],
   "schemaVersion": 39,
-  "tags": ["apme", "otel"],
-  "templating": { "list": [] },
-  "time": { "from": "now-30m", "to": "now" },
+  "tags": [
+    "apme",
+    "grpc",
+    "otel"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
   "timezone": "browser",
   "title": "APME Scan Times",
   "uid": "apme-scan-times",
-  "version": 7
+  "version": 8
 }

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -64,6 +64,14 @@ spec:
       env:
         - name: APME_NATIVE_VALIDATOR_LISTEN
           value: "0.0.0.0:50055"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://127.0.0.1:4318"
+        - name: OTEL_SERVICE_NAME
+          value: "apme-native"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.namespace=apme,service.instance.id=apme-pod"
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: "10000"
       ports:
         - containerPort: 50055
           hostPort: 50055
@@ -72,6 +80,14 @@ spec:
       env:
         - name: APME_OPA_VALIDATOR_LISTEN
           value: "0.0.0.0:50054"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://127.0.0.1:4318"
+        - name: OTEL_SERVICE_NAME
+          value: "apme-opa"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.namespace=apme,service.instance.id=apme-pod"
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: "10000"
       ports:
         - containerPort: 50054
           hostPort: 50054
@@ -82,6 +98,14 @@ spec:
           value: "0.0.0.0:50053"
         - name: APME_GALAXY_PROXY_URL
           value: "http://127.0.0.1:8765"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://127.0.0.1:4318"
+        - name: OTEL_SERVICE_NAME
+          value: "apme-ansible"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.namespace=apme,service.instance.id=apme-pod"
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: "10000"
       ports:
         - containerPort: 50053
           hostPort: 50053
@@ -94,6 +118,14 @@ spec:
       env:
         - name: APME_GITLEAKS_VALIDATOR_LISTEN
           value: "0.0.0.0:50056"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://127.0.0.1:4318"
+        - name: OTEL_SERVICE_NAME
+          value: "apme-gitleaks"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.namespace=apme,service.instance.id=apme-pod"
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: "10000"
       ports:
         - containerPort: 50056
           hostPort: 50056
@@ -102,6 +134,14 @@ spec:
       env:
         - name: APME_COLLECTION_HEALTH_VALIDATOR_LISTEN
           value: "0.0.0.0:50058"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://127.0.0.1:4318"
+        - name: OTEL_SERVICE_NAME
+          value: "apme-collection-health"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.namespace=apme,service.instance.id=apme-pod"
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: "10000"
       ports:
         - containerPort: 50058
           hostPort: 50058
@@ -114,6 +154,14 @@ spec:
       env:
         - name: APME_DEP_AUDIT_VALIDATOR_LISTEN
           value: "0.0.0.0:50059"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://127.0.0.1:4318"
+        - name: OTEL_SERVICE_NAME
+          value: "apme-dep-audit"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.namespace=apme,service.instance.id=apme-pod"
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: "10000"
       ports:
         - containerPort: 50059
           hostPort: 50059

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -443,7 +443,7 @@ The underlying scripts in `containers/podman/` remain directly callable for debu
 
 ### Observability (OTel → Prometheus → Grafana)
 
-The pod includes an `otel-collector` that scrapes as **http://localhost:8889/metrics**. Primary exports scan/phase/validator duration histograms; Gateway and Galaxy Proxy export HTTP request durations.
+The pod includes an `otel-collector` that scrapes as **http://localhost:8889/metrics**. Primary exports scan/phase/validator duration histograms; each validator exports `apme.grpc.server.*` for `Validate`/`Health` RPCs; Gateway and Galaxy Proxy export HTTP request durations. See ADR-067.
 
 ```bash
 ./containers/observability/up.sh     # Prometheus :9091, Grafana :3002

--- a/src/apme_engine/daemon/ansible_validator_main.py
+++ b/src/apme_engine/daemon/ansible_validator_main.py
@@ -26,8 +26,10 @@ def main() -> None:
     Uses APME_ANSIBLE_VALIDATOR_LISTEN for bind address. Exits with code 1 on failure.
     """
     from apme_engine.log_bridge import install_handler
+    from apme_engine.observability import setup_otel, shutdown_otel
 
     install_handler()
+    setup_otel(service_name=os.environ.get("OTEL_SERVICE_NAME", "apme-ansible"))
 
     listen = os.environ.get("APME_ANSIBLE_VALIDATOR_LISTEN", "0.0.0.0:50053")
     try:
@@ -37,6 +39,8 @@ def main() -> None:
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
         sys.exit(1)
+    finally:
+        shutdown_otel()
 
 
 if __name__ == "__main__":

--- a/src/apme_engine/daemon/ansible_validator_server.py
+++ b/src/apme_engine/daemon/ansible_validator_server.py
@@ -255,18 +255,11 @@ async def serve(listen: str = "0.0.0.0:50053") -> grpc.aio.Server:
     Returns:
         Started gRPC server (caller must wait_for_termination).
     """
-    server = grpc.aio.server(
-        maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
-        options=[
-            ("grpc.max_receive_message_length", 50 * 1024 * 1024),
-            ("grpc.max_send_message_length", 50 * 1024 * 1024),
-        ],
+    from apme_engine.daemon.validator_grpc import start_validator_server
+
+    return await start_validator_server(
+        AnsibleValidatorServicer(),
+        listen,
+        service="ansible",
+        max_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
     )
-    validate_pb2_grpc.add_ValidatorServicer_to_server(AnsibleValidatorServicer(), server)  # type: ignore[no-untyped-call]
-    if ":" in listen:
-        _, _, port = listen.rpartition(":")
-        server.add_insecure_port(f"[::]:{port}")
-    else:
-        server.add_insecure_port(listen)
-    await server.start()
-    return server

--- a/src/apme_engine/daemon/collection_health_main.py
+++ b/src/apme_engine/daemon/collection_health_main.py
@@ -22,8 +22,10 @@ def main() -> None:
     Exits with code 1 on failure.
     """
     from apme_engine.log_bridge import install_handler
+    from apme_engine.observability import setup_otel, shutdown_otel
 
     install_handler()
+    setup_otel(service_name=os.environ.get("OTEL_SERVICE_NAME", "apme-collection-health"))
 
     listen = os.environ.get("APME_COLLECTION_HEALTH_VALIDATOR_LISTEN", "0.0.0.0:50058")
     try:
@@ -33,6 +35,8 @@ def main() -> None:
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
         sys.exit(1)
+    finally:
+        shutdown_otel()
 
 
 if __name__ == "__main__":

--- a/src/apme_engine/daemon/collection_health_server.py
+++ b/src/apme_engine/daemon/collection_health_server.py
@@ -155,6 +155,6 @@ async def serve(listen: str = "0.0.0.0:50058") -> grpc.aio.Server:
     return await start_validator_server(
         CollectionHealthValidatorServicer(),
         listen,
-        service="collection-health",
+        service="collection_health",
         max_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
     )

--- a/src/apme_engine/daemon/collection_health_server.py
+++ b/src/apme_engine/daemon/collection_health_server.py
@@ -150,18 +150,11 @@ async def serve(listen: str = "0.0.0.0:50058") -> grpc.aio.Server:
     Returns:
         Started gRPC server (caller must wait_for_termination).
     """
-    server = grpc.aio.server(
-        maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
-        options=[
-            ("grpc.max_receive_message_length", 50 * 1024 * 1024),
-            ("grpc.max_send_message_length", 50 * 1024 * 1024),
-        ],
+    from apme_engine.daemon.validator_grpc import start_validator_server
+
+    return await start_validator_server(
+        CollectionHealthValidatorServicer(),
+        listen,
+        service="collection-health",
+        max_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
     )
-    validate_pb2_grpc.add_ValidatorServicer_to_server(CollectionHealthValidatorServicer(), server)  # type: ignore[no-untyped-call]
-    if ":" in listen:
-        _, _, port = listen.rpartition(":")
-        server.add_insecure_port(f"[::]:{port}")
-    else:
-        server.add_insecure_port(listen)
-    await server.start()
-    return server

--- a/src/apme_engine/daemon/dep_audit_main.py
+++ b/src/apme_engine/daemon/dep_audit_main.py
@@ -21,8 +21,10 @@ def main() -> None:
     Uses APME_DEP_AUDIT_VALIDATOR_LISTEN for bind address. Exits with code 1 on failure.
     """
     from apme_engine.log_bridge import install_handler
+    from apme_engine.observability import setup_otel, shutdown_otel
 
     install_handler()
+    setup_otel(service_name=os.environ.get("OTEL_SERVICE_NAME", "apme-dep-audit"))
 
     listen = os.environ.get("APME_DEP_AUDIT_VALIDATOR_LISTEN", "0.0.0.0:50059")
     try:
@@ -32,6 +34,8 @@ def main() -> None:
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
         sys.exit(1)
+    finally:
+        shutdown_otel()
 
 
 if __name__ == "__main__":

--- a/src/apme_engine/daemon/dep_audit_server.py
+++ b/src/apme_engine/daemon/dep_audit_server.py
@@ -156,6 +156,6 @@ async def serve(listen: str = "0.0.0.0:50059") -> grpc.aio.Server:
     return await start_validator_server(
         DepAuditValidatorServicer(),
         listen,
-        service="dep-audit",
+        service="dep_audit",
         max_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
     )

--- a/src/apme_engine/daemon/dep_audit_server.py
+++ b/src/apme_engine/daemon/dep_audit_server.py
@@ -151,18 +151,11 @@ async def serve(listen: str = "0.0.0.0:50059") -> grpc.aio.Server:
     Returns:
         Started gRPC server (caller must wait_for_termination).
     """
-    server = grpc.aio.server(
-        maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
-        options=[
-            ("grpc.max_receive_message_length", 50 * 1024 * 1024),
-            ("grpc.max_send_message_length", 50 * 1024 * 1024),
-        ],
+    from apme_engine.daemon.validator_grpc import start_validator_server
+
+    return await start_validator_server(
+        DepAuditValidatorServicer(),
+        listen,
+        service="dep-audit",
+        max_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
     )
-    validate_pb2_grpc.add_ValidatorServicer_to_server(DepAuditValidatorServicer(), server)  # type: ignore[no-untyped-call]
-    if ":" in listen:
-        _, _, port = listen.rpartition(":")
-        server.add_insecure_port(f"[::]:{port}")
-    else:
-        server.add_insecure_port(listen)
-    await server.start()
-    return server

--- a/src/apme_engine/daemon/gitleaks_validator_main.py
+++ b/src/apme_engine/daemon/gitleaks_validator_main.py
@@ -21,8 +21,10 @@ def main() -> None:
     Uses APME_GITLEAKS_VALIDATOR_LISTEN for bind address. Exits with code 1 on failure.
     """
     from apme_engine.log_bridge import install_handler
+    from apme_engine.observability import setup_otel, shutdown_otel
 
     install_handler()
+    setup_otel(service_name=os.environ.get("OTEL_SERVICE_NAME", "apme-gitleaks"))
 
     listen = os.environ.get("APME_GITLEAKS_VALIDATOR_LISTEN", "0.0.0.0:50056")
     try:
@@ -32,6 +34,8 @@ def main() -> None:
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
         sys.exit(1)
+    finally:
+        shutdown_otel()
 
 
 if __name__ == "__main__":

--- a/src/apme_engine/daemon/gitleaks_validator_server.py
+++ b/src/apme_engine/daemon/gitleaks_validator_server.py
@@ -235,18 +235,11 @@ async def serve(listen: str = "0.0.0.0:50056") -> grpc.aio.Server:
     Returns:
         Started gRPC server (caller must wait_for_termination).
     """
-    server = grpc.aio.server(
-        maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
-        options=[
-            ("grpc.max_receive_message_length", 50 * 1024 * 1024),
-            ("grpc.max_send_message_length", 50 * 1024 * 1024),
-        ],
+    from apme_engine.daemon.validator_grpc import start_validator_server
+
+    return await start_validator_server(
+        GitleaksValidatorServicer(),
+        listen,
+        service="gitleaks",
+        max_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
     )
-    validate_pb2_grpc.add_ValidatorServicer_to_server(GitleaksValidatorServicer(), server)  # type: ignore[no-untyped-call]
-    if ":" in listen:
-        _, _, port = listen.rpartition(":")
-        server.add_insecure_port(f"[::]:{port}")
-    else:
-        server.add_insecure_port(listen)
-    await server.start()
-    return server

--- a/src/apme_engine/daemon/native_validator_main.py
+++ b/src/apme_engine/daemon/native_validator_main.py
@@ -18,8 +18,10 @@ async def _run(listen: str) -> None:
 def main() -> None:
     """Run the Native validator gRPC server (entry point)."""
     from apme_engine.log_bridge import install_handler
+    from apme_engine.observability import setup_otel, shutdown_otel
 
     install_handler()
+    setup_otel(service_name=os.environ.get("OTEL_SERVICE_NAME", "apme-native"))
 
     listen = os.environ.get("APME_NATIVE_VALIDATOR_LISTEN", "0.0.0.0:50055")
     try:
@@ -29,6 +31,8 @@ def main() -> None:
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
         sys.exit(1)
+    finally:
+        shutdown_otel()
 
 
 if __name__ == "__main__":

--- a/src/apme_engine/daemon/native_validator_server.py
+++ b/src/apme_engine/daemon/native_validator_server.py
@@ -184,18 +184,11 @@ async def serve(listen: str = "0.0.0.0:50055") -> grpc.aio.Server:
     Returns:
         Started gRPC server (caller must wait_for_termination).
     """
-    server = grpc.aio.server(
-        maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
-        options=[
-            ("grpc.max_receive_message_length", 50 * 1024 * 1024),
-            ("grpc.max_send_message_length", 50 * 1024 * 1024),
-        ],
+    from apme_engine.daemon.validator_grpc import start_validator_server
+
+    return await start_validator_server(
+        NativeValidatorServicer(),
+        listen,
+        service="native",
+        max_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
     )
-    validate_pb2_grpc.add_ValidatorServicer_to_server(NativeValidatorServicer(), server)  # type: ignore[no-untyped-call]
-    if ":" in listen:
-        _, _, port = listen.rpartition(":")
-        server.add_insecure_port(f"[::]:{port}")
-    else:
-        server.add_insecure_port(listen)
-    await server.start()
-    return server

--- a/src/apme_engine/daemon/opa_validator_main.py
+++ b/src/apme_engine/daemon/opa_validator_main.py
@@ -26,8 +26,10 @@ def main() -> None:
     Uses APME_OPA_VALIDATOR_LISTEN for bind address. Exits with code 1 on failure.
     """
     from apme_engine.log_bridge import install_handler
+    from apme_engine.observability import setup_otel, shutdown_otel
 
     install_handler()
+    setup_otel(service_name=os.environ.get("OTEL_SERVICE_NAME", "apme-opa"))
 
     listen = os.environ.get("APME_OPA_VALIDATOR_LISTEN", "0.0.0.0:50054")
     try:
@@ -37,6 +39,8 @@ def main() -> None:
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
         sys.exit(1)
+    finally:
+        shutdown_otel()
 
 
 if __name__ == "__main__":

--- a/src/apme_engine/daemon/opa_validator_server.py
+++ b/src/apme_engine/daemon/opa_validator_server.py
@@ -143,18 +143,11 @@ async def serve(listen: str = "0.0.0.0:50054") -> grpc.aio.Server:
     Returns:
         Started gRPC server (caller must wait_for_termination).
     """
-    server = grpc.aio.server(
-        maximum_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
-        options=[
-            ("grpc.max_receive_message_length", 50 * 1024 * 1024),
-            ("grpc.max_send_message_length", 50 * 1024 * 1024),
-        ],
+    from apme_engine.daemon.validator_grpc import start_validator_server
+
+    return await start_validator_server(
+        OpaValidatorServicer(),
+        listen,
+        service="opa",
+        max_concurrent_rpcs=_MAX_CONCURRENT_RPCS,
     )
-    validate_pb2_grpc.add_ValidatorServicer_to_server(OpaValidatorServicer(), server)  # type: ignore[no-untyped-call]
-    if ":" in listen:
-        _, _, port = listen.rpartition(":")
-        server.add_insecure_port(f"[::]:{port}")
-    else:
-        server.add_insecure_port(listen)
-    await server.start()
-    return server

--- a/src/apme_engine/daemon/validator_grpc.py
+++ b/src/apme_engine/daemon/validator_grpc.py
@@ -1,0 +1,47 @@
+"""Shared helpers for APME Validator gRPC aio servers."""
+
+from __future__ import annotations
+
+import grpc
+import grpc.aio
+
+from apme.v1 import validate_pb2_grpc
+from apme_engine.observability.grpc_middleware import GrpcMetricsInterceptor
+
+_DEFAULT_OPTIONS: list[tuple[str, int]] = [
+    ("grpc.max_receive_message_length", 50 * 1024 * 1024),
+    ("grpc.max_send_message_length", 50 * 1024 * 1024),
+]
+
+
+async def start_validator_server(
+    servicer: validate_pb2_grpc.ValidatorServicer,
+    listen: str,
+    *,
+    service: str,
+    max_concurrent_rpcs: int,
+) -> grpc.aio.Server:
+    """Create, bind, and start a Validator gRPC server with metrics middleware.
+
+    Args:
+        servicer: Concrete ``ValidatorServicer`` implementation.
+        listen: Host:port (or bare port) to bind.
+        service: Short service label for OTel attributes (``native``, ``opa``, …).
+        max_concurrent_rpcs: gRPC concurrent RPC limit for this process.
+
+    Returns:
+        Started gRPC server (caller must ``wait_for_termination``).
+    """
+    server = grpc.aio.server(
+        interceptors=[GrpcMetricsInterceptor(service=service)],
+        maximum_concurrent_rpcs=max_concurrent_rpcs,
+        options=list(_DEFAULT_OPTIONS),
+    )
+    validate_pb2_grpc.add_ValidatorServicer_to_server(servicer, server)  # type: ignore[no-untyped-call]
+    if ":" in listen:
+        _, _, port = listen.rpartition(":")
+        server.add_insecure_port(f"[::]:{port}")
+    else:
+        server.add_insecure_port(listen)
+    await server.start()
+    return server

--- a/src/apme_engine/daemon/validator_grpc.py
+++ b/src/apme_engine/daemon/validator_grpc.py
@@ -25,7 +25,7 @@ async def start_validator_server(
 
     Args:
         servicer: Concrete ``ValidatorServicer`` implementation.
-        listen: Host:port (or bare port) to bind.
+        listen: Address passed to ``add_insecure_port`` (e.g. ``0.0.0.0:50059``).
         service: Short service label for OTel attributes (``native``, ``opa``, …).
         max_concurrent_rpcs: gRPC concurrent RPC limit for this process.
 
@@ -38,10 +38,8 @@ async def start_validator_server(
         options=list(_DEFAULT_OPTIONS),
     )
     validate_pb2_grpc.add_ValidatorServicer_to_server(servicer, server)  # type: ignore[no-untyped-call]
-    if ":" in listen:
-        _, _, port = listen.rpartition(":")
-        server.add_insecure_port(f"[::]:{port}")
-    else:
-        server.add_insecure_port(listen)
+    # Honor the configured address (e.g. 0.0.0.0:50059 or 127.0.0.1:50059).
+    # Do not rewrite host:port to [::]:port — that would expand loopback to a wildcard.
+    server.add_insecure_port(listen)
     await server.start()
     return server

--- a/src/apme_engine/observability/__init__.py
+++ b/src/apme_engine/observability/__init__.py
@@ -7,6 +7,7 @@ This package exports fleet/ops metrics via OTLP when configured.
 from apme_engine.observability.metrics import (
     record_galaxy_fetch,
     record_galaxy_wheel_serve,
+    record_grpc_request,
     record_scan_diagnostics,
     record_venv_acquire,
 )
@@ -16,6 +17,7 @@ __all__ = [
     "get_meter",
     "record_galaxy_fetch",
     "record_galaxy_wheel_serve",
+    "record_grpc_request",
     "record_scan_diagnostics",
     "record_venv_acquire",
     "setup_otel",

--- a/src/apme_engine/observability/grpc_middleware.py
+++ b/src/apme_engine/observability/grpc_middleware.py
@@ -1,0 +1,115 @@
+"""gRPC aio server interceptor that records RPC durations via OTel metrics."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import grpc
+from grpc import aio
+
+logger = logging.getLogger("apme.observability.grpc")
+
+
+def _method_label(full_method: str) -> str:
+    """Return the bare RPC method name from a full gRPC path.
+
+    Args:
+        full_method: Path like ``/apme.v1.Validator/Validate``.
+
+    Returns:
+        Trailing segment (e.g. ``Validate``), or ``unknown``.
+    """
+    if not full_method:
+        return "unknown"
+    return full_method.rsplit("/", 1)[-1] or "unknown"
+
+
+def _status_label(context: Any) -> str:
+    """Map the active servicer context code to a stable label.
+
+    Args:
+        context: Active gRPC aio servicer context.
+
+    Returns:
+        Status code name (e.g. ``OK``, ``INTERNAL``).
+    """
+    try:
+        code = context.code()
+    except Exception:  # noqa: BLE001 — best-effort status only
+        return "UNKNOWN"
+    if code is None:
+        return "OK"
+    return getattr(code, "name", None) or str(code)
+
+
+class GrpcMetricsInterceptor(aio.ServerInterceptor):  # type: ignore[type-arg]
+    """Record ``apme.grpc.server.duration`` for unary RPCs.
+
+    Metrics failures are swallowed so observability never breaks the RPC.
+    """
+
+    def __init__(self, *, service: str) -> None:
+        """Tag metrics with a logical service name.
+
+        Args:
+            service: Short validator label (``native``, ``opa``, …).
+        """
+        self.service = service
+
+    async def intercept_service(
+        self,
+        continuation: Callable[[grpc.HandlerCallDetails], Awaitable[Any]],
+        handler_call_details: grpc.HandlerCallDetails,
+    ) -> Any:
+        """Wrap the resolved handler to time unary-unary RPCs.
+
+        Args:
+            continuation: Next interceptor / handler lookup.
+            handler_call_details: Incoming call metadata.
+
+        Returns:
+            Possibly wrapped ``RpcMethodHandler``, or ``None``.
+        """
+        handler = await continuation(handler_call_details)
+        if handler is None:
+            return None
+
+        method = _method_label(handler_call_details.method)
+        if handler.unary_unary is None:
+            return handler
+
+        original = handler.unary_unary
+
+        async def unary_unary_wrapper(request: Any, context: Any) -> Any:
+            started = time.perf_counter()
+            status = "OK"
+            try:
+                return await original(request, context)
+            except Exception:
+                status = _status_label(context)
+                if status == "OK":
+                    status = "UNKNOWN"
+                raise
+            finally:
+                if status == "OK":
+                    status = _status_label(context)
+                try:
+                    from apme_engine.observability.metrics import record_grpc_request
+
+                    record_grpc_request(
+                        time.perf_counter() - started,
+                        method=method,
+                        status_code=status,
+                        service=self.service,
+                    )
+                except Exception:  # noqa: BLE001 — metrics must never break RPCs
+                    logger.debug("Failed to record gRPC metrics", exc_info=True)
+
+        return grpc.unary_unary_rpc_method_handler(
+            unary_unary_wrapper,
+            request_deserializer=handler.request_deserializer,
+            response_serializer=handler.response_serializer,
+        )

--- a/src/apme_engine/observability/metrics.py
+++ b/src/apme_engine/observability/metrics.py
@@ -34,6 +34,8 @@ _galaxy_fetch_duration: Any = None
 _galaxy_fetch_completed: Any = None
 _galaxy_wheel_duration: Any = None
 _galaxy_wheel_completed: Any = None
+_grpc_duration: Any = None
+_grpc_completed: Any = None
 _instruments_ready = False
 
 
@@ -46,7 +48,8 @@ def _ensure_instruments() -> bool:
     global _scan_duration, _phase_duration, _validator_duration, _scan_completed
     global _http_duration, _venv_duration, _venv_completed
     global _galaxy_fetch_duration, _galaxy_fetch_completed
-    global _galaxy_wheel_duration, _galaxy_wheel_completed, _instruments_ready
+    global _galaxy_wheel_duration, _galaxy_wheel_completed
+    global _grpc_duration, _grpc_completed, _instruments_ready
     if _instruments_ready:
         return _scan_duration is not None
 
@@ -119,6 +122,17 @@ def _ensure_instruments() -> bool:
         unit="{scan}",
         description="Completed APME scans by status",
     )
+    _grpc_duration = meter.create_histogram(
+        name="apme.grpc.server.duration",
+        unit="s",
+        description="gRPC server RPC duration (Validator Validate/Health)",
+        explicit_bucket_boundaries_advisory=list(VALIDATOR_DURATION_BUCKETS_S),
+    )
+    _grpc_completed = meter.create_counter(
+        name="apme.grpc.server.completed",
+        unit="{rpc}",
+        description="Completed gRPC server RPCs by method and status",
+    )
     return True
 
 
@@ -127,7 +141,8 @@ def reset_instruments() -> None:
     global _scan_duration, _phase_duration, _validator_duration, _scan_completed
     global _http_duration, _venv_duration, _venv_completed
     global _galaxy_fetch_duration, _galaxy_fetch_completed
-    global _galaxy_wheel_duration, _galaxy_wheel_completed, _instruments_ready
+    global _galaxy_wheel_duration, _galaxy_wheel_completed
+    global _grpc_duration, _grpc_completed, _instruments_ready
     _scan_duration = None
     _phase_duration = None
     _validator_duration = None
@@ -139,6 +154,8 @@ def reset_instruments() -> None:
     _galaxy_fetch_completed = None
     _galaxy_wheel_duration = None
     _galaxy_wheel_completed = None
+    _grpc_duration = None
+    _grpc_completed = None
     _instruments_ready = False
 
 
@@ -255,6 +272,40 @@ def record_http_request(duration_s: float, *, method: str, status_code: int, ser
         )
     except Exception:  # noqa: BLE001
         logger.debug("Failed to record HTTP metrics", exc_info=True)
+
+
+def record_grpc_request(
+    duration_s: float,
+    *,
+    method: str,
+    status_code: str,
+    service: str,
+) -> None:
+    """Record a gRPC server RPC duration (validator ``Validate`` / ``Health``).
+
+    Distinct from ``apme.validator.duration``, which Primary records from
+    ADR-013 scan diagnostics after fan-out completes.
+
+    Args:
+        duration_s: RPC wall time in seconds.
+        method: Bare RPC method name (``Validate``, ``Health``).
+        status_code: gRPC status code name (``OK``, ``INTERNAL``, …).
+        service: Logical service label (``native``, ``opa``, …).
+    """
+    if not _ensure_instruments():
+        return
+    if _grpc_duration is None or _grpc_completed is None:
+        return
+    try:
+        attrs = {
+            "rpc.method": method or "unknown",
+            "rpc.grpc.status_code": status_code or "UNKNOWN",
+            "service": service or "unknown",
+        }
+        _grpc_duration.record(max(duration_s, 0.0), attrs)
+        _grpc_completed.add(1, attrs)
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to record gRPC metrics", exc_info=True)
 
 
 def record_galaxy_fetch(

--- a/src/apme_engine/observability/otel_setup.py
+++ b/src/apme_engine/observability/otel_setup.py
@@ -141,6 +141,10 @@ def setup_otel(service_name: str | None = None) -> None:
                 instrument_name="apme.galaxy.wheel.serve.duration",
                 aggregation=ExplicitBucketHistogramAggregation(boundaries=list(GALAXY_FETCH_DURATION_BUCKETS_S)),
             ),
+            View(
+                instrument_name="apme.grpc.server.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
+            ),
         ]
         _provider = MeterProvider(
             resource=Resource.create(resource_attrs),

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -413,3 +413,90 @@ def test_record_galaxy_wheel_serve_with_inmemory_reader(monkeypatch: pytest.Monk
                         outcomes.add(point.attributes["outcome"])
     assert outcomes == {"hit", "miss"}
     provider.shutdown()
+
+
+def test_record_grpc_request_with_inmemory_reader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Validator gRPC server metrics cover Validate/Health by service.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, View
+    from opentelemetry.sdk.resources import Resource
+
+    from apme_engine.observability.buckets import VALIDATOR_DURATION_BUCKETS_S
+
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+        views=[
+            View(
+                instrument_name="apme.grpc.server.duration",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=list(VALIDATOR_DURATION_BUCKETS_S)),
+            ),
+        ],
+    )
+    meter = provider.get_meter("apme", "0.1.0")
+    monkeypatch.setattr(otel_setup, "_meter", meter)
+    monkeypatch.setattr(metrics_mod, "_instruments_ready", False)
+    metrics_mod.reset_instruments()
+
+    metrics_mod.record_grpc_request(0.12, method="Validate", status_code="OK", service="opa")
+    metrics_mod.record_grpc_request(0.01, method="Health", status_code="OK", service="opa")
+    metrics_mod.record_grpc_request(2.5, method="Validate", status_code="INTERNAL", service="native")
+
+    data = reader.get_metrics_data()
+    names = {metric.name for rm in data.resource_metrics for sm in rm.scope_metrics for metric in sm.metrics}
+    assert "apme.grpc.server.duration" in names
+    assert "apme.grpc.server.completed" in names
+
+    methods: set[str] = set()
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == "apme.grpc.server.duration":
+                    for point in metric.data.data_points:
+                        assert list(point.explicit_bounds) == list(VALIDATOR_DURATION_BUCKETS_S)
+                        methods.add(point.attributes["rpc.method"])
+    assert methods == {"Validate", "Health"}
+    provider.shutdown()
+
+
+def test_grpc_method_label_and_interceptor_wraps_unary() -> None:
+    """Interceptor extracts method names and wraps unary-unary handlers."""
+    import asyncio
+    from types import SimpleNamespace
+
+    import grpc
+
+    from apme_engine.observability.grpc_middleware import GrpcMetricsInterceptor, _method_label
+
+    assert _method_label("/apme.v1.Validator/Validate") == "Validate"
+    assert _method_label("") == "unknown"
+
+    async def _run() -> None:
+        called = {"n": 0}
+
+        async def original(request: object, context: object) -> str:
+            called["n"] += 1
+            return "ok"
+
+        handler = grpc.unary_unary_rpc_method_handler(original)
+        interceptor = GrpcMetricsInterceptor(service="opa")
+
+        async def continuation(_details: object) -> object:
+            return handler
+
+        details = SimpleNamespace(method="/apme.v1.Validator/Validate")
+        wrapped = await interceptor.intercept_service(continuation, details)  # type: ignore[arg-type]
+        assert wrapped is not None
+        assert wrapped.unary_unary is not None
+        context = SimpleNamespace(code=lambda: None)
+        result = await wrapped.unary_unary({"x": 1}, context)
+        assert result == "ok"
+        assert called["n"] == 1
+
+    asyncio.run(_run())

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -466,9 +466,10 @@ def test_record_grpc_request_with_inmemory_reader(monkeypatch: pytest.MonkeyPatc
 
 
 def test_grpc_method_label_and_interceptor_wraps_unary() -> None:
-    """Interceptor extracts method names and wraps unary-unary handlers."""
+    """Interceptor extracts method names, wraps unary handlers, and records metrics."""
     import asyncio
     from types import SimpleNamespace
+    from unittest.mock import patch
 
     import grpc
 
@@ -479,24 +480,63 @@ def test_grpc_method_label_and_interceptor_wraps_unary() -> None:
 
     async def _run() -> None:
         called = {"n": 0}
+        recorded: list[dict[str, object]] = []
 
         async def original(request: object, context: object) -> str:
             called["n"] += 1
             return "ok"
 
-        handler = grpc.unary_unary_rpc_method_handler(original)
-        interceptor = GrpcMetricsInterceptor(service="opa")
+        async def failing(request: object, context: object) -> str:
+            raise RuntimeError("boom")
 
-        async def continuation(_details: object) -> object:
-            return handler
+        def _record(
+            duration_s: float,
+            *,
+            method: str,
+            status_code: str,
+            service: str,
+        ) -> None:
+            recorded.append(
+                {
+                    "duration_s": duration_s,
+                    "method": method,
+                    "status_code": status_code,
+                    "service": service,
+                }
+            )
+
+        interceptor = GrpcMetricsInterceptor(service="collection_health")
+
+        async def continuation_ok(_details: object) -> object:
+            return grpc.unary_unary_rpc_method_handler(original)
+
+        async def continuation_fail(_details: object) -> object:
+            return grpc.unary_unary_rpc_method_handler(failing)
 
         details = SimpleNamespace(method="/apme.v1.Validator/Validate")
-        wrapped = await interceptor.intercept_service(continuation, details)  # type: ignore[arg-type]
-        assert wrapped is not None
-        assert wrapped.unary_unary is not None
-        context = SimpleNamespace(code=lambda: None)
-        result = await wrapped.unary_unary({"x": 1}, context)
-        assert result == "ok"
-        assert called["n"] == 1
+        with patch(
+            "apme_engine.observability.metrics.record_grpc_request",
+            side_effect=_record,
+        ):
+            wrapped = await interceptor.intercept_service(continuation_ok, details)  # type: ignore[arg-type]
+            assert wrapped is not None
+            assert wrapped.unary_unary is not None
+            context = SimpleNamespace(code=lambda: None)
+            result = await wrapped.unary_unary({"x": 1}, context)
+            assert result == "ok"
+            assert called["n"] == 1
+            assert len(recorded) == 1
+            assert recorded[0]["method"] == "Validate"
+            assert recorded[0]["status_code"] == "OK"
+            assert recorded[0]["service"] == "collection_health"
+            assert isinstance(recorded[0]["duration_s"], float)
+
+            wrapped_fail = await interceptor.intercept_service(continuation_fail, details)  # type: ignore[arg-type]
+            assert wrapped_fail is not None
+            assert wrapped_fail.unary_unary is not None
+            with pytest.raises(RuntimeError, match="boom"):
+                await wrapped_fail.unary_unary({"x": 1}, context)
+            assert len(recorded) == 2
+            assert recorded[1]["status_code"] == "UNKNOWN"
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Add a shared aio gRPC `ServerInterceptor` so all six validators emit `apme.grpc.server.duration` / `apme.grpc.server.completed` for incoming `Validate` / `Health` RPCs (distinct from Primary’s ADR-013 `apme.validator.duration`).
- Wire `setup_otel` / `shutdown_otel` + podman `OTEL_*` on every validator container; extend the Scan Times Grafana dashboard with Validate/Health latency and RPC status panels.

## Changes
- `GrpcMetricsInterceptor` + `start_validator_server()` used by native, opa, ansible, gitleaks, collection_health, dep_audit
- Metric attrs: `service` (aligned with ADR-013 validator names), `rpc.method`, `rpc.grpc.status_code`
- `start_validator_server` passes the configured listen address unchanged to `add_insecure_port` (no `[::]` rewrite)
- Grafana: Validate p95/mean, Health mean, RPC totals, non-OK count
- Docs: ADR-067 notes/acceptance, observability README, DEVELOPMENT.md
- Unit coverage for instruments + interceptor record/exception paths

## Test plan
- [x] `tox -e lint`
- [x] `tox -e unit -- tests/test_observability_metrics.py --no-cov` (13 passed)
- [x] CI green after bind-address fix (`2d5cd74`)
- [ ] Optional: `tox -e up` + `containers/observability/up.sh`, run a scan, confirm new panels populate

## Follow-ups
- Helm `OTEL_*` on engine validators/collector: https://github.com/ansible/apme/issues/487
- OTLP forward-out: https://github.com/ansible/apme/issues/457