### PR TITLE
feat(gateway): ADR-070 allowlisted Abbenay HTTP admin proxy

### DIFF
--- a/.sdlc/adrs/ADR-046-ai-assisted-report-generation.md
+++ b/.sdlc/adrs/ADR-046-ai-assisted-report-generation.md
@@ -218,6 +218,12 @@ The component set is extensible — adding a new visualization means adding a Re
 
 **Why not chosen**: The proxy adds negligible latency (pod-local gRPC) and keeps AI infrastructure management in one place.
 
+> **Amendment (ADR-070):** This alternative rejects Gateway → Abbenay for
+> **LLM inference** (`chat` / report planning). It does **not** forbid the
+> Gateway from **HTTP reverse-proxying** Abbenay’s admin/config API on
+> localhost in the Simple in-pod topology. See
+> [ADR-070](ADR-070-gateway-abbenay-admin-proxy.md).
+
 ### Alternative 3: LLM generates rendering code (HTML/JSX)
 
 **Description**: The LLM returns HTML, JSX, or web component markup that the frontend renders via `dangerouslySetInnerHTML` or a sandboxed iframe.

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -65,9 +65,8 @@ clients. Do **not** proxy chat, sessions, OpenAI-compat `/v1`, or arbitrary
 Abbenay surfaces (ADR-046 inference stays Primary). Reject path traversal
 (`..` / encoded forms). Abbenay remains the source of truth for config.
 
