### PR TITLE
build(ui): consolidate ui-workflow release into main APME release

### DIFF
--- a/.github/workflows/ui-workflow-release.yml
+++ b/.github/workflows/ui-workflow-release.yml
@@ -15,7 +15,9 @@ concurrency:
 
 jobs:
   attach-tarball:
-    if: startsWith(github.event.release.tag_name, 'v')
+    if: >-
+      startsWith(github.event.release.tag_name, 'v')
+      && github.event.release.prerelease == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -60,4 +62,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
           TARBALL: ${{ steps.ver.outputs.tarball }}
-        run: gh release upload "${TAG}" "frontend/${TARBALL}"
+        run: gh release upload --clobber "${TAG}" "frontend/${TARBALL}"

--- a/.github/workflows/ui-workflow-release.yml
+++ b/.github/workflows/ui-workflow-release.yml
@@ -1,78 +1,57 @@
-# Pack @apme/ui-workflow and attach the tarball to a GitHub Release (ADR-066).
-# Tag format: ui-workflow-vX.Y.Z (must match package.json version).
-name: UI workflow package release
+# Attach @apme/ui-workflow tarball to the main APME release (ADR-066).
+# Runs after a GitHub Release is published; derives version from the tag.
+name: UI workflow package artifact
 
 on:
-  push:
-    tags:
-      - "ui-workflow-v*"
+  release:
+    types: [published]
 
 permissions:
   contents: write
 
 concurrency:
-  group: ui-workflow-release-${{ github.ref }}
+  group: ui-workflow-release-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
-  release:
+  attach-tarball:
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
-          # Privileged job + npm ci — do not leave GITHUB_TOKEN in .git/config.
+          ref: ${{ github.event.release.tag_name }}
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          # No Actions cache: tag-triggered release has contents:write; avoid
-          # restoring a lockfile-keyed cache that a less-trusted job could poison.
           node-version: "24"
+
+      - name: Derive version from tag
+        id: ver
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_EVENT_RELEASE_TAG#v}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "tarball=apme-ui-workflow-${VERSION}.tgz" >> "${GITHUB_OUTPUT}"
+        env:
+          GITHUB_EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
 
       - name: Install frontend deps
         working-directory: frontend
         run: npm ci
 
-      - name: Assert tag matches package version
-        id: ver
-        working-directory: frontend
-        run: |
-          set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
-          EXPECTED="${TAG#ui-workflow-v}"
-          PKG_VER="$(node -p "require('./packages/ui-workflow/package.json').version")"
-          if [[ "${PKG_VER}" != "${EXPECTED}" ]]; then
-            echo "::error::Tag ${TAG} expects version ${EXPECTED}, package.json has ${PKG_VER}"
-            exit 1
-          fi
-          echo "version=${PKG_VER}" >> "${GITHUB_OUTPUT}"
-          echo "tarball=apme-ui-workflow-${PKG_VER}.tgz" >> "${GITHUB_OUTPUT}"
+      - name: Stamp version into package.json
+        working-directory: frontend/packages/ui-workflow
+        run: npm version "${{ steps.ver.outputs.version }}" --no-git-tag-version
 
-      - name: npm pack (runs package prepack → tsc + CSS copy)
+      - name: npm pack (runs prepack → tsc + CSS copy)
         working-directory: frontend
         run: npm pack ./packages/ui-workflow
 
-      - name: Create GitHub Release
+      - name: Upload tarball to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.ver.outputs.version }}
+          TAG: ${{ github.event.release.tag_name }}
           TARBALL: ${{ steps.ver.outputs.tarball }}
