### PR TITLE
feat(gateway): allowlist GET /ai/engines

### DIFF
--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -65,7 +65,7 @@ clients. Do **not** proxy chat, sessions, OpenAI-compat `/v1`, or arbitrary
 Abbenay surfaces (ADR-046 inference stays Primary). Reject path traversal
 (`..` / encoded forms). Abbenay remains the source of truth for config.
 
-Allowlist (initial): `GET/POST /config`, `GET /providers`,
+Allowlist: `GET/POST /config`, `GET /engines`, `GET /providers`,
 `POST /provider/{id}/configure`, `DELETE /provider/{id}`.
 
 **3. Enable Abbenay HTTP on loopback when Abbenay is enabled.**  
@@ -224,3 +224,4 @@ runtime admin API.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-08-03 | cidrblock | Accepted — Simple in-pod Abbenay; Gateway HTTP admin proxy |
+| 2026-08-03 | bthornto | Amended allowlist: added `GET /engines` for read-only engine discovery |

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -185,16 +185,16 @@ runtime admin API.
 - **Env**: e.g. `APME_ABBENAY_HTTP_URL` default `http://127.0.0.1:8787`;  
   `APME_ABBENAY_HTTP_TOKEN` (or shared secret with Abbenay `server.api_token_env`).
 - **Deploy**: Helm Simple sidecar + Podman — `abbenay web --host 127.0.0.1
-  --port 8787` plus gRPC flags (image ≥ v2026.8.0); no Service port 8787;
-  chart README notes ADR-070. Podman uses `--grpc-host 0.0.0.0` with
-  `--insecure` for plaintext hostPort; Helm binds gRPC to loopback.
+  --port 8787 --grpc-host 127.0.0.1 --grpc-port 50057` (image ≥ v2026.8.0);
+  no Service/hostPort for HTTP or gRPC; chart README notes ADR-070. Both
+  topologies bind Abbenay to loopback (pod-shared netns).
 - **Conflict**: `GET /api/v1/ai/models` remains Primary-backed; proxy excludes
   `models` for all methods. Register main router before the proxy mount.
 - **OpenAPI**: proxy routes `include_in_schema=False` (Abbenay owns schemas);
   Gateway `info.description` references ADR-070.
-- **Tests**: path rewrite, Bearer inject, 502, models/chat not proxied,
-  traversal rejected, missing token 503, Set-Cookie stripped; helm asserts
-  `web` / `8787` / Gateway HTTP URL.
+- **Tests**: path rewrite, Bearer inject, Cookie strip, 502, models/chat not
+  proxied, traversal rejected, missing token 503, Set-Cookie stripped; helm
+  asserts ordered `--host`/`127.0.0.1`/`--port`/`8787` and Gateway HTTP URL.
 - **Portal UI**: out of scope for the first implementation PR; catalog proxy +
   Quality settings follow in a later change.
 - **Follow-up**: writable Abbenay config volume (seed ConfigMap → emptyDir/PVC)

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -185,7 +185,9 @@ runtime admin API.
 - **Env**: e.g. `APME_ABBENAY_HTTP_URL` default `http://127.0.0.1:8787`;  
   `APME_ABBENAY_HTTP_TOKEN` (or shared secret with Abbenay `server.api_token_env`).
 - **Deploy**: Helm Simple sidecar + Podman — `abbenay web --host 127.0.0.1
-  --port 8787` plus gRPC flags; no Service port 8787; chart README notes ADR-070.
+  --port 8787` plus gRPC flags (image ≥ v2026.8.0); no Service port 8787;
+  chart README notes ADR-070. Podman uses `--grpc-host 0.0.0.0` with
+  `--insecure` for plaintext hostPort; Helm binds gRPC to loopback.
 - **Conflict**: `GET /api/v1/ai/models` remains Primary-backed; proxy excludes
   `models` for all methods. Register main router before the proxy mount.
 - **OpenAPI**: proxy routes `include_in_schema=False` (Abbenay owns schemas);

--- a/containers/podman/build.sh
+++ b/containers/podman/build.sh
@@ -16,7 +16,7 @@ echo "==> Building base image (shared dependencies)..."
 podman build "${BUILD_ARGS[@]}" -t localhost/apme-base:latest -f containers/base/Dockerfile .
 
 echo "==> Pulling Abbenay AI image..."
-podman pull ghcr.io/redhat-developer/abbenay:2026.4.1-alpha
+podman pull ghcr.io/redhat-developer/abbenay:v2026.8.0
 
 echo "==> Building service images..."
 podman build "${BUILD_ARGS[@]}" -t apme-primary:latest -f containers/primary/Dockerfile .

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -216,8 +216,9 @@ spec:
         - containerPort: 8081
           hostPort: 8081
     - name: abbenay
-      image: ghcr.io/redhat-developer/abbenay:2026.4.1-alpha
-      # ADR-070: gRPC for Primary + HTTP admin on loopback (no hostPort 8787)
+      image: ghcr.io/redhat-developer/abbenay:v2026.8.0
+      # ADR-070: HTTP admin on loopback; gRPC on 0.0.0.0 for hostPort.
+      # --insecure: plaintext gRPC on non-loopback bind (Abbenay ≥ v2026.8.0).
       args:
         - "web"
         - "--host"
@@ -228,6 +229,7 @@ spec:
         - "0.0.0.0"
         - "--grpc-port"
         - "50057"
+        - "--insecure"
       env:
         - name: OPENROUTER_API_KEY
           value: "${OPENROUTER_API_KEY}"

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -217,8 +217,8 @@ spec:
           hostPort: 8081
     - name: abbenay
       image: ghcr.io/redhat-developer/abbenay:v2026.8.0
-      # ADR-070: HTTP admin on loopback; gRPC on 0.0.0.0 for hostPort.
-      # --insecure: plaintext gRPC on non-loopback bind (Abbenay ≥ v2026.8.0).
+      # ADR-070: HTTP + gRPC on loopback (pod-shared netns). No hostPort for
+      # Abbenay — matches Helm Simple and avoids plaintext host exposure.
       args:
         - "web"
         - "--host"
@@ -226,10 +226,9 @@ spec:
         - "--port"
         - "8787"
         - "--grpc-host"
-        - "0.0.0.0"
+        - "127.0.0.1"
         - "--grpc-port"
         - "50057"
-        - "--insecure"
       env:
         - name: OPENROUTER_API_KEY
           value: "${OPENROUTER_API_KEY}"
@@ -243,7 +242,7 @@ spec:
           value: "/tmp/abbenay-run"
       ports:
         - containerPort: 50057
-          hostPort: 50057
+          # no hostPort
       volumeMounts:
         - name: abbenay-config
           mountPath: /home/abbenay/.config/abbenay/config.yaml

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -175,7 +175,7 @@ Gateway DB and Abbenay down together.
 - **Abbenay** (optional): AI provider gRPC on `127.0.0.1:50057` plus HTTP
   admin on `127.0.0.1:8787` (no Service / hostPort). Gateway reverse-proxies
   **allowlisted** admin paths under `/api/v1/ai/` → Abbenay `/api/` (config,
-  providers, provider configure/delete; not chat/sessions/OpenAI-compat) —
+  engines, providers, provider configure/delete; not chat/sessions/OpenAI-compat) —
   see [ADR-070](../../../.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md).
   `GET /api/v1/ai/models` remains Primary `ListAIModels`.
 

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -194,7 +194,7 @@ Gateway DB and Abbenay down together.
 | `ui.replicas` | `1` | Must be `1` when UI enabled |
 | `abbenay.enabled` | `false` | Enable AI provider sidecar |
 | `abbenay.token` | `""` | Abbenay gRPC + HTTP admin token (required when `abbenay.enabled=true`) |
-| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:2026.4.1-alpha` | Abbenay image |
+| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:v2026.8.0` | Abbenay image |
 | `abbenay.providers` | `{}` | LLM provider map (see [ABBENAY_AI.md](../../../docs/guides/ABBENAY_AI.md)) |
 | `abbenay.aiModel` | `""` | Default AI model ID |
 | `ingress.enabled` | `false` | Create Kubernetes Ingress |

--- a/deploy/helm/apme/templates/engine-deployment.yaml
+++ b/deploy/helm/apme/templates/engine-deployment.yaml
@@ -457,7 +457,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          # ADR-070: gRPC for Primary + HTTP admin on loopback (no Service/hostPort 8787)
+          # ADR-070: HTTP admin + gRPC on loopback (no Service/hostPort 8787).
           args:
             - "web"
             - "--host"

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -154,7 +154,7 @@ ui:
 # See docs/guides/ABBENAY_AI.md for GCP-specific setup.
 abbenay:
   enabled: false
-  image: ghcr.io/redhat-developer/abbenay:2026.4.1-alpha
+  image: ghcr.io/redhat-developer/abbenay:v2026.8.0
   # -- Token APME uses to authenticate with Abbenay (required when enabled)
   token: ""
   # -- Override the default model APME selects (e.g. "vertex-claude/claude-sonnet-4-6")

--- a/docs/design/DESIGN_AI_ESCALATION.md
+++ b/docs/design/DESIGN_AI_ESCALATION.md
@@ -583,7 +583,7 @@ podman pull ghcr.io/redhat-developer/abbenay:latest
 |-----|---------|
 | `:main` | Latest merged code |
 | `:sha-<short>` | Specific commit |
-| `:2026.4.1-alpha` | Release (no `v` prefix) |
+| `:v2026.8.0` | Release (`v` prefix; APME pin) |
 | `:latest` | Latest stable release |
 
 ```

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -6,11 +6,12 @@ Vercel AI SDK.
 
 ## Gateway admin proxy (ADR-070)
 
