### PR TITLE
feat(ui-workflow): multi-tag rule ID filter with node-inclusion

### DIFF
--- a/frontend/packages/ui-workflow/src/components/AiEscalationPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AiEscalationPanel.tsx
@@ -16,6 +16,10 @@ import {
   orderPresentNodeTypes,
   type FindingNodeType,
 } from '../remediation/nodeType';
+import {
+  filterByRuleKeepingNodeContext,
+  presentRuleIds,
+} from '../remediation/ruleFilter';
 import { AssessNodeDetail } from './AssessFindingsPanel';
 import {
   toggleInFilterSet,
@@ -23,6 +27,7 @@ import {
 } from './ReviewFilterBar';
 import { ReviewInventoryRow } from './ReviewInventoryRow';
 import { ReviewStepShell } from './ReviewStepShell';
+import { RuleFilterInput } from './RuleFilterInput';
 import type { NodeDecision, NodeReviewItem } from './NodeReviewList';
 import {
   SEVERITY_LABELS,
@@ -136,6 +141,7 @@ export function AiEscalationPanel({
   const [nodeTypeFilters, setNodeTypeFilters] = useState<Set<FindingNodeType>>(
     () => new Set(presentNodeTypeOptions(candidates)),
   );
+  const [ruleFilters, setRuleFilters] = useState<string[]>([]);
 
   useEffect(() => {
     const paths = pathKey ? pathKey.split('\0') : [];
@@ -152,6 +158,25 @@ export function AiEscalationPanel({
     () => presentNodeTypeOptions(candidates),
     [candidates],
   );
+  const presentRules = useMemo(() => presentRuleIds(candidates), [candidates]);
+  const presentRulesKey = presentRules.join(',');
+  const ruleFilterSet = useMemo(() => new Set(ruleFilters), [ruleFilters]);
+
+  useEffect(() => {
+    const present = new Set(presentRules);
+    setRuleFilters((prev) => {
+      const next = prev.filter((r) => present.has(r));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [presentRulesKey, presentRules]);
+
+  const toggleRuleFilter = useCallback((bareId: string) => {
+    setRuleFilters((prev) =>
+      prev.includes(bareId)
+        ? prev.filter((r) => r !== bareId)
+        : [...prev, bareId],
+    );
+  }, []);
 
   const severityCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -232,7 +257,7 @@ export function AiEscalationPanel({
   }, [allGroups, decisions]);
 
   const filteredFindings = useMemo(() => {
-    return candidates.filter((f) => {
+    return filterByRuleKeepingNodeContext(candidates, ruleFilterSet, (f) => {
       const sev = severityClass(f.severity || 'info', f.rule_id);
       if (!sevFilters.has(sev)) return false;
       const nt = normalizeFindingNodeType(f.node_type);
@@ -241,7 +266,14 @@ export function AiEscalationPanel({
       if (!decisionFilters.has(effectiveDecision(path, decisions))) return false;
       return true;
     });
-  }, [candidates, sevFilters, nodeTypeFilters, decisionFilters, decisions]);
+  }, [
+    candidates,
+    sevFilters,
+    nodeTypeFilters,
+    decisionFilters,
+    decisions,
+    ruleFilterSet,
+  ]);
 
   const filteredGroups = useMemo(
     () => groupByLocation(filteredFindings),
@@ -249,6 +281,7 @@ export function AiEscalationPanel({
   );
 
   const hasNarrowedFilters =
+    ruleFilters.length > 0 ||
     decisionFilters.size < DECISION_FILTER_ORDER.length ||
     presentSeverities.some((s) => !sevFilters.has(s)) ||
     presentNodeTypes.some((t) => !nodeTypeFilters.has(t));
@@ -274,10 +307,16 @@ export function AiEscalationPanel({
             </>
           ),
           hasDetail: g.findings.length > 0,
-          detail: <AssessNodeDetail findings={g.findings} enableAi />,
+          detail: (
+            <AssessNodeDetail
+              findings={g.findings}
+              enableAi
+              onRuleClick={toggleRuleFilter}
+            />
+          ),
         };
       }),
-    [filteredGroups],
+    [filteredGroups, toggleRuleFilter],
   );
 
   /** Bulk Include/Skip only currently visible undecided locations. */
@@ -452,6 +491,13 @@ export function AiEscalationPanel({
           isDisabled: escalating || pendingCount > 0,
         }}
         filterGroups={filterGroups}
+        filterAccessory={
+          <RuleFilterInput
+            options={presentRules}
+            selected={ruleFilters}
+            onChange={setRuleFilters}
+          />
+        }
         emptyMessage="No locations match the current filters."
         list={
           listItems.length === 0
@@ -464,7 +510,7 @@ export function AiEscalationPanel({
                 onDecisionChange: handleDecisionChange,
                 defaultExpanded: true,
                 showExpandControls: true,
-                resetKey: `ai-esc-${pathKey}-${filteredFindings.length}-${sevFilters.size}-${nodeTypeFilters.size}-${decisionFilters.size}`,
+                resetKey: `ai-esc-${pathKey}-${filteredFindings.length}-${sevFilters.size}-${nodeTypeFilters.size}-${decisionFilters.size}-${ruleFilters.join(',')}`,
                 onAcceptRemaining: includeRemaining,
                 onDeclineRemaining: skipRemaining,
                 pendingCount: visiblePendingPaths.length,

--- a/frontend/packages/ui-workflow/src/components/AiEscalationPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AiEscalationPanel.tsx
@@ -19,7 +19,7 @@ import {
 import {
   filterByRuleKeepingNodeContext,
   presentRuleIds,
-} from '../remediation/ruleFilter';
+} from '../remediation';
 import { AssessNodeDetail } from './AssessFindingsPanel';
 import {
   toggleInFilterSet,
@@ -257,15 +257,22 @@ export function AiEscalationPanel({
   }, [allGroups, decisions]);
 
   const filteredFindings = useMemo(() => {
-    return filterByRuleKeepingNodeContext(candidates, ruleFilterSet, (f) => {
-      const sev = severityClass(f.severity || 'info', f.rule_id);
-      if (!sevFilters.has(sev)) return false;
-      const nt = normalizeFindingNodeType(f.node_type);
-      if (!nodeTypeFilters.has(nt)) return false;
-      const path = locationPath(f);
-      if (!decisionFilters.has(effectiveDecision(path, decisions))) return false;
-      return true;
-    });
+    // Rule filter is node-scoped. Decision stays location-level after that
+    // (one decision per path — drop whole location if its decision is hidden).
+    const afterRules = filterByRuleKeepingNodeContext(
+      candidates,
+      ruleFilterSet,
+      (f) => {
+        const sev = severityClass(f.severity || 'info', f.rule_id);
+        if (!sevFilters.has(sev)) return false;
+        const nt = normalizeFindingNodeType(f.node_type);
+        if (!nodeTypeFilters.has(nt)) return false;
+        return true;
+      },
+    );
+    return afterRules.filter((f) =>
+      decisionFilters.has(effectiveDecision(locationPath(f), decisions)),
+    );
   }, [
     candidates,
     sevFilters,
@@ -493,6 +500,7 @@ export function AiEscalationPanel({
         filterGroups={filterGroups}
         filterAccessory={
           <RuleFilterInput
+            id="ai-escalation-rule-filter"
             options={presentRules}
             selected={ruleFilters}
             onChange={setRuleFilters}

--- a/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
@@ -616,6 +616,7 @@ export function AssessFindingsPanel({
         filterGroups={filterGroups}
         filterAccessory={
           <RuleFilterInput
+            id="assess-rule-filter"
             options={presentRules}
             selected={ruleFilters}
             onChange={setRuleFilters}

--- a/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
@@ -4,13 +4,14 @@
  * Domain mapping only; shared chrome lives in ReviewStepShell / NodeReviewList.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, Label } from '@patternfly/react-core';
 import { RuleId } from '../shared/RuleId';
 import { CurrentYamlView } from './DiffView';
 import { type NodeReviewItem } from './NodeReviewList';
 import { ReviewStepShell } from './ReviewStepShell';
 import { ReviewInventoryRow } from './ReviewInventoryRow';
+import { RuleFilterInput } from './RuleFilterInput';
 import {
   toggleInFilterSet,
   type ReviewFilterGroup,
@@ -28,12 +29,14 @@ import {
 } from '../hooks/useProjectOperationState';
 import {
   effectiveFixType,
+  filterByRuleKeepingNodeContext,
   fixMethodLabel,
   fixTypeLabelColor,
   nodeTypeLabel,
   nodeTypeLabelColor,
   normalizeFindingNodeType,
   orderPresentNodeTypes,
+  presentRuleIds,
   type FindingNodeType,
   type FixType,
 } from '../remediation';
@@ -134,11 +137,13 @@ function FindingRow({
   snippetYaml,
   enableAi,
   onHighlightLine,
+  onRuleClick,
 }: {
   f: AssessFinding;
   snippetYaml: string;
   enableAi: boolean;
   onHighlightLine?: (line: number | null) => void;
+  onRuleClick?: (bareId: string) => void;
 }) {
   const fix = findingFixType(f, enableAi);
   const sev = f.severity || 'info';
@@ -148,6 +153,7 @@ function FindingRow({
     <div className="apme-assess-finding-row">
       <RuleId
         ruleId={f.rule_id}
+        onRuleClick={onRuleClick}
         onHoverChange={
           canHighlight
             ? (hovering) =>
@@ -196,9 +202,11 @@ function findingCardTitle(f: AssessFinding): string {
 export function AssessNodeDetail({
   findings,
   enableAi,
+  onRuleClick,
 }: {
   findings: AssessFinding[];
   enableAi: boolean;
+  onRuleClick?: (bareId: string) => void;
 }) {
   const [highlightLine, setHighlightLine] = useState<number | null>(null);
   // Assess/history findings are read-only: current YAML only. Proposed diffs
@@ -214,6 +222,7 @@ export function AssessNodeDetail({
             f={f}
             snippetYaml={beforeYaml}
             enableAi={enableAi}
+            onRuleClick={onRuleClick}
             onHighlightLine={
               beforeYaml.trim() ? setHighlightLine : undefined
             }
@@ -233,7 +242,11 @@ function findingsToNodeItem(
   id: string,
   title: string,
   findings: AssessFinding[],
-  opts: { isSingleton?: boolean; enableAi: boolean },
+  opts: {
+    isSingleton?: boolean;
+    enableAi: boolean;
+    onRuleClick?: (bareId: string) => void;
+  },
 ): NodeReviewItem {
   const nodeType = normalizeFindingNodeType(
     findings.find((f) => (f.node_type || '').trim())?.node_type,
@@ -253,7 +266,13 @@ function findingsToNodeItem(
         </Label>
       </>
     ),
-    detail: <AssessNodeDetail findings={findings} enableAi={opts.enableAi} />,
+    detail: (
+      <AssessNodeDetail
+        findings={findings}
+        enableAi={opts.enableAi}
+        onRuleClick={opts.onRuleClick}
+      />
+    ),
   };
 }
 
@@ -297,6 +316,8 @@ export function AssessFindingsPanel({
   const [nodeTypeFilters, setNodeTypeFilters] = useState<Set<FindingNodeType>>(
     () => new Set(presentNodeTypeOptions(findings)),
   );
+  /** Selected bare rule IDs (OR). Empty = no rule filter. */
+  const [ruleFilters, setRuleFilters] = useState<string[]>([]);
 
   const presentSeverities = useMemo(
     () => presentSeverityOptions(findings),
@@ -310,6 +331,27 @@ export function AssessFindingsPanel({
     () => presentNodeTypeOptions(findings),
     [findings],
   );
+  const presentRules = useMemo(() => presentRuleIds(findings), [findings]);
+  const presentRulesKey = presentRules.join(',');
+
+  // Drop selected rules that disappeared from the scan payload.
+  useEffect(() => {
+    const present = new Set(presentRules);
+    setRuleFilters((prev) => {
+      const next = prev.filter((r) => present.has(r));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [presentRulesKey, presentRules]);
+
+  const toggleRuleFilter = useCallback((bareId: string) => {
+    setRuleFilters((prev) =>
+      prev.includes(bareId)
+        ? prev.filter((r) => r !== bareId)
+        : [...prev, bareId],
+    );
+  }, []);
+
+  const ruleFilterSet = useMemo(() => new Set(ruleFilters), [ruleFilters]);
 
   const severityCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -355,7 +397,7 @@ export function AssessFindingsPanel({
   ]);
 
   const filteredFindings = useMemo(() => {
-    return findings.filter((f) => {
+    return filterByRuleKeepingNodeContext(findings, ruleFilterSet, (f) => {
       const sev = severityClass(f.severity || 'info', f.rule_id);
       if (!sevFilters.has(sev)) return false;
       const fix = findingFixType(f, enableAi);
@@ -364,7 +406,14 @@ export function AssessFindingsPanel({
       if (!nodeTypeFilters.has(nt)) return false;
       return true;
     });
-  }, [findings, sevFilters, fixFilters, nodeTypeFilters, enableAi]);
+  }, [
+    findings,
+    sevFilters,
+    fixFilters,
+    nodeTypeFilters,
+    ruleFilterSet,
+    enableAi,
+  ]);
 
   const groups = useMemo(() => groupFindings(filteredFindings), [filteredFindings]);
 
@@ -385,6 +434,7 @@ export function AssessFindingsPanel({
   }, [findings, enableAi]);
 
   const hasNarrowedFilters =
+    ruleFilters.length > 0 ||
     presentSeverities.some((s) => !sevFilters.has(s)) ||
     presentFixTypes.some((t) => !fixFilters.has(t)) ||
     presentNodeTypes.some((t) => !nodeTypeFilters.has(t));
@@ -396,7 +446,11 @@ export function AssessFindingsPanel({
           `flat-${f.rule_id}-${f.file}-${f.line ?? 0}-${i}`,
           findingCardTitle(f),
           [f],
-          { isSingleton: !(f.path || '').trim(), enableAi },
+          {
+            isSingleton: !(f.path || '').trim(),
+            enableAi,
+            onRuleClick: toggleRuleFilter,
+          },
         ),
       );
     }
@@ -404,9 +458,10 @@ export function AssessFindingsPanel({
       findingsToNodeItem(g.key, g.title, g.findings, {
         isSingleton: g.isSingleton,
         enableAi,
+        onRuleClick: toggleRuleFilter,
       }),
     );
-  }, [view, filteredFindings, groups, enableAi]);
+  }, [view, filteredFindings, groups, enableAi, toggleRuleFilter]);
 
   const filterGroups: ReviewFilterGroup[] = useMemo(
     () => [
@@ -559,6 +614,13 @@ export function AssessFindingsPanel({
             : undefined
         }
         filterGroups={filterGroups}
+        filterAccessory={
+          <RuleFilterInput
+            options={presentRules}
+            selected={ruleFilters}
+            onChange={setRuleFilters}
+          />
+        }
         emptyMessage="No findings match the current filters."
         list={
           filteredFindings.length === 0
@@ -569,7 +631,7 @@ export function AssessFindingsPanel({
                   view === 'flat' ? 'Findings (flat)' : 'Findings by location',
                 defaultExpanded: true,
                 showExpandControls: true,
-                resetKey: `assess-${view}-${filteredFindings.length}-${groups.length}-${sevFilters.size}-${fixFilters.size}-${nodeTypeFilters.size}`,
+                resetKey: `assess-${view}-${filteredFindings.length}-${groups.length}-${sevFilters.size}-${fixFilters.size}-${nodeTypeFilters.size}-${ruleFilters.join(',')}`,
               }
         }
       />

--- a/frontend/packages/ui-workflow/src/components/ProposalReviewPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/ProposalReviewPanel.tsx
@@ -26,17 +26,20 @@ import {
 } from '../shared/severity';
 import {
   descendantProposalIds,
+  filterByRuleKeepingNodeContext,
   fixTypeLabelColor,
   isAiRemediationProposal,
   nodeTypeLabel,
   nodeTypeLabelColor,
   normalizeFindingNodeType,
   orderPresentNodeTypes,
+  presentRuleIds,
   proposalHasVisibleDiff,
   proposalNodeTitle,
   proposalsGateKey,
   type FindingNodeType,
 } from '../remediation';
+import { RuleFilterInput } from './RuleFilterInput';
 
 type DecisionFilter = 'pending' | 'accepted' | 'declined';
 const DECISION_FILTER_ORDER: DecisionFilter[] = [
@@ -201,6 +204,7 @@ export function ProposalReviewPanel({
         ),
       ),
   );
+  const [ruleFilters, setRuleFilters] = useState<string[]>([]);
   const [showDeclined, setShowDeclined] = useState(false);
   const [feedbackTarget, setFeedbackTarget] = useState<OperationProposal | null>(null);
   const draftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -218,6 +222,26 @@ export function ProposalReviewPanel({
       ),
     [actionable],
   );
+
+  const presentRules = useMemo(() => presentRuleIds(actionable), [actionable]);
+  const presentRulesKey = presentRules.join(',');
+  const ruleFilterSet = useMemo(() => new Set(ruleFilters), [ruleFilters]);
+
+  useEffect(() => {
+    const present = new Set(presentRules);
+    setRuleFilters((prev) => {
+      const next = prev.filter((r) => present.has(r));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [presentRulesKey, presentRules]);
+
+  const toggleRuleFilter = useCallback((bareId: string) => {
+    setRuleFilters((prev) =>
+      prev.includes(bareId)
+        ? prev.filter((r) => r !== bareId)
+        : [...prev, bareId],
+    );
+  }, []);
 
   const severityCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -452,7 +476,7 @@ export function ProposalReviewPanel({
           hasDetail,
           meta: (
             <>
-              <RuleId ruleId={p.rule_id} />
+              <RuleId ruleId={p.rule_id} onRuleClick={toggleRuleFilter} />
               <Label
                 isCompact
                 color={fixTypeLabelColor(isAiGate ? 'ai' : 'auto')}
@@ -481,7 +505,12 @@ export function ProposalReviewPanel({
                         key={`${p.id}-desc-${i}`}
                         className="apme-assess-finding-row"
                       >
-                        {ruleId ? <RuleId ruleId={ruleId} /> : null}
+                        {ruleId ? (
+                          <RuleId
+                            ruleId={ruleId}
+                            onRuleClick={toggleRuleFilter}
+                          />
+                        ) : null}
                         {(ruleId || severity) && (
                           <Label
                             isCompact
@@ -522,10 +551,11 @@ export function ProposalReviewPanel({
           ),
         };
       }),
-    [actionable, isAiGate, feedbackEnabled],
+    [actionable, isAiGate, feedbackEnabled, toggleRuleFilter],
   );
 
   const hasNarrowedFilters =
+    ruleFilters.length > 0 ||
     decisionFilters.size < DECISION_FILTER_ORDER.length ||
     (presentSeverities.length > 0 &&
       sevFilters.size < presentSeverities.length) ||
@@ -533,22 +563,24 @@ export function ProposalReviewPanel({
       presentNodeTypes.some((t) => !nodeTypeFilters.has(t)));
 
   const filteredActionableItems = useMemo(() => {
-    const byId = new Map(actionable.map((p) => [p.id, p]));
-    return actionableItems.filter((item) => {
-      const decision = effectiveDecision(item.id, decisions);
-      if (!decisionFilters.has(decision)) return false;
-      const proposal = byId.get(item.id);
-      if (!proposal) return false;
-      if (presentSeverities.length > 0 && sevFilters.size > 0) {
-        const sev = proposalSeverity(proposal);
-        if (!sevFilters.has(sev)) return false;
-      }
-      if (presentNodeTypes.length > 0 && nodeTypeFilters.size > 0) {
-        const nt = normalizeFindingNodeType(proposal.node_type);
-        if (!nodeTypeFilters.has(nt)) return false;
-      }
-      return true;
-    });
+    const visibleProposals = filterByRuleKeepingNodeContext(
+      actionable,
+      ruleFilterSet,
+      (proposal) => {
+        const decision = effectiveDecision(proposal.id, decisions);
+        if (!decisionFilters.has(decision)) return false;
+        if (presentSeverities.length > 0 && sevFilters.size > 0) {
+          if (!sevFilters.has(proposalSeverity(proposal))) return false;
+        }
+        if (presentNodeTypes.length > 0 && nodeTypeFilters.size > 0) {
+          const nt = normalizeFindingNodeType(proposal.node_type);
+          if (!nodeTypeFilters.has(nt)) return false;
+        }
+        return true;
+      },
+    );
+    const visible = new Set(visibleProposals.map((p) => p.id));
+    return actionableItems.filter((item) => visible.has(item.id));
   }, [
     actionableItems,
     actionable,
@@ -556,6 +588,7 @@ export function ProposalReviewPanel({
     decisionFilters,
     sevFilters,
     nodeTypeFilters,
+    ruleFilterSet,
     presentSeverities.length,
     presentNodeTypes.length,
   ]);
@@ -746,6 +779,13 @@ export function ProposalReviewPanel({
       onCancel={onCancel}
       next={workflowNext}
       filterGroups={filterGroups}
+      filterAccessory={
+        <RuleFilterInput
+          options={presentRules}
+          selected={ruleFilters}
+          onChange={setRuleFilters}
+        />
+      }
       emptyMessage="No proposals match the current filters."
       list={
         filteredActionableItems.length === 0
@@ -756,7 +796,7 @@ export function ProposalReviewPanel({
               decisionMode: true,
               decisions,
               onDecisionChange: handleDecisionChange,
-              resetKey: gateKey,
+              resetKey: `${gateKey}|${ruleFilters.join(',')}`,
               defaultExpanded: true,
               showExpandControls: true,
               onAcceptRemaining: acceptRemaining,

--- a/frontend/packages/ui-workflow/src/components/ProposalReviewPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/ProposalReviewPanel.tsx
@@ -563,12 +563,12 @@ export function ProposalReviewPanel({
       presentNodeTypes.some((t) => !nodeTypeFilters.has(t)));
 
   const filteredActionableItems = useMemo(() => {
-    const visibleProposals = filterByRuleKeepingNodeContext(
+    // Rule filter is node-scoped (siblings stay). Decision stays row-level so
+    // Accepted/Declined chips do not re-surface via a sibling on the same path.
+    const afterRules = filterByRuleKeepingNodeContext(
       actionable,
       ruleFilterSet,
       (proposal) => {
-        const decision = effectiveDecision(proposal.id, decisions);
-        if (!decisionFilters.has(decision)) return false;
         if (presentSeverities.length > 0 && sevFilters.size > 0) {
           if (!sevFilters.has(proposalSeverity(proposal))) return false;
         }
@@ -579,7 +579,13 @@ export function ProposalReviewPanel({
         return true;
       },
     );
-    const visible = new Set(visibleProposals.map((p) => p.id));
+    const visible = new Set(
+      afterRules
+        .filter((p) =>
+          decisionFilters.has(effectiveDecision(p.id, decisions)),
+        )
+        .map((p) => p.id),
+    );
     return actionableItems.filter((item) => visible.has(item.id));
   }, [
     actionableItems,
@@ -781,6 +787,7 @@ export function ProposalReviewPanel({
       filterGroups={filterGroups}
       filterAccessory={
         <RuleFilterInput
+          id="proposal-rule-filter"
           options={presentRules}
           selected={ruleFilters}
           onChange={setRuleFilters}

--- a/frontend/packages/ui-workflow/src/components/ReviewStepShell.tsx
+++ b/frontend/packages/ui-workflow/src/components/ReviewStepShell.tsx
@@ -24,6 +24,8 @@ export interface ReviewStepShellProps {
   next?: WorkflowNextConfig;
   onCancel?: () => void;
   filterGroups?: ReviewFilterGroup[];
+  /** Extra filter controls under the pill row (e.g. rule ID typeahead). */
+  filterAccessory?: ReactNode;
   /** Main review list; omit or pass empty items with emptyMessage for empty state. */
   list?: NodeReviewListProps;
   /** Shown when ``list`` is omitted or ``list.items`` is empty. */
@@ -40,6 +42,7 @@ export function ReviewStepShell({
   next,
   onCancel,
   filterGroups = [],
+  filterAccessory,
   list,
   emptyMessage = 'Nothing to show.',
   children,
@@ -93,6 +96,9 @@ export function ReviewStepShell({
         </div>
 
         <ReviewFilterBar groups={filterGroups} />
+        {filterAccessory != null ? (
+          <div className="apme-review-filter-accessory">{filterAccessory}</div>
+        ) : null}
 
         {!hasItems ? (
           <div style={{ padding: 24, textAlign: 'center', opacity: 0.65 }}>

--- a/frontend/packages/ui-workflow/src/components/RuleFilterInput.tsx
+++ b/frontend/packages/ui-workflow/src/components/RuleFilterInput.tsx
@@ -1,0 +1,285 @@
+/**
+ * Multi-tag typeahead for filtering review lists by rule ID.
+ *
+ * Options come from the full present set for the scan (not the currently
+ * narrowed rows), so users can add more rules after the list shrinks.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Button,
+  Label,
+  LabelGroup,
+  MenuToggle,
+  type MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+  type SelectOptionProps,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+
+const NO_RESULTS = '__no_results__';
+
+export interface RuleFilterInputProps {
+  /** Bare rule IDs present in the current scan (autocomplete source). */
+  options: string[];
+  /** Currently selected bare rule IDs (OR filter). */
+  selected: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+  id?: string;
+}
+
+export function RuleFilterInput({
+  options,
+  selected,
+  onChange,
+  placeholder = 'Filter by rule ID…',
+  id = 'rule-filter',
+}: RuleFilterInputProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [focusedItemIndex, setFocusedItemIndex] = useState<number | null>(null);
+  const [activeItemId, setActiveItemId] = useState<string | null>(null);
+  const textInputRef = useRef<HTMLInputElement>(null);
+
+  const selectOptions: SelectOptionProps[] = useMemo(() => {
+    const q = inputValue.trim().toLowerCase();
+    let filtered = options;
+    if (q) {
+      filtered = options.filter((r) => r.toLowerCase().includes(q));
+    }
+    // Prefer unselected rules first so the menu stays useful with many tags.
+    filtered = [...filtered].sort((a, b) => {
+      const aSel = selected.includes(a) ? 1 : 0;
+      const bSel = selected.includes(b) ? 1 : 0;
+      if (aSel !== bSel) return aSel - bSel;
+      return a.localeCompare(b);
+    });
+    if (filtered.length === 0) {
+      return [
+        {
+          isAriaDisabled: true,
+          children: q
+            ? `No rules match "${inputValue.trim()}"`
+            : 'No rules in this scan',
+          value: NO_RESULTS,
+        },
+      ];
+    }
+    return filtered.map((r) => ({
+      value: r,
+      children: r,
+      isSelected: selected.includes(r),
+    }));
+  }, [options, selected, inputValue]);
+
+  useEffect(() => {
+    if (inputValue && !isOpen) {
+      setIsOpen(true);
+    }
+  }, [inputValue, isOpen]);
+
+  const createItemId = (value: string) =>
+    `${id}-option-${value.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+
+  const resetFocus = () => {
+    setFocusedItemIndex(null);
+    setActiveItemId(null);
+  };
+
+  const closeMenu = () => {
+    setIsOpen(false);
+    resetFocus();
+  };
+
+  const toggleRule = (value: string) => {
+    if (!value || value === NO_RESULTS) return;
+    onChange(
+      selected.includes(value)
+        ? selected.filter((s) => s !== value)
+        : [...selected, value],
+    );
+    setInputValue('');
+    // Close after pick — multi-add is via reopening / typing / clicking a RuleId.
+    closeMenu();
+  };
+
+  const handleMenuArrowKeys = (key: string) => {
+    if (!isOpen) setIsOpen(true);
+    if (selectOptions.every((o) => o.isAriaDisabled || o.isDisabled)) return;
+
+    let indexToFocus = 0;
+    if (key === 'ArrowUp') {
+      if (focusedItemIndex === null || focusedItemIndex === 0) {
+        indexToFocus = selectOptions.length - 1;
+      } else {
+        indexToFocus = focusedItemIndex - 1;
+      }
+      while (selectOptions[indexToFocus]?.isAriaDisabled || selectOptions[indexToFocus]?.isDisabled) {
+        indexToFocus--;
+        if (indexToFocus < 0) indexToFocus = selectOptions.length - 1;
+      }
+    } else {
+      if (
+        focusedItemIndex === null ||
+        focusedItemIndex === selectOptions.length - 1
+      ) {
+        indexToFocus = 0;
+      } else {
+        indexToFocus = focusedItemIndex + 1;
+      }
+      while (selectOptions[indexToFocus]?.isAriaDisabled || selectOptions[indexToFocus]?.isDisabled) {
+        indexToFocus++;
+        if (indexToFocus >= selectOptions.length) indexToFocus = 0;
+      }
+    }
+    setFocusedItemIndex(indexToFocus);
+    const focused = selectOptions[indexToFocus];
+    if (focused?.value) setActiveItemId(createItemId(String(focused.value)));
+  };
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const focused =
+      focusedItemIndex !== null ? selectOptions[focusedItemIndex] : null;
+    switch (event.key) {
+      case 'Enter':
+        if (
+          isOpen &&
+          focused?.value &&
+          focused.value !== NO_RESULTS &&
+          !focused.isAriaDisabled
+        ) {
+          event.preventDefault();
+          toggleRule(String(focused.value));
+        } else if (!isOpen) {
+          setIsOpen(true);
+        }
+        break;
+      case 'Backspace':
+        if (!inputValue && selected.length > 0) {
+          onChange(selected.slice(0, -1));
+        }
+        break;
+      case 'Escape':
+        if (isOpen) {
+          event.stopPropagation();
+          closeMenu();
+        }
+        break;
+      case 'ArrowUp':
+      case 'ArrowDown':
+        event.preventDefault();
+        handleMenuArrowKeys(event.key);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      variant="typeahead"
+      aria-label="Filter by rule ID"
+      onClick={() => {
+        setIsOpen((o) => !o);
+        textInputRef.current?.focus();
+      }}
+      innerRef={toggleRef}
+      isExpanded={isOpen}
+      className="apme-rule-filter-toggle"
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={inputValue}
+          onClick={() => {
+            if (!isOpen) setIsOpen(true);
+          }}
+          onChange={(_e, value) => {
+            setInputValue(value);
+            resetFocus();
+          }}
+          onKeyDown={onInputKeyDown}
+          id={`${id}-input`}
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder={selected.length === 0 ? placeholder : ''}
+          {...(activeItemId ? { 'aria-activedescendant': activeItemId } : {})}
+          role="combobox"
+          isExpanded={isOpen}
+          aria-controls={`${id}-listbox`}
+        >
+          <LabelGroup aria-label="Selected rule filters" numLabels={12}>
+            {selected.map((rule) => (
+              <Label
+                key={rule}
+                variant="outline"
+                onClose={(ev) => {
+                  ev.stopPropagation();
+                  toggleRule(rule);
+                }}
+              >
+                {rule}
+              </Label>
+            ))}
+          </LabelGroup>
+        </TextInputGroupMain>
+        <TextInputGroupUtilities
+          {...(selected.length === 0 ? { style: { display: 'none' } } : {})}
+        >
+          <Button
+            variant="plain"
+            onClick={() => {
+              onChange([]);
+              setInputValue('');
+              resetFocus();
+              textInputRef.current?.focus();
+            }}
+            aria-label="Clear rule filters"
+            icon={<TimesIcon />}
+          />
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  if (options.length === 0 && selected.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="apme-rule-filter">
+      <span className="apme-rule-filter__label">Rule</span>
+      <Select
+        id={id}
+        isOpen={isOpen}
+        selected={selected}
+        onSelect={(_event, selection) => toggleRule(String(selection))}
+        onOpenChange={(open) => {
+          if (!open) closeMenu();
+        }}
+        toggle={toggle}
+        variant="typeahead"
+      >
+        <SelectList isAriaMultiselectable id={`${id}-listbox`}>
+          {selectOptions.map((option, index) => (
+            <SelectOption
+              key={String(option.value ?? option.children)}
+              isFocused={focusedItemIndex === index}
+              id={createItemId(String(option.value))}
+              value={option.value}
+              isAriaDisabled={option.isAriaDisabled}
+              isSelected={option.isSelected}
+            >
+              {option.children}
+            </SelectOption>
+          ))}
+        </SelectList>
+      </Select>
+    </div>
+  );
+}

--- a/frontend/packages/ui-workflow/src/remediation/index.ts
+++ b/frontend/packages/ui-workflow/src/remediation/index.ts
@@ -24,6 +24,14 @@ export {
   splitRuleIds,
 } from './proposalTier';
 export {
+  filterByRuleKeepingNodeContext,
+  matchesRuleFilters,
+  presentRuleIds,
+  reviewNodeKey,
+  type NodeKeyed,
+  type RuleIdCarrier,
+} from './ruleFilter';
+export {
   emptyWorkflowLatch,
   needsCommitStep,
   resolveCurrentWorkflowStep,

--- a/frontend/packages/ui-workflow/src/remediation/ruleFilter.ts
+++ b/frontend/packages/ui-workflow/src/remediation/ruleFilter.ts
@@ -1,0 +1,84 @@
+/**
+ * Rule-ID filter helpers for Assess / Gate / AI review panels.
+ *
+ * Semantics: selected rules pick **nodes**. If any finding/proposal on a node
+ * matches, every item on that node stays in view (sibling violations included).
+ * Other filters (severity, kind, …) decide which nodes qualify, not which
+ * sibling rows survive once a node is in.
+ */
+
+import { bareRuleId } from '../shared/severity';
+import { splitRuleIds } from './proposalTier';
+
+export interface RuleIdCarrier {
+  rule_id?: string;
+}
+
+export interface NodeKeyed {
+  path?: string;
+  file?: string;
+}
+
+/** Stable node key for grouping (graph path, else file, else singleton bucket). */
+export function reviewNodeKey(item: NodeKeyed): string {
+  const path = (item.path || '').trim();
+  if (path) return path;
+  const file = (item.file || '').trim();
+  if (file) return file;
+  return '__singleton__';
+}
+
+/** Bare rule IDs present in the scan (sorted) — autocomplete source. */
+export function presentRuleIds(items: RuleIdCarrier[]): string[] {
+  const ids = new Set<string>();
+  for (const item of items) {
+    for (const part of splitRuleIds(item.rule_id || '')) {
+      const bare = bareRuleId(part);
+      if (bare) ids.add(bare);
+    }
+  }
+  return [...ids].sort((a, b) => a.localeCompare(b));
+}
+
+/** True when no rules selected, or the item carries at least one selected bare ID. */
+export function matchesRuleFilters(
+  item: RuleIdCarrier,
+  selected: ReadonlySet<string>,
+): boolean {
+  if (selected.size === 0) return true;
+  return splitRuleIds(item.rule_id || '').some((r) =>
+    selected.has(bareRuleId(r)),
+  );
+}
+
+/**
+ * Filter review items with node-inclusion for rule IDs.
+ *
+ * - No rules selected → ``itemPassesOtherFilters`` only (row-level).
+ * - Rules selected → keep **all** items on nodes that both (a) carry a
+ *   selected rule and (b) have at least one item passing other filters.
+ */
+export function filterByRuleKeepingNodeContext<
+  T extends RuleIdCarrier & NodeKeyed,
+>(
+  items: readonly T[],
+  selectedRules: ReadonlySet<string>,
+  itemPassesOtherFilters: (item: T) => boolean = () => true,
+): T[] {
+  if (selectedRules.size === 0) {
+    return items.filter(itemPassesOtherFilters);
+  }
+
+  const ruleNodes = new Set<string>();
+  const qualifyNodes = new Set<string>();
+  for (const item of items) {
+    const key = reviewNodeKey(item);
+    if (matchesRuleFilters(item, selectedRules)) ruleNodes.add(key);
+    if (itemPassesOtherFilters(item)) qualifyNodes.add(key);
+  }
+
+  return items.filter((item) => {
+    const key = reviewNodeKey(item);
+    return ruleNodes.has(key) && qualifyNodes.has(key);
+  });
+}

--- a/frontend/packages/ui-workflow/src/shared/RuleId.tsx
+++ b/frontend/packages/ui-workflow/src/shared/RuleId.tsx
@@ -39,7 +39,7 @@ function SingleRuleId({
     <span
       className={spanClassName}
       tabIndex={interactive ? 0 : undefined}
-      title={clickable ? `Filter by ${bare}` : undefined}
+      title={clickable ? `Toggle filter: ${bare}` : undefined}
       role={clickable ? 'button' : undefined}
       onMouseEnter={hoverable ? () => onHoverChange(true) : undefined}
       onMouseLeave={hoverable ? () => onHoverChange(false) : undefined}

--- a/frontend/packages/ui-workflow/src/shared/RuleId.tsx
+++ b/frontend/packages/ui-workflow/src/shared/RuleId.tsx
@@ -5,22 +5,32 @@ export interface RuleIdProps {
   className?: string;
   /** When set, hover/focus reports true/false (e.g. YAML line highlight). */
   onHoverChange?: (hovering: boolean) => void;
+  /**
+   * When set, each bare rule chip is clickable (e.g. add to rule filter).
+   * Receives the bare rule ID that was clicked.
+   */
+  onRuleClick?: (bareId: string) => void;
 }
 
 function SingleRuleId({
   ruleId,
   className,
   onHoverChange,
+  onRuleClick,
 }: {
   ruleId: string;
   className?: string;
   onHoverChange?: (hovering: boolean) => void;
+  onRuleClick?: (bareId: string) => void;
 }) {
   const bare = bareRuleId(ruleId);
-  const interactive = onHoverChange != null;
+  const clickable = onRuleClick != null;
+  const hoverable = onHoverChange != null;
+  const interactive = clickable || hoverable;
   const spanClassName = [
     className ?? 'apme-rule-id',
     interactive ? 'apme-rule-id-hoverable' : '',
+    clickable ? 'apme-rule-id-clickable' : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -29,17 +39,43 @@ function SingleRuleId({
     <span
       className={spanClassName}
       tabIndex={interactive ? 0 : undefined}
-      onMouseEnter={interactive ? () => onHoverChange(true) : undefined}
-      onMouseLeave={interactive ? () => onHoverChange(false) : undefined}
-      onFocus={interactive ? () => onHoverChange(true) : undefined}
-      onBlur={interactive ? () => onHoverChange(false) : undefined}
+      title={clickable ? `Filter by ${bare}` : undefined}
+      role={clickable ? 'button' : undefined}
+      onMouseEnter={hoverable ? () => onHoverChange(true) : undefined}
+      onMouseLeave={hoverable ? () => onHoverChange(false) : undefined}
+      onFocus={hoverable ? () => onHoverChange(true) : undefined}
+      onBlur={hoverable ? () => onHoverChange(false) : undefined}
+      onClick={
+        clickable
+          ? (e) => {
+              e.stopPropagation();
+              onRuleClick(bare);
+            }
+          : undefined
+      }
+      onKeyDown={
+        clickable
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                onRuleClick(bare);
+              }
+            }
+          : undefined
+      }
     >
       {bare}
     </span>
   );
 }
 
-export function RuleId({ ruleId, className, onHoverChange }: RuleIdProps) {
+export function RuleId({
+  ruleId,
+  className,
+  onHoverChange,
+  onRuleClick,
+}: RuleIdProps) {
   const ids = ruleId.split(',').map((s) => s.trim()).filter(Boolean);
   if (ids.length <= 1) {
     return (
@@ -47,6 +83,7 @@ export function RuleId({ ruleId, className, onHoverChange }: RuleIdProps) {
         ruleId={ruleId}
         className={className}
         onHoverChange={onHoverChange}
+        onRuleClick={onRuleClick}
       />
     );
   }
@@ -59,6 +96,7 @@ export function RuleId({ ruleId, className, onHoverChange }: RuleIdProps) {
             ruleId={id}
             className={className}
             onHoverChange={onHoverChange}
+            onRuleClick={onRuleClick}
           />
         </span>
       ))}

--- a/frontend/packages/ui-workflow/src/styles/workflow.css
+++ b/frontend/packages/ui-workflow/src/styles/workflow.css
@@ -539,6 +539,41 @@
   cursor: pointer;
 }
 
+.apme-review-filter-accessory {
+  margin-bottom: 12px;
+}
+
+.apme-rule-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 36rem;
+}
+
+.apme-rule-filter__label {
+  font-size: 12px;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.apme-rule-filter .apme-rule-filter-toggle,
+.apme-rule-filter .pf-v6-c-menu-toggle {
+  flex: 1;
+  min-width: 0;
+}
+
+.apme-rule-id-clickable {
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
+.apme-rule-id-clickable:hover,
+.apme-rule-id-clickable:focus {
+  text-decoration-style: solid;
+}
+
 /* Indent expanded body under the node title (chevron + header gap). */
 .apme-proposal-detail {
   margin: 0 16px 12px;

--- a/frontend/src/test/AssessFindingsPanel.test.tsx
+++ b/frontend/src/test/AssessFindingsPanel.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AssessFindingsPanel } from "@apme/ui-workflow";
+import type { AssessFinding } from "@apme/ui-workflow";
+
+const findings: AssessFinding[] = [
+  {
+    rule_id: "native:L050",
+    severity: "high",
+    message: "needs FQCN",
+    file: "play.yml",
+    path: "play.yml/plays[0]/tasks[0]",
+    node_type: "task",
+    remediation_class: 1,
+    original_yaml: "- name: a\n  debug:\n    msg: hi\n",
+  },
+  {
+    rule_id: "M001",
+    severity: "medium",
+    message: "legacy module",
+    file: "play.yml",
+    path: "play.yml/plays[0]/tasks[1]",
+    node_type: "task",
+    remediation_class: 2,
+    original_yaml: "- name: b\n  debug:\n    msg: bye\n",
+  },
+  {
+    rule_id: "L050,M001",
+    severity: "low",
+    message: "coupled",
+    file: "roles/x/tasks/main.yml",
+    path: "roles/x/tasks/main.yml/tasks[0]",
+    node_type: "task",
+    remediation_class: 3,
+  },
+];
+
+describe("AssessFindingsPanel rule filter", () => {
+  it("filters to selected rule via typeahead and shows count title", async () => {
+    const user = userEvent.setup();
+    render(<AssessFindingsPanel findings={findings} />);
+
+    await user.click(screen.getByLabelText("Filter by rule ID"));
+    const combobox = screen.getByRole("combobox");
+    await user.type(combobox, "L050");
+    await user.click(within(await screen.findByRole("listbox")).getByText("L050"));
+
+    expect(screen.getByText(/Showing 2 findings of 3/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Selected rule filters"),
+    ).toHaveTextContent("L050");
+  });
+
+  it("OR-filters when multiple rules are selected", async () => {
+    const user = userEvent.setup();
+    render(<AssessFindingsPanel findings={findings} />);
+
+    await user.click(screen.getByLabelText("Filter by rule ID"));
+    await user.type(screen.getByRole("combobox"), "L050");
+    await user.click(within(await screen.findByRole("listbox")).getByText("L050"));
+
+    await user.click(screen.getByLabelText("Filter by rule ID"));
+    await user.type(screen.getByRole("combobox"), "M001");
+    await user.click(within(await screen.findByRole("listbox")).getByText("M001"));
+
+    // All three findings match L050 or M001.
+    expect(screen.getByText(/Showing 3 findings of 3/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Selected rule filters"),
+    ).toHaveTextContent("L050");
+    expect(
+      screen.getByLabelText("Selected rule filters"),
+    ).toHaveTextContent("M001");
+  });
+
+  it("clicking a RuleId chip toggles that rule into the filter", async () => {
+    const user = userEvent.setup();
+    render(<AssessFindingsPanel findings={findings} />);
+
+    // defaultExpanded — rule chips are already visible.
+    const ruleChips = screen.getAllByRole("button", { name: "L050" });
+    await user.click(ruleChips[0]!);
+
+    expect(screen.getByText(/Showing 2 findings of 3/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Selected rule filters"),
+    ).toHaveTextContent("L050");
+  });
+});

--- a/frontend/src/test/ruleFilter.test.ts
+++ b/frontend/src/test/ruleFilter.test.ts
@@ -89,4 +89,24 @@ describe("filterByRuleKeepingNodeContext", () => {
     );
     expect(result.some((f) => f.rule_id === "R099")).toBe(false);
   });
+
+  it("supports row-level post-filter after node inclusion (decision pattern)", () => {
+    // Panels apply decision after node-inclusion so Accepted siblings do not
+    // reappear when filtering Pending + a rule.
+    const proposals = [
+      { rule_id: "L050", path: "a", decision: "pending" },
+      { rule_id: "M001", path: "a", decision: "accepted" },
+      { rule_id: "L050", path: "b", decision: "pending" },
+    ];
+    const afterRules = filterByRuleKeepingNodeContext(
+      proposals,
+      new Set(["L050"]),
+    );
+    expect(afterRules).toHaveLength(3); // siblings on path a kept
+    const pendingOnly = afterRules.filter((p) => p.decision === "pending");
+    expect(pendingOnly.map((p) => `${p.path}:${p.rule_id}`)).toEqual([
+      "a:L050",
+      "b:L050",
+    ]);
+  });
 });

--- a/frontend/src/test/ruleFilter.test.ts
+++ b/frontend/src/test/ruleFilter.test.ts
@@ -1,0 +1,92 @@
+/** @vitest-environment node */
+import { describe, it, expect } from "vitest";
+import {
+  filterByRuleKeepingNodeContext,
+  matchesRuleFilters,
+  presentRuleIds,
+  reviewNodeKey,
+} from "../../packages/ui-workflow/src/remediation/ruleFilter";
+
+const findings = [
+  {
+    rule_id: "native:L050",
+    path: "play.yml/plays[0]/tasks[0]",
+    severity: "high",
+  },
+  {
+    rule_id: "M001",
+    path: "play.yml/plays[0]/tasks[0]",
+    severity: "medium",
+  },
+  {
+    rule_id: "R099",
+    path: "play.yml/plays[0]/tasks[1]",
+    severity: "low",
+  },
+];
+
+describe("presentRuleIds", () => {
+  it("collects bare IDs, splits coupled, strips prefixes", () => {
+    expect(
+      presentRuleIds([
+        { rule_id: "native:L050" },
+        { rule_id: "M001" },
+        { rule_id: "L050,M001" },
+        { rule_id: "" },
+      ]),
+    ).toEqual(["L050", "M001"]);
+  });
+});
+
+describe("matchesRuleFilters", () => {
+  it("passes all when nothing selected", () => {
+    expect(matchesRuleFilters({ rule_id: "L050" }, new Set())).toBe(true);
+  });
+
+  it("matches bare and prefixed IDs", () => {
+    const selected = new Set(["L050"]);
+    expect(matchesRuleFilters({ rule_id: "native:L050" }, selected)).toBe(true);
+    expect(matchesRuleFilters({ rule_id: "L050,M001" }, selected)).toBe(true);
+    expect(matchesRuleFilters({ rule_id: "M001" }, selected)).toBe(false);
+  });
+});
+
+describe("filterByRuleKeepingNodeContext", () => {
+  it("returns row-level filter when no rules selected", () => {
+    const result = filterByRuleKeepingNodeContext(
+      findings,
+      new Set(),
+      (f) => f.severity === "high",
+    );
+    expect(result.map((f) => f.rule_id)).toEqual(["native:L050"]);
+  });
+
+  it("keeps all findings on a node when any match the rule", () => {
+    const result = filterByRuleKeepingNodeContext(
+      findings,
+      new Set(["L050"]),
+    );
+    expect(result.map((f) => f.rule_id)).toEqual(["native:L050", "M001"]);
+    expect(result.every((f) => reviewNodeKey(f) === findings[0]!.path)).toBe(
+      true,
+    );
+  });
+
+  it("other filters qualify nodes but do not strip siblings", () => {
+    // Only high passes "other"; node still qualifies via L050 high, so M001 stays.
+    const result = filterByRuleKeepingNodeContext(
+      findings,
+      new Set(["L050"]),
+      (f) => f.severity === "high",
+    );
+    expect(result.map((f) => f.rule_id)).toEqual(["native:L050", "M001"]);
+  });
+
+  it("drops nodes with no rule match", () => {
+    const result = filterByRuleKeepingNodeContext(
+      findings,
+      new Set(["L050"]),
+    );
+    expect(result.some((f) => f.rule_id === "R099")).toBe(false);
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,42 +1,45 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  configurable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
+// Pure unit tests may use @vitest-environment node (no DOM).
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
 
-/** jsdom does not implement EventSource; stub for SSE hooks in AppShell tests. */
-class MockEventSource {
-  static readonly CONNECTING = 0;
-  static readonly OPEN = 1;
-  static readonly CLOSED = 2;
-  readonly url: string;
-  readyState = MockEventSource.CONNECTING;
-  onmessage: ((ev: MessageEvent) => void) | null = null;
-  onerror: ((ev: Event) => void) | null = null;
-  onopen: ((ev: Event) => void) | null = null;
-  constructor(url: string) {
-    this.url = url;
+  /** jsdom does not implement EventSource; stub for SSE hooks in AppShell tests. */
+  class MockEventSource {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSED = 2;
+    readonly url: string;
+    readyState = MockEventSource.CONNECTING;
+    onmessage: ((ev: MessageEvent) => void) | null = null;
+    onerror: ((ev: Event) => void) | null = null;
+    onopen: ((ev: Event) => void) | null = null;
+    constructor(url: string) {
+      this.url = url;
+    }
+    addEventListener(): void {}
+    removeEventListener(): void {}
+    close(): void {
+      this.readyState = MockEventSource.CLOSED;
+    }
+    dispatchEvent(): boolean {
+      return false;
+    }
   }
-  addEventListener(): void {}
-  removeEventListener(): void {}
-  close(): void {
-    this.readyState = MockEventSource.CLOSED;
-  }
-  dispatchEvent(): boolean {
-    return false;
-  }
+
+  vi.stubGlobal("EventSource", MockEventSource);
 }
-
-vi.stubGlobal("EventSource", MockEventSource);


### PR DESCRIPTION
## Summary
- Add a PatternFly multi-tag typeahead to filter Assess, Quick-fix/AI proposal gates, and AI escalation by rule ID
- Matching a rule keeps the **whole node** (sibling findings/proposals stay visible for context)
- Click a `RuleId` chip to toggle the filter; dropdown closes after each pick
- Accept / Decline remaining (and Include / Skip remaining) still apply only to the **currently visible** undecided set — so filter → accept remaining → clear filter → decline remaining works
- Decision filters stay row/location-level so Accepted siblings do not reappear when filtering Pending + a rule

## Test plan
- [ ] Activity / Assess: type a rule ID, confirm siblings on the same path stay; clear chip restores all
- [ ] Click a RuleId in a finding row → filter toggles; click again clears
- [ ] Gate 1: filter by rule → Accept remaining → clear filter → Decline remaining → Next unlocks
- [ ] AI escalation: same Include/Skip remaining behavior with rule filter
- [ ] `cd frontend && npm test -- --run src/test/ruleFilter.test.ts`
- [x] `tox -e lint` / `tox -e unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rule-based filtering to AI escalation, findings, and proposal review panels.
  * Rule IDs can be selected through searchable multi-select controls or clicked directly from findings.
  * Filters preserve relevant node context while narrowing results by severity, type, location, and decision.
  * Added clear selections, keyboard navigation, and no-results messaging for rule filters.
* **Bug Fixes**
  * Automatically removes rule selections that are no longer available.
  * Improved list reset behavior when filters change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->