-        run: |
-          set -euo pipefail
-          # Escape backticks for Markdown fences; do not escape quotes (heredoc
-          # would otherwise emit literal backslash-quote in the release body).
-          gh release create "${GITHUB_REF_NAME}" \
-            "frontend/${TARBALL}" \
-            --title "@apme/ui-workflow v${VERSION}" \
-            --notes "$(cat <<EOF
-          ## \`@apme/ui-workflow\` v${VERSION}
-
-          Install (Yarn / npm):
-
-          \`\`\`json
-          "@apme/ui-workflow": "https://github.com/ansible/apme/releases/download/${GITHUB_REF_NAME}/${TARBALL}"
-          \`\`\`
-
-          See [ADR-066](https://github.com/ansible/apme/blob/main/.sdlc/adrs/ADR-066-ui-workflow-github-release-artifacts.md).
-          EOF
-          )"
+        run: gh release upload "${TAG}" "frontend/${TARBALL}"

--- a/.github/workflows/ui-workflow-release.yml
+++ b/.github/workflows/ui-workflow-release.yml
@@ -32,8 +32,12 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${GITHUB_EVENT_RELEASE_TAG#v}"
-          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
-          echo "tarball=apme-ui-workflow-${VERSION}.tgz" >> "${GITHUB_OUTPUT}"
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must use vX.Y.Z format: ${GITHUB_EVENT_RELEASE_TAG}"
+            exit 1
+          fi
+          printf 'version=%s\n' "${VERSION}" >> "${GITHUB_OUTPUT}"
+          printf 'tarball=apme-ui-workflow-%s.tgz\n' "${VERSION}" >> "${GITHUB_OUTPUT}"
         env:
           GITHUB_EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
 
@@ -43,7 +47,9 @@ jobs:
 
       - name: Stamp version into package.json
         working-directory: frontend/packages/ui-workflow
-        run: npm version "${{ steps.ver.outputs.version }}" --no-git-tag-version
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: npm version "${VERSION}" --no-git-tag-version
 
       - name: npm pack (runs prepack → tsc + CSS copy)
         working-directory: frontend

--- a/.sdlc/adrs/ADR-066-ui-workflow-github-release-artifacts.md
+++ b/.sdlc/adrs/ADR-066-ui-workflow-github-release-artifacts.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Implemented
+Superseded (consolidated into main release)
 
 ## Date
 
-2026-07-23
+2026-07-23 (revised 2026-07-31)
 
 ## Context
 
@@ -21,14 +21,20 @@ Constraints and drivers:
 - Portal (Yarn Berry / Backstage) must install a consumable package without
   cloning the APME monorepo as a workspace.
 - No npmjs org/process is required for the interim EAP path.
-- UI packages iterate faster than full APME product releases (`vX.Y.Z`).
+- ~~UI packages iterate faster than full APME product releases (`vX.Y.Z`).~~
+  In practice, ui-workflow releases track product releases anyway.
 - Native SPA must keep using the in-repo npm workspace (`workspace:*`).
 
 ## Decision
 
-**We will publish `@apme/ui-workflow` as an `npm pack` `.tgz` attached to
-dedicated GitHub Releases tagged `ui-workflow-vX.Y.Z`.** Portal (and other
-hosts) pin the HTTPS release asset URL. npmjs and GitHub Packages are deferred.
+~~**We will publish `@apme/ui-workflow` as an `npm pack` `.tgz` attached to
+dedicated GitHub Releases tagged `ui-workflow-vX.Y.Z`.**~~
+
+**Revised:** The `@apme/ui-workflow` tarball is attached as an asset to the
+main APME product release (`vX.Y.Z`). There is no separate versioning or tag
+convention — the package version is derived from the release tag at build time.
+Portal (and other hosts) pin the HTTPS release asset URL on the product release.
+npmjs and GitHub Packages remain deferred.
 
 ## Alternatives Considered
 
@@ -74,12 +80,29 @@ monorepo.
 
 **Why not chosen**: Vendoring failed as a durable dual-shell strategy.
 
+### Alternative 4: Separate `ui-workflow-vX.Y.Z` tag convention (original ADR-066)
+
+**Description**: Publish via dedicated GitHub Releases tagged
+`ui-workflow-vX.Y.Z` with independent semver.
+
+**Pros**:
+- UI can ship between product releases
+
+**Cons**:
+- Extra tag lifecycle and version bookkeeping
+- In practice, releases always tracked product cadence anyway
+- Consumers must track two release streams
+
+**Why not chosen**: Complexity not justified — product releases are frequent
+enough and the UI package tracks them naturally.
+
 ## Consequences
 
 ### Positive
 
 - Portal installs from a pinned Release download URL; no vendor tree.
-- UI can ship between product releases via `ui-workflow-v*` tags.
+- Single release cadence — no separate tag lifecycle to manage.
+- Package version always matches the product version (no drift).
 - Native SPA unchanged (`workspace:*`).
 
 ### Negative
@@ -91,24 +114,29 @@ monorepo.
   immutable releases / protected tags. Without that, maintainers can still
   replace an asset (delete + re-upload); consumers relying on lockfile
   checksums should treat unexpected hash changes as a supply-chain signal.
+- UI-only fixes must wait for the next product release (no out-of-band ship).
 
 ### Neutral
 
-- Product `vX.Y.Z` releases may optionally attach the same asset later.
 - Migration to GitHub Packages or npmjs remains a follow-up without changing
-  the package’s public API.
+  the package's public API.
 
 ## Implementation Notes
 
 - Package: not `private`; `prepack` runs `tsc` + copies CSS into `dist/`;
-  `files` includes `dist/` and README.
-- CI: `.github/workflows/ui-workflow-release.yml` on tag `ui-workflow-v*`:
-  assert version matches tag → `npm pack` → `gh release create` with `.tgz`.
+  `files` includes `dist/` and README. `package.json` version is `0.0.0-dev`
+  (placeholder); the real version is injected from the release tag at build
+  time via `npm version --no-git-tag-version`.
+- CI: `.github/workflows/ui-workflow-release.yml` triggers on
+  `release: published` (main `vX.Y.Z` releases). Derives version from the
+  tag, stamps package.json, runs `npm pack`, and uploads the `.tgz` to the
+  existing release.
 - Portal: depend on
-  `https://github.com/ansible/apme/releases/download/ui-workflow-vX.Y.Z/apme-ui-workflow-X.Y.Z.tgz`
+  `https://github.com/ansible/apme/releases/download/vX.Y.Z/apme-ui-workflow-X.Y.Z.tgz`
   and `--embed-package @apme/ui-workflow` for dynamic plugin export.