-In the Simple in-pod topology (ADR-069), Abbenay serves HTTP admin on port
-`8787` (no cluster Service / hostPort). The Gateway reaches it at
-`http://127.0.0.1:8787`. Abbenay binds HTTP with `--host 127.0.0.1`
-(image ≥ v2026.8.0; no cluster Service / hostPort). The Gateway reverse-proxies
-an **allowlisted** admin surface:
+In the Simple in-pod topology (ADR-069 / ADR-070), Abbenay serves HTTP admin
+and gRPC on loopback (`--host 127.0.0.1 --port 8787` and
+`--grpc-host 127.0.0.1 --grpc-port 50057`; image ≥ v2026.8.0). No cluster
+Service or hostPort — Helm Simple and Podman share a netns, so Primary/
+Gateway reach Abbenay at `127.0.0.1`. The Gateway reverse-proxies an
+**allowlisted** admin surface:
 
 | Gateway | Abbenay |
 |---------|---------|

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -6,9 +6,11 @@ Vercel AI SDK.
 
 ## Gateway admin proxy (ADR-070)
 
-In the Simple in-pod topology (ADR-069), Abbenay listens for HTTP admin on
-`127.0.0.1:8787` (no cluster Service). The Gateway reverse-proxies an
-**allowlisted** admin surface:
+In the Simple in-pod topology (ADR-069), Abbenay serves HTTP admin on port
+`8787` (no cluster Service / hostPort). The Gateway reaches it at
+`http://127.0.0.1:8787`. Abbenay binds HTTP with `--host 127.0.0.1`
+(image ≥ v2026.8.0; no cluster Service / hostPort). The Gateway reverse-proxies
+an **allowlisted** admin surface:
 
 | Gateway | Abbenay |
 |---------|---------|

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -13,6 +13,7 @@ In the Simple in-pod topology (ADR-069), Abbenay listens for HTTP admin on
 | Gateway | Abbenay |
 |---------|---------|
 | `GET/POST /api/v1/ai/config` | `/api/config` |