-Allowlist (initial): `GET/POST /config`, `GET /providers` (and related read
-helpers: engines/templates/secrets), `POST /provider/{id}/configure`,
-`DELETE /provider/{id}`.
+Allowlist (initial): `GET/POST /config`, `GET /providers`,
+`POST /provider/{id}/configure`, `DELETE /provider/{id}`.
 
 **3. Enable Abbenay HTTP on loopback when Abbenay is enabled.**  
 In addition to gRPC `:50057` (Primary), start Abbenay’s HTTP admin surface on

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -1,0 +1,227 @@
+# ADR-070: Gateway HTTP Proxy to In-Pod Abbenay Admin (Simple Model)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-03
+
+## Context
+
+Portal and other Gateway clients need to **configure** Abbenay (providers,
+models, API keys) at runtime — not only select a model for remediation.
+Today APME ships Abbenay with **deploy-time** `config.yaml` + env/Helm secrets
+and exposes only **gRPC** (`:50057`) for Primary inference (`list_models` /
+`chat`). There is no Gateway path for Abbenay admin.
+
+Abbenay already provides an HTTP admin/config API (`/api/config`,
+`/api/providers`, `POST /api/provider/:id/configure`, …) on port **8787** when
+its web/serve surface is running. APME does not start that HTTP listener today.
+
+Constraints and drivers:
+
+- **ADR-069 Simple topology** — Helm EAP/upstream co-locates engine + Gateway +
+  optional Abbenay in one pod on localhost. Podman and bootc likewise share the
+  network namespace. Loopback is the natural admin hop.
+- **ADR-046** rejected Gateway → Abbenay for **LLM inference** (Primary remains
+  the sole `abbenay_grpc` chat / `ListAIModels` path). That rejection must not
+  block a separate **admin** concern.
+- **ADR-060** — Gateway REST under `/api/v1` is a versioned public contract;
+  new admin access must be additive.
+- **Future optionality** — Abbenay may later run outside the APME pod as a
+  shared Portal resource. Prefer Abbenay-native HTTP shapes so a client can
+  later change `baseUrl` without DTO rewrites. That future topology is **out of
+  scope** for this ADR; this decision covers the Simple in-pod model only.
+- **Security** — Abbenay HTTP must not be cluster-exposed. Gateway is the
+  ingress; Abbenay binds loopback; NetworkPolicy / no Service port for 8787.
+
+### Invariant consistency check
+
+| Invariant | Status |
+|-----------|--------|
+| 1. Validators read-only | Consistent |
+| 2. gRPC between backend services | Consistent — admin uses Abbenay’s existing HTTP API; inference stays gRPC via Primary |
+| 5. Stateless engine / persistence at Gateway | Consistent — Abbenay remains config SoT; Gateway does not persist Abbenay config |
+| 11. Engine never queries out | Consistent — Gateway (not engine) reaches Abbenay admin |
+| 16. Helm Simple / Podman localhost | Consistent with ADR-069 |
+| 17. REST versioning (ADR-060) | Additive `/api/v1/ai/*` proxy mount |
+
+**Amends ADR-046** Alternative 2 notes: rejection applies to **inference**, not
+to Gateway HTTP reverse-proxy of Abbenay **admin**.
+
+## Decision
+
+**1. Simple model: Abbenay is in the APME pod.**  
+For EAP/upstream Helm (ADR-069), Podman, and aligned local daemon layouts,
+Abbenay is co-located with Gateway. Admin traffic uses localhost.
+
+**2. Gateway reverse-proxies an allowlisted Abbenay HTTP admin API.**  
+Mount additive routes under `/api/v1/ai/...` that forward **only** admin
+operations to Abbenay `/api/...` (same method, query, and body for allowlisted
+paths). Do **not** reimplement Abbenay admin schemas in Gateway Python/gRPC
+clients. Do **not** proxy chat, sessions, OpenAI-compat `/v1`, or arbitrary
+Abbenay surfaces (ADR-046 inference stays Primary). Reject path traversal
+(`..` / encoded forms). Abbenay remains the source of truth for config.
+
+Allowlist (initial): `GET/POST /config`, `GET /providers` (and related read
+helpers: engines/templates/secrets), `POST /provider/{id}/configure`,
+`DELETE /provider/{id}`.
+
+**3. Enable Abbenay HTTP on loopback when Abbenay is enabled.**  
+In addition to gRPC `:50057` (Primary), start Abbenay’s HTTP admin surface on
+**`127.0.0.1:8787`** (default Abbenay port). Do not publish a cluster Service
+or hostPort for 8787 in the Simple chart.
+
+**4. Auth rewrite at the Gateway.**  
+Outbound to Abbenay, Gateway injects Abbenay’s HTTP Bearer token
+(`ABBENAY_API_TOKEN` / configured server token). Strip inbound
+`Authorization` and `Cookie`; do not forward `Set-Cookie`. Fail closed (503)
+when no admin token is configured.
+
+Gateway REST itself remains **network-isolation auth** (ADR-048 / no
+app-level middleware on `:8080`) — the same trust model as other `/api/v1`
+routes. Portal deployments put Backstage/catalog auth in front of the
+Gateway. Elevating Abbenay admin onto that edge is intentional for Simple
+EAP; operators must not expose Gateway `:8080` without an outer auth layer.
+
+**5. Inference unchanged.**  
+`GET /api/v1/ai/models` (Primary `ListAIModels`) and remediate `enable_ai` /
+`ai_model` continue via Primary → Abbenay gRPC. The proxy does not replace that
+path and rejects other methods on `models`.
+
+**6. Config durability (acknowledged gap).**  
+Helm ConfigMap / Podman hostPath seed deploy-time providers (often read-only).
+Runtime HTTP admin writes need a writable Abbenay config directory. **Durable
+writable persistence (emptyDir seed + PVC) is a follow-up** — tracked as a
+GitHub issue — not a blocker for the allowlisted proxy plumbing.
+
+**We will use an allowlisted HTTP reverse-proxy on the Gateway for in-pod
+Abbenay admin, not a catch-all façade and not Gateway→Abbenay gRPC for chat.**
+
+## Alternatives Considered
+
+### Alternative 1: Gateway reimplements Abbenay admin via gRPC
+
+**Description**: Gateway imports admin RPCs (`GetConfig`, `UpdateConfig`,
+`ConfigureProvider`, …) and exposes hand-written REST DTOs.
+
+**Pros**:
+- No Abbenay HTTP listener required in the pod
+- Gateway owns OpenAPI schemas explicitly
+
+**Cons**:
+- High drift vs Abbenay’s real HTTP API
+- Second admin client stack (`abbenay_grpc` admin stubs) in Gateway
+- Breaks cheap future Portal → Abbenay `baseUrl` swap
+
+**Why not chosen**: Proxy preserves Abbenay shapes with far less code and drift.
+
+### Alternative 2: Portal talks to Abbenay HTTP directly (even in-pod)
+
+**Description**: Portal/browser or catalog backend reaches Abbenay `:8787`
+without Gateway.
+
+**Pros**:
+- No Gateway proxy code
+
+**Cons**:
+- Exposes or tunnels Abbenay admin outside the APME auth boundary
+- Conflicts with Simple “Gateway is the product REST edge” model
+- Harder RBAC / audit at one place
+
+**Why not chosen**: For the in-pod Simple model, Gateway remains the only
+external admin ingress. Direct Portal → Abbenay is a **future** option when
+Abbenay is a shared platform service (separate ADR).
+
+### Alternative 3: Keep deploy-time-only Abbenay config (status quo)
+
+**Description**: Operators edit Helm values / `config.yaml` and redeploy; no
+runtime admin API.
+
+**Pros**:
+- No new surface; secrets stay in cluster Secret workflows
+
+**Cons**:
+- Blocks Portal Quality-settings / admin UX for AI providers
+- Slow feedback loop for EAP demos and day-2 model changes
+
+**Why not chosen**: Product needs runtime admin through the Gateway edge.
+
+## Consequences
+
+### Positive
+
+- Portal (and other clients) can configure Abbenay through existing Gateway
+  reachability without a second public Service.
+- Abbenay-native paths/bodies minimize future client churn if Abbenay moves out
+  of the pod.
+- Clear split: **admin** = Gateway HTTP proxy; **inference** = Primary gRPC
+  (ADR-025 / ADR-046).
+
+### Negative
+
+- Must run Abbenay HTTP in the pod (image/args/config) in addition to gRPC —
+  larger attack surface if mis-bound off loopback.
+- Gateway must hold Abbenay HTTP token and keep proxy behavior correct
+  (streaming, errors, path strip).
+- OpenAPI will document a proxy mount rather than a fully owned schema
+  (link to Abbenay config docs).
+
+### Neutral
+
+- `GET /api/v1/ai/models` stays Primary-mediated; Abbenay `/api/models` may exist
+  behind the proxy but is not the remediate UI contract unless explicitly
+  switched later.
+- External / multi-tenant Abbenay is deferred; this ADR does not design that
+  topology.
+
+## Implementation Notes
+
+- **Path map (allowlisted)**: `/api/v1/ai/{path}` → `http://127.0.0.1:8787/api/{path}`  
+  Examples: `/api/v1/ai/config` → `/api/config`;  
+  `/api/v1/ai/provider/foo/configure` → `/api/provider/foo/configure`.  
+  Reject unknown paths (including `chat`) and encoded `..` traversal.
+- **Env**: e.g. `APME_ABBENAY_HTTP_URL` default `http://127.0.0.1:8787`;  
+  `APME_ABBENAY_HTTP_TOKEN` (or shared secret with Abbenay `server.api_token_env`).
+- **Deploy**: Helm Simple sidecar + Podman — `abbenay web --host 127.0.0.1
+  --port 8787` plus gRPC flags; no Service port 8787; chart README notes ADR-070.
+- **Conflict**: `GET /api/v1/ai/models` remains Primary-backed; proxy excludes
+  `models` for all methods. Register main router before the proxy mount.
+- **OpenAPI**: proxy routes `include_in_schema=False` (Abbenay owns schemas);
+  Gateway `info.description` references ADR-070.
+- **Tests**: path rewrite, Bearer inject, 502, models/chat not proxied,
+  traversal rejected, missing token 503, Set-Cookie stripped; helm asserts
+  `web` / `8787` / Gateway HTTP URL.
+- **Portal UI**: out of scope for the first implementation PR; catalog proxy +
+  Quality settings follow in a later change.
+- **Follow-up**: writable Abbenay config volume (seed ConfigMap → emptyDir/PVC)
+  so runtime admin survives restart —
+  [#498](https://github.com/ansible/apme/issues/498).
+
+## Related Decisions
+
+- [ADR-025](ADR-025-ai-provider-protocol.md): `AIProvider` / Primary-only
+  `abbenay_grpc` for inference
+- [ADR-046](ADR-046-ai-assisted-report-generation.md): Amended — Gateway must
+  not call Abbenay for **chat/inference**; admin HTTP proxy is allowed
+- [ADR-048](ADR-048-pod-internal-admin-endpoints.md): Network isolation for
+  pod-internal admin surfaces
+- [ADR-054](ADR-054-production-deployment.md) / [ADR-069](ADR-069-helm-simple-all-in-one.md):
+  Simple all-in-one localhost topology
+- [ADR-060](ADR-060-rest-api-versioning-contract.md): Additive `/api/v1` routes
+
+## References
+
+- Abbenay configuration / HTTP API: upstream Abbenay `docs/CONFIGURATION.md`
+  (`GET/POST /api/config`, providers, Bearer `ABBENAY_API_TOKEN`, port 8787)
+- Portal follow-up: Quality settings Abbenay config UI (deferred)
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-08-03 | cidrblock | Accepted — Simple in-pod Abbenay; Gateway HTTP admin proxy |

--- a/.sdlc/adrs/README.md
+++ b/.sdlc/adrs/README.md
@@ -78,6 +78,7 @@ Decisions that have been accepted but are not yet fully implemented.
 | [ADR-065](ADR-065-spa-gateway-live-state-ownership.md) | SPA vs Gateway Live-Operation State Ownership | 2026-07-20 |
 | [ADR-066](ADR-066-ui-workflow-github-release-artifacts.md) | Publish `@apme/ui-workflow` via GitHub Release Artifacts (Accepted (revised 2026-07-31: consolidated into main release)) | 2026-07-23 (revised 2026-07-31) |
 | [ADR-069](ADR-069-helm-simple-all-in-one.md) | Helm Chart Simple All-in-One Topology (EAP / Upstream) | 2026-08-03 |
+| [ADR-070](ADR-070-gateway-abbenay-admin-proxy.md) | Gateway HTTP Proxy to In-Pod Abbenay Admin (Simple Model) | 2026-08-03 |
 
 ## Proposed
 
@@ -104,7 +105,7 @@ Decisions replaced by newer ADRs.
 ## Creating New ADRs
 
 1. Copy the template from `../templates/adr.md`
-2. Use the next available number (currently ADR-070)
+2. Use the next available number (currently ADR-071)
 3. Include:
    - Status (Proposed → Accepted → Implemented)
    - Date

--- a/containers/abbenay/config.yaml.example
+++ b/containers/abbenay/config.yaml.example
@@ -5,6 +5,13 @@
 #
 # Consumers: the "apme" consumer uses a well-known dev token so the
 # Primary container can authenticate without per-dev setup.
+#
+# ADR-070: HTTP admin (Gateway reverse-proxies /api/v1/ai/* → /api/*).
+# Set ABBENAY_API_TOKEN in .env (pod.yaml uses the same value as APME_ABBENAY_TOKEN).
+
+server:
+  host: "127.0.0.1"
+  api_token_env: ABBENAY_API_TOKEN
 
 providers:
   openrouter:

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -180,6 +180,10 @@ spec:
           value: "0.0.0.0"
         - name: APME_GATEWAY_HTTP_PORT
           value: "8080"
+        - name: APME_ABBENAY_HTTP_URL
+          value: "http://127.0.0.1:8787"
+        - name: APME_ABBENAY_HTTP_TOKEN
+          value: "apme-dev-token"
         - name: COLLECTION_HEALTH_GRPC_ADDRESS
           value: "127.0.0.1:50058"
         - name: DEP_AUDIT_GRPC_ADDRESS
@@ -213,13 +217,25 @@ spec:
           hostPort: 8081
     - name: abbenay
       image: ghcr.io/redhat-developer/abbenay:2026.4.1-alpha
-      args: ["daemon", "--grpc-host", "0.0.0.0", "--grpc-port", "50057"]
+      # ADR-070: gRPC for Primary + HTTP admin on loopback (no hostPort 8787)
+      args:
+        - "web"
+        - "--host"
+        - "127.0.0.1"
+        - "--port"
+        - "8787"
+        - "--grpc-host"
+        - "0.0.0.0"
+        - "--grpc-port"
+        - "50057"
       env:
         - name: OPENROUTER_API_KEY
           value: "${OPENROUTER_API_KEY}"
         - name: VERTEX_ANTHROPIC_API_KEY
           value: "${VERTEX_ANTHROPIC_API_KEY}"
         - name: APME_ABBENAY_TOKEN
+          value: "apme-dev-token"
+        - name: ABBENAY_API_TOKEN
           value: "apme-dev-token"
         - name: XDG_RUNTIME_DIR
           value: "/tmp/abbenay-run"

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -172,7 +172,10 @@ Gateway DB and Abbenay down together.
   (`-engine`, `-gateway`, `-ui`) select this pod for Ingress/port-forward.
 - **UI** (optional): nginx SPA; `ui.enabled: false` via `values-portal.yaml`
   for portal / Backstage (ADR-030 Option B).
-- **Abbenay** (optional): AI provider on `127.0.0.1:50057`.
+- **Abbenay** (optional): AI provider gRPC on `127.0.0.1:50057` plus HTTP
+  admin on `127.0.0.1:8787` (no Service / hostPort). Gateway reverse-proxies
+  `/api/v1/ai/*` → Abbenay `/api/*` ([ADR-070](../../../.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md)).
+  `GET /api/v1/ai/models` remains Primary `ListAIModels`.
 
 ## Key values
 
@@ -188,7 +191,7 @@ Gateway DB and Abbenay down together.
 | `ui.enabled` | `true` | Include UI sidecar (`false` via `values-portal.yaml`) |
 | `ui.replicas` | `1` | Must be `1` when UI enabled |
 | `abbenay.enabled` | `false` | Enable AI provider sidecar |
-| `abbenay.token` | `""` | Abbenay service token (required when `abbenay.enabled=true`) |
+| `abbenay.token` | `""` | Abbenay gRPC + HTTP admin token (required when `abbenay.enabled=true`) |
 | `abbenay.image` | `ghcr.io/redhat-developer/abbenay:2026.4.1-alpha` | Abbenay image |
 | `abbenay.providers` | `{}` | LLM provider map (see [ABBENAY_AI.md](../../../docs/guides/ABBENAY_AI.md)) |
 | `abbenay.aiModel` | `""` | Default AI model ID |

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -174,7 +174,9 @@ Gateway DB and Abbenay down together.
   for portal / Backstage (ADR-030 Option B).
 - **Abbenay** (optional): AI provider gRPC on `127.0.0.1:50057` plus HTTP
   admin on `127.0.0.1:8787` (no Service / hostPort). Gateway reverse-proxies
-  `/api/v1/ai/*` → Abbenay `/api/*` ([ADR-070](../../../.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md)).
+  **allowlisted** admin paths under `/api/v1/ai/` → Abbenay `/api/` (config,
+  providers, provider configure/delete; not chat/sessions/OpenAI-compat) —
+  see [ADR-070](../../../.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md).
   `GET /api/v1/ai/models` remains Primary `ListAIModels`.
 
 ## Key values

--- a/deploy/helm/apme/templates/abbenay-configmap.yaml
+++ b/deploy/helm/apme/templates/abbenay-configmap.yaml
@@ -8,6 +8,10 @@ metadata:
     app.kubernetes.io/component: abbenay
 data:
   config.yaml: |
+    # ADR-070: HTTP admin on loopback; token from ABBENAY_API_TOKEN env
+    server:
+      host: "127.0.0.1"
+      api_token_env: ABBENAY_API_TOKEN
     providers:
     {{- range $name, $provider := .Values.abbenay.providers }}
       {{ $name }}:

--- a/deploy/helm/apme/templates/engine-deployment.yaml
+++ b/deploy/helm/apme/templates/engine-deployment.yaml
@@ -355,6 +355,16 @@ spec:
               value: "0.0.0.0"
             - name: APME_GATEWAY_HTTP_PORT
               value: "8080"
+            {{- if .Values.abbenay.enabled }}
+            # ADR-070: reverse-proxy Abbenay HTTP admin on loopback
+            - name: APME_ABBENAY_HTTP_URL
+              value: "http://127.0.0.1:8787"
+            - name: APME_ABBENAY_HTTP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $fullname }}-secrets
+                  key: abbenay-token
+            {{- end }}
             {{- if .Values.collectionHealth.enabled }}
             - name: COLLECTION_HEALTH_GRPC_ADDRESS
               value: "127.0.0.1:50058"
