### PR TITLE
feat(ci): add release SBOM generation and cosign image signing

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -122,6 +122,11 @@ jobs:
     needs: build-images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    outputs:
+      consumer_tags: ${{ steps.tags.outputs.tags }}
+      owner_lc: ${{ steps.owner.outputs.lc }}
+      quay_enabled: ${{ steps.quay-check.outputs.enabled }}
+      quay_ns: ${{ steps.quay-check.outputs.ns }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
@@ -172,26 +177,155 @@ jobs:
         env:
           DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
         run: |
-          jq -r '.tags[]' <<<"$DOCKER_METADATA_OUTPUT_JSON" \
-            | awk -F: '{print $NF}' \
-            | sort -u \
-            > /tmp/consumer-tags.txt
+          mapfile -t tag_lines < <(
+            jq -r '.tags[]' <<<"$DOCKER_METADATA_OUTPUT_JSON" \
+              | awk -F: '{print $NF}' \
+              | sort -u
+          )
+          printf '%s\n' "${tag_lines[@]}" > /tmp/consumer-tags.txt
           echo "Consumer tags:"
           cat /tmp/consumer-tags.txt
+          {
+            echo 'tags<<EOF'
+            printf '%s\n' "${tag_lines[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Merge multi-arch manifests
         env:
           GHCR_REGISTRY: ${{ env.GHCR_REGISTRY }}
           QUAY_REGISTRY: ${{ env.QUAY_REGISTRY }}
+          OWNER_LC: ${{ steps.owner.outputs.lc }}
+          QUAY_ENABLED: ${{ steps.quay-check.outputs.enabled }}
+          QUAY_NS: ${{ steps.quay-check.outputs.ns }}
           # Parallel imagetools create across images (merge was the wall-clock bottleneck).
           MERGE_PARALLELISM: "6"
         run: |
           args=(
-            --owner "${{ steps.owner.outputs.lc }}"
+            --owner "$OWNER_LC"
             --sha "${{ github.sha }}"
             --tags-file /tmp/consumer-tags.txt
           )
-          if [ "${{ steps.quay-check.outputs.enabled }}" = "true" ]; then
-            args+=(--quay-ns "${{ steps.quay-check.outputs.ns }}")
+          if [ "$QUAY_ENABLED" = "true" ]; then
+            args+=(--quay-ns "$QUAY_NS")
           fi
           ./containers/ci/merge-manifests.sh "${args[@]}"
+
+  supply-chain:
+    needs: merge-manifests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      subjects: ${{ steps.subjects.outputs.subjects }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+
+      - name: Restore consumer tags from merge-manifests
+        env:
+          CONSUMER_TAGS: ${{ needs.merge-manifests.outputs.consumer_tags }}
+        run: |
+          printf '%s\n' "$CONSUMER_TAGS" > /tmp/consumer-tags.txt
+          echo "Consumer tags:"
+          cat /tmp/consumer-tags.txt
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        if: needs.merge-manifests.outputs.quay_enabled == 'true'
+        with:
+          registry: ${{ env.QUAY_REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
+        with:
+          enable-cache: false
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign images and generate container SBOMs
+        env:
+          GHCR_REGISTRY: ${{ env.GHCR_REGISTRY }}
+          QUAY_REGISTRY: ${{ env.QUAY_REGISTRY }}
+          OWNER_LC: ${{ needs.merge-manifests.outputs.owner_lc }}
+          QUAY_ENABLED: ${{ needs.merge-manifests.outputs.quay_enabled }}
+          QUAY_NS: ${{ needs.merge-manifests.outputs.quay_ns }}
+        run: |
+          args=(
+            --owner "$OWNER_LC"
+            --tags-file /tmp/consumer-tags.txt
+            --output-dir /tmp/sboms/containers
+            --list-subjects /tmp/subjects.json
+          )
+          if [ "$QUAY_ENABLED" = "true" ]; then
+            args+=(--quay-ns "$QUAY_NS")
+          fi
+          ./containers/ci/supply-chain.sh "${args[@]}"
+
+      - name: Generate Python wheel SBOM
+        run: ./containers/ci/generate-python-sbom.sh --output-dir /tmp/sboms/python
+
+      - name: Upload release SBOM artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-sboms-${{ github.sha }}
+          path: /tmp/sboms/
+          retention-days: 90
+
+      - name: Write provenance subject matrix
+        id: subjects
+        run: |
+          if [ ! -s /tmp/subjects.json ] || [ "$(jq 'length' /tmp/subjects.json)" -eq 0 ]; then
+            echo "No provenance subjects produced" >&2
+            exit 1
+          fi
+          echo "subjects=$(jq -c '.' /tmp/subjects.json)" >> "$GITHUB_OUTPUT"
+
+  attest-provenance:
+    needs: [merge-manifests, supply-chain]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        subject: ${{ fromJson(needs.supply-chain.outputs.subjects) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          persist-credentials: false
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        if: needs.merge-manifests.outputs.quay_enabled == 'true'
+        with:
+          registry: ${{ env.QUAY_REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ matrix.subject.name }}
+          subject-digest: ${{ matrix.subject.digest }}
+          push-to-registry: true

--- a/containers/ci/generate-python-sbom.sh
+++ b/containers/ci/generate-python-sbom.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Build the Python wheel and emit a CycloneDX 1.5 SBOM (issue #203).
+#
+# Usage:
+#   generate-python-sbom.sh --output-dir dist/sbom
+#
+# Locally runnable (lean CI): complements container image SBOMs from supply-chain.sh.
+set -euo pipefail
+
+OUTPUT_DIR=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  local code="${1:-1}"
+  sed -n '2,7p' "$0" | sed 's/^# \{0,1\}//'
+  exit "$code"
+}
+
+# shellcheck source=install-syft.sh
+source "${SCRIPT_DIR}/install-syft.sh"
+
+ensure_syft() {
+  install_syft
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      usage 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+  echo "--output-dir is required" >&2
+  usage
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required to build the Python wheel" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+wheel_dir="$(mktemp -d)"
+trap 'rm -rf "${wheel_dir}"' EXIT
+
+echo "==> Building Python wheel"
+uv build --wheel --out-dir "${wheel_dir}"
+
+wheel="$(ls -1 "${wheel_dir}"/*.whl 2>/dev/null | head -1 || true)"
+if [[ -z "$wheel" ]]; then
+  echo "No wheel found under ${wheel_dir}/" >&2
+  exit 1
+fi
+
+ensure_syft
+sbom_file="${OUTPUT_DIR}/$(basename "${wheel}").cdx.json"
+echo "==> Generating CycloneDX SBOM for ${wheel}"
+"${SYFT_BIN}" "file:${wheel}" -o cyclonedx-json@1.5 >"${sbom_file}"
+echo "OK SBOM: ${sbom_file}"

--- a/containers/ci/install-syft.sh
+++ b/containers/ci/install-syft.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Install a pinned syft release with checksum verification.
+#
+# Usage (source from other containers/ci scripts):
+#   source "$(dirname "${BASH_SOURCE[0]}")/install-syft.sh"
+#   install_syft
+#
+# Environment:
+#   SYFT_VERSION      Release version without leading v (default: 1.21.0)
+#   SYFT_INSTALL_DIR  Install directory (default: ${HOME}/.cache/apme/bin)
+set -euo pipefail
+
+_INSTALL_SYFT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYFT_VERSION="${SYFT_VERSION:-1.21.0}"
+SYFT_INSTALL_DIR="${SYFT_INSTALL_DIR:-${HOME}/.cache/apme/bin}"
+SYFT_BIN="${SYFT_INSTALL_DIR}/syft"
+SYFT_CHECKSUMS_FILE="${_INSTALL_SYFT_DIR}/syft-release-checksums.txt"
+
+sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file}" | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${file}" | awk '{ print $1 }'
+  else
+    echo "Neither sha256sum nor shasum is available for checksum verification" >&2
+    return 1
+  fi
+}
+
+sha256_string() {
+  local data="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "${data}" | sha256sum | awk '{ print $1 }'
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s' "${data}" | shasum -a 256 | awk '{ print $1 }'
+  else
+    echo "Neither sha256sum nor shasum is available for checksum verification" >&2
+    return 1
+  fi
+}
+
+lookup_committed_checksum() {
+  local version="$1"
+  local os="$2"
+  local arch="$3"
+  awk -v ver="${version}" -v os="${os}" -v arch="${arch}" \
+    '$1 == ver && $2 == os && $3 == arch { print $4; exit }' "${SYFT_CHECKSUMS_FILE}"
+}
+
+install_syft() (
+  local os arch archive version url tmpdir expected actual
+
+  if [[ -x "${SYFT_BIN}" ]]; then
+    return 0
+  fi
+
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64) arch=amd64 ;;
+    aarch64 | arm64) arch=arm64 ;;
+    *)
+      echo "Unsupported architecture for syft install: ${arch}" >&2
+      return 1
+      ;;
+  esac
+
+  if [[ ! -f "${SYFT_CHECKSUMS_FILE}" ]]; then
+    echo "Syft checksum file not found: ${SYFT_CHECKSUMS_FILE}" >&2
+    return 1
+  fi
+
+  expected="$(lookup_committed_checksum "${SYFT_VERSION}" "${os}" "${arch}")"
+  if [[ -z "$expected" ]]; then
+    echo "Unsupported syft release/platform: ${SYFT_VERSION} (${os}/${arch})" >&2
+    echo "Add a committed checksum to ${SYFT_CHECKSUMS_FILE} after verifying the release." >&2
+    return 1
+  fi
+
+  version="v${SYFT_VERSION}"
+  archive="syft_${SYFT_VERSION}_${os}_${arch}.tar.gz"
+  url="https://github.com/anchore/syft/releases/download/${version}/${archive}"
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf -- "${tmpdir}"' EXIT
+
+  echo "==> Installing syft ${version} (${os}/${arch})"
+  curl -sSfL -o "${tmpdir}/${archive}" "${url}"
+
+  actual="$(sha256_file "${tmpdir}/${archive}")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Checksum mismatch for ${archive}" >&2
+    return 1
+  fi
+
+  tar -xzf "${tmpdir}/${archive}" -C "${tmpdir}" syft
+  install -d "${SYFT_INSTALL_DIR}"
+  install -m 0755 "${tmpdir}/syft" "${SYFT_BIN}"
+)

--- a/containers/ci/supply-chain.sh
+++ b/containers/ci/supply-chain.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# Sign published multi-arch images and generate CycloneDX SBOMs (issues #203, #204).
+#
+# Expects consumer tags already merged on GHCR:
+#   ghcr.io/<owner>/apme-<name>:<tag>
+#
+# Image names are read from containers/ci/images.txt (single source of truth).
+#
+# Usage:
+#   supply-chain.sh --owner ansible --tags-file /tmp/tags.txt --output-dir /tmp/sboms
+#   supply-chain.sh ... --quay-ns ansible          # also sign Quay copies when published
+#   supply-chain.sh ... --skip-sign                  # SBOM generation only (no cosign)
+#   supply-chain.sh ... --list-subjects /tmp/subjects.json  # write provenance subjects
+#
+# Locally runnable (lean CI): logic lives here, not only in workflow YAML.
+# Requires: docker buildx, cosign (for signing), syft (installed automatically if missing).
+set -euo pipefail
+
+OWNER=""
+TAGS_FILE=""
+OUTPUT_DIR=""
+QUAY_NS=""
+SKIP_SIGN=0
+LIST_SUBJECTS=""
+GHCR_REGISTRY="${GHCR_REGISTRY:-ghcr.io}"
+QUAY_REGISTRY="${QUAY_REGISTRY:-quay.io}"
+ENGINE="${CONTAINER_ENGINE:-docker}"
+# Cap concurrent registry ops (sign + SBOM per image/tag).
+SUPPLY_CHAIN_PARALLELISM="${SUPPLY_CHAIN_PARALLELISM:-4}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGES_FILE="${IMAGES_FILE:-${SCRIPT_DIR}/images.txt}"
+
+usage() {
+  local code="${1:-1}"
+  sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+  exit "$code"
+}
+
+load_images() {
+  local line
+  IMAGES=()
+  if [[ ! -f "$IMAGES_FILE" ]]; then
+    echo "Images file not found: $IMAGES_FILE" >&2
+    exit 1
+  fi
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line//$'\r'/}"
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    IMAGES+=("$line")
+  done <"$IMAGES_FILE"
+  if [[ ${#IMAGES[@]} -eq 0 ]]; then
+    echo "No images listed in ${IMAGES_FILE}" >&2
+    exit 1
+  fi
+}
+
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# shellcheck source=install-syft.sh
+source "${SCRIPT_DIR}/install-syft.sh"
+
+ensure_syft() {
+  install_syft
+}
+
+ref_slug() {
+  local ref="$1"
+  local slug hash
+  # Readable prefix plus hash of full ref avoids collisions (e.g. foo/bar_baz vs foo_bar/baz).
+  slug="$(printf '%s' "${ref%:*}" | tr '/:.' '_')"
+  hash="$(sha256_string "${ref}" | awk '{ print substr($1, 1, 8) }')"
+  printf '%s_%s' "${slug}" "${hash}"
+}
+
+image_digest() {
+  local ref="$1"
+  "${ENGINE}" buildx imagetools inspect "${ref}" --format '{{.Manifest.Digest}}'
+}
+
+registry_refs() {
+  local name="$1"
+  local tag="$2"
+  local -a refs=()
+  refs+=("${GHCR_REGISTRY}/${OWNER}/apme-${name}:${tag}")
+  if [[ -n "$QUAY_NS" ]]; then
+    refs+=("${QUAY_REGISTRY}/${QUAY_NS}/apme-${name}:${tag}")
+  fi
+  printf '%s\n' "${refs[@]}"
+}
+
+# Run up to SUPPLY_CHAIN_PARALLELISM background jobs; fail if any child fails.
+run_parallel() {
+  local -a pids=()
+  local -a labels=()
+  local fail=0
+  local pid label done_label item fn i
+  local -a parts=()
+  local -a fn_args=()
+
+  if [[ $# -eq 0 ]]; then
+    echo "run_parallel: no tasks" >&2
+    return 1
+  fi
+
+  for item in "$@"; do
+    parts=()
+    fn_args=()
+    IFS=$'\t' read -r -a parts <<<"$item"
+    if [[ ${#parts[@]} -lt 2 ]]; then
+      echo "ERROR: malformed parallel task (need label\\tfunction[\\targs...]): ${item}" >&2
+      return 1
+    fi
+    label="${parts[0]}"
+    fn="${parts[1]}"
+    if [[ ${#parts[@]} -gt 2 ]]; then
+      fn_args=("${parts[@]:2}")
+    fi
+    case "$fn" in
+      process_image_tag | process_ref) ;;
+      *)
+        echo "ERROR: refused unknown parallel function: ${fn}" >&2
+        return 1
+        ;;
+    esac
+
+    while [[ ${#pids[@]} -ge $SUPPLY_CHAIN_PARALLELISM ]]; do
+      pid="${pids[0]}"
+      done_label="${labels[0]}"
+      pids=("${pids[@]:1}")
+      labels=("${labels[@]:1}")
+      if ! wait "$pid"; then
+        echo "ERROR: parallel task failed: ${done_label}" >&2
+        fail=1
+      fi
+    done
+    (
+      set -euo pipefail
+      "$fn" "${fn_args[@]}"
+    ) &
+    pids+=("$!")
+    labels+=("$label")
+  done
+
+  for i in "${!pids[@]}"; do
+    pid="${pids[$i]}"
+    done_label="${labels[$i]}"
+    if ! wait "$pid"; then
+      echo "ERROR: parallel task failed: ${done_label}" >&2
+      fail=1
+    fi
+  done
+
+  if [[ "$fail" -ne 0 ]]; then
+    return 1
+  fi
+}
+
+process_ref() {
+  local ref="$1"
+  local name="$2"
+  local tag="$3"
+  local digest sbom_file safe_tag
+  digest="$(image_digest "${ref}")"
+  safe_tag="${tag//\//_}"
+  sbom_file="${OUTPUT_DIR}/$(ref_slug "${ref}")-${safe_tag}.cdx.json"
+
+  echo "==> ${ref} @ ${digest}"
+
+  if [[ "$SKIP_SIGN" -eq 0 ]]; then
+    cosign sign --yes "${ref}@${digest}"
+  fi
+
+  "${SYFT_BIN}" "${ref}@${digest}" -o cyclonedx-json@1.5 >"${sbom_file}"
+  echo "OK SBOM: ${sbom_file}"
+
+  if [[ "$SKIP_SIGN" -eq 0 ]]; then
+    cosign attest --yes \
+      --predicate "${sbom_file}" \
+      --type cyclonedx \
+      "${ref}@${digest}"
+  fi
+
+  if [[ -n "$LIST_SUBJECTS" ]]; then
+    # subject-name for attest-build-provenance excludes the tag.
+    local subject_name="${ref%:*}"
+    printf '%s\t%s\n' "${subject_name}" "${digest}" \
+      >"${LIST_SUBJECTS}.d/$(ref_slug "${ref}")-${safe_tag}.row"
+  fi
+}
+
+process_image_tag() {
+  local name="$1"
+  local tag="$2"
+  local ref
+  while IFS= read -r ref; do
+    [[ -z "$ref" ]] && continue
+    process_ref "${ref}" "${name}" "${tag}"
+  done < <(registry_refs "${name}" "${tag}")
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --owner)
+      OWNER="${2:-}"
+      shift 2
+      ;;
+    --tags-file)
+      TAGS_FILE="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --quay-ns)
+      QUAY_NS="${2:-}"
+      shift 2
+      ;;
+    --skip-sign)
+      SKIP_SIGN=1
+      shift
+      ;;
+    --list-subjects)
+      LIST_SUBJECTS="${2:-}"
+      shift 2
+      ;;
+    --parallelism)
+      SUPPLY_CHAIN_PARALLELISM="${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      usage 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [[ -z "$OWNER" || -z "$TAGS_FILE" || -z "$OUTPUT_DIR" ]]; then
+  echo "--owner, --tags-file, and --output-dir are required" >&2
+  usage
+fi
+
+if [[ ! -f "$TAGS_FILE" ]]; then
+  echo "Tags file not found: $TAGS_FILE" >&2
+  exit 1
+fi
+
+if ! [[ "$SUPPLY_CHAIN_PARALLELISM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "SUPPLY_CHAIN_PARALLELISM must be a positive integer (got: ${SUPPLY_CHAIN_PARALLELISM})" >&2
+  exit 1
+fi
+
+if [[ "$SKIP_SIGN" -eq 0 ]] && ! command -v cosign >/dev/null 2>&1; then
+  echo "cosign is required for signing (use --skip-sign to generate SBOMs only)" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+TAGS=()
+while IFS= read -r line || [[ -n "$line" ]]; do
+  line="${line//$'\r'/}"
+  [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+  TAGS+=("$(trim "$line")")
+done <"$TAGS_FILE"
+
+if [[ ${#TAGS[@]} -eq 0 ]]; then
+  echo "No consumer tags to process" >&2
+  exit 1
+fi
+
+load_images
+ensure_syft
+
+echo "==> Supply chain for owner=${OWNER} images=${#IMAGES[@]} tags=${#TAGS[@]}"
+echo "==> Output: ${OUTPUT_DIR}"
+echo "==> Parallelism: ${SUPPLY_CHAIN_PARALLELISM}"
+if [[ -n "$QUAY_NS" ]]; then
+  echo "==> Also processing ${QUAY_REGISTRY}/${QUAY_NS}"
+fi
+if [[ "$SKIP_SIGN" -eq 1 ]]; then
+  echo "==> Signing disabled (--skip-sign)"
+fi
+
+if [[ -n "$LIST_SUBJECTS" ]]; then
+  rm -f "${LIST_SUBJECTS}.tmp"
+  rm -rf "${LIST_SUBJECTS}.d"
+  mkdir -p "${LIST_SUBJECTS}.d"
+fi
+
+tasks=()
+for name in "${IMAGES[@]}"; do
+  for tag in "${TAGS[@]}"; do
+    tasks+=("supply:${name}:${tag}"$'\t'"process_image_tag"$'\t'"${name}"$'\t'"${tag}")
+  done
+done
+run_parallel "${tasks[@]}"
+
+if [[ -n "$LIST_SUBJECTS" ]]; then
+  find "${LIST_SUBJECTS}.d" -maxdepth 1 -name '*.row' -exec cat {} + >"${LIST_SUBJECTS}.tmp"
+  rm -rf "${LIST_SUBJECTS}.d"
+  # shellcheck source=write-provenance-subjects.sh
+  source "${SCRIPT_DIR}/write-provenance-subjects.sh"
+  write_provenance_subjects "${LIST_SUBJECTS}"
+fi
+
+echo "==> Supply chain complete"

--- a/containers/ci/syft-release-checksums.txt
+++ b/containers/ci/syft-release-checksums.txt
@@ -1,0 +1,7 @@
+# Syft release archive SHA-256 checksums (independent integrity source).
+# Verify entries against https://github.com/anchore/syft/releases before bumping SYFT_VERSION.
+# Format: VERSION OS ARCH CHECKSUM
+1.21.0 linux amd64 0ee8161dfa4f79487e46e734305a414e1e7fbcdc114d69809d069e89483c4898
+1.21.0 linux arm64 b7617868459cb707e4f9f56c8cb121124bf90b2c944f30e2f3c773807e1e05d7
+1.21.0 darwin amd64 41f5bcfc5480ebec0dcbc0e3911a5e4190915358dbc427a03861393c6c9f954a
+1.21.0 darwin arm64 7ab33ccddc017b8eccdcfa68d28b426174f36185b634c5b10c6c43cbe5c1de70

--- a/containers/ci/write-provenance-subjects.sh
+++ b/containers/ci/write-provenance-subjects.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Write deduplicated provenance subject JSON from a tab-separated tmp file.
+#
+# Usage (source from supply-chain.sh or tests):
+#   source "$(dirname "${BASH_SOURCE[0]}")/write-provenance-subjects.sh"
+#   write_provenance_subjects /tmp/subjects.json
+write_provenance_subjects() {
+  local list_subjects="$1"
+  local line name digest invalid_rows=0 input_rows=0 unique_valid_rows=0 output_rows=0
+  local -a fields=()
+
+  if [[ -f "${list_subjects}.tmp" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      [[ -z "$line" ]] && continue
+      input_rows=$((input_rows + 1))
+      fields=()
+      IFS=$'\t' read -r -a fields <<<"$line"
+      name="${fields[0]:-}"
+      digest="${fields[1]:-}"
+      if [[ ${#fields[@]} -ne 2 || -z "$name" || -z "$digest" ]]; then
+        echo "ERROR: malformed provenance subject row (expected name<TAB>digest): ${line}" >&2
+        invalid_rows=$((invalid_rows + 1))
+      fi
+    done < <(tr -d $'\r' <"${list_subjects}.tmp")
+
+    if [[ "$invalid_rows" -ne 0 ]]; then
+      return 1
+    fi
+
+    unique_valid_rows="$(
+      tr -d $'\r' <"${list_subjects}.tmp" \
+        | awk -F'\t' 'NF == 2 && $1 != "" && $2 != "" { print }' \
+        | sort -u | wc -l | tr -d '[:space:]'
+    )"
+
+    tr -d $'\r' <"${list_subjects}.tmp" | sort -u \
+      | jq -R -s 'split("\n")
+          | map(select(length > 0) | split("\t"))
+          | map(select(length == 2 and (.[0] | length > 0) and (.[1] | length > 0)))
+          | map({name: .[0], digest: .[1]})' >"${list_subjects}"
+
+    output_rows="$(jq 'length' "${list_subjects}")"
+    if [[ "${output_rows}" -eq 0 ]]; then
+      echo "ERROR: no valid provenance subjects in ${list_subjects}.tmp" >&2
+      return 1
+    fi
+    if [[ "${output_rows}" -ne "${unique_valid_rows}" ]]; then
+      echo "ERROR: provenance subject count mismatch (parsed ${output_rows}, expected ${unique_valid_rows})" >&2
+      return 1
+    fi
+    echo "==> Provenance subjects: ${output_rows} of ${input_rows} rows (deduplicated)" >&2
+    rm -f "${list_subjects}.tmp"
+    echo "==> Wrote provenance subjects: ${list_subjects}" >&2
+  else
+    echo '[]' >"${list_subjects}"
+  fi
+}

--- a/tests/test_release_supply_chain.py
+++ b/tests/test_release_supply_chain.py
@@ -1,0 +1,465 @@
+"""Tests for release supply-chain scripts (issues #203, #204)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SUPPLY_CHAIN_SH = REPO_ROOT / "containers" / "ci" / "supply-chain.sh"
+PYTHON_SBOM_SH = REPO_ROOT / "containers" / "ci" / "generate-python-sbom.sh"
+CONTAINER_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "container-images.yml"
+IMAGES_FILE = REPO_ROOT / "containers" / "ci" / "images.txt"
+
+
+def test_supply_chain_parallel_allowlist_includes_dispatch_function() -> None:
+    """run_parallel must allow the function used by the task builder."""
+    content = SUPPLY_CHAIN_SH.read_text(encoding="utf-8")
+    assert "process_image_tag|process_ref)" in content.replace(" ", "")
+
+
+def test_install_syft_verifies_checksum_before_install() -> None:
+    """Syft install must pin a release and verify against committed checksums."""
+    install_sh = REPO_ROOT / "containers" / "ci" / "install-syft.sh"
+    checksums = REPO_ROOT / "containers" / "ci" / "syft-release-checksums.txt"
+    content = install_sh.read_text(encoding="utf-8")
+    checksum_content = checksums.read_text(encoding="utf-8")
+    assert content.startswith("#!/usr/bin/env bash")
+    assert "install_syft() (" in content
+    assert "trap" in content and "EXIT" in content
+    assert "syft-release-checksums.txt" in content
+    assert "lookup_committed_checksum" in content
+    assert "checksums_url" not in content
+    assert "sha256_file" in content
+    assert "sha256_string" in content
+    assert "shasum -a 256" in content
+    assert "Checksum mismatch" in content
+    assert "github.com/anchore/syft/releases/download" in content
+    assert "command -v syft" not in content
+    assert "${HOME}/.cache/apme/bin" in content
+    assert "SYFT_BIN" in content
+    assert "1.21.0 linux amd64" in checksum_content
+    assert "1.21.0 darwin arm64" in checksum_content
+    assert "SYFT_CHECKSUMS_FILE:-" not in content
+
+
+def test_install_syft_rejects_unsupported_release() -> None:
+    """Unsupported SYFT_VERSION must fail before any download."""
+    install_sh = REPO_ROOT / "containers" / "ci" / "install-syft.sh"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+                set -euo pipefail
+                export SYFT_INSTALL_DIR="{tmpdir}/bin"
+                source {install_sh}
+                SYFT_VERSION=0.0.0 install_syft
+                """,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    assert result.returncode != 0
+    assert "Unsupported syft release/platform" in (result.stderr or result.stdout)
+
+
+def test_install_syft_rejects_unsupported_architecture() -> None:
+    """Unsupported host architecture must fail before any download."""
+    install_sh = REPO_ROOT / "containers" / "ci" / "install-syft.sh"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+                set -euo pipefail
+                export SYFT_INSTALL_DIR="{tmpdir}/bin"
+                uname() {{
+                  case "$1" in
+                    -s) echo linux ;;
+                    -m) echo ppc64le ;;
+                    *) command uname "$@" ;;
+                  esac
+                }}
+                export -f uname
+                source {install_sh}
+                install_syft
+                """,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    assert result.returncode != 0
+    assert "Unsupported architecture for syft install" in (result.stderr or result.stdout)
+
+
+def test_python_sbom_builds_into_isolated_output_dir() -> None:
+    """Wheel SBOM must come from this run's build, not stale dist/ artifacts."""
+    content = PYTHON_SBOM_SH.read_text(encoding="utf-8")
+    assert "mktemp -d" in content
+    assert "--out-dir" in content
+    assert "dist/*.whl" not in content
+
+
+def test_container_workflow_runs_supply_chain_after_merge() -> None:
+    """Published images must be signed and SBOM'd after manifest merge."""
+    workflow = yaml.safe_load(CONTAINER_WORKFLOW.read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+    assert "supply-chain" in jobs
+    assert jobs["supply-chain"]["needs"] == "merge-manifests"
+    assert jobs["merge-manifests"]["outputs"]["consumer_tags"] == "${{ steps.tags.outputs.tags }}"
+
+    supply_steps = jobs["supply-chain"]["steps"]
+    step_names = [step.get("name", "") for step in supply_steps if isinstance(step, dict)]
+    assert "Restore consumer tags from merge-manifests" in step_names
+    assert "docker/metadata-action@" not in yaml.dump(jobs["supply-chain"])
+
+    run_blocks = " ".join(step["run"] for step in supply_steps if isinstance(step, dict) and "run" in step)
+    assert "supply-chain.sh" in run_blocks
+    assert "generate-python-sbom.sh" in run_blocks
+
+    uses_blocks = " ".join(step["uses"] for step in supply_steps if isinstance(step, dict) and "uses" in step)
+    assert "cosign-installer" in uses_blocks
+    assert "attest-build-provenance" not in uses_blocks
+
+    attest_steps = jobs["attest-provenance"]["steps"]
+    attest_uses = [step["uses"] for step in attest_steps if isinstance(step, dict) and "uses" in step]
+    assert any(value.startswith("actions/attest-build-provenance@") for value in attest_uses), attest_uses
+
+    checkout_steps = [
+        step
+        for step in supply_steps + jobs["attest-provenance"]["steps"]
+        if isinstance(step, dict) and step.get("uses", "").startswith("actions/checkout@")
+    ]
+    assert all(step.get("with", {}).get("persist-credentials") is False for step in checkout_steps)
+
+
+def test_signing_permissions_are_job_scoped() -> None:
+    """Signing permissions must be scoped to supply-chain and attest-provenance only."""
+    workflow = yaml.safe_load(CONTAINER_WORKFLOW.read_text(encoding="utf-8"))
+    workflow_perms = workflow.get("permissions", {})
+    assert "id-token" not in workflow_perms
+    assert "attestations" not in workflow_perms
+
+    jobs = workflow["jobs"]
+    assert jobs["supply-chain"]["permissions"]["id-token"] == "write"
+    assert "attestations" not in jobs["supply-chain"].get("permissions", {})
+    assert jobs["attest-provenance"]["permissions"]["attestations"] == "write"
+    for name in ("build-base", "build-images", "merge-manifests"):
+        assert "id-token" not in jobs[name].get("permissions", {})
+
+
+def test_container_workflow_rejects_empty_provenance_subjects() -> None:
+    """Empty [] subjects must fail before attest-provenance matrix expansion."""
+    content = CONTAINER_WORKFLOW.read_text(encoding="utf-8")
+    assert "jq 'length' /tmp/subjects.json" in content
+    assert "No provenance subjects produced" in content
+
+
+def test_attest_provenance_logs_into_quay_when_configured() -> None:
+    """Quay matrix legs need registry credentials for push-to-registry."""
+    workflow = yaml.safe_load(CONTAINER_WORKFLOW.read_text(encoding="utf-8"))
+    attest_job = workflow["jobs"]["attest-provenance"]
+    assert attest_job["needs"] == ["merge-manifests", "supply-chain"]
+
+    attest_steps = attest_job["steps"]
+    step_ids = [step.get("id", "") for step in attest_steps if isinstance(step, dict)]
+    assert "quay-check" not in step_ids
+    assert "owner" not in step_ids
+
+    login_steps = [
+        step
+        for step in attest_steps
+        if isinstance(step, dict) and step.get("uses", "").startswith("docker/login-action@")
+    ]
+    quay_login = next(
+        step for step in login_steps if step.get("if", "").endswith("merge-manifests.outputs.quay_enabled == 'true'")
+    )
+    assert quay_login["with"]["registry"] == "${{ env.QUAY_REGISTRY }}"
+    assert quay_login["with"]["username"] == "${{ secrets.QUAY_USERNAME }}"
+
+
+def test_supply_chain_validates_cosign_before_registry_work() -> None:
+    """Cosign must be checked once before parallel image processing starts."""
+    content = SUPPLY_CHAIN_SH.read_text(encoding="utf-8")
+    process_ref_body = content.split("process_ref() {", 1)[1].split("\n}\n", 1)[0]
+    assert "command -v cosign" not in process_ref_body
+    assert content.index("command -v cosign") < content.index('run_parallel "${tasks[@]}"')
+
+
+def test_supply_chain_script_is_executable_bash() -> None:
+    """Supply-chain script must exist and use bash with strict mode."""
+    content = SUPPLY_CHAIN_SH.read_text(encoding="utf-8")
+    assert content.startswith("#!/usr/bin/env bash")
+    assert "set -euo pipefail" in content
+    assert "cosign sign" in content
+    assert "cyclonedx-json@1.5" in content
+    assert "cosign attest" in content
+    assert "images.txt" in content
+    assert '"${SYFT_BIN}" "${ref}@${digest}"' in content
+    assert "${LIST_SUBJECTS}.d/" in content
+    assert "write-provenance-subjects.sh" in content
+
+
+def test_python_sbom_script_is_executable_bash() -> None:
+    """Python SBOM script must build a wheel and emit CycloneDX JSON."""
+    content = PYTHON_SBOM_SH.read_text(encoding="utf-8")
+    assert content.startswith("#!/usr/bin/env bash")
+    assert "set -euo pipefail" in content
+    assert "uv build --wheel" in content
+    assert "cyclonedx-json@1.5" in content
+    assert '"${SYFT_BIN}"' in content
+
+
+def test_supply_chain_help_exits_zero() -> None:
+    """--help should be a safe local entrypoint."""
+    result = subprocess.run(
+        ["bash", str(SUPPLY_CHAIN_SH), "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "--tags-file" in result.stdout
+
+
+def test_python_sbom_help_exits_zero() -> None:
+    """--help should be a safe local entrypoint."""
+    result = subprocess.run(
+        ["bash", str(PYTHON_SBOM_SH), "--help"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "--output-dir" in result.stdout
+
+
+def test_subjects_json_format_from_supply_chain_skip_sign() -> None:
+    """Provenance subjects must flow through supply-chain.sh dispatch and deduplication."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        bindir = root / "bin"
+        bindir.mkdir()
+        output_dir = root / "sboms"
+        subjects_file = root / "subjects.json"
+        images_file = root / "images.txt"
+        tags_file = root / "tags.txt"
+        images_file.write_text("primary\ngateway\n", encoding="utf-8")
+        tags_file.write_text("v1.0.0\n", encoding="utf-8")
+
+        docker_stub = """\
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "buildx" && "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
+  case "${4:-}" in
+    *apme-primary*) echo "sha256:aaa111" ;;
+    *apme-gateway*) echo "sha256:bbb222" ;;
+    *)
+      echo "unexpected image ref: ${4:-}" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+echo "unexpected docker invocation: $*" >&2
+exit 1
+"""
+        syft_stub = """\
+#!/usr/bin/env bash
+set -euo pipefail
+echo '{"bomFormat":"CycloneDX","specVersion":"1.5","version":1,"components":[]}'
+"""
+        for name, body in (("docker", docker_stub), ("syft", syft_stub)):
+            script = bindir / name
+            script.write_text(body, encoding="utf-8")
+            script.chmod(0o755)
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+                set -euo pipefail
+                export PATH="{bindir}:$PATH"
+                export SYFT_INSTALL_DIR="{bindir}"
+                export IMAGES_FILE="{images_file}"
+                export SUPPLY_CHAIN_PARALLELISM=2
+                {SUPPLY_CHAIN_SH} \\
+                  --owner ansible \\
+                  --tags-file {tags_file} \\
+                  --output-dir {output_dir} \\
+                  --skip-sign \\
+                  --list-subjects {subjects_file}
+                """,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
+        subjects = json.loads(subjects_file.read_text(encoding="utf-8"))
+    assert sorted(subjects, key=lambda item: item["name"]) == [
+        {"name": "ghcr.io/ansible/apme-gateway", "digest": "sha256:bbb222"},
+        {"name": "ghcr.io/ansible/apme-primary", "digest": "sha256:aaa111"},
+    ]
+
+
+def test_subjects_json_format_from_supply_chain_helper() -> None:
+    """Provenance subject list must be valid JSON for the attest matrix."""
+    helper = REPO_ROOT / "containers" / "ci" / "write-provenance-subjects.sh"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subjects_file = Path(tmpdir) / "subjects.json"
+        tmp_file = Path(f"{subjects_file}.tmp")
+        tmp_file.write_text(
+            "\n".join(
+                [
+                    "ghcr.io/ansible/apme-primary\tsha256:abc",
+                    "ghcr.io/ansible/apme-primary\tsha256:abc",
+                    "ghcr.io/ansible/apme-gateway\tsha256:def",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+                set -euo pipefail
+                source {helper}
+                write_provenance_subjects {subjects_file}
+                cat {subjects_file}
+                """,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    subjects = json.loads(result.stdout)
+    assert sorted(subjects, key=lambda item: item["name"]) == [
+        {"name": "ghcr.io/ansible/apme-gateway", "digest": "sha256:def"},
+        {"name": "ghcr.io/ansible/apme-primary", "digest": "sha256:abc"},
+    ]
+
+
+def test_subjects_json_rejects_malformed_rows() -> None:
+    """Malformed provenance subject rows must fail instead of being dropped silently."""
+    helper = REPO_ROOT / "containers" / "ci" / "write-provenance-subjects.sh"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subjects_file = Path(tmpdir) / "subjects.json"
+        tmp_file = Path(f"{subjects_file}.tmp")
+        tmp_file.write_text(
+            "ghcr.io/ansible/apme-primary\tsha256:abc\n"
+            "missing-digest-column\n"
+            "ghcr.io/ansible/apme-gateway\tsha256:def\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+                set -euo pipefail
+                source {helper}
+                write_provenance_subjects {subjects_file}
+                """,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    assert result.returncode != 0
+    assert "malformed provenance subject row" in (result.stderr or result.stdout)
+
+
+def test_subjects_json_rejects_extra_fields() -> None:
+    """Rows with more than two tab-separated fields must fail explicitly."""
+    helper = REPO_ROOT / "containers" / "ci" / "write-provenance-subjects.sh"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subjects_file = Path(tmpdir) / "subjects.json"
+        tmp_file = Path(f"{subjects_file}.tmp")
+        tmp_file.write_text(
+            "ghcr.io/ansible/apme-primary\tsha256:abc\nghcr.io/ansible/apme-gateway\tsha256:def\textra-field\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+                set -euo pipefail
+                source {helper}
+                write_provenance_subjects {subjects_file}
+                """,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    assert result.returncode != 0
+    assert "malformed provenance subject row" in (result.stderr or result.stdout)
+
+
+def test_subjects_json_normalizes_crlf_input() -> None:
+    """CRLF subject rows must normalize to the same digest as LF rows."""
+    helper = REPO_ROOT / "containers" / "ci" / "write-provenance-subjects.sh"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subjects_file = Path(tmpdir) / "subjects.json"
+        tmp_file = Path(f"{subjects_file}.tmp")
+        tmp_file.write_bytes(
+            b"ghcr.io/ansible/apme-primary\tsha256:abc\r\nghcr.io/ansible/apme-gateway\tsha256:def\r\n"
+        )
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+                set -euo pipefail
+                source {helper}
+                write_provenance_subjects {subjects_file}
+                cat {subjects_file}
+                """,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    subjects = json.loads(result.stdout)
+    assert sorted(subjects, key=lambda item: item["name"]) == [
+        {"name": "ghcr.io/ansible/apme-gateway", "digest": "sha256:def"},
+        {"name": "ghcr.io/ansible/apme-primary", "digest": "sha256:abc"},
+    ]
+
+
+def test_images_file_lists_published_services() -> None:
+    """Supply-chain reads the same image inventory as merge-manifests."""
+    names = {
+        line.strip()
+        for line in IMAGES_FILE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+    for image_name in ("primary", "gateway", "ui"):
+        assert image_name in names

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,12 @@ skip_install = true
 allowlist_externals = bash
 commands = bash containers/podman/build.sh {posargs}
 
+[testenv:release-supply-chain]
+description = Generate local Python wheel SBOM (syft installed on demand)
+skip_install = true
+allowlist_externals = bash
+commands = bash containers/ci/generate-python-sbom.sh --output-dir dist/sbom {posargs}
+
 [testenv:up]
 description = Build images and start the APME pod
 skip_install = true


### PR DESCRIPTION
## Summary

- **#203** — Automate release-time CycloneDX 1.5 SBOM generation for APME's own artifacts: all published container images (via syft) and the Python wheel (`uv build` + syft)
- **#204** — Sign published multi-arch container images with keyless cosign (Sigstore OIDC) and attach SLSA Build L2 provenance attestations via `actions/attest-build-provenance`

Adds locally runnable CI scripts (`containers/ci/supply-chain.sh`, `containers/ci/generate-python-sbom.sh`, `containers/ci/install-syft.sh`, `containers/ci/write-provenance-subjects.sh`) following the lean-CI pattern used by `merge-manifests.sh`. New `supply-chain` and `attest-provenance` jobs run after manifest merge in `container-images.yml`. SBOM artifacts are uploaded to GitHub Actions (90-day retention).

## Changes

- `containers/ci/supply-chain.sh` — cosign sign, syft CycloneDX SBOM, cosign SBOM attestation per image/tag
- `containers/ci/generate-python-sbom.sh` — isolated wheel build + CycloneDX SBOM
- `containers/ci/install-syft.sh` — pinned syft release install with checksum verification
- `containers/ci/write-provenance-subjects.sh` — shared provenance subject JSON formatter
- `.github/workflows/container-images.yml` — `supply-chain` + `attest-provenance` jobs; signing permissions scoped per job; `merge-manifests` exports consumer tags for signing; `persist-credentials: false` on checkout; step env vars instead of inline `${{ }}` in run blocks
- `tox -e release-supply-chain` — local Python wheel SBOM generation
- `tests/test_release_supply_chain.py` — script/workflow validation via YAML parsing and helper invocation

## Review hardening (squashed in `0e9ca48`, follow-up `617a296`)

- Scoped `id-token` / `attestations` permissions to signing jobs only
- Fixed `run_parallel` allowlist (`process_image_tag`)
- Pinned syft install with release checksum verification; no PATH-based trust
- Build wheel SBOM from isolated temp directory; container SBOMs from `${ref}@${digest}`
- Collision-resistant SBOM filenames; registry-specific artifact names
- GHCR + conditional Quay login for `attest-provenance` `push-to-registry`
- Reject empty `[]` provenance subject list before matrix expansion
- Disable `setup-uv` cache in signing job; cosign fail-fast before registry work
- Reuse `merge-manifests` consumer tag outputs in `supply-chain` (no duplicate metadata-action)
- YAML-based workflow tests; provenance subject helper tested directly
- Committed syft release checksums (independent integrity source); Darwin-compatible hashing
- Provenance subject helper rejects malformed rows instead of silent filtering

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` passes
- [x] `tox -e release-supply-chain` — Python wheel SBOM generated locally
- [ ] `container-images` workflow succeeds on merge (signing + attestations require GHCR publish)

## Closes

Closes #203
Closes #204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated container image signing and provenance attestations.
  * Added CycloneDX SBOM generation for container images and Python wheels.
  * Added support for GHCR and optional Quay image registries.
  * Added validated provenance exports and SBOM artifact uploads.
  * Added configurable, checksum-verified Syft installation.

* **Bug Fixes**
  * Improved validation and error handling across release supply-chain workflows.
  * Added safeguards for malformed inputs, unsupported platforms, missing dependencies, and failed signing or SBOM operations.

* **Tests**
  * Added comprehensive coverage for supply-chain workflows, SBOM generation, provenance, signing, and image publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->