+| `GET /api/v1/ai/engines` | `/api/engines` |
 | `GET /api/v1/ai/providers` | `/api/providers` |
 | `POST /api/v1/ai/provider/{id}/configure` | `/api/provider/{id}/configure` |
 | `DELETE /api/v1/ai/provider/{id}` | `/api/provider/{id}` |

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -327,7 +327,7 @@ See [PODMAN_OPA_ISSUES.md](PODMAN_OPA_ISSUES.md) for common Podman rootless issu
 | 50054 | OPA | `APME_OPA_VALIDATOR_LISTEN` |
 | 50055 | Native | `APME_NATIVE_VALIDATOR_LISTEN` |
 | 50056 | Gitleaks | `APME_GITLEAKS_VALIDATOR_LISTEN` |
-| 50057 | Abbenay AI | `--grpc-port` (Abbenay daemon flag) |
+| 50057 | Abbenay AI (pod-local) | `--grpc-host 127.0.0.1 --grpc-port` (no hostPort) |
 | 50058 | Collection Health | `APME_COLLECTION_HEALTH_VALIDATOR_LISTEN` |
 | 50059 | Dep Audit | `APME_DEP_AUDIT_VALIDATOR_LISTEN` |
 | 50060 | Gateway (gRPC) | `APME_GATEWAY_GRPC_LISTEN` |

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -53,7 +53,7 @@ This builds a shared base image, eleven service images, and pulls one official i
 | `apme-gateway:latest` | `containers/gateway/Dockerfile` | REST API + gRPC Reporting service (SQLite) |
 | `apme-ui:latest` | `containers/ui/Dockerfile` | React SPA served by nginx (proxies API to Gateway) |
 | `apme-cli:latest` | `containers/cli/Dockerfile` | CLI client |