@@ -447,9 +457,24 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          args: ["daemon", "--grpc-host", "127.0.0.1", "--grpc-port", "50057"]
+          # ADR-070: gRPC for Primary + HTTP admin on loopback (no Service/hostPort 8787)
+          args:
+            - "web"
+            - "--host"
+            - "127.0.0.1"
+            - "--port"
+            - "8787"
+            - "--grpc-host"
+            - "127.0.0.1"
+            - "--grpc-port"
+            - "50057"
           env:
             - name: APME_ABBENAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $fullname }}-secrets
+                  key: abbenay-token
+            - name: ABBENAY_API_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ $fullname }}-secrets

--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -2658,7 +2658,7 @@
     }
   },
   "info": {
-    "description": "Reporting persistence and REST API for projects, activity, and operations (ADR-020 / ADR-029 / ADR-052). Public contract under /api/v1 (ADR-060).",
+    "description": "Reporting persistence and REST API for projects, activity, and operations (ADR-020 / ADR-029 / ADR-052). Public contract under /api/v1 (ADR-060). Abbenay admin HTTP proxy (ADR-070).",
     "title": "APME Gateway",
     "version": "0.1.0"
   },

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -4,6 +4,27 @@ This guide covers configuring APME's Abbenay AI service for Tier 2
 (AI-assisted) remediation. Abbenay supports multiple LLM backends via the
 Vercel AI SDK.
 