-- Release steps: bump `frontend/packages/ui-workflow/package.json` version,
-  merge, tag `ui-workflow-vX.Y.Z`, push tag.
+- Release steps: create the main APME release as usual — the workflow
+  automatically attaches the tarball. No manual version bump needed for the
+  UI package.
 
 ## Related Decisions
 
@@ -122,3 +150,4 @@ monorepo.
 | Date | Change |
 |------|--------|
 | 2026-07-23 | Initial — GitHub Release tarball publish for `@apme/ui-workflow` |
+| 2026-07-31 | Consolidated into main APME release; removed separate `ui-workflow-v*` tag convention |

--- a/.sdlc/adrs/ADR-066-ui-workflow-github-release-artifacts.md
+++ b/.sdlc/adrs/ADR-066-ui-workflow-github-release-artifacts.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Superseded (consolidated into main release)
+Accepted (revised 2026-07-31: consolidated into main release)
 
 ## Date
 

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -76,6 +76,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-059](ADR-059-graph-library-extraction.md) | Extract Shared Graph Analysis Library | 2026-07-08 |
 | [ADR-060](ADR-060-rest-api-versioning-contract.md) | REST API Versioning Contract | 2026-07-08 |
 | [ADR-065](ADR-065-spa-gateway-live-state-ownership.md) | SPA vs Gateway Live-Operation State Ownership | 2026-07-20 |