-| `ghcr.io/redhat-developer/abbenay:2026.4.1-alpha` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
+| `ghcr.io/redhat-developer/abbenay:v2026.8.0` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
 
 ### Configure Abbenay AI (optional)
 

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -145,8 +145,10 @@ assert_template_contains "abbenay sidecar" "${RENDER}" $'- name: abbenay\n'
 assert_template_contains "Abbenay loopback" "${RENDER}" "--grpc-host"
 assert_template_contains "Abbenay loopback host" "${RENDER}" "127.0.0.1"
 assert_template_contains "Abbenay HTTP web (ADR-070)" "${RENDER}" '"web"'
-assert_template_contains "Abbenay HTTP port (ADR-070)" "${RENDER}" '"8787"'
-assert_template_contains "Abbenay HTTP host loopback (ADR-070)" "${RENDER}" $'--host"\n            - "127.0.0.1"'
+assert_template_contains "Abbenay HTTP host (ADR-070)" "${RENDER}" '"--host"'
+assert_template_contains "Abbenay HTTP host value (ADR-070)" "${RENDER}" '"127.0.0.1"'
+assert_template_contains "Abbenay HTTP port (ADR-070)" "${RENDER}" '"--port"'
+assert_template_contains "Abbenay HTTP port value (ADR-070)" "${RENDER}" '"8787"'
 assert_template_contains "Gateway Abbenay HTTP URL (ADR-070)" "${RENDER}" 'value: "http://127.0.0.1:8787"'
 assert_template_lacks "no Abbenay HTTP Service port" "${RENDER}" "name: abbenay-http"
 assert_template_lacks "no Abbenay HTTP hostPort" "${RENDER}" $'containerPort: 8787\n          hostPort:'

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -143,12 +143,9 @@ assert_template_contains "gateway sidecar" "${RENDER}" $'- name: gateway\n'
 assert_template_contains "ui sidecar" "${RENDER}" $'- name: ui\n'
 assert_template_contains "abbenay sidecar" "${RENDER}" $'- name: abbenay\n'
 assert_template_contains "Abbenay loopback" "${RENDER}" "--grpc-host"