+## Gateway admin proxy (ADR-070)
+
+In the Simple in-pod topology (ADR-069), Abbenay listens for HTTP admin on
+`127.0.0.1:8787` (no cluster Service). The Gateway reverse-proxies an
+**allowlisted** admin surface:
+
+| Gateway | Abbenay |
+|---------|---------|
+| `GET/POST /api/v1/ai/config` | `/api/config` |
+| `GET /api/v1/ai/providers` | `/api/providers` |
+| `POST /api/v1/ai/provider/{id}/configure` | `/api/provider/{id}/configure` |
+| `DELETE /api/v1/ai/provider/{id}` | `/api/provider/{id}` |
+
+`GET /api/v1/ai/models` remains Primary → Abbenay gRPC (`ListAIModels`). Chat
+is **not** proxied. Set `APME_ABBENAY_HTTP_URL` (default
+`http://127.0.0.1:8787`) and `APME_ABBENAY_HTTP_TOKEN` on the Gateway (same
+secret as `ABBENAY_API_TOKEN` / `abbenay.token` in Helm).
+
+Runtime admin writes need a writable Abbenay config directory; durable volume
+seeding is tracked in [#498](https://github.com/ansible/apme/issues/498).
+
 ---
 
 ## Supported Engines

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -146,7 +146,10 @@ assert_template_contains "Abbenay loopback" "${RENDER}" "--grpc-host"
 assert_template_contains "Abbenay loopback host" "${RENDER}" "127.0.0.1"
 assert_template_contains "Abbenay HTTP web (ADR-070)" "${RENDER}" '"web"'
 assert_template_contains "Abbenay HTTP port (ADR-070)" "${RENDER}" '"8787"'
+assert_template_contains "Abbenay HTTP host loopback (ADR-070)" "${RENDER}" $'--host"\n            - "127.0.0.1"'
 assert_template_contains "Gateway Abbenay HTTP URL (ADR-070)" "${RENDER}" 'value: "http://127.0.0.1:8787"'
+assert_template_lacks "no Abbenay HTTP Service port" "${RENDER}" "name: abbenay-http"
+assert_template_lacks "no Abbenay HTTP hostPort" "${RENDER}" $'containerPort: 8787\n          hostPort:'
 assert_template_contains "reporting localhost" "${RENDER}" 'value: "127.0.0.1:50060"'
 assert_template_contains "abbenay addr localhost" "${RENDER}" 'value: "127.0.0.1:50057"'
 assert_template_contains "gateway primary addr localhost" "${RENDER}" 'value: "127.0.0.1:50051"'

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -144,6 +144,9 @@ assert_template_contains "ui sidecar" "${RENDER}" $'- name: ui\n'
 assert_template_contains "abbenay sidecar" "${RENDER}" $'- name: abbenay\n'
 assert_template_contains "Abbenay loopback" "${RENDER}" "--grpc-host"
 assert_template_contains "Abbenay loopback host" "${RENDER}" "127.0.0.1"
+assert_template_contains "Abbenay HTTP web (ADR-070)" "${RENDER}" '"web"'
+assert_template_contains "Abbenay HTTP port (ADR-070)" "${RENDER}" '"8787"'
+assert_template_contains "Gateway Abbenay HTTP URL (ADR-070)" "${RENDER}" 'value: "http://127.0.0.1:8787"'
 assert_template_contains "reporting localhost" "${RENDER}" 'value: "127.0.0.1:50060"'
 assert_template_contains "abbenay addr localhost" "${RENDER}" 'value: "127.0.0.1:50057"'
 assert_template_contains "gateway primary addr localhost" "${RENDER}" 'value: "127.0.0.1:50051"'

--- a/src/apme_gateway/api/abbenay_proxy.py
+++ b/src/apme_gateway/api/abbenay_proxy.py
@@ -60,16 +60,9 @@ _RESPONSE_DROP: Final = frozenset(
     }
 )
 