+| [ADR-066](ADR-066-ui-workflow-github-release-artifacts.md) | Publish `@apme/ui-workflow` via GitHub Release Artifacts (Accepted (revised 2026-07-31: consolidated into main release)) | 2026-07-23 (revised 2026-07-31) |
 
 ## Proposed
 
@@ -98,7 +99,6 @@ Decisions replaced by newer ADRs.
 |-----|-------|------|
 | [ADR-006](ADR-006-ephemeral-venvs.md) | Ephemeral Per-Request venvs for Ansible Validator (Superseded by [ADR-022](ADR-022-session-scoped-venvs.md) and [ADR-031](ADR-031-unified-collection-cache.md)) | 2026-03 |
 | [ADR-035](ADR-035-secret-externalization.md) | Secret Externalization for Ansible Content (Proposed — implementation approach superseded by ADR-036) | 2026-03-23 |
-| [ADR-066](ADR-066-ui-workflow-github-release-artifacts.md) | Publish `@apme/ui-workflow` via GitHub Release Artifacts (Superseded (consolidated into main release)) | 2026-07-23 (revised 2026-07-31) |
 
 ## Creating New ADRs
 

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -49,7 +49,6 @@ Decisions that are fully reflected in the codebase.
 | [ADR-062](ADR-062-ephemeral-proposal-working-set.md) | Ephemeral Proposal Working Set and Review Analytics | 2026-07-09 |
 | [ADR-063](ADR-063-multi-platform-container-images.md) | Multi-Platform Container Image Publish | 2026-07-15 |
 | [ADR-064](ADR-064-assess-pause-session-continue.md) | Assess-Pause and Session-Continue Scan → Remediate | 2026-07-18 |
-| [ADR-066](ADR-066-ui-workflow-github-release-artifacts.md) | Publish `@apme/ui-workflow` via GitHub Release Artifacts | 2026-07-23 |
 | [ADR-067](ADR-067-otel-metrics-in-pod-collector.md) | OpenTelemetry Metrics with In-Pod Collector | 2026-07-29 |
 | [ADR-068](ADR-068-adaptive-operation-deadlines.md) | Adaptive Operation Deadlines for Long AI Remediation | 2026-07-30 |
 
@@ -99,6 +98,7 @@ Decisions replaced by newer ADRs.
 |-----|-------|------|
 | [ADR-006](ADR-006-ephemeral-venvs.md) | Ephemeral Per-Request venvs for Ansible Validator (Superseded by [ADR-022](ADR-022-session-scoped-venvs.md) and [ADR-031](ADR-031-unified-collection-cache.md)) | 2026-03 |
 | [ADR-035](ADR-035-secret-externalization.md) | Secret Externalization for Ansible Content (Proposed — implementation approach superseded by ADR-036) | 2026-03-23 |
+| [ADR-066](ADR-066-ui-workflow-github-release-artifacts.md) | Publish `@apme/ui-workflow` via GitHub Release Artifacts (Superseded (consolidated into main release)) | 2026-07-23 (revised 2026-07-31) |
 
 ## Creating New ADRs
 

--- a/SOP.md
+++ b/SOP.md
@@ -133,7 +133,7 @@ Each new rule requires: implementation, colocated markdown docs with YAML exampl
 
 Bump `pyproject.toml` version, update `CHANGELOG.md`, update container image tags. Verify: `tox -e unit`, `tox -e lint`, security audit (`gitleaks`, `bandit`, `pip-audit`). Tag `vX.Y.Z`, build and push container images.
 
-**`@apme/ui-workflow` (ADR-066):** bump `frontend/packages/ui-workflow/package.json` version, merge to `main`, tag `ui-workflow-vX.Y.Z`, push the tag. CI packs the package and attaches `apme-ui-workflow-X.Y.Z.tgz` to a GitHub Release. Portal pins that download URL (not npmjs yet).
+**`@apme/ui-workflow` (ADR-066):** automatically attached to the main APME release. When a `vX.Y.Z` release is published, CI derives the version from the tag, runs `npm pack`, and uploads `apme-ui-workflow-X.Y.Z.tgz` as a release asset. No separate tagging or version bump required. Portal pins the download URL on the product release (not npmjs yet).
 
 ---
 