-assert_template_contains "Abbenay loopback host" "${RENDER}" "127.0.0.1"
 assert_template_contains "Abbenay HTTP web (ADR-070)" "${RENDER}" '"web"'
-assert_template_contains "Abbenay HTTP host (ADR-070)" "${RENDER}" '"--host"'
-assert_template_contains "Abbenay HTTP host value (ADR-070)" "${RENDER}" '"127.0.0.1"'
-assert_template_contains "Abbenay HTTP port (ADR-070)" "${RENDER}" '"--port"'
-assert_template_contains "Abbenay HTTP port value (ADR-070)" "${RENDER}" '"8787"'
+assert_template_contains "Abbenay HTTP args ordered (ADR-070)" "${RENDER}" \
+  $'- "--host"\n            - "127.0.0.1"\n            - "--port"\n            - "8787"'
 assert_template_contains "Gateway Abbenay HTTP URL (ADR-070)" "${RENDER}" 'value: "http://127.0.0.1:8787"'
 assert_template_lacks "no Abbenay HTTP Service port" "${RENDER}" "name: abbenay-http"
 assert_template_lacks "no Abbenay HTTP hostPort" "${RENDER}" $'containerPort: 8787\n          hostPort:'

--- a/src/apme_gateway/api/abbenay_proxy.py
+++ b/src/apme_gateway/api/abbenay_proxy.py
@@ -4,6 +4,8 @@ Maps a **small allowlist** of Gateway ``/api/v1/ai/...`` routes to Abbenay
 ``/api/...`` on localhost. Injects Abbenay's HTTP Bearer token; does not pass
 through caller ``Authorization``. Inference (``GET /api/v1/ai/models`` and
 Abbenay chat) is **not** proxied — chat stays Primary → Abbenay gRPC.