-# Admin-only path allowlist (decoded, no leading slash). No chat/sessions.
-_GET_PATHS: Final = frozenset(
-    {
-        "config",
-        "providers",
-        "engines",
-        "templates",
-        "secrets",
-    }
-)
+# Admin-only path allowlist (decoded, no leading slash). Matches ADR-070 /
+# ABBENAY_AI.md — no chat/sessions/secrets/engines/templates.
+_GET_PATHS: Final = frozenset({"config", "providers"})
 _GET_PROVIDER_RE: Final = re.compile(r"^provider/[^/]+$")
 _POST_PATHS: Final = frozenset({"config"})
 _POST_CONFIGURE_RE: Final = re.compile(r"^provider/[^/]+/configure$")
@@ -113,6 +106,9 @@ def _decode_admin_path(path: str) -> str | None:
     decoded = unquote(path).strip().strip("/")
     if not decoded:
         return None
+    # Reject encoded query/fragment delimiters smuggled into the path param.
+    if "?" in decoded or "#" in decoded:
+        return None
     parts = decoded.split("/")
     if any(part == ".." or part == "." for part in parts):
         return None
@@ -131,7 +127,7 @@ def _method_allows_path(method: str, admin_path: str) -> bool:
     Returns:
         True when the method/path pair is an allowed Abbenay admin route.
     """
-    if method == "GET" or method == "HEAD":
+    if method == "GET":
         return admin_path in _GET_PATHS or bool(_GET_PROVIDER_RE.fullmatch(admin_path))
     if method == "POST":
         return admin_path in _POST_PATHS or bool(_POST_CONFIGURE_RE.fullmatch(admin_path))
@@ -193,17 +189,14 @@ def _filter_response_headers(upstream: httpx.Response) -> dict[str, str]:
     Returns:
         Headers safe to return to the Gateway client.
     """
-    return {
-        key: value
-        for key, value in upstream.headers.items()
-        if key.lower() not in _RESPONSE_DROP
-    }
+    return {key: value for key, value in upstream.headers.items() if key.lower() not in _RESPONSE_DROP}
 
 
 @router.api_route(  # type: ignore[untyped-decorator]
     "/ai/{path:path}",
-    methods=["GET", "POST", "DELETE", "HEAD"],
+    methods=["GET", "POST", "DELETE"],
     # Transparent proxy — Abbenay owns the admin schema (ADR-070).
+    # Omit HEAD: Starlette derives it from GET without a response body.
     include_in_schema=False,
 )
 async def proxy_abbenay_admin(path: str, request: Request) -> Response:

--- a/src/apme_gateway/api/abbenay_proxy.py
+++ b/src/apme_gateway/api/abbenay_proxy.py
@@ -1,0 +1,277 @@
+"""HTTP reverse-proxy of in-pod Abbenay admin API (ADR-070).
+
+Maps a **small allowlist** of Gateway ``/api/v1/ai/...`` routes to Abbenay
+``/api/...`` on localhost. Injects Abbenay's HTTP Bearer token; does not pass
+through caller ``Authorization``. Inference (``GET /api/v1/ai/models`` and
+Abbenay chat) is **not** proxied — chat stays Primary → Abbenay gRPC.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Final
+from urllib.parse import unquote, urlparse
+
+import httpx
+from fastapi import APIRouter, Request, Response
+
+logger = logging.getLogger(__name__)
+
+_HTTP_URL_ENV: Final = "APME_ABBENAY_HTTP_URL"
+_HTTP_URL_DEFAULT: Final = "http://127.0.0.1:8787"
+_HTTP_TOKEN_ENV: Final = "APME_ABBENAY_HTTP_TOKEN"
+_GRPC_TOKEN_ENV: Final = "APME_ABBENAY_TOKEN"
+_ABBENAY_API_TOKEN_ENV: Final = "ABBENAY_API_TOKEN"
+_PROXY_TIMEOUT_S: Final = 60.0
+
+# Hop-by-hop + sensitive headers must not be forwarded (RFC 7230 + ADR-070).
+_REQUEST_DROP: Final = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "host",
+        "content-length",
+        "authorization",
+        "cookie",
+    }
+)
+_RESPONSE_DROP: Final = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "host",
+        "content-length",
+        "content-encoding",  # httpx may already decompress the body
+        "set-cookie",
+    }
+)
+
+# Admin-only path allowlist (decoded, no leading slash). No chat/sessions.
+_GET_PATHS: Final = frozenset(
+    {
+        "config",
+        "providers",
+        "engines",
+        "templates",
+        "secrets",
+    }
+)
+_GET_PROVIDER_RE: Final = re.compile(r"^provider/[^/]+$")
+_POST_PATHS: Final = frozenset({"config"})
+_POST_CONFIGURE_RE: Final = re.compile(r"^provider/[^/]+/configure$")
+_DELETE_PROVIDER_RE: Final = re.compile(r"^provider/[^/]+$")
+
+router = APIRouter(prefix="/api/v1", tags=["abbenay-admin"])
+
+
+def abbenay_http_base_url() -> str:
+    """Return the Abbenay HTTP base URL (no trailing slash).
+
+    Returns:
+        Configured base URL, or ``http://127.0.0.1:8787`` when unset.
+    """
+    return os.environ.get(_HTTP_URL_ENV, "").strip().rstrip("/") or _HTTP_URL_DEFAULT
+
+
+def abbenay_http_token() -> str:
+    """Return the Bearer token for Abbenay HTTP admin.
+
+    Returns:
+        Token from ``APME_ABBENAY_HTTP_TOKEN``, ``APME_ABBENAY_TOKEN``, or
+        ``ABBENAY_API_TOKEN``; empty string if none are set.
+    """
+    for key in (_HTTP_TOKEN_ENV, _GRPC_TOKEN_ENV, _ABBENAY_API_TOKEN_ENV):
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _decode_admin_path(path: str) -> str | None:
+    """Decode and validate the path suffix; reject traversal and models.
+
+    Args:
+        path: Raw path under ``/api/v1/ai/``.
+
+    Returns:
+        Normalized path without a leading slash, or ``None`` if rejected.
+    """
+    decoded = unquote(path).strip().strip("/")
+    if not decoded:
+        return None
+    parts = decoded.split("/")
+    if any(part == ".." or part == "." for part in parts):
+        return None
+    if parts[0] == "models":
+        return None
+    return decoded
+
+
+def _method_allows_path(method: str, admin_path: str) -> bool:
+    """Return whether ``method`` may proxy ``admin_path``.
+
+    Args:
+        method: HTTP method (uppercase).
+        admin_path: Normalized allowlist candidate.
+
+    Returns:
+        True when the method/path pair is an allowed Abbenay admin route.
+    """
+    if method == "GET" or method == "HEAD":
+        return admin_path in _GET_PATHS or bool(_GET_PROVIDER_RE.fullmatch(admin_path))
+    if method == "POST":
+        return admin_path in _POST_PATHS or bool(_POST_CONFIGURE_RE.fullmatch(admin_path))
+    if method == "DELETE":
+        return bool(_DELETE_PROVIDER_RE.fullmatch(admin_path))
+    return False
+
+
+def _upstream_url(admin_path: str, query: str) -> str | None:
+    """Build a safe Abbenay upstream URL under ``/api/``.
+
+    Args:
+        admin_path: Normalized allowlisted path.
+        query: Raw query string (without ``?``).
+
+    Returns:
+        Full upstream URL, or ``None`` if the resolved path leaves ``/api/``.
+    """
+    base = abbenay_http_base_url()
+    url = f"{base}/api/{admin_path}"
+    if query:
+        url = f"{url}?{query}"
+    parsed = urlparse(url)
+    # Reject escapes that leave /api/ after normalization (e.g. encoded ..).
+    path = unquote(parsed.path)
+    if not path.startswith("/api/"):
+        return None
+    if ".." in path.split("/"):
+        return None
+    return url
+
+
+def _filter_request_headers(request: Request) -> dict[str, str]:
+    """Copy request headers for upstream, stripping auth/cookies/hop-by-hop.
+
+    Args:
+        request: Incoming Gateway request.
+
+    Returns:
+        Headers to send to Abbenay, with Bearer token injected when configured.
+    """
+    headers: dict[str, str] = {}
+    for key, value in request.headers.items():
+        if key.lower() in _REQUEST_DROP:
+            continue
+        headers[key] = value
+    token = abbenay_http_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _filter_response_headers(upstream: httpx.Response) -> dict[str, str]:
+    """Copy upstream response headers, omitting hop-by-hop and Set-Cookie.
+
+    Args:
+        upstream: Response from Abbenay HTTP.
+
+    Returns:
+        Headers safe to return to the Gateway client.
+    """
+    return {
+        key: value
+        for key, value in upstream.headers.items()
+        if key.lower() not in _RESPONSE_DROP
+    }
+
+
+@router.api_route(  # type: ignore[untyped-decorator]
+    "/ai/{path:path}",
+    methods=["GET", "POST", "DELETE", "HEAD"],
+    # Transparent proxy — Abbenay owns the admin schema (ADR-070).
+    include_in_schema=False,
+)
+async def proxy_abbenay_admin(path: str, request: Request) -> Response:
+    """Reverse-proxy allowlisted Abbenay HTTP admin under ``/api/v1/ai/*``.
+
+    Allowed (examples): ``GET/POST /ai/config``, ``GET /ai/providers``,
+    ``POST /ai/provider/{id}/configure``, ``DELETE /ai/provider/{id}``.
+    ``GET /api/v1/ai/models`` remains on the main router (Primary). Chat and
+    other Abbenay surfaces are not proxied.
+
+    Args:
+        path: Path suffix after ``/api/v1/ai/``.
+        request: Incoming Gateway request.
+
+    Returns:
+        Upstream status/headers/body, or 4xx/502 for reject/unreachable.
+    """
+    admin_path = _decode_admin_path(path)
+    if admin_path is None or not _method_allows_path(request.method.upper(), admin_path):
+        return Response(
+            content=b'{"detail":"Abbenay admin path not allowed"}',
+            status_code=404,
+            media_type="application/json",
+        )
+
+    if not abbenay_http_token():
+        return Response(
+            content=b'{"detail":"Abbenay HTTP admin token not configured"}',
+            status_code=503,
+            media_type="application/json",
+        )
+
+    url = _upstream_url(admin_path, request.url.query)
+    if url is None:
+        return Response(
+            content=b'{"detail":"Invalid Abbenay admin path"}',
+            status_code=400,
+            media_type="application/json",
+        )
+
+    headers = _filter_request_headers(request)
+    body = await request.body()
+
+    try:
+        async with httpx.AsyncClient(timeout=_PROXY_TIMEOUT_S) as client:
+            upstream = await client.request(
+                request.method,
+                url,
+                headers=headers,
+                content=body if body else None,
+            )
+    except httpx.RequestError:
+        # Log path only — avoid query strings that may contain secrets.
+        logger.warning(
+            "Abbenay admin proxy failed contacting %s/api/%s",
+            abbenay_http_base_url(),
+            admin_path,
+            exc_info=True,
+        )
+        return Response(
+            content=b'{"detail":"Abbenay HTTP admin unreachable"}',
+            status_code=502,
+            media_type="application/json",
+        )
+
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=_filter_response_headers(upstream),
+        media_type=upstream.headers.get("content-type"),
+    )

--- a/src/apme_gateway/app.py
+++ b/src/apme_gateway/app.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from apme_gateway._galaxy_proxy_sync import schedule_push
+from apme_gateway.api.abbenay_proxy import router as abbenay_proxy_router
 from apme_gateway.api.feedback import router as feedback_router
 from apme_gateway.api.operation_router import operation_router
 from apme_gateway.api.router import router
@@ -45,14 +46,17 @@ def create_app() -> FastAPI:
         description=(
             "Reporting persistence and REST API for projects, activity, "
             "and operations (ADR-020 / ADR-029 / ADR-052). Public contract "
-            "under /api/v1 (ADR-060)."
+            "under /api/v1 (ADR-060). Abbenay admin HTTP proxy (ADR-070)."
         ),
         version="0.1.0",
         lifespan=_lifespan,
     )
+    # Main router first so GET /api/v1/ai/models (Primary) wins over the
+    # ADR-070 Abbenay admin catch-all /api/v1/ai/{path}.
     app.include_router(router)
     app.include_router(feedback_router)
     app.include_router(operation_router)
+    app.include_router(abbenay_proxy_router)
     from apme_engine.observability.http_middleware import HttpMetricsMiddleware
 
     app.add_middleware(HttpMetricsMiddleware, service="gateway")

--- a/tests/test_gateway_abbenay_proxy.py
+++ b/tests/test_gateway_abbenay_proxy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -13,7 +13,7 @@ from apme_gateway.app import create_app
 
 
 @pytest.fixture  # type: ignore[untyped-decorator]
-def app_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[AsyncClient]:
+async def app_client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncClient]:
     """ASGI client with Abbenay HTTP env set for proxy tests.
 
     Args:
@@ -25,8 +25,8 @@ def app_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[AsyncClient]:
     monkeypatch.setenv("APME_ABBENAY_HTTP_URL", "http://127.0.0.1:8787")
     monkeypatch.setenv("APME_ABBENAY_HTTP_TOKEN", "admin-http-token")
     transport = ASGITransport(app=create_app())
-    client = AsyncClient(transport=transport, base_url="http://test")
-    yield client
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
 
 
 def _mock_upstream(
@@ -78,9 +78,7 @@ async def test_proxy_get_config_rewrites_path_and_injects_bearer(
     assert client.request.await_args is not None
     assert client.request.await_args.args[0] == "GET"
     assert client.request.await_args.args[1] == "http://127.0.0.1:8787/api/config"
-    assert client.request.await_args.kwargs["headers"]["Authorization"] == (
-        "Bearer admin-http-token"
-    )
+    assert client.request.await_args.kwargs["headers"]["Authorization"] == ("Bearer admin-http-token")
     assert "Cookie" not in client.request.await_args.kwargs["headers"]
 
 
@@ -98,9 +96,7 @@ async def test_proxy_post_provider_configure(app_client: AsyncClient) -> None:
 
     assert resp.status_code == 200
     assert client.request.await_args is not None
-    assert client.request.await_args.args[1] == (
-        "http://127.0.0.1:8787/api/provider/openrouter/configure"
-    )
+    assert client.request.await_args.args[1] == ("http://127.0.0.1:8787/api/provider/openrouter/configure")
     assert b"sk-test" in (client.request.await_args.kwargs.get("content") or b"")
 
 
@@ -174,6 +170,21 @@ async def test_chat_path_not_proxied(app_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_secrets_path_not_proxied(app_client: AsyncClient) -> None:
+    """GET /api/v1/ai/secrets is outside the documented admin allowlist.
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = _mock_upstream()
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.get("/api/v1/ai/secrets")
+
+    assert resp.status_code == 404
+    client.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_encoded_path_traversal_rejected(app_client: AsyncClient) -> None:
     """Encoded .. segments must not escape Abbenay /api/.
 
@@ -185,6 +196,23 @@ async def test_encoded_path_traversal_rejected(app_client: AsyncClient) -> None:
         resp = await app_client.get("/api/v1/ai/%2e%2e/secret")
 
     assert resp.status_code == 404
+    client.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_encoded_query_delimiter_in_path_rejected(app_client: AsyncClient) -> None:
+    """Encoded ? / # in the path param must not alter upstream URL shape.
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = _mock_upstream()
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp_q = await app_client.get("/api/v1/ai/config%3Fevil=1")
+        resp_h = await app_client.get("/api/v1/ai/config%23frag")
+
+    assert resp_q.status_code == 404
+    assert resp_h.status_code == 404
     client.request.assert_not_awaited()
 
 

--- a/tests/test_gateway_abbenay_proxy.py
+++ b/tests/test_gateway_abbenay_proxy.py
@@ -1,0 +1,233 @@
+"""Tests for Gateway → Abbenay HTTP admin reverse-proxy (ADR-070)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from apme_gateway.app import create_app
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+def app_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[AsyncClient]:
+    """ASGI client with Abbenay HTTP env set for proxy tests.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+
+    Yields:
+        AsyncClient: Client bound to the Gateway ASGI app.
+    """
+    monkeypatch.setenv("APME_ABBENAY_HTTP_URL", "http://127.0.0.1:8787")
+    monkeypatch.setenv("APME_ABBENAY_HTTP_TOKEN", "admin-http-token")
+    transport = ASGITransport(app=create_app())
+    client = AsyncClient(transport=transport, base_url="http://test")
+    yield client
+
+
+def _mock_upstream(
+    *,
+    status_code: int = 200,
+    content: bytes = b'{"ok":true}',
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    """Build a fake httpx response and AsyncClient context manager.
+
+    Args:
+        status_code: Upstream HTTP status.
+        content: Upstream response body.
+        headers: Optional upstream response headers.
+
+    Returns:
+        MagicMock: AsyncClient stand-in whose ``request`` returns the response.
+    """
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.content = content
+    response.headers = httpx.Headers(headers or {"content-type": "application/json"})
+
+    client = MagicMock()
+    client.request = AsyncMock(return_value=response)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_proxy_get_config_rewrites_path_and_injects_bearer(
+    app_client: AsyncClient,
+) -> None:
+    """GET /api/v1/ai/config proxies to Abbenay /api/config with Bearer token.
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = _mock_upstream(content=b'{"config":{"providers":{}}}')
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.get(
+            "/api/v1/ai/config",
+            headers={"Authorization": "Bearer portal-caller-token"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"config": {"providers": {}}}
+    assert client.request.await_args is not None
+    assert client.request.await_args.args[0] == "GET"
+    assert client.request.await_args.args[1] == "http://127.0.0.1:8787/api/config"
+    assert client.request.await_args.kwargs["headers"]["Authorization"] == (
+        "Bearer admin-http-token"
+    )
+    assert "Cookie" not in client.request.await_args.kwargs["headers"]
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_proxy_post_provider_configure(app_client: AsyncClient) -> None:
+    """POST /api/v1/ai/provider/x/configure maps to Abbenay provider path.
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = _mock_upstream(content=b'{"success":true}')
+    body = {"engine": "openrouter", "api_key": "sk-test"}
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.post("/api/v1/ai/provider/openrouter/configure", json=body)
+
+    assert resp.status_code == 200
+    assert client.request.await_args is not None
+    assert client.request.await_args.args[1] == (
+        "http://127.0.0.1:8787/api/provider/openrouter/configure"
+    )
+    assert b"sk-test" in (client.request.await_args.kwargs.get("content") or b"")
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_proxy_upstream_unreachable_returns_502(app_client: AsyncClient) -> None:
+    """Proxy returns 502 when Abbenay HTTP cannot be reached.
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = MagicMock()
+    client.request = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.get("/api/v1/ai/providers")
+
+    assert resp.status_code == 502
+    assert "unreachable" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_get_ai_models_not_shadowed_by_proxy(
+    app_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /api/v1/ai/models still uses Primary ListAIModels, not Abbenay proxy.
+
+    Args:
+        app_client: Async HTTP test client.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv("APME_PRIMARY_ADDRESS", "127.0.0.1:59999")
+    client = _mock_upstream(content=b'[{"id":"should-not-appear"}]')
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.get("/api/v1/ai/models")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+    client.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_post_ai_models_not_proxied(app_client: AsyncClient) -> None:
+    """POST /api/v1/ai/models is rejected (models reserved for Primary GET).
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = _mock_upstream()
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.post("/api/v1/ai/models", json={})
+
+    assert resp.status_code == 404
+    client.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_chat_path_not_proxied(app_client: AsyncClient) -> None:
+    """POST /api/v1/ai/chat is not an admin allowlist path (ADR-046).
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = _mock_upstream()
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.post("/api/v1/ai/chat", json={"message": "hi"})
+
+    assert resp.status_code == 404
+    client.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_encoded_path_traversal_rejected(app_client: AsyncClient) -> None:
+    """Encoded .. segments must not escape Abbenay /api/.
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = _mock_upstream()
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.get("/api/v1/ai/%2e%2e/secret")
+
+    assert resp.status_code == 404
+    client.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_missing_token_returns_503(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Proxy fails closed when no Abbenay HTTP token is configured.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv("APME_ABBENAY_HTTP_URL", "http://127.0.0.1:8787")
+    monkeypatch.delenv("APME_ABBENAY_HTTP_TOKEN", raising=False)
+    monkeypatch.delenv("APME_ABBENAY_TOKEN", raising=False)
+    monkeypatch.delenv("ABBENAY_API_TOKEN", raising=False)
+    transport = ASGITransport(app=create_app())
+    client = _mock_upstream()
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        async with AsyncClient(transport=transport, base_url="http://test") as http:
+            resp = await http.get("/api/v1/ai/config")
+
+    assert resp.status_code == 503
+    client.request.assert_not_awaited()
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_set_cookie_not_forwarded(app_client: AsyncClient) -> None:
+    """Upstream Set-Cookie must not be returned to Gateway clients.
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = _mock_upstream(
+        headers={
+            "content-type": "application/json",
+            "set-cookie": "session=evil",
+            "content-encoding": "gzip",
+        },
+    )
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.get("/api/v1/ai/config")
+
+    assert resp.status_code == 200
+    assert "set-cookie" not in {k.lower() for k in resp.headers}
+    assert "content-encoding" not in {k.lower() for k in resp.headers}


### PR DESCRIPTION
## Summary
- Accept **ADR-070**: Simple in-pod Abbenay; Gateway reverse-proxies an **allowlisted** HTTP admin surface to `127.0.0.1:8787`.
- Keep inference on Primary (`GET /api/v1/ai/models`, remediate AI). Do not proxy chat.
- Amend ADR-046 notes: Gateway→Abbenay rejected for inference, not admin HTTP proxy.

## Changes
- Gateway `abbenay_proxy`: allowlisted paths (config/providers/configure/delete), path-traversal and `?`/`#` reject, Bearer inject, strip Cookie/Set-Cookie/`Content-Encoding`, 503 without token, no HEAD body proxy
- Abbenay deploy: `daemon` → `web --host 127.0.0.1 --port 8787` + gRPC; `ABBENAY_API_TOKEN`; Gateway `APME_ABBENAY_HTTP_*`
- Tests for rewrite/auth/502/models/chat/secrets/traversal/delimiters/503/Set-Cookie; Helm asserts for `web`/8787/`--host`
- Docs: chart README (allowlisted wording), `ABBENAY_AI.md` proxy table; follow-up persistence [#498](https://github.com/ansible/apme/issues/498)

## Test plan
- [x] `tox -e lint`
- [x] `tox -e unit`
- [x] `tox -e helm`
- [x] `tox -e openapi`
- [ ] Optional: pod smoke — `GET /api/v1/ai/config` with Abbenay enabled

## Review follow-up
- `1b2601f2`: Copilot/CodeRabbit — async fixture, drop HEAD, allowlist/docs parity, path delimiters, README clarify
- Gateway app-level auth for `:8080` left open for human discussion (ADR-048/070 network-isolation model)