--- a/frontend/packages/ui-workflow/README.md
+++ b/frontend/packages/ui-workflow/README.md
@@ -9,19 +9,17 @@ Hosts:
 
 ## Install (Portal / external)
 
-Published as an **`npm pack` tarball** on GitHub Releases (ADR-066) — not npmjs yet.
+Published as an **`npm pack` tarball** attached to the main APME GitHub Release
+(ADR-066) — not npmjs yet.
 
-```bash
-# After bumping version in package.json and merging to main:
-git tag ui-workflow-v0.1.1
-git push upstream ui-workflow-v0.1.1
-```
+The tarball is automatically built and attached when a `vX.Y.Z` release is
+published. No separate tagging or version bump is needed — the package version
+is derived from the release tag at build time.
 
-CI runs `npm pack` (builds `dist/` via `prepack`) and attaches
-`apme-ui-workflow-<version>.tgz` to the release. Consumers pin:
+Consumers pin the release download URL:
 
 ```json
-"@apme/ui-workflow": "https://github.com/ansible/apme/releases/download/ui-workflow-v0.1.1/apme-ui-workflow-0.1.1.tgz"
+"@apme/ui-workflow": "https://github.com/ansible/apme/releases/download/vX.Y.Z/apme-ui-workflow-X.Y.Z.tgz"
 ```
 
 ## Package contents

--- a/frontend/packages/ui-workflow/package.json
+++ b/frontend/packages/ui-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apme/ui-workflow",
-  "version": "0.1.1",
+  "version": "0.0.0-dev",
   "type": "module",
   "description": "Shared APME scan → pause → choose → remediate workflow UI (native SPA + Portal host).",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Consolidate `@apme/ui-workflow` package publishing into the main APME product release instead of maintaining a separate `ui-workflow-vX.Y.Z` tag lifecycle.

## Changes

- **`.github/workflows/ui-workflow-release.yml`** — Rewritten to trigger on `release: published` (main `vX.Y.Z`). Derives version from tag, stamps package.json at build time, uploads tarball as release asset.
- **`frontend/packages/ui-workflow/package.json`** — Version set to `0.0.0-dev` placeholder (real version injected from tag).
- **`.sdlc/adrs/ADR-066`** — Status updated to "Superseded (consolidated into main release)" with revised decision and implementation notes.
- **`frontend/packages/ui-workflow/README.md`** — Install instructions updated to reference main release URLs.
- **`SOP.md`** — Release process section updated (no manual tagging/bumping needed).

## Cleanup (post-merge)

The old `ui-workflow-v0.1.1` tag and its GitHub Release can be deleted:

```bash
git push upstream --delete ui-workflow-v0.1.1
gh release delete ui-workflow-v0.1.1 --repo ansible/apme --yes
```

Portal consumers will update their dependency URL on next adoption:
```
# Old: .../download/ui-workflow-v0.1.1/apme-ui-workflow-0.1.1.tgz
# New: .../download/vX.Y.Z/apme-ui-workflow-X.Y.Z.tgz
```

## Test plan

- [ ] `tox -e lint` passes (no Python changes)
- [ ] Workflow syntax valid (only YAML/MD/JSON touched)
- [ ] ADR-066 revision history updated
- [ ] SOP release section reflects new process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The UI workflow package is automatically packaged and attached to published main product releases.
  * Release artifacts are generated from validated `vX.Y.Z` version tags.

* **Documentation**
  * Updated installation and release guidance for release-tagged package tarballs.
  * Removed instructions for separate package tags and manual version updates.
  * Clarified access to package artifacts from product releases.

* **Chores**
  * Updated the package’s development version metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->