+``GET /api/v1/ai/engines`` proxies Abbenay's engine registry (read-only
+discovery path, ADR-070 amendment 2026-08-03).
 """
 
 from __future__ import annotations
@@ -61,8 +63,8 @@ _RESPONSE_DROP: Final = frozenset(
 )
 
 # Admin-only path allowlist (decoded, no leading slash). Matches ADR-070 /
-# ABBENAY_AI.md — no chat/sessions/secrets/engines/templates.
-_GET_PATHS: Final = frozenset({"config", "providers"})
+# ABBENAY_AI.md — no chat/sessions/secrets/templates.
+_GET_PATHS: Final = frozenset({"config", "engines", "providers"})
 _GET_PROVIDER_RE: Final = re.compile(r"^provider/[^/]+$")
 _POST_PATHS: Final = frozenset({"config"})
 _POST_CONFIGURE_RE: Final = re.compile(r"^provider/[^/]+/configure$")
@@ -202,8 +204,9 @@ def _filter_response_headers(upstream: httpx.Response) -> dict[str, str]:
 async def proxy_abbenay_admin(path: str, request: Request) -> Response:
     """Reverse-proxy allowlisted Abbenay HTTP admin under ``/api/v1/ai/*``.
 
-    Allowed (examples): ``GET/POST /ai/config``, ``GET /ai/providers``,
-    ``POST /ai/provider/{id}/configure``, ``DELETE /ai/provider/{id}``.
+    Allowed (examples): ``GET/POST /ai/config``, ``GET /ai/engines``,
+    ``GET /ai/providers``, ``POST /ai/provider/{id}/configure``,
+    ``DELETE /ai/provider/{id}``.
     ``GET /api/v1/ai/models`` remains on the main router (Primary). Chat and
     other Abbenay surfaces are not proxied.
 

--- a/tests/test_gateway_abbenay_proxy.py
+++ b/tests/test_gateway_abbenay_proxy.py
@@ -101,6 +101,33 @@ async def test_proxy_post_provider_configure(app_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_proxy_get_engines_rewrites_path_and_injects_bearer(
+    app_client: AsyncClient,
+) -> None:
+    """GET /api/v1/ai/engines proxies to Abbenay /api/engines with Bearer token.
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    engines_body = b'{"engines":[{"id":"openrouter","requiresKey":true,"defaultEnvVar":"OPENROUTER_API_KEY"}]}'
+    client = _mock_upstream(content=engines_body)
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.get(
+            "/api/v1/ai/engines",
+            headers={"Authorization": "Bearer portal-caller-token"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "engines" in data
+    assert client.request.await_args is not None
+    assert client.request.await_args.args[0] == "GET"
+    assert client.request.await_args.args[1] == "http://127.0.0.1:8787/api/engines"
+    assert client.request.await_args.kwargs["headers"]["Authorization"] == "Bearer admin-http-token"
+    assert "Cookie" not in client.request.await_args.kwargs["headers"]
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_proxy_upstream_unreachable_returns_502(app_client: AsyncClient) -> None:
     """Proxy returns 502 when Abbenay HTTP cannot be reached.
 

--- a/tests/test_gateway_abbenay_proxy.py
+++ b/tests/test_gateway_abbenay_proxy.py
@@ -114,12 +114,14 @@ async def test_proxy_get_engines_rewrites_path_and_injects_bearer(
     with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
         resp = await app_client.get(
             "/api/v1/ai/engines",
-            headers={"Authorization": "Bearer portal-caller-token"},
+            headers={
+                "Authorization": "Bearer portal-caller-token",
+                "Cookie": "session=caller-cookie",
+            },
         )
 
     assert resp.status_code == 200
-    data = resp.json()
-    assert "engines" in data
+    assert resp.content == engines_body
     assert client.request.await_args is not None
     assert client.request.await_args.args[0] == "GET"
     assert client.request.await_args.args[1] == "http://127.0.0.1:8787/api/engines"


### PR DESCRIPTION
## Summary
- Add `engines` to the ADR-070 Gateway Abbenay admin GET allowlist (`GET /api/v1/ai/engines` → Abbenay `/api/engines`).
- Enables Portal Quality settings to load the live engine registry (follow-up to #499).
- Bump Abbenay image pin to `v2026.8.0` and bind HTTP + gRPC to loopback (`127.0.0.1`) in Helm and Podman (no `--insecure`, no Abbenay hostPort).
- Docs: ADR-070 amend, ABBENAY_AI.md, DEPLOYMENT.md, Helm README / chart asserts.

## Review follow-ups (this push)
- Harden `test_proxy_get_engines_rewrites_path_and_injects_bearer`: send caller `Cookie`, assert full response body, keep Cookie-not-forwarded check.
- Podman Abbenay: `--grpc-host 127.0.0.1`, drop `--insecure` and `hostPort: 50057` (matches Helm Simple / ADR-070).
- Helm chart asserts: ordered `--host` / `127.0.0.1` / `--port` / `8787` block instead of weak independent substring checks.

## Test plan
- [x] `tox -e lint`
- [x] `tox -e unit -- -k abbenay_proxy` (12 passed; coverage gate N/A on filtered run)
- [x] `tox -e helm`
- [x] Local pod: Abbenay stable on v2026.8.0; health Abbenay AI ok; `/ai/models` non-empty; `/ai/engines` 200
- [ ] Portal Add provider Select loads engines after Gateway rebuild with this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gateway support for retrieving the Abbenay engine registry through `GET /api/v1/ai/engines`.
* **Bug Fixes**
  * Improved proxy handling with secure administrative authentication and protection against forwarding caller cookies.
* **Deployment**
  * Updated the default Abbenay image to `v2026.8.0`.
  * Restricted HTTP and gRPC services to pod-local loopback access and removed external gRPC port exposure.
* **Documentation**
  * Updated deployment, topology, and configuration guidance to reflect the new engine route and networking requirements.
* **Tests**
  * Added coverage for engine-registry proxying and deployment argument validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->