### PR TITLE
fix(abbenay): prepare gRPC TLS for Abbenay C2 policy (fixes #400)

### DIFF
--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -213,7 +213,9 @@ spec:
           hostPort: 8081
     - name: abbenay
       image: ghcr.io/redhat-developer/abbenay:2026.4.1-alpha
-      args: ["daemon", "--grpc-host", "0.0.0.0", "--grpc-port", "50057"]
+      # Loopback bind keeps plaintext gRPC valid under Abbenay C2 policy (issue #400).
+      # Primary reaches Abbenay at 127.0.0.1:50057 in the shared pod network namespace.
+      args: ["daemon", "--grpc-host", "127.0.0.1", "--grpc-port", "50057"]
       env:
         - name: OPENROUTER_API_KEY
           value: "${OPENROUTER_API_KEY}"

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -25,8 +25,9 @@ SECURITY WARNING: Abbenay gRPC is using plaintext (abbenay.grpc.insecure=true).
 The auth token and AI chat traffic are visible on the cluster network.
 This default is transitional until TLS CA distribution across pods lands (issue #400).
 For production: set abbenay.grpc.tls=true, abbenay.grpc.insecure=false,
-provide abbenay.grpc.caCertSecret (existing Secret name/key), and set
-abbenay.grpc.caCertPath to the mounted PEM path (default /etc/abbenay-tls/ca.crt).
+provide abbenay.grpc.caCertSecret (existing Secret with server.crt, server.key,
+and ca.crt keys), and set abbenay.grpc.caCertPath to the mounted PEM path
+(default /etc/abbenay-tls/ca.crt).
 {{- end }}
 
 {{- if .Values.route.enabled }}

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -19,6 +19,15 @@ Components deployed:
   - Abbenay AI provider
 {{- end }}
 
+{{- if and .Values.abbenay.enabled .Values.abbenay.grpc.insecure (not .Values.abbenay.grpc.tls) }}
+
+SECURITY WARNING: Abbenay gRPC is using plaintext (abbenay.grpc.insecure=true).
+The auth token and AI chat traffic are visible on the cluster network.
+This default is transitional until TLS CA distribution across pods lands (issue #400).
+For production: set abbenay.grpc.tls=true, abbenay.grpc.insecure=false, and
+mount the Abbenay CA via abbenay.grpc.caCertPath on the engine Primary container.
+{{- end }}
+
 {{- if .Values.route.enabled }}
 
 OpenShift Routes:

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -24,8 +24,9 @@ Components deployed:
 SECURITY WARNING: Abbenay gRPC is using plaintext (abbenay.grpc.insecure=true).
 The auth token and AI chat traffic are visible on the cluster network.
 This default is transitional until TLS CA distribution across pods lands (issue #400).
-For production: set abbenay.grpc.tls=true, abbenay.grpc.insecure=false, and
-mount the Abbenay CA via abbenay.grpc.caCertPath on the engine Primary container.
+For production: set abbenay.grpc.tls=true, abbenay.grpc.insecure=false,
+provide abbenay.grpc.caCertSecret (existing Secret name/key), and set
+abbenay.grpc.caCertPath to the mounted PEM path (default /etc/abbenay-tls/ca.crt).
 {{- end }}
 
 {{- if .Values.route.enabled }}

--- a/deploy/helm/apme/templates/_abbenay-validation.tpl
+++ b/deploy/helm/apme/templates/_abbenay-validation.tpl
@@ -240,3 +240,34 @@ URLs resolve to an invalid endpoint.
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Require CA Secret when engine→Abbenay TLS is enabled so Primary receives a mounted PEM.
+*/}}
+{{- define "apme.abbenay.validateGrpcTls" -}}
+{{- if and .Values.abbenay.enabled .Values.abbenay.grpc.tls }}
+  {{- if not .Values.abbenay.grpc.caCertSecret.name }}
+  {{- fail `
+
+abbenay.grpc.caCertSecret.name is required when abbenay.grpc.tls=true.
+
+Mount an existing Secret containing the Abbenay CA PEM into the engine Primary
+container and set caCertPath to the mounted file path (default /etc/abbenay-tls/ca.crt):
+
+  abbenay:
+    grpc:
+      tls: true
+      insecure: false
+      caCertPath: "/etc/abbenay-tls/ca.crt"
+      caCertSecret:
+        name: "my-abbenay-ca"
+        key: "ca.crt"
+
+See deploy/helm/apme/templates/NOTES.txt for production TLS guidance.
+` }}
+  {{- end }}
+  {{- if not .Values.abbenay.grpc.caCertSecret.key }}
+  {{- fail "abbenay.grpc.caCertSecret.key is required when abbenay.grpc.tls=true (the key within the Secret)" }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/deploy/helm/apme/templates/_abbenay-validation.tpl
+++ b/deploy/helm/apme/templates/_abbenay-validation.tpl
@@ -282,8 +282,10 @@ Require CA Secret when engine→Abbenay TLS is enabled so Primary receives a mou
 
 abbenay.grpc.caCertSecret.name is required when abbenay.grpc.tls=true.
 
-Mount an existing Secret containing the Abbenay CA PEM into the engine Primary
-container and set caCertPath to the mounted file path (default /etc/abbenay-tls/ca.crt):
+Provide an existing Secret with matching server and CA PEMs for both the
+Abbenay daemon and engine Primary (server.crt, server.key, ca.crt by default).
+The chart seeds those files into Abbenay's runtime TLS directory before start
+and mounts the CA into Primary for client trust:
 
   abbenay:
     grpc:
@@ -291,14 +293,22 @@ container and set caCertPath to the mounted file path (default /etc/abbenay-tls/
       insecure: false
       caCertPath: "/etc/abbenay-tls/ca.crt"
       caCertSecret:
-        name: "my-abbenay-ca"
+        name: "my-abbenay-tls"
         key: "ca.crt"
+        serverCertKey: "server.crt"
+        serverKeyKey: "server.key"
 
 See deploy/helm/apme/templates/NOTES.txt for production TLS guidance.
 ` }}
   {{- end }}
   {{- if not .Values.abbenay.grpc.caCertSecret.key }}
   {{- fail "abbenay.grpc.caCertSecret.key is required when abbenay.grpc.tls=true (the key within the Secret)" }}
+  {{- end }}
+  {{- if not .Values.abbenay.grpc.caCertSecret.serverCertKey }}
+  {{- fail "abbenay.grpc.caCertSecret.serverCertKey is required when abbenay.grpc.tls=true (server certificate PEM in the Secret)" }}
+  {{- end }}
+  {{- if not .Values.abbenay.grpc.caCertSecret.serverKeyKey }}
+  {{- fail "abbenay.grpc.caCertSecret.serverKeyKey is required when abbenay.grpc.tls=true (server private key PEM in the Secret)" }}
   {{- end }}
 {{- end }}
 {{- end -}}

--- a/deploy/helm/apme/templates/_abbenay-validation.tpl
+++ b/deploy/helm/apme/templates/_abbenay-validation.tpl
@@ -242,6 +242,37 @@ URLs resolve to an invalid endpoint.
 {{- end -}}
 
 {{/*
+Reject non-loopback gRPC binds without TLS or explicit --insecure (Abbenay C2 policy).
+*/}}
+{{- define "apme.abbenay.validateGrpcBind" -}}
+{{- if .Values.abbenay.enabled }}
+  {{- $host := .Values.abbenay.grpc.host | trim -}}
+  {{- $loopback := list "127.0.0.1" "localhost" "::1" -}}
+  {{- $isLoopback := false -}}
+  {{- range $lb := $loopback }}
+    {{- if eq $host $lb }}
+      {{- $isLoopback = true }}
+    {{- end }}
+  {{- end }}
+  {{- if and (not $isLoopback) (not .Values.abbenay.grpc.tls) (not .Values.abbenay.grpc.insecure) }}
+  {{- fail `
+
+abbenay.grpc.host is a non-loopback address but neither abbenay.grpc.tls nor
+abbenay.grpc.insecure is enabled. Abbenay rejects daemon binds that are not
+loopback unless --grpc-tls or --insecure is set (issue #400).
+
+Use one of:
+  - abbenay.grpc.tls: true (with caCertSecret for engine→Abbenay TLS), or
+  - abbenay.grpc.insecure: true (plaintext; transitional only), or
+  - abbenay.grpc.host: "127.0.0.1" for loopback-only binds.
+
+See deploy/helm/apme/templates/NOTES.txt for production TLS guidance.
+` }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Require CA Secret when engine→Abbenay TLS is enabled so Primary receives a mounted PEM.
 */}}
 {{- define "apme.abbenay.validateGrpcTls" -}}

--- a/deploy/helm/apme/templates/abbenay-deployment.yaml
+++ b/deploy/helm/apme/templates/abbenay-deployment.yaml
@@ -5,6 +5,7 @@
 {{- include "apme.abbenay.validateApiKeySecrets" . -}}
 {{- include "apme.abbenay.validateProviderAuth" . -}}
 {{- include "apme.abbenay.validateVertexADC" . -}}
+{{- include "apme.abbenay.validateGrpcTls" . -}}
 {{- $fullname := include "apme.fullname" . -}}
 {{- $hasGcpCreds := or .Values.abbenay.gcp.serviceAccountKey .Values.abbenay.gcp.existingSecret -}}
 {{- $hasVertexADC := false -}}

--- a/deploy/helm/apme/templates/abbenay-deployment.yaml
+++ b/deploy/helm/apme/templates/abbenay-deployment.yaml
@@ -49,7 +49,17 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          args: ["daemon", "--grpc-host", "0.0.0.0", "--grpc-port", "50057"]
+          args:
+            - daemon
+            - --grpc-host
+            - {{ .Values.abbenay.grpc.host | quote }}
+            - --grpc-port
+            - {{ .Values.abbenay.grpc.port | quote }}
+            {{- if .Values.abbenay.grpc.tls }}
+            - --grpc-tls
+            {{- else if .Values.abbenay.grpc.insecure }}
+            - --insecure
+            {{- end }}
           env:
             - name: APME_ABBENAY_TOKEN
               valueFrom:

--- a/deploy/helm/apme/templates/abbenay-deployment.yaml
+++ b/deploy/helm/apme/templates/abbenay-deployment.yaml
@@ -43,6 +43,26 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.abbenay.grpc.tls }}
+      initContainers:
+        - name: seed-abbenay-tls
+          image: busybox:1.36
+          command:
+            - sh
+            - -ec
+            - |
+              mkdir -p /tmp/abbenay-run/abbenay/tls
+              cp "/secret/{{ .Values.abbenay.grpc.caCertSecret.serverCertKey }}" /tmp/abbenay-run/abbenay/tls/server.crt
+              cp "/secret/{{ .Values.abbenay.grpc.caCertSecret.serverKeyKey }}" /tmp/abbenay-run/abbenay/tls/server.key
+              cp "/secret/{{ .Values.abbenay.grpc.caCertSecret.key }}" /tmp/abbenay-run/abbenay/tls/ca.crt
+              chmod 600 /tmp/abbenay-run/abbenay/tls/server.key
+          volumeMounts:
+            - name: abbenay-tls-secret
+              mountPath: /secret
+              readOnly: true
+            - name: abbenay-tls-runtime
+              mountPath: /tmp/abbenay-run
+      {{- end }}
       containers:
         - name: abbenay
           image: {{ .Values.abbenay.image }}
@@ -133,6 +153,10 @@ spec:
             - name: abbenay-config
               mountPath: /etc/abbenay-config/abbenay
               readOnly: true
+            {{- if .Values.abbenay.grpc.tls }}
+            - name: abbenay-tls-runtime
+              mountPath: /tmp/abbenay-run
+            {{- end }}
             {{- if and $hasVertexADC $hasGcpCreds }}
             - name: gcp-credentials
               mountPath: /var/run/secrets/gcp
@@ -142,6 +166,13 @@ spec:
         - name: abbenay-config
           configMap:
             name: {{ $fullname }}-abbenay-config
+        {{- if .Values.abbenay.grpc.tls }}
+        - name: abbenay-tls-runtime
+          emptyDir: {}
+        - name: abbenay-tls-secret
+          secret:
+            secretName: {{ .Values.abbenay.grpc.caCertSecret.name }}
+        {{- end }}
         {{- if and $hasVertexADC $hasGcpCreds }}
         - name: gcp-credentials
           secret:

--- a/deploy/helm/apme/templates/abbenay-deployment.yaml
+++ b/deploy/helm/apme/templates/abbenay-deployment.yaml
@@ -5,6 +5,7 @@
 {{- include "apme.abbenay.validateApiKeySecrets" . -}}
 {{- include "apme.abbenay.validateProviderAuth" . -}}
 {{- include "apme.abbenay.validateVertexADC" . -}}
+{{- include "apme.abbenay.validateGrpcBind" . -}}
 {{- include "apme.abbenay.validateGrpcTls" . -}}
 {{- $fullname := include "apme.fullname" . -}}
 {{- $hasGcpCreds := or .Values.abbenay.gcp.serviceAccountKey .Values.abbenay.gcp.existingSecret -}}
@@ -114,16 +115,16 @@ spec:
             {{- end }}
           ports:
             - name: grpc
-              containerPort: 50057
+              containerPort: {{ .Values.abbenay.grpc.port }}
               protocol: TCP
           readinessProbe:
             tcpSocket:
-              port: 50057
+              port: grpc
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             tcpSocket:
-              port: 50057
+              port: grpc
             initialDelaySeconds: 15
             periodSeconds: 30
           resources:

--- a/deploy/helm/apme/templates/engine-deployment.yaml
+++ b/deploy/helm/apme/templates/engine-deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "apme.abbenay.validateGrpcBind" . -}}
 {{- include "apme.abbenay.validateGrpcTls" . -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/helm/apme/templates/engine-deployment.yaml
+++ b/deploy/helm/apme/templates/engine-deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "apme.abbenay.validateGrpcTls" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -106,9 +107,9 @@ spec:
           volumeMounts:
             - name: sessions
               mountPath: /sessions
-            {{- if and .Values.abbenay.enabled .Values.abbenay.grpc.tls .Values.abbenay.grpc.caCertSecret.name }}
+            {{- if and .Values.abbenay.enabled .Values.abbenay.grpc.tls }}
             - name: abbenay-ca
-              mountPath: /etc/abbenay-tls
+              mountPath: {{ dir .Values.abbenay.grpc.caCertPath }}
               readOnly: true
             {{- end }}
           resources:
@@ -317,13 +318,13 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "apme.fullname" . }}-proxy-cache
           {{- end }}
-        {{- if and .Values.abbenay.enabled .Values.abbenay.grpc.tls .Values.abbenay.grpc.caCertSecret.name }}
+        {{- if and .Values.abbenay.enabled .Values.abbenay.grpc.tls }}
         - name: abbenay-ca
           secret:
             secretName: {{ .Values.abbenay.grpc.caCertSecret.name }}
             items:
               - key: {{ .Values.abbenay.grpc.caCertSecret.key }}
-                path: ca.crt
+                path: {{ base .Values.abbenay.grpc.caCertPath }}
         {{- end }}
       {{- with .Values.engine.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/apme/templates/engine-deployment.yaml
+++ b/deploy/helm/apme/templates/engine-deployment.yaml
@@ -82,6 +82,14 @@ spec:
             - name: APME_AI_MODEL
               value: {{ .Values.abbenay.aiModel | quote }}
             {{- end }}
+            {{- if .Values.abbenay.grpc.tls }}
+            - name: APME_ABBENAY_TLS
+              value: "true"
+            {{- with .Values.abbenay.grpc.caCertPath }}
+            - name: APME_ABBENAY_CA_CERT
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
             {{- end }}
           ports:
             - name: grpc

--- a/deploy/helm/apme/templates/engine-deployment.yaml
+++ b/deploy/helm/apme/templates/engine-deployment.yaml
@@ -85,10 +85,8 @@ spec:
             {{- if .Values.abbenay.grpc.tls }}
             - name: APME_ABBENAY_TLS
               value: "true"
-            {{- with .Values.abbenay.grpc.caCertPath }}
             - name: APME_ABBENAY_CA_CERT
-              value: {{ . | quote }}
-            {{- end }}
+              value: {{ .Values.abbenay.grpc.caCertPath | quote }}
             {{- end }}
             {{- end }}
           ports:
@@ -108,6 +106,11 @@ spec:
           volumeMounts:
             - name: sessions
               mountPath: /sessions
+            {{- if and .Values.abbenay.enabled .Values.abbenay.grpc.tls .Values.abbenay.grpc.caCertSecret.name }}
+            - name: abbenay-ca
+              mountPath: /etc/abbenay-tls
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.engine.resources.primary | nindent 12 }}
 
@@ -314,6 +317,14 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "apme.fullname" . }}-proxy-cache
           {{- end }}
+        {{- if and .Values.abbenay.enabled .Values.abbenay.grpc.tls .Values.abbenay.grpc.caCertSecret.name }}
+        - name: abbenay-ca
+          secret:
+            secretName: {{ .Values.abbenay.grpc.caCertSecret.name }}
+            items:
+              - key: {{ .Values.abbenay.grpc.caCertSecret.key }}
+                path: ca.crt
+        {{- end }}
       {{- with .Values.engine.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -181,7 +181,8 @@ abbenay:
     insecure: true
     # -- Enable TLS with auto-generated certs in the Abbenay container runtime dir.
     tls: false
-    # -- CA cert path inside the engine primary container when tls=true.
+    # -- CA cert file path inside the engine primary container when tls=true.
+    # Chart mounts caCertSecret at the parent directory (dir(caCertPath)).
     caCertPath: "/etc/abbenay-tls/ca.crt"
     # -- Existing Secret containing the Abbenay CA PEM (required when tls=true).
     caCertSecret:

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -181,8 +181,12 @@ abbenay:
     insecure: true
     # -- Enable TLS with auto-generated certs in the Abbenay container runtime dir.
     tls: false
-    # -- CA cert path inside the engine primary container when tls=true (mount from Secret).
-    caCertPath: ""
+    # -- CA cert path inside the engine primary container when tls=true.
+    caCertPath: "/etc/abbenay-tls/ca.crt"
+    # -- Existing Secret containing the Abbenay CA PEM (required when tls=true).
+    caCertSecret:
+      name: ""
+      key: "ca.crt"
   # -- Token APME uses to authenticate with Abbenay (required when enabled)
   token: ""
   # -- Override the default model APME selects (e.g. "vertex-claude/claude-sonnet-4-6")

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -165,6 +165,18 @@ ui:
 abbenay:
   enabled: false
   image: ghcr.io/redhat-developer/abbenay:2026.4.1-alpha
+  grpc:
+    # -- gRPC bind host for the Abbenay daemon container.
+    host: "0.0.0.0"
+    port: 50057
+    # -- Allow plaintext on non-loopback binds (required for engine→abbenay Service
+    # DNS until TLS CA is shared across pods). Abbenay C2 policy: use --insecure
+    # or --grpc-tls when binding 0.0.0.0 (issue #400).
+    insecure: true
+    # -- Enable TLS with auto-generated certs in the Abbenay container runtime dir.
+    tls: false
+    # -- CA cert path inside the engine primary container when tls=true (mount from Secret).
+    caCertPath: ""
   # -- Token APME uses to authenticate with Abbenay (required when enabled)
   token: ""
   # -- Override the default model APME selects (e.g. "vertex-claude/claude-sonnet-4-6")

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -179,7 +179,9 @@ abbenay:
     # tls=true, mount a CA via caCertPath, and set insecure=false once CA
     # distribution across pods is available (issue #400).
     insecure: true
-    # -- Enable TLS with auto-generated certs in the Abbenay container runtime dir.
+    # -- Enable TLS with operator-provided PEMs shared across Abbenay and Engine.
+    # Requires Abbenay cert reuse (redhat-developer/abbenay#65) so seeded
+    # server.crt/server.key are honored instead of regenerated on every start.
     tls: false
     # -- CA cert file path inside the engine primary container when tls=true.
     # Chart mounts caCertSecret at the parent directory (dir(caCertPath)).
@@ -188,6 +190,9 @@ abbenay:
     caCertSecret:
       name: ""
       key: "ca.crt"
+      # Server TLS material seeded into the Abbenay runtime dir before daemon start.
+      serverCertKey: "server.crt"
+      serverKeyKey: "server.key"
   # -- Token APME uses to authenticate with Abbenay (required when enabled)
   token: ""
   # -- Override the default model APME selects (e.g. "vertex-claude/claude-sonnet-4-6")

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -172,6 +172,12 @@ abbenay:
     # -- Allow plaintext on non-loopback binds (required for engine→abbenay Service
     # DNS until TLS CA is shared across pods). Abbenay C2 policy: use --insecure
     # or --grpc-tls when binding 0.0.0.0 (issue #400).
+    #
+    # SECURITY WARNING (transitional default): insecure=true with host 0.0.0.0
+    # sends APME_ABBENAY_TOKEN and AI prompts over plaintext gRPC on the cluster
+    # network. Helm install NOTES.txt repeats this warning. For production, set
+    # tls=true, mount a CA via caCertPath, and set insecure=false once CA
+    # distribution across pods is available (issue #400).
     insecure: true
     # -- Enable TLS with auto-generated certs in the Abbenay container runtime dir.
     tls: false

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -136,6 +136,9 @@ Reports status of all services (Primary, Native, OPA, Ansible, Gitleaks, Collect
 | `APME_REPORTING_ENDPOINT` | — | Gateway gRPC Reporting address (e.g., `127.0.0.1:50060`). Events are pushed after each check or remediate run. |
 | `APME_ABBENAY_ADDR` | — | Abbenay AI daemon address (e.g., `127.0.0.1:50057`). Supports `host:port` and `unix://` formats. |
 | `APME_ABBENAY_TOKEN` | — | Consumer token for Abbenay authentication. Must match a token in Abbenay's `config.yaml`. |
+| `APME_ABBENAY_TLS` | — | Set to `true` when the Abbenay daemon uses `--grpc-tls` (required for non-loopback TCP after Abbenay C2). |
+| `APME_ABBENAY_CA_CERT` | — | Path to the Abbenay CA PEM inside the Primary container (e.g. `/tmp/abbenay-run/abbenay/tls/ca.crt` in Podman). |
+| `APME_ABBENAY_SSL_TARGET_NAME` | `abbenay-grpc` | TLS server name override for Abbenay auto-generated certs. |
 | `APME_AI_MODEL` | — | Default AI model ID (e.g., `anthropic/claude-sonnet-4`). Overridden by UI Settings or CLI `--model`. |
 | `APME_RULE_AUTHORITY` | `true` | Set to `true` on exactly one Primary in multi-pod deployments. Only the authority registers the rule catalog to the Gateway (ADR-041). |
 

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -100,6 +100,37 @@ ensure_helm
 echo "==> helm lint ${CHART_DIR}"
 "${HELM_BIN}" lint "${CHART_DIR}"
 
+echo "==> helm template abbenay TLS validation (engine deployment)"
+TLS_VALUES="${ROOT}/tests/fixtures/helm_abbenay_tls_base.yaml"
+if "${HELM_BIN}" template test-release "${CHART_DIR}" \
+  --show-only templates/engine-deployment.yaml \
+  -f "${TLS_VALUES}" \
+  --set abbenay.grpc.tls=true \
+  --set abbenay.grpc.caCertSecret.name="" >/dev/null 2>&1; then
+  echo "Expected helm template to fail when abbenay.grpc.tls=true without caCertSecret.name" >&2
+  exit 1
+fi
+
+ENGINE_YAML="$("${HELM_BIN}" template test-release "${CHART_DIR}" \
+  --show-only templates/engine-deployment.yaml \
+  -f "${TLS_VALUES}" \
+  --set abbenay.grpc.tls=true \
+  --set abbenay.grpc.caCertSecret.name=my-abbenay-ca \
+  --set abbenay.grpc.caCertPath=/custom/tls/ca.pem)"
+
+if ! grep -Fq 'mountPath: /custom/tls' <<<"${ENGINE_YAML}"; then
+  echo "Expected CA volume mountPath derived from abbenay.grpc.caCertPath parent dir" >&2
+  exit 1
+fi
+if ! grep -Fq 'value: "/custom/tls/ca.pem"' <<<"${ENGINE_YAML}"; then
+  echo "Expected APME_ABBENAY_CA_CERT to match abbenay.grpc.caCertPath" >&2
+  exit 1
+fi
+if ! grep -Fq 'path: ca.pem' <<<"${ENGINE_YAML}"; then
+  echo "Expected Secret volume item path derived from abbenay.grpc.caCertPath basename" >&2
+  exit 1
+fi
+
 mkdir -p "${OUT_DIR}"
 echo "==> helm package ${CHART_DIR} -> ${OUT_DIR}"
 "${HELM_BIN}" package "${CHART_DIR}" -d "${OUT_DIR}"

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -131,6 +131,26 @@ if ! grep -Fq 'path: ca.pem' <<<"${ENGINE_YAML}"; then
   exit 1
 fi
 
+echo "==> helm template abbenay TLS secret seeding (abbenay deployment)"
+ABBENAY_TLS_YAML="$("${HELM_BIN}" template test-release "${CHART_DIR}" \
+  --show-only templates/abbenay-deployment.yaml \
+  -f "${TLS_VALUES}" \
+  --set abbenay.grpc.tls=true \
+  --set abbenay.grpc.insecure=false \
+  --set abbenay.grpc.caCertSecret.name=my-abbenay-tls)"
+if ! grep -Fq 'name: seed-abbenay-tls' <<<"${ABBENAY_TLS_YAML}"; then
+  echo "Expected abbenay TLS init container to seed shared runtime material" >&2
+  exit 1
+fi
+if ! grep -Fq 'name: abbenay-tls-runtime' <<<"${ABBENAY_TLS_YAML}"; then
+  echo "Expected abbenay TLS runtime emptyDir volume when tls=true" >&2
+  exit 1
+fi
+if ! grep -Fq 'cp "/secret/server.crt" /tmp/abbenay-run/abbenay/tls/server.crt' <<<"${ABBENAY_TLS_YAML}"; then
+  echo "Expected abbenay TLS init container to copy server certificate from Secret" >&2
+  exit 1
+fi
+
 echo "==> helm template abbenay bind validation (non-loopback without tls/insecure)"
 if "${HELM_BIN}" template test-release "${CHART_DIR}" \
   --show-only templates/abbenay-deployment.yaml \

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -131,6 +131,31 @@ if ! grep -Fq 'path: ca.pem' <<<"${ENGINE_YAML}"; then
   exit 1
 fi
 
+echo "==> helm template abbenay bind validation (non-loopback without tls/insecure)"
+if "${HELM_BIN}" template test-release "${CHART_DIR}" \
+  --show-only templates/abbenay-deployment.yaml \
+  -f "${TLS_VALUES}" \
+  --set abbenay.grpc.host=0.0.0.0 \
+  --set abbenay.grpc.tls=false \
+  --set abbenay.grpc.insecure=false >/dev/null 2>&1; then
+  echo "Expected helm template to fail for non-loopback bind without tls or insecure" >&2
+  exit 1
+fi
+
+echo "==> helm template abbenay deployment uses configurable grpc port"
+ABBENAY_YAML="$("${HELM_BIN}" template test-release "${CHART_DIR}" \
+  --show-only templates/abbenay-deployment.yaml \
+  -f "${TLS_VALUES}" \
+  --set abbenay.grpc.port=50123)"
+if ! grep -Fq 'containerPort: 50123' <<<"${ABBENAY_YAML}"; then
+  echo "Expected abbenay containerPort to match abbenay.grpc.port" >&2
+  exit 1
+fi
+if ! grep -Fq 'port: grpc' <<<"${ABBENAY_YAML}"; then
+  echo "Expected abbenay probes to reference the named grpc port" >&2
+  exit 1
+fi
+
 mkdir -p "${OUT_DIR}"
 echo "==> helm package ${CHART_DIR} -> ${OUT_DIR}"
 "${HELM_BIN}" package "${CHART_DIR}" -d "${OUT_DIR}"

--- a/src/apme_engine/daemon/primary_server.py
+++ b/src/apme_engine/daemon/primary_server.py
@@ -3411,7 +3411,7 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             ListAIModelsResponse with available models.
         """
         try:
-            from abbenay_grpc import AbbenayClient  # noqa: PLC0415
+            from apme_engine.remediation.abbenay_client_factory import build_abbenay_client  # noqa: PLC0415
         except ImportError:
             logger.debug("abbenay_grpc not installed — returning empty model list")
             return ListAIModelsResponse(models=[])
@@ -3421,19 +3421,12 @@ class PrimaryServicer(primary_pb2_grpc.PrimaryServicer):
             return ListAIModelsResponse(models=[])
 
         try:
-            if addr.startswith("unix://"):
-                client = AbbenayClient(addr)
-            else:
-                host, sep, port_str = addr.rpartition(":")
-                if sep:
-                    client = AbbenayClient(host=host or "localhost", port=int(port_str))
-                else:
-                    client = AbbenayClient(host=addr)
-            await client.connect()
+            client = build_abbenay_client(addr)
+            await client.connect()  # type: ignore[attr-defined]
             try:
-                raw_models = await client.list_models()
+                raw_models = await client.list_models()  # type: ignore[attr-defined]
             finally:
-                await client.disconnect()
+                await client.disconnect()  # type: ignore[attr-defined]
 
             models = [AIModelInfo(id=m.id, provider=m.provider, name=m.name) for m in raw_models]
             return ListAIModelsResponse(models=models)

--- a/src/apme_engine/remediation/abbenay_client_factory.py
+++ b/src/apme_engine/remediation/abbenay_client_factory.py
@@ -1,0 +1,221 @@
+"""Factory for Abbenay gRPC clients with optional TLS (issue #400).
+
+Older ``abbenay-client`` wheels lack ``tls`` / ``ca_cert`` constructor kwargs.
+When TLS is required, a thin subclass overrides ``connect()`` to use
+``grpc.aio.secure_channel`` until the dependency ships native TLS support.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import os
+from dataclasses import dataclass
+
+import grpc
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CA_CERT = "/tmp/abbenay-run/abbenay/tls/ca.crt"
+_DEFAULT_SSL_TARGET_NAME = "abbenay-grpc"
+
+
+@dataclass(frozen=True)
+class AbbenayTlsConfig:
+    """TLS settings for TCP connections to Abbenay.
+
+    Attributes:
+        enabled: Whether to use TLS for TCP connections.
+        ca_cert: Path to CA PEM, if any.
+        ssl_target_name: TLS server name override for auto-generated certs.
+    """
+
+    enabled: bool
+    ca_cert: str | None
+    ssl_target_name: str
+
+
+def resolve_abbenay_tls_config(addr: str) -> AbbenayTlsConfig:
+    """Resolve TLS settings from environment and address type.
+
+    Args:
+        addr: Abbenay daemon address (``host:port`` or ``unix://``).
+
+    Returns:
+        TLS configuration for ``build_abbenay_client``.
+    """
+    explicit_tls = os.environ.get("APME_ABBENAY_TLS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    ca_cert = os.environ.get("APME_ABBENAY_CA_CERT", "").strip() or None
+    ssl_target_name = os.environ.get("APME_ABBENAY_SSL_TARGET_NAME", _DEFAULT_SSL_TARGET_NAME).strip()
+
+    if not explicit_tls and ca_cert is None and _is_tcp_addr(addr) and os.path.isfile(_DEFAULT_CA_CERT):
+        ca_cert = _DEFAULT_CA_CERT
+        explicit_tls = True
+
+    enabled = explicit_tls or ca_cert is not None
+    return AbbenayTlsConfig(enabled=enabled, ca_cert=ca_cert, ssl_target_name=ssl_target_name)
+
+
+def build_abbenay_client(addr: str) -> object:
+    """Create an AbbenayClient for the given daemon address.
+
+    Args:
+        addr: Daemon address from ``APME_ABBENAY_ADDR`` or auto-discovery.
+
+    Returns:
+        ``AbbenayClient`` instance (not yet connected).
+    """
+    from abbenay_grpc import AbbenayClient  # noqa: PLC0415
+
+    kwargs = _parse_addr_kwargs(addr)
+    tls = resolve_abbenay_tls_config(addr)
+    use_tls = tls.enabled and not addr.startswith("unix://")
+
+    if not use_tls:
+        return AbbenayClient(**kwargs)
+
+    if "tls" in inspect.signature(AbbenayClient.__init__).parameters:
+        return AbbenayClient(
+            **kwargs,
+            tls=True,
+            ca_cert=tls.ca_cert,
+            ssl_target_name=tls.ssl_target_name,
+        )
+
+    if "socket_path" in kwargs:
+        return _TlsAbbenayClient(
+            socket_path=str(kwargs["socket_path"]),
+            ca_cert=tls.ca_cert,
+            ssl_target_name=tls.ssl_target_name,
+        )
+    return _TlsAbbenayClient(
+        host=str(kwargs.get("host", "localhost")),
+        port=int(kwargs.get("port", 50051)),
+        ca_cert=tls.ca_cert,
+        ssl_target_name=tls.ssl_target_name,
+    )
+
+
+def _is_tcp_addr(addr: str) -> bool:
+    return not addr.startswith("unix://") and bool(addr)
+
+
+def _parse_addr_kwargs(addr: str) -> dict[str, str | int]:
+    if addr.startswith("unix://"):
+        return {"socket_path": addr.removeprefix("unix://")}
+    if ":" in addr:
+        host, _, port_str = addr.rpartition(":")
+        return {"host": host or "localhost", "port": int(port_str)}
+    return {"host": addr}
+
+
+class _TlsAbbenayClient:
+    """AbbenayClient shim that connects over TLS for older client wheels."""
+
+    def __init__(
+        self,
+        *,
+        socket_path: str | None = None,
+        host: str | None = None,
+        port: int = 50051,
+        ca_cert: str | None = None,
+        ssl_target_name: str = _DEFAULT_SSL_TARGET_NAME,
+    ) -> None:
+        """Initialize the TLS shim around a delegate AbbenayClient.
+
+        Args:
+            socket_path: Unix socket path, if used.
+            host: TCP host, if used.
+            port: TCP port.
+            ca_cert: Path to CA PEM matching the daemon certificate.
+            ssl_target_name: TLS server name override.
+        """
+        from abbenay_grpc import AbbenayClient  # noqa: PLC0415
+
+        self._delegate = AbbenayClient(
+            socket_path=socket_path,
+            host=host,
+            port=port,
+        )
+        self._target = self._delegate._target  # noqa: SLF001
+        self._ca_cert = ca_cert
+        self._ssl_target_name = ssl_target_name
+        self._channel: grpc.aio.Channel | None = None
+        self._stub: object | None = None
+        self._client_id: str | None = None
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._delegate, name)
+
+    async def connect(self) -> None:
+        from abbenay_grpc.client import (  # noqa: PLC0415  # noqa: PLC0415
+            AbbenayError,
+            grpc_service,
+            proto,
+        )
+        from abbenay_grpc.client import (
+            ConnectionError as AbbenayConnectionError,
+        )
+
+        if grpc_service is None or proto is None:
+            raise AbbenayError("gRPC stubs failed to import")
+
+        if self._channel is not None:
+            usable = False
+            try:
+                state = self._channel.get_state(try_to_connect=False)
+                usable = state in (
+                    grpc.ChannelConnectivity.IDLE,
+                    grpc.ChannelConnectivity.READY,
+                    grpc.ChannelConnectivity.CONNECTING,
+                )
+            except Exception:
+                logger.debug("Abbenay TLS channel state check failed", exc_info=True)
+            if usable and self._stub is not None and self._client_id is not None:
+                return
+            try:
+                await self._channel.close(grace=None)
+            except Exception:
+                logger.debug("Abbenay TLS channel close failed", exc_info=True)
+            self._channel = None
+            self._stub = None
+            self._client_id = None
+
+        try:
+            root_certs = None
+            if self._ca_cert:
+                with open(self._ca_cert, "rb") as cert_file:
+                    root_certs = cert_file.read()
+            credentials = grpc.ssl_channel_credentials(root_certificates=root_certs)
+            options = [
+                ("grpc.ssl_target_name_override", self._ssl_target_name),
+                ("grpc.default_authority", self._ssl_target_name),
+            ]
+            self._channel = grpc.aio.secure_channel(self._target, credentials, options=options)
+            stub = grpc_service.AbbenayStub(self._channel)
+            response = await stub.Register(
+                proto.RegisterRequest(
+                    client=proto.ClientInfo(client_type=proto.CLIENT_TYPE_PYTHON),
+                    is_spawner=False,
+                )
+            )
+            self._stub = stub
+            self._client_id = response.client_id
+            self._delegate._channel = self._channel  # noqa: SLF001
+            self._delegate._stub = stub  # noqa: SLF001
+            self._delegate._client_id = self._client_id  # noqa: SLF001
+        except grpc.aio.AioRpcError as exc:
+            self._channel = None
+            self._stub = None
+            self._client_id = None
+            raise AbbenayConnectionError(f"Failed to connect to daemon: {exc}") from exc
+
+    async def disconnect(self) -> None:
+        await self._delegate.disconnect()
+
+    async def reconnect(self) -> None:
+        await self._delegate.reconnect()

--- a/src/apme_engine/remediation/abbenay_client_factory.py
+++ b/src/apme_engine/remediation/abbenay_client_factory.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import inspect
 import logging
 import os
+import stat
 from dataclasses import dataclass
 
 import grpc
@@ -27,12 +28,14 @@ class AbbenayTlsConfig:
 
     Attributes:
         enabled: Whether to use TLS for TCP connections.
-        ca_cert: Path to CA PEM, if any.
+        ca_cert: Path to CA PEM from ``APME_ABBENAY_CA_CERT``, if any.
+        ca_cert_pem: Pre-validated PEM bytes from auto-discovery, if any.
         ssl_target_name: TLS server name override for auto-generated certs.
     """
 
     enabled: bool
     ca_cert: str | None
+    ca_cert_pem: bytes | None
     ssl_target_name: str
 
 
@@ -51,16 +54,22 @@ def resolve_abbenay_tls_config(addr: str) -> AbbenayTlsConfig:
         "yes",
     }
     ca_cert = os.environ.get("APME_ABBENAY_CA_CERT", "").strip() or None
+    ca_cert_pem: bytes | None = None
     ssl_target_name = os.environ.get("APME_ABBENAY_SSL_TARGET_NAME", _DEFAULT_SSL_TARGET_NAME).strip()
 
     if not explicit_tls and ca_cert is None and _is_tcp_addr(addr):
         discovered = _discover_default_ca_cert()
         if discovered is not None:
-            ca_cert = discovered
+            ca_cert_pem = discovered
             explicit_tls = True
 
-    enabled = explicit_tls or ca_cert is not None
-    return AbbenayTlsConfig(enabled=enabled, ca_cert=ca_cert, ssl_target_name=ssl_target_name)
+    enabled = explicit_tls or ca_cert is not None or ca_cert_pem is not None
+    return AbbenayTlsConfig(
+        enabled=enabled,
+        ca_cert=ca_cert,
+        ca_cert_pem=ca_cert_pem,
+        ssl_target_name=ssl_target_name,
+    )
 
 
 def build_abbenay_client(addr: str) -> object:
@@ -93,12 +102,14 @@ def build_abbenay_client(addr: str) -> object:
         return _TlsAbbenayClient(
             socket_path=str(kwargs["socket_path"]),
             ca_cert=tls.ca_cert,
+            ca_cert_pem=tls.ca_cert_pem,
             ssl_target_name=tls.ssl_target_name,
         )
     return _TlsAbbenayClient(
         host=str(kwargs.get("host", "localhost")),
         port=int(kwargs.get("port", 50051)),
         ca_cert=tls.ca_cert,
+        ca_cert_pem=tls.ca_cert_pem,
         ssl_target_name=tls.ssl_target_name,
     )
 
@@ -118,33 +129,59 @@ def _default_ca_cert_candidates() -> list[str]:
     return candidates
 
 
-def _is_trusted_ca_cert(path: str) -> bool:
-    """Return True when ``path`` is a CA file owned by us and not group/world-writable.
+def _is_trusted_ca_stat(file_stat: os.stat_result) -> bool:
+    """Return True when ``file_stat`` describes a CA file we can trust.
 
     Args:
-        path: Candidate CA PEM path.
+        file_stat: ``os.fstat`` result for an open CA descriptor.
 
     Returns:
         Whether the file is safe to trust as a TLS CA.
     """
-    try:
-        file_stat = os.stat(path)
-    except OSError:
+    if not stat.S_ISREG(file_stat.st_mode):
         return False
     if file_stat.st_uid not in {os.getuid(), 0}:
         return False
     return (file_stat.st_mode & 0o022) == 0
 
 
-def _discover_default_ca_cert() -> str | None:
-    """Return the first trusted auto-generated Abbenay CA path, if any.
+def _read_trusted_ca_pem(path: str) -> bytes | None:
+    """Open, validate, and read a candidate CA PEM without following symlinks.
+
+    Args:
+        path: Candidate CA PEM path.
 
     Returns:
-        Trusted CA path, or None when no candidate is safe.
+        PEM bytes when the file is trusted, otherwise None.
+    """
+    open_flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        open_flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(path, open_flags)
+    except OSError:
+        return None
+    try:
+        file_stat = os.fstat(fd)
+        if not _is_trusted_ca_stat(file_stat):
+            return None
+        return os.read(fd, file_stat.st_size + 1)
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+
+
+def _discover_default_ca_cert() -> bytes | None:
+    """Return trusted auto-generated Abbenay CA PEM bytes, if any.
+
+    Returns:
+        Trusted CA PEM, or None when no candidate is safe.
     """
     for candidate in _default_ca_cert_candidates():
-        if os.path.isfile(candidate) and _is_trusted_ca_cert(candidate):
-            return candidate
+        pem = _read_trusted_ca_pem(candidate)
+        if pem is not None:
+            return pem
     return None
 
 
@@ -167,6 +204,7 @@ class _TlsAbbenayClient:
         host: str | None = None,
         port: int = 50051,
         ca_cert: str | None = None,
+        ca_cert_pem: bytes | None = None,
         ssl_target_name: str = _DEFAULT_SSL_TARGET_NAME,
     ) -> None:
         """Initialize the TLS shim around a delegate AbbenayClient.
@@ -176,6 +214,7 @@ class _TlsAbbenayClient:
             host: TCP host, if used.
             port: TCP port.
             ca_cert: Path to CA PEM matching the daemon certificate.
+            ca_cert_pem: Pre-validated CA PEM from auto-discovery.
             ssl_target_name: TLS server name override.
         """
         from abbenay_grpc import AbbenayClient  # noqa: PLC0415
@@ -187,6 +226,7 @@ class _TlsAbbenayClient:
         )
         self._target = self._delegate._target  # noqa: SLF001
         self._ca_cert = ca_cert
+        self._ca_cert_pem = ca_cert_pem
         self._ssl_target_name = ssl_target_name
         self._channel: grpc.aio.Channel | None = None
         self._stub: object | None = None
@@ -231,7 +271,9 @@ class _TlsAbbenayClient:
 
         try:
             root_certs = None
-            if self._ca_cert:
+            if self._ca_cert_pem is not None:
+                root_certs = self._ca_cert_pem
+            elif self._ca_cert:
                 with open(self._ca_cert, "rb") as cert_file:
                     root_certs = cert_file.read()
             credentials = grpc.ssl_channel_credentials(root_certificates=root_certs)
@@ -252,7 +294,7 @@ class _TlsAbbenayClient:
             self._delegate._channel = self._channel  # noqa: SLF001
             self._delegate._stub = stub  # noqa: SLF001
             self._delegate._client_id = self._client_id  # noqa: SLF001
-        except grpc.aio.AioRpcError as exc:
+        except (grpc.aio.AioRpcError, OSError, ValueError) as exc:
             self._channel = None
             self._stub = None
             self._client_id = None

--- a/src/apme_engine/remediation/abbenay_client_factory.py
+++ b/src/apme_engine/remediation/abbenay_client_factory.py
@@ -7,6 +7,7 @@ When TLS is required, a thin subclass overrides ``connect()`` to use
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import os
@@ -231,6 +232,7 @@ class _TlsAbbenayClient:
         self._channel: grpc.aio.Channel | None = None
         self._stub: object | None = None
         self._client_id: str | None = None
+        self._connect_lock = asyncio.Lock()
 
     def __getattr__(self, name: str) -> object:
         return getattr(self._delegate, name)
@@ -245,60 +247,61 @@ class _TlsAbbenayClient:
             ConnectionError as AbbenayConnectionError,
         )
 
-        if grpc_service is None or proto is None:
-            raise AbbenayError("gRPC stubs failed to import")
+        async with self._connect_lock:
+            if grpc_service is None or proto is None:
+                raise AbbenayError("gRPC stubs failed to import")
 
-        if self._channel is not None:
-            usable = False
-            try:
-                state = self._channel.get_state(try_to_connect=False)
-                usable = state in (
-                    grpc.ChannelConnectivity.IDLE,
-                    grpc.ChannelConnectivity.READY,
-                    grpc.ChannelConnectivity.CONNECTING,
-                )
-            except Exception:
-                logger.debug("Abbenay TLS channel state check failed", exc_info=True)
-            if usable and self._stub is not None and self._client_id is not None:
-                return
-            try:
-                await self._channel.close(grace=None)
-            except Exception:
-                logger.debug("Abbenay TLS channel close failed", exc_info=True)
-            self._channel = None
-            self._stub = None
-            self._client_id = None
+            if self._channel is not None:
+                usable = False
+                try:
+                    state = self._channel.get_state(try_to_connect=False)
+                    usable = state in (
+                        grpc.ChannelConnectivity.IDLE,
+                        grpc.ChannelConnectivity.READY,
+                        grpc.ChannelConnectivity.CONNECTING,
+                    )
+                except Exception:
+                    logger.debug("Abbenay TLS channel state check failed", exc_info=True)
+                if usable and self._stub is not None and self._client_id is not None:
+                    return
+                try:
+                    await self._channel.close(grace=None)
+                except Exception:
+                    logger.debug("Abbenay TLS channel close failed", exc_info=True)
+                self._channel = None
+                self._stub = None
+                self._client_id = None
 
-        try:
-            root_certs = None
-            if self._ca_cert_pem is not None:
-                root_certs = self._ca_cert_pem
-            elif self._ca_cert:
-                with open(self._ca_cert, "rb") as cert_file:
-                    root_certs = cert_file.read()
-            credentials = grpc.ssl_channel_credentials(root_certificates=root_certs)
-            options = [
-                ("grpc.ssl_target_name_override", self._ssl_target_name),
-                ("grpc.default_authority", self._ssl_target_name),
-            ]
-            self._channel = grpc.aio.secure_channel(self._target, credentials, options=options)
-            stub = grpc_service.AbbenayStub(self._channel)
-            response = await stub.Register(
-                proto.RegisterRequest(
-                    client=proto.ClientInfo(client_type=proto.CLIENT_TYPE_PYTHON),
-                    is_spawner=False,
+            try:
+                root_certs = None
+                if self._ca_cert_pem is not None:
+                    root_certs = self._ca_cert_pem
+                elif self._ca_cert:
+                    with open(self._ca_cert, "rb") as cert_file:
+                        root_certs = cert_file.read()
+                credentials = grpc.ssl_channel_credentials(root_certificates=root_certs)
+                options = [
+                    ("grpc.ssl_target_name_override", self._ssl_target_name),
+                    ("grpc.default_authority", self._ssl_target_name),
+                ]
+                self._channel = grpc.aio.secure_channel(self._target, credentials, options=options)
+                stub = grpc_service.AbbenayStub(self._channel)
+                response = await stub.Register(
+                    proto.RegisterRequest(
+                        client=proto.ClientInfo(client_type=proto.CLIENT_TYPE_PYTHON),
+                        is_spawner=False,
+                    )
                 )
-            )
-            self._stub = stub
-            self._client_id = response.client_id
-            self._delegate._channel = self._channel  # noqa: SLF001
-            self._delegate._stub = stub  # noqa: SLF001
-            self._delegate._client_id = self._client_id  # noqa: SLF001
-        except (grpc.aio.AioRpcError, OSError, ValueError) as exc:
-            self._channel = None
-            self._stub = None
-            self._client_id = None
-            raise AbbenayConnectionError(f"Failed to connect to daemon: {exc}") from exc
+                self._stub = stub
+                self._client_id = response.client_id
+                self._delegate._channel = self._channel  # noqa: SLF001
+                self._delegate._stub = stub  # noqa: SLF001
+                self._delegate._client_id = self._client_id  # noqa: SLF001
+            except (grpc.aio.AioRpcError, OSError, ValueError) as exc:
+                self._channel = None
+                self._stub = None
+                self._client_id = None
+                raise AbbenayConnectionError(f"Failed to connect to daemon: {exc}") from exc
 
     async def disconnect(self) -> None:
         await self._delegate.disconnect()

--- a/src/apme_engine/remediation/abbenay_client_factory.py
+++ b/src/apme_engine/remediation/abbenay_client_factory.py
@@ -16,7 +16,8 @@ import grpc
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_CA_CERT = "/tmp/abbenay-run/abbenay/tls/ca.crt"
+_TLS_CA_RELATIVE = os.path.join("abbenay", "tls", "ca.crt")
+_LEGACY_RUNTIME_DIR = "/tmp/abbenay-run"
 _DEFAULT_SSL_TARGET_NAME = "abbenay-grpc"
 
 
@@ -52,9 +53,11 @@ def resolve_abbenay_tls_config(addr: str) -> AbbenayTlsConfig:
     ca_cert = os.environ.get("APME_ABBENAY_CA_CERT", "").strip() or None
     ssl_target_name = os.environ.get("APME_ABBENAY_SSL_TARGET_NAME", _DEFAULT_SSL_TARGET_NAME).strip()
 
-    if not explicit_tls and ca_cert is None and _is_tcp_addr(addr) and os.path.isfile(_DEFAULT_CA_CERT):
-        ca_cert = _DEFAULT_CA_CERT
-        explicit_tls = True
+    if not explicit_tls and ca_cert is None and _is_tcp_addr(addr):
+        discovered = _discover_default_ca_cert()
+        if discovered is not None:
+            ca_cert = discovered
+            explicit_tls = True
 
     enabled = explicit_tls or ca_cert is not None
     return AbbenayTlsConfig(enabled=enabled, ca_cert=ca_cert, ssl_target_name=ssl_target_name)
@@ -102,6 +105,47 @@ def build_abbenay_client(addr: str) -> object:
 
 def _is_tcp_addr(addr: str) -> bool:
     return not addr.startswith("unix://") and bool(addr)
+
+
+def _default_ca_cert_candidates() -> list[str]:
+    candidates: list[str] = []
+    xdg = os.environ.get("XDG_RUNTIME_DIR", "").strip()
+    if xdg:
+        candidates.append(os.path.join(xdg, _TLS_CA_RELATIVE))
+    legacy = os.path.join(_LEGACY_RUNTIME_DIR, _TLS_CA_RELATIVE)
+    if legacy not in candidates:
+        candidates.append(legacy)
+    return candidates
+
+
+def _is_trusted_ca_cert(path: str) -> bool:
+    """Return True when ``path`` is a CA file owned by us and not group/world-writable.
+
+    Args:
+        path: Candidate CA PEM path.
+
+    Returns:
+        Whether the file is safe to trust as a TLS CA.
+    """
+    try:
+        file_stat = os.stat(path)
+    except OSError:
+        return False
+    if file_stat.st_uid not in {os.getuid(), 0}:
+        return False
+    return (file_stat.st_mode & 0o022) == 0
+
+
+def _discover_default_ca_cert() -> str | None:
+    """Return the first trusted auto-generated Abbenay CA path, if any.
+
+    Returns:
+        Trusted CA path, or None when no candidate is safe.
+    """
+    for candidate in _default_ca_cert_candidates():
+        if os.path.isfile(candidate) and _is_trusted_ca_cert(candidate):
+            return candidate
+    return None
 
 
 def _parse_addr_kwargs(addr: str) -> dict[str, str | int]:
@@ -218,4 +262,5 @@ class _TlsAbbenayClient:
         await self._delegate.disconnect()
 
     async def reconnect(self) -> None:
-        await self._delegate.reconnect()
+        # Delegate reconnect() uses insecure_channel; route through TLS connect().
+        await self.connect()

--- a/src/apme_engine/remediation/abbenay_provider.py
+++ b/src/apme_engine/remediation/abbenay_provider.py
@@ -653,24 +653,19 @@ class AbbenayProvider:
             ImportError: If abbenay_grpc is not installed.
         """
         try:
-            from abbenay_grpc import AbbenayClient  # noqa: PLC0415
+            from apme_engine.remediation.abbenay_client_factory import (  # noqa: PLC0415
+                build_abbenay_client,
+            )
         except ImportError:
             raise ImportError(
                 "AI escalation requires the 'ai' extra.\nInstall with: pip install apme-engine[ai]"
             ) from None
 
-        if addr.startswith("unix://"):
-            socket_path = addr.removeprefix("unix://")
-            self._client: object = AbbenayClient(socket_path=socket_path)
-        elif ":" in addr:
-            host, _, port_str = addr.rpartition(":")
-            self._client = AbbenayClient(host=host, port=int(port_str))
-        else:
-            self._client = AbbenayClient(host=addr)
+        self._client: object = build_abbenay_client(addr)
         self._addr = addr
         self._token = token
         self._model = model
-        self._AbbenayClient = AbbenayClient
+        self._build_client = build_abbenay_client
 
     def _make_client(self) -> object:
         """Create a fresh AbbenayClient instance for the current event loop.
@@ -678,13 +673,7 @@ class AbbenayProvider:
         Returns:
             New AbbenayClient bound to the current asyncio loop.
         """
-        addr = self._addr
-        if addr.startswith("unix://"):
-            return self._AbbenayClient(socket_path=addr.removeprefix("unix://"))
-        if ":" in addr:
-            host, _, port_str = addr.rpartition(":")
-            return self._AbbenayClient(host=host, port=int(port_str))
-        return self._AbbenayClient(host=addr)
+        return self._build_client(self._addr)
 
     async def preflight(self) -> bool:
         """Connect to the daemon and run a health check.

--- a/src/apme_engine/remediation/abbenay_provider.py
+++ b/src/apme_engine/remediation/abbenay_provider.py
@@ -656,12 +656,12 @@ class AbbenayProvider:
             from apme_engine.remediation.abbenay_client_factory import (  # noqa: PLC0415
                 build_abbenay_client,
             )
+
+            self._client: object = build_abbenay_client(addr)
         except ImportError:
             raise ImportError(
                 "AI escalation requires the 'ai' extra.\nInstall with: pip install apme-engine[ai]"
             ) from None
-
-        self._client: object = build_abbenay_client(addr)
         self._addr = addr
         self._token = token
         self._model = model

--- a/tests/fixtures/helm_abbenay_tls_base.yaml
+++ b/tests/fixtures/helm_abbenay_tls_base.yaml
@@ -1,0 +1,9 @@
+# Minimal Abbenay values for Helm template TLS render tests (scripts/helm_chart.sh).
+abbenay:
+  enabled: true
+  token: "helm-render-test-token"
+  providers:
+    mock:
+      engine: mock
+      models:
+        test: {}

--- a/tests/test_abbenay_client_factory.py
+++ b/tests/test_abbenay_client_factory.py
@@ -11,6 +11,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from apme_engine.remediation.abbenay_client_factory import (
+    _LEGACY_RUNTIME_DIR,
+    _TLS_CA_RELATIVE,
     _discover_default_ca_cert,
     _TlsAbbenayClient,
     build_abbenay_client,
@@ -53,7 +55,8 @@ class TestResolveAbbenayTlsConfig:
         """
         monkeypatch.delenv("APME_ABBENAY_TLS", raising=False)
         monkeypatch.delenv("APME_ABBENAY_CA_CERT", raising=False)
-        ca_path = "/tmp/abbenay-run/abbenay/tls/ca.crt"
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        ca_path = os.path.join(_LEGACY_RUNTIME_DIR, _TLS_CA_RELATIVE)
         trusted = os.stat_result((stat.S_IFREG | 0o644, 0, 0, 0, os.getuid(), 0, 0, 0, 0, 0))
         with (
             patch("apme_engine.remediation.abbenay_client_factory.os.path.isfile", return_value=True),

--- a/tests/test_abbenay_client_factory.py
+++ b/tests/test_abbenay_client_factory.py
@@ -1,0 +1,139 @@
+"""Tests for Abbenay client factory TLS resolution (issue #400)."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from apme_engine.remediation.abbenay_client_factory import (
+    build_abbenay_client,
+    resolve_abbenay_tls_config,
+)
+
+
+class TestResolveAbbenayTlsConfig:
+    """TLS config resolution from environment."""
+
+    def test_unix_addr_never_enables_tls(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unix sockets stay plaintext regardless of TLS env vars.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("APME_ABBENAY_TLS", "true")
+        monkeypatch.setenv("APME_ABBENAY_CA_CERT", "/etc/ca.crt")
+        cfg = resolve_abbenay_tls_config("unix:///run/abbenay.sock")
+        assert cfg.enabled is True
+        assert cfg.ca_cert == "/etc/ca.crt"
+
+    def test_tcp_plaintext_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """TCP without env vars or default CA path stays plaintext.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("APME_ABBENAY_TLS", raising=False)
+        monkeypatch.delenv("APME_ABBENAY_CA_CERT", raising=False)
+        with patch("apme_engine.remediation.abbenay_client_factory.os.path.isfile", return_value=False):
+            cfg = resolve_abbenay_tls_config("abbenay:50057")
+        assert cfg.enabled is False
+
+    def test_auto_tls_when_default_ca_exists(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Podman shared runtime CA enables TLS without explicit env.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("APME_ABBENAY_TLS", raising=False)
+        monkeypatch.delenv("APME_ABBENAY_CA_CERT", raising=False)
+        with patch("apme_engine.remediation.abbenay_client_factory.os.path.isfile", return_value=True):
+            cfg = resolve_abbenay_tls_config("127.0.0.1:50057")
+        assert cfg.enabled is True
+        assert cfg.ca_cert == "/tmp/abbenay-run/abbenay/tls/ca.crt"
+
+
+class TestBuildAbbenayClient:
+    """Client construction for TCP, Unix, and TLS paths."""
+
+    def test_plaintext_tcp_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """TCP without TLS builds a standard AbbenayClient.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("APME_ABBENAY_TLS", raising=False)
+        calls: list[dict[str, object]] = []
+
+        class FakeAbbenayClient:
+            def __init__(
+                self,
+                *,
+                socket_path: str | None = None,
+                host: str | None = None,
+                port: int = 50051,
+            ) -> None:
+                calls.append({"socket_path": socket_path, "host": host, "port": port})
+
+        fake_module = type(sys)("abbenay_grpc")
+        fake_module.AbbenayClient = FakeAbbenayClient  # type: ignore[attr-defined]
+
+        with (
+            patch.dict(sys.modules, {"abbenay_grpc": fake_module}),
+            patch("apme_engine.remediation.abbenay_client_factory.os.path.isfile", return_value=False),
+        ):
+            client = build_abbenay_client("127.0.0.1:50057")
+
+        assert isinstance(client, FakeAbbenayClient)
+        assert calls == [{"socket_path": None, "host": "127.0.0.1", "port": 50057}]
+
+    def test_tls_uses_native_client_when_supported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Newer abbenay-client wheels receive tls kwargs directly.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("APME_ABBENAY_TLS", "true")
+        monkeypatch.setenv("APME_ABBENAY_CA_CERT", "/etc/ca.crt")
+        calls: list[dict[str, object]] = []
+
+        class FakeAbbenayClient:
+            def __init__(
+                self,
+                *,
+                socket_path: str | None = None,
+                host: str | None = None,
+                port: int = 50051,
+                tls: bool = False,
+                ca_cert: str | None = None,
+                ssl_target_name: str | None = None,
+            ) -> None:
+                calls.append(
+                    {
+                        "socket_path": socket_path,
+                        "host": host,
+                        "port": port,
+                        "tls": tls,
+                        "ca_cert": ca_cert,
+                        "ssl_target_name": ssl_target_name,
+                    }
+                )
+
+        fake_module = type(sys)("abbenay_grpc")
+        fake_module.AbbenayClient = FakeAbbenayClient  # type: ignore[attr-defined]
+
+        with patch.dict(sys.modules, {"abbenay_grpc": fake_module}):
+            client = build_abbenay_client("abbenay:50057")
+
+        assert isinstance(client, FakeAbbenayClient)
+        assert calls == [
+            {
+                "socket_path": None,
+                "host": "abbenay",
+                "port": 50057,
+                "tls": True,
+                "ca_cert": "/etc/ca.crt",
+                "ssl_target_name": "abbenay-grpc",
+            }
+        ]

--- a/tests/test_abbenay_client_factory.py
+++ b/tests/test_abbenay_client_factory.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import stat
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,8 +10,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from apme_engine.remediation.abbenay_client_factory import (
-    _LEGACY_RUNTIME_DIR,
-    _TLS_CA_RELATIVE,
     _discover_default_ca_cert,
     _TlsAbbenayClient,
     build_abbenay_client,
@@ -47,39 +44,43 @@ class TestResolveAbbenayTlsConfig:
             cfg = resolve_abbenay_tls_config("abbenay:50057")
         assert cfg.enabled is False
 
-    def test_auto_tls_when_default_ca_exists(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_auto_tls_when_default_ca_exists(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """Podman shared runtime CA enables TLS without explicit env.
 
         Args:
             monkeypatch: Pytest monkeypatch fixture.
+            tmp_path: Pytest temporary directory fixture.
         """
+        runtime = tmp_path / "runtime"
+        ca_path = runtime / "abbenay" / "tls" / "ca.crt"
+        ca_path.parent.mkdir(parents=True)
+        pem = b"-----BEGIN CERTIFICATE-----\npem\n-----END CERTIFICATE-----\n"
+        ca_path.write_bytes(pem)
+        os.chmod(ca_path, 0o644)
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime))
         monkeypatch.delenv("APME_ABBENAY_TLS", raising=False)
         monkeypatch.delenv("APME_ABBENAY_CA_CERT", raising=False)
-        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-        ca_path = os.path.join(_LEGACY_RUNTIME_DIR, _TLS_CA_RELATIVE)
-        trusted = os.stat_result((stat.S_IFREG | 0o644, 0, 0, 0, os.getuid(), 0, 0, 0, 0, 0))
-        with (
-            patch("apme_engine.remediation.abbenay_client_factory.os.path.isfile", return_value=True),
-            patch("apme_engine.remediation.abbenay_client_factory.os.stat", return_value=trusted),
-        ):
-            cfg = resolve_abbenay_tls_config("127.0.0.1:50057")
+        cfg = resolve_abbenay_tls_config("127.0.0.1:50057")
         assert cfg.enabled is True
-        assert cfg.ca_cert == ca_path
+        assert cfg.ca_cert is None
+        assert cfg.ca_cert_pem == pem
 
-    def test_ignores_untrusted_default_ca(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_ignores_untrusted_default_ca(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """World-writable CA files under /tmp are not auto-trusted.
 
         Args:
             monkeypatch: Pytest monkeypatch fixture.
+            tmp_path: Pytest temporary directory fixture.
         """
+        runtime = tmp_path / "runtime"
+        ca_path = runtime / "abbenay" / "tls" / "ca.crt"
+        ca_path.parent.mkdir(parents=True)
+        ca_path.write_text("pem", encoding="utf-8")
+        os.chmod(ca_path, 0o666)
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime))
         monkeypatch.delenv("APME_ABBENAY_TLS", raising=False)
         monkeypatch.delenv("APME_ABBENAY_CA_CERT", raising=False)
-        untrusted = os.stat_result((stat.S_IFREG | 0o666, 0, 0, 0, os.getuid(), 0, 0, 0, 0, 0))
-        with (
-            patch("apme_engine.remediation.abbenay_client_factory.os.path.isfile", return_value=True),
-            patch("apme_engine.remediation.abbenay_client_factory.os.stat", return_value=untrusted),
-        ):
-            cfg = resolve_abbenay_tls_config("127.0.0.1:50057")
+        cfg = resolve_abbenay_tls_config("127.0.0.1:50057")
         assert cfg.enabled is False
 
     def test_prefers_xdg_runtime_dir_ca(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -93,10 +94,12 @@ class TestResolveAbbenayTlsConfig:
         runtime.mkdir()
         ca_path = runtime / "abbenay" / "tls" / "ca.crt"
         ca_path.parent.mkdir(parents=True)
-        ca_path.write_text("pem", encoding="utf-8")
+        pem = b"pem-bytes"
+        ca_path.write_bytes(pem)
+        os.chmod(ca_path, 0o644)
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime))
         discovered = _discover_default_ca_cert()
-        assert discovered == str(ca_path)
+        assert discovered == pem
 
 
 class TestBuildAbbenayClient:
@@ -203,3 +206,24 @@ class TestTlsAbbenayClientReconnect:
 
         connect_mock.assert_awaited_once()
         client._delegate.reconnect.assert_not_awaited()  # noqa: SLF001
+
+
+class TestTlsAbbenayClientConnect:
+    """TLS shim connect error handling."""
+
+    @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+    async def test_connect_wraps_missing_ca_file(self) -> None:
+        """Unreadable CA paths raise AbbenayConnectionError, not raw OSError."""
+        fake_client_module = type(sys)("abbenay_grpc.client")
+        fake_client_module.AbbenayError = Exception  # type: ignore[attr-defined]
+        fake_client_module.ConnectionError = type("AbbenayConnectionError", (Exception,), {})  # type: ignore[attr-defined]
+        fake_client_module.grpc_service = MagicMock()  # type: ignore[attr-defined]
+        fake_client_module.proto = MagicMock()  # type: ignore[attr-defined]
+
+        fake_module = type(sys)("abbenay_grpc")
+        fake_module.AbbenayClient = MagicMock(return_value=MagicMock(_target="127.0.0.1:50057"))  # type: ignore[attr-defined]
+
+        with patch.dict(sys.modules, {"abbenay_grpc": fake_module, "abbenay_grpc.client": fake_client_module}):
+            client = _TlsAbbenayClient(host="127.0.0.1", port=50057, ca_cert="/missing/ca.crt")
+            with pytest.raises(fake_client_module.ConnectionError, match="Failed to connect to daemon"):
+                await client.connect()

--- a/tests/test_abbenay_client_factory.py
+++ b/tests/test_abbenay_client_factory.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import os
+import stat
 import sys
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from apme_engine.remediation.abbenay_client_factory import (
+    _discover_default_ca_cert,
+    _TlsAbbenayClient,
     build_abbenay_client,
     resolve_abbenay_tls_config,
 )
@@ -48,10 +53,47 @@ class TestResolveAbbenayTlsConfig:
         """
         monkeypatch.delenv("APME_ABBENAY_TLS", raising=False)
         monkeypatch.delenv("APME_ABBENAY_CA_CERT", raising=False)
-        with patch("apme_engine.remediation.abbenay_client_factory.os.path.isfile", return_value=True):
+        ca_path = "/tmp/abbenay-run/abbenay/tls/ca.crt"
+        trusted = os.stat_result((stat.S_IFREG | 0o644, 0, 0, 0, os.getuid(), 0, 0, 0, 0, 0))
+        with (
+            patch("apme_engine.remediation.abbenay_client_factory.os.path.isfile", return_value=True),
+            patch("apme_engine.remediation.abbenay_client_factory.os.stat", return_value=trusted),
+        ):
             cfg = resolve_abbenay_tls_config("127.0.0.1:50057")
         assert cfg.enabled is True
-        assert cfg.ca_cert == "/tmp/abbenay-run/abbenay/tls/ca.crt"
+        assert cfg.ca_cert == ca_path
+
+    def test_ignores_untrusted_default_ca(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """World-writable CA files under /tmp are not auto-trusted.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("APME_ABBENAY_TLS", raising=False)
+        monkeypatch.delenv("APME_ABBENAY_CA_CERT", raising=False)
+        untrusted = os.stat_result((stat.S_IFREG | 0o666, 0, 0, 0, os.getuid(), 0, 0, 0, 0, 0))
+        with (
+            patch("apme_engine.remediation.abbenay_client_factory.os.path.isfile", return_value=True),
+            patch("apme_engine.remediation.abbenay_client_factory.os.stat", return_value=untrusted),
+        ):
+            cfg = resolve_abbenay_tls_config("127.0.0.1:50057")
+        assert cfg.enabled is False
+
+    def test_prefers_xdg_runtime_dir_ca(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """XDG_RUNTIME_DIR CA path is preferred over the legacy /tmp fallback.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
+            tmp_path: Pytest temporary directory fixture.
+        """
+        runtime = tmp_path / "runtime"
+        runtime.mkdir()
+        ca_path = runtime / "abbenay" / "tls" / "ca.crt"
+        ca_path.parent.mkdir(parents=True)
+        ca_path.write_text("pem", encoding="utf-8")
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime))
+        discovered = _discover_default_ca_cert()
+        assert discovered == str(ca_path)
 
 
 class TestBuildAbbenayClient:
@@ -137,3 +179,24 @@ class TestBuildAbbenayClient:
                 "ssl_target_name": "abbenay-grpc",
             }
         ]
+
+
+class TestTlsAbbenayClientReconnect:
+    """TLS shim reconnect must preserve secure_channel configuration."""
+
+    @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+    async def test_reconnect_uses_tls_connect(self) -> None:
+        """reconnect() must not delegate to AbbenayClient.reconnect (insecure)."""
+        fake_module = type(sys)("abbenay_grpc")
+        fake_module.AbbenayClient = MagicMock(return_value=MagicMock(_target="127.0.0.1:50057"))  # type: ignore[attr-defined]
+
+        with patch.dict(sys.modules, {"abbenay_grpc": fake_module}):
+            client = _TlsAbbenayClient(host="127.0.0.1", port=50057, ca_cert="/etc/ca.crt")
+            connect_mock = AsyncMock()
+            client.connect = connect_mock  # type: ignore[method-assign]
+            client._delegate.reconnect = AsyncMock()  # noqa: SLF001
+
+            await client.reconnect()
+
+        connect_mock.assert_awaited_once()
+        client._delegate.reconnect.assert_not_awaited()  # noqa: SLF001

--- a/tests/test_abbenay_client_factory.py
+++ b/tests/test_abbenay_client_factory.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import grpc
 import pytest
 
 from apme_engine.remediation.abbenay_client_factory import (
@@ -112,6 +114,7 @@ class TestBuildAbbenayClient:
             monkeypatch: Pytest monkeypatch fixture.
         """
         monkeypatch.delenv("APME_ABBENAY_TLS", raising=False)
+        monkeypatch.delenv("APME_ABBENAY_CA_CERT", raising=False)
         calls: list[dict[str, object]] = []
 
         class FakeAbbenayClient:
@@ -129,7 +132,7 @@ class TestBuildAbbenayClient:
 
         with (
             patch.dict(sys.modules, {"abbenay_grpc": fake_module}),
-            patch("apme_engine.remediation.abbenay_client_factory.os.path.isfile", return_value=False),
+            patch("apme_engine.remediation.abbenay_client_factory._discover_default_ca_cert", return_value=None),
         ):
             client = build_abbenay_client("127.0.0.1:50057")
 
@@ -227,3 +230,60 @@ class TestTlsAbbenayClientConnect:
             client = _TlsAbbenayClient(host="127.0.0.1", port=50057, ca_cert="/missing/ca.crt")
             with pytest.raises(fake_client_module.ConnectionError, match="Failed to connect to daemon"):
                 await client.connect()
+
+    @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+    async def test_connect_serializes_concurrent_calls(self) -> None:
+        """Concurrent connect/reconnect calls share one channel registration."""
+        fake_client_module = type(sys)("abbenay_grpc.client")
+        fake_client_module.AbbenayError = Exception  # type: ignore[attr-defined]
+        fake_client_module.ConnectionError = type("AbbenayConnectionError", (Exception,), {})  # type: ignore[attr-defined]
+        fake_client_module.grpc_service = MagicMock()  # type: ignore[attr-defined]
+        fake_client_module.proto = MagicMock()  # type: ignore[attr-defined]
+        fake_client_module.proto.RegisterRequest = MagicMock(return_value="register-request")
+        fake_client_module.proto.ClientInfo = MagicMock(return_value="client-info")
+        fake_client_module.proto.CLIENT_TYPE_PYTHON = 1
+
+        register_calls = 0
+        connect_started = asyncio.Event()
+        release_connect = asyncio.Event()
+
+        async def slow_register(*_args: object, **_kwargs: object) -> MagicMock:
+            nonlocal register_calls
+            register_calls += 1
+            connect_started.set()
+            await release_connect.wait()
+            response = MagicMock()
+            response.client_id = "client-1"
+            return response
+
+        fake_stub = MagicMock()
+        fake_stub.Register = slow_register
+
+        fake_client_module.grpc_service.AbbenayStub = MagicMock(return_value=fake_stub)
+
+        fake_channel = MagicMock()
+        fake_channel.get_state = MagicMock(return_value=grpc.ChannelConnectivity.READY)
+        fake_channel.close = AsyncMock()
+
+        fake_module = type(sys)("abbenay_grpc")
+        fake_module.AbbenayClient = MagicMock(return_value=MagicMock(_target="127.0.0.1:50057"))  # type: ignore[attr-defined]
+
+        with (
+            patch.dict(sys.modules, {"abbenay_grpc": fake_module, "abbenay_grpc.client": fake_client_module}),
+            patch(
+                "apme_engine.remediation.abbenay_client_factory.grpc.aio.secure_channel",
+                return_value=fake_channel,
+            ),
+        ):
+            client = _TlsAbbenayClient(
+                host="127.0.0.1",
+                port=50057,
+                ca_cert_pem=b"pem-bytes",
+            )
+            first = asyncio.create_task(client.connect())
+            await connect_started.wait()
+            second = asyncio.create_task(client.reconnect())
+            release_connect.set()
+            await asyncio.gather(first, second)
+
+        assert register_calls == 1


### PR DESCRIPTION
## Summary
- Adds `build_abbenay_client()` with optional TLS for TCP connections (native `tls` kwargs when available, shim for older `abbenay-client` wheels)
- Podman: bind Abbenay to `127.0.0.1` so loopback plaintext stays valid under Abbenay C2 policy
- Helm: configurable `abbenay.grpc.insecure` (default `true`) and `abbenay.grpc.tls` with engine `APME_ABBENAY_*` env wiring
- Documents new `APME_ABBENAY_TLS`, `APME_ABBENAY_CA_CERT`, and `APME_ABBENAY_SSL_TARGET_NAME` env vars

Closes #400.

## Context
Abbenay [PR #63](https://github.com/redhat-developer/abbenay/pull/63) fail-closes non-loopback gRPC binds without `--grpc-tls` or `--insecure`. This prepares APME before bumping the Abbenay image past that change.

## Test plan
- [x] `tox -e lint`
- [x] `tox -e unit`
- [ ] `tox -e up` smoke: AI preflight/health with Abbenay enabled
- [ ] Helm: verify `abbenay.grpc.insecure=true` renders `--insecure` on abbenay deployment


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Abbenay gRPC host, port, plaintext, and TLS settings.
  * Added custom CA certificate support and TLS server-name overrides.
  * Improved secure client connections and compatibility with older client versions.
  * Added configurable TLS certificate mounting for deployments.

* **Bug Fixes**
  * Restricted shared-container gRPC communication to localhost by default.

* **Documentation**
  * Added deployment guidance and warnings for plaintext gRPC configurations.

* **Validation**
  * Added checks for secure binds, required TLS certificates, ports, and health probes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->