### PR TITLE
feat(abbenay): writable config volume for runtime admin (#498)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ env/
 *.pem
 *.key
 containers/abbenay/config.yaml
+# Runtime-writable Abbenay config dir (seeded by up.sh; SoT after configure)
+containers/abbenay/config/
 
 # Testing
 .pytest_cache/

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -102,7 +102,8 @@ admin writes persist there as the source of truth after first configure:
 - **Podman**: `containers/abbenay/config/` is a hostPath RW mount at
   `/home/abbenay/.config/abbenay`. `up.sh` seeds `config.yaml` from the legacy
   `containers/abbenay/config.yaml` (or `.example`) when the dir is empty, then
-  `chmod a+rwX` so UID 1001 can write under rootless Podman host-UID mapping.
+  `podman unshare chown -R 1001:1001` so UID 1001 can write under rootless
+  Podman host-UID mapping.
 
 After the first successful configure, the writable file is SoT — Helm value /
 ConfigMap changes do not overwrite an existing runtime config.

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -90,11 +90,22 @@ EAP; operators must not expose Gateway `:8080` without an outer auth layer.
 `ai_model` continue via Primary → Abbenay gRPC. The proxy does not replace that
 path and rejects other methods on `models`.
 
-**6. Config durability (acknowledged gap).**  
-Helm ConfigMap / Podman hostPath seed deploy-time providers (often read-only).
-Runtime HTTP admin writes need a writable Abbenay config directory. **Durable
-writable persistence (emptyDir seed + PVC) is a follow-up** — tracked as a
-GitHub issue — not a blocker for the allowlisted proxy plumbing.
+**6. Config durability (implemented — [#498](https://github.com/ansible/apme/issues/498)).**  
+Deploy-time providers seed a writable Abbenay config directory; runtime HTTP
+admin writes persist there as the source of truth after first configure:
+
+- **Helm**: ConfigMap (`*-abbenay-config`) is mounted read-only as a seed.
+  Init container `init-abbenay-config` copies `config.yaml` into the writable
+  volume **once** (only if the file is absent). Default volume is `emptyDir`
+  (pod lifetime). Optional PVC via `persistence.abbenay.enabled=true` survives
+  restarts. Abbenay mounts the writable dir at `/etc/abbenay-config`.
+- **Podman**: `containers/abbenay/config/` is a hostPath RW mount at
+  `/home/abbenay/.config/abbenay`. `up.sh` seeds `config.yaml` from the legacy
+  `containers/abbenay/config.yaml` (or `.example`) when the dir is empty, then
+  `chmod a+rwX` so UID 1001 can write under rootless Podman host-UID mapping.
+
+After the first successful configure, the writable file is SoT — Helm value /
+ConfigMap changes do not overwrite an existing runtime config.
 
 **We will use an allowlisted HTTP reverse-proxy on the Gateway for in-pod
 Abbenay admin, not a catch-all façade and not Gateway→Abbenay gRPC for chat.**
@@ -197,9 +208,10 @@ runtime admin API.
   asserts ordered `--host`/`127.0.0.1`/`--port`/`8787` and Gateway HTTP URL.
 - **Portal UI**: out of scope for the first implementation PR; catalog proxy +
   Quality settings follow in a later change.
-- **Follow-up**: writable Abbenay config volume (seed ConfigMap → emptyDir/PVC)
-  so runtime admin survives restart —
-  [#498](https://github.com/ansible/apme/issues/498).
+- **Config durability** ([#498](https://github.com/ansible/apme/issues/498)):
+  implemented — seed ConfigMap → writable emptyDir (default) / optional PVC
+  (`persistence.abbenay`); Podman RW `containers/abbenay/config/`; seed-once;
+  runtime SoT after first configure.
 
 ## Related Decisions
 
@@ -227,3 +239,4 @@ runtime admin API.
 |------|--------|--------|
 | 2026-08-03 | cidrblock | Accepted — Simple in-pod Abbenay; Gateway HTTP admin proxy |
 | 2026-08-03 | bthornto | Amended allowlist: added `GET /engines` for read-only engine discovery |
+| 2026-08-03 | bthornto | §6 Config durability implemented (#498): seed→RW emptyDir/PVC; Podman RW config dir |

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -240,13 +240,14 @@ spec:
           value: "apme-dev-token"
         - name: XDG_RUNTIME_DIR
           value: "/tmp/abbenay-run"
+        - name: XDG_CONFIG_HOME
+          value: "/home/abbenay/.config"
       ports:
         - containerPort: 50057
           # no hostPort
       volumeMounts:
         - name: abbenay-config
-          mountPath: /home/abbenay/.config/abbenay/config.yaml
-          readOnly: true
+          mountPath: /home/abbenay/.config/abbenay
     - name: galaxy-proxy
       image: apme-galaxy-proxy:latest
       env:
@@ -288,8 +289,8 @@ spec:
         claimName: apme-proxy-cache
     - name: abbenay-config
       hostPath:
-        path: ${APME_ROOT}/containers/abbenay/config.yaml
-        type: File
+        path: ${APME_ROOT}/containers/abbenay/config
+        type: Directory
     - name: otel-config
       hostPath:
         path: ${APME_ROOT}/containers/otel-collector/config.yaml

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -413,6 +413,9 @@ if [[ ! -f "$ABBENAY_CONFIG_DIR/config.yaml" ]]; then
     echo "Seeded Abbenay config from containers/abbenay/config.yaml.example"
   fi
 fi
+# Relabel seeded files while still host-owned; chcon after podman unshare
+# chown to a subordinate UID can fail on Enforcing hosts.
+_relabel_host_path_for_podman "$ABBENAY_CONFIG_DIR"
 if command -v podman >/dev/null 2>&1; then
   if ! podman unshare chown -R 1001:1001 "$ABBENAY_CONFIG_DIR"; then
     echo "ERROR: could not chown Abbenay config dir to 1001:1001 via podman unshare" >&2
@@ -422,8 +425,6 @@ else
   echo "ERROR: podman is required to set Abbenay config ownership (UID 1001)" >&2
   exit 1
 fi
-# Re-relabel after seed/chown so config.yaml itself is container_file_t.
-_relabel_host_path_for_podman "$ABBENAY_CONFIG_DIR"
 _relabel_host_path_for_podman "$ROOT/containers/otel-collector/config.yaml"
 if [[ -n "$ABBENAY_CA_BUNDLE" ]]; then
   _relabel_host_path_for_podman "$ABBENAY_CA_BUNDLE"

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -40,7 +40,14 @@ _relabel_host_path_for_podman() {
     echo "ERROR: SELinux is Enforcing but chcon is not available; cannot relabel $host_path" >&2
     return 1
   fi
-  if ! chcon -l s0 -t container_file_t "$host_path" 2>/dev/null; then
+  # Directories must be labeled recursively so files created after mkdir
+  # (e.g. seeded config.yaml) are readable inside the container.
+  if [[ -d "$host_path" ]]; then
+    if ! chcon -R -l s0 -t container_file_t "$host_path" 2>/dev/null; then
+      echo "ERROR: could not recursively relabel $host_path for SELinux" >&2
+      return 1
+    fi
+  elif ! chcon -l s0 -t container_file_t "$host_path" 2>/dev/null; then
     echo "ERROR: could not relabel $host_path for SELinux" >&2
     return 1
   fi
@@ -215,7 +222,11 @@ mount = '$CA_MOUNT_PATH'
 ca_path_yaml = json.dumps(ca_path)
 mount_yaml = json.dumps(mount)
 abbenay_env_marker = '        - name: XDG_RUNTIME_DIR'
-abbenay_vol_marker = '          readOnly: true\n    - name: galaxy-proxy'
+# Writable config dir has no readOnly; anchor on mountPath before galaxy-proxy.
+abbenay_vol_marker = (
+    '          mountPath: /home/abbenay/.config/abbenay\n'
+    '    - name: galaxy-proxy'
+)
 gateway_env_marker = '        - name: APME_FEEDBACK_GITHUB_TOKEN'
 gateway_vol_marker = '      volumeMounts:\n        - name: gateway-data'
 galaxy_marker = '    - name: galaxy-proxy\n      image: apme-galaxy-proxy:latest'
@@ -237,7 +248,7 @@ yaml = yaml.replace(
     '        ' + abbenay_env_marker.lstrip())
 yaml = yaml.replace(
     abbenay_vol_marker,
-    '          readOnly: true\n'
+    '          mountPath: /home/abbenay/.config/abbenay\n'
     '        - name: abbenay-ca-bundle\n'
     '          mountPath: ' + mount_yaml + '\n'
     '          readOnly: true\n'
@@ -386,11 +397,13 @@ fi
 # Set up writable Abbenay config directory (seed from legacy config.yaml if present).
 # The hostPath Directory mount replaces the old read-only File mount so that
 # runtime admin writes (POST /api/v1/ai/provider/.../configure) survive restarts.
-# Rootless Podman maps host-owned files to root inside the container; Abbenay
-# runs as UID 1001, so the seed dir/file must be world-writable (a+rwX) or
-# configure returns EACCES.
+# Rootless Podman maps host UID to root inside the user namespace; Abbenay runs
+# as UID 1001, so ownership must be 1001:1001 in that namespace (podman unshare
+# chown) or configure returns EACCES. Avoid world-writable chmod.
 ABBENAY_CONFIG_DIR="$ROOT/containers/abbenay/config"
 mkdir -p "$ABBENAY_CONFIG_DIR"
+# Relabel the empty dir first so seed copies land on a container-readable parent.
+_relabel_host_path_for_podman "$ABBENAY_CONFIG_DIR"
 if [[ ! -f "$ABBENAY_CONFIG_DIR/config.yaml" ]]; then
   if [[ -f "$ROOT/containers/abbenay/config.yaml" ]]; then
     cp "$ROOT/containers/abbenay/config.yaml" "$ABBENAY_CONFIG_DIR/config.yaml"
@@ -400,10 +413,16 @@ if [[ ! -f "$ABBENAY_CONFIG_DIR/config.yaml" ]]; then
     echo "Seeded Abbenay config from containers/abbenay/config.yaml.example"
   fi
 fi
-chmod a+rwX "$ABBENAY_CONFIG_DIR"
-if [[ -f "$ABBENAY_CONFIG_DIR/config.yaml" ]]; then
-  chmod a+rw "$ABBENAY_CONFIG_DIR/config.yaml"
+if command -v podman >/dev/null 2>&1; then
+  if ! podman unshare chown -R 1001:1001 "$ABBENAY_CONFIG_DIR"; then
+    echo "ERROR: could not chown Abbenay config dir to 1001:1001 via podman unshare" >&2
+    exit 1
+  fi
+else
+  echo "ERROR: podman is required to set Abbenay config ownership (UID 1001)" >&2
+  exit 1
 fi
+# Re-relabel after seed/chown so config.yaml itself is container_file_t.
 _relabel_host_path_for_podman "$ABBENAY_CONFIG_DIR"
 _relabel_host_path_for_podman "$ROOT/containers/otel-collector/config.yaml"
 if [[ -n "$ABBENAY_CA_BUNDLE" ]]; then

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -352,8 +352,7 @@ project_yaml = json.dumps(gcp_project)
 location_yaml = json.dumps(gcp_location)
 abbenay_env_marker = '        - name: XDG_RUNTIME_DIR'
 abbenay_config_mount_marker = (
-    '          mountPath: /home/abbenay/.config/abbenay/config.yaml\n'
-    '          readOnly: true'
+    '          mountPath: /home/abbenay/.config/abbenay'
 )
 if abbenay_env_marker not in yaml or abbenay_config_mount_marker not in yaml:
     print('ERROR: pod.yaml markers not found; GCP credentials injection failed', file=sys.stderr)
@@ -384,7 +383,28 @@ print(yaml)
   echo "Vertex AI project: $GOOGLE_VERTEX_PROJECT (location: $GOOGLE_VERTEX_LOCATION)"
 fi
 
-_relabel_host_path_for_podman "$ROOT/containers/abbenay/config.yaml"
+# Set up writable Abbenay config directory (seed from legacy config.yaml if present).
+# The hostPath Directory mount replaces the old read-only File mount so that
+# runtime admin writes (POST /api/v1/ai/provider/.../configure) survive restarts.
+# Rootless Podman maps host-owned files to root inside the container; Abbenay
+# runs as UID 1001, so the seed dir/file must be world-writable (a+rwX) or
+# configure returns EACCES.
+ABBENAY_CONFIG_DIR="$ROOT/containers/abbenay/config"
+mkdir -p "$ABBENAY_CONFIG_DIR"
+if [[ ! -f "$ABBENAY_CONFIG_DIR/config.yaml" ]]; then
+  if [[ -f "$ROOT/containers/abbenay/config.yaml" ]]; then
+    cp "$ROOT/containers/abbenay/config.yaml" "$ABBENAY_CONFIG_DIR/config.yaml"
+    echo "Seeded Abbenay config from containers/abbenay/config.yaml (legacy location)"
+  elif [[ -f "$ROOT/containers/abbenay/config.yaml.example" ]]; then
+    cp "$ROOT/containers/abbenay/config.yaml.example" "$ABBENAY_CONFIG_DIR/config.yaml"
+    echo "Seeded Abbenay config from containers/abbenay/config.yaml.example"
+  fi
+fi
+chmod a+rwX "$ABBENAY_CONFIG_DIR"
+if [[ -f "$ABBENAY_CONFIG_DIR/config.yaml" ]]; then
+  chmod a+rw "$ABBENAY_CONFIG_DIR/config.yaml"
+fi
+_relabel_host_path_for_podman "$ABBENAY_CONFIG_DIR"
 _relabel_host_path_for_podman "$ROOT/containers/otel-collector/config.yaml"
 if [[ -n "$ABBENAY_CA_BUNDLE" ]]; then
   _relabel_host_path_for_podman "$ABBENAY_CA_BUNDLE"

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -204,6 +204,8 @@ Gateway DB and Abbenay down together.
 | `podDisruptionBudget.enabled` | `false` | Enable PDB |
 | `persistence.sessions.size` | `10Gi` | Session venv PVC size |
 | `persistence.gateway.size` | `5Gi` | Gateway DB PVC size |
+| `persistence.abbenay.enabled` | `false` | When `true` (and `abbenay.enabled`), PVC for Abbenay runtime config; otherwise `emptyDir` |
+| `persistence.abbenay.size` | `100Mi` | Abbenay config PVC size (seed-once from ConfigMap; runtime SoT after configure) |
 
 See [`values.yaml`](values.yaml) for the complete reference with all resource
 limits, tolerations, affinity, and topology spread constraints.

--- a/deploy/helm/apme/templates/engine-deployment.yaml
+++ b/deploy/helm/apme/templates/engine-deployment.yaml
@@ -65,8 +65,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.ui.enabled }}
+      {{- if or .Values.ui.enabled .Values.abbenay.enabled }}
       initContainers:
+        {{- if .Values.ui.enabled }}
         - name: init-nginx-conf
           image: {{ include "apme.image" (dict "registry" .Values.image.registry "name" "ui" "tag" .Values.image.tag "fallbackTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -78,6 +79,30 @@ spec:
           volumeMounts:
             - name: nginx-conf
               mountPath: /mnt/conf.d
+        {{- end }}
+        {{- if .Values.abbenay.enabled }}
+        - name: init-abbenay-config
+          image: {{ .Values.abbenay.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /mnt/config/abbenay
+              if [ ! -f /mnt/config/abbenay/config.yaml ]; then
+                cp /seed/config.yaml /mnt/config/abbenay/config.yaml
+              fi
+          volumeMounts:
+            - name: abbenay-config-seed
+              mountPath: /seed
+              readOnly: true
+            - name: abbenay-config
+              mountPath: /mnt/config
+        {{- end }}
       {{- end }}
       containers:
         # -- Primary orchestrator
@@ -548,8 +573,7 @@ spec:
             {{- toYaml .Values.abbenay.resources | nindent 12 }}
           volumeMounts:
             - name: abbenay-config
-              mountPath: /etc/abbenay-config/abbenay
-              readOnly: true
+              mountPath: /etc/abbenay-config
             {{- if and $hasVertexADC $hasGcpCreds }}
             - name: gcp-credentials
               mountPath: /var/run/secrets/gcp
@@ -576,9 +600,16 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- if .Values.abbenay.enabled }}
-        - name: abbenay-config
+        - name: abbenay-config-seed
           configMap:
             name: {{ $fullname }}-abbenay-config
+        - name: abbenay-config
+          {{- if .Values.persistence.abbenay.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $fullname }}-abbenay-config
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- if and $hasVertexADC $hasGcpCreds }}
         - name: gcp-credentials
           secret:

--- a/deploy/helm/apme/templates/pvc.yaml
+++ b/deploy/helm/apme/templates/pvc.yaml
@@ -45,3 +45,22 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.proxyCache.size }}
+{{- if and .Values.abbenay.enabled .Values.persistence.abbenay.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "apme.fullname" . }}-abbenay-config
+  labels:
+    {{- include "apme.labels" . | nindent 4 }}
+    app.kubernetes.io/component: abbenay
+spec:
+  accessModes:
+    - {{ .Values.persistence.abbenay.accessMode }}
+  {{- if .Values.persistence.abbenay.storageClass }}
+  storageClassName: {{ .Values.persistence.abbenay.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.abbenay.size }}
+{{- end }}

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -253,6 +253,14 @@ persistence:
     size: 10Gi
     storageClass: ""
     accessMode: ReadWriteOnce
+  # -- Writable config volume for Abbenay runtime admin (ADR-070 / #498).
+  # emptyDir by default (pod lifetime only — config resets on pod restart).
+  # Enable persistence for a PVC that survives restarts.
+  abbenay:
+    enabled: false
+    size: 100Mi
+    storageClass: ""
+    accessMode: ReadWriteOnce
 
 # -- Ingress for Gateway REST API and UI
 ingress:

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -35,7 +35,7 @@ the first write, the runtime file is the source of truth.
 | Deploy | Seed | Writable volume | Notes |
 |--------|------|-----------------|-------|
 | **Helm** | ConfigMap `*-abbenay-config` (from `abbenay.providers`) | `emptyDir` by default; optional PVC via `persistence.abbenay.enabled=true` | Init `init-abbenay-config` copies seed only if `config.yaml` is absent. Mount: `/etc/abbenay-config`. |
-| **Podman** | `containers/abbenay/config.yaml` (or `.example`) on first `tox -e up` | Host dir `containers/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds when the dir has no `config.yaml`, then `chmod a+rwX` so UID 1001 can write under rootless Podman. Dir is gitignored. |
+| **Podman** | `containers/abbenay/config.yaml` (or `.example`) on first `tox -e up` | Host dir `containers/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds when the dir has no `config.yaml`, then `podman unshare chown -R 1001:1001` so UID 1001 can write under rootless Podman. Dir is gitignored. |
 
 Helm PVC knobs (`persistence.abbenay.*`):
 

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -26,8 +26,29 @@ is **not** proxied. Set `APME_ABBENAY_HTTP_URL` (default
 `http://127.0.0.1:8787`) and `APME_ABBENAY_HTTP_TOKEN` on the Gateway (same
 secret as `ABBENAY_API_TOKEN` / `abbenay.token` in Helm).
 
-Runtime admin writes need a writable Abbenay config directory; durable volume
-seeding is tracked in [#498](https://github.com/ansible/apme/issues/498).
+### Writable config volume (#498)
+
+Runtime admin writes (configure / delete provider) persist on a **writable**
+Abbenay config directory. Deploy-time values seed that directory once; after
+the first write, the runtime file is the source of truth.
+
+| Deploy | Seed | Writable volume | Notes |
+|--------|------|-----------------|-------|
+| **Helm** | ConfigMap `*-abbenay-config` (from `abbenay.providers`) | `emptyDir` by default; optional PVC via `persistence.abbenay.enabled=true` | Init `init-abbenay-config` copies seed only if `config.yaml` is absent. Mount: `/etc/abbenay-config`. |
+| **Podman** | `containers/abbenay/config.yaml` (or `.example`) on first `tox -e up` | Host dir `containers/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds when the dir has no `config.yaml`, then `chmod a+rwX` so UID 1001 can write under rootless Podman. Dir is gitignored. |
+
+Helm PVC knobs (`persistence.abbenay.*`):
+
+```yaml
+persistence:
+  abbenay:
+    enabled: true    # false = emptyDir (lost on pod restart)
+    size: 100Mi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+```
+
+See [ADR-070](../../.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md) §6.
 
 ---
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -68,8 +68,9 @@ The `.env` file is gitignored. Abbenay config lives in the **writable** host
 directory `containers/abbenay/config/` (mounted RW at
 `/home/abbenay/.config/abbenay`). On first `tox -e up`, `up.sh` seeds
 `config.yaml` from `containers/abbenay/config.yaml` or
-`config.yaml.example` if the directory is empty, then applies `chmod a+rwX`
-so the container UID 1001 can write under rootless Podman. Edit
+`config.yaml.example` if the directory is empty, then runs
+`podman unshare chown -R 1001:1001` so the container UID 1001 can write under
+rootless Podman. Edit
 `containers/abbenay/config/config.yaml` (or use the Gateway admin proxy) to
 change providers/models — runtime configure writes persist across container
 restarts.

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -64,7 +64,15 @@ cp containers/abbenay/.env.example containers/abbenay/.env
 # Edit .env and set your LLM provider API key (e.g., OPENROUTER_API_KEY)
 ```
 
-The `.env` file is gitignored. The default `config.yaml` configures the LLM provider and consumer token. To use a different provider or model, edit `containers/abbenay/config.yaml`.
+The `.env` file is gitignored. Abbenay config lives in the **writable** host
+directory `containers/abbenay/config/` (mounted RW at
+`/home/abbenay/.config/abbenay`). On first `tox -e up`, `up.sh` seeds
+`config.yaml` from `containers/abbenay/config.yaml` or
+`config.yaml.example` if the directory is empty, then applies `chmod a+rwX`
+so the container UID 1001 can write under rootless Podman. Edit
+`containers/abbenay/config/config.yaml` (or use the Gateway admin proxy) to
+change providers/models — runtime configure writes persist across container
+restarts.
 
 If `.env` is missing or the key is empty, the Abbenay container starts but model queries return empty results. AI remediation gracefully degrades — Tier 1 deterministic fixes still work.
 
@@ -209,7 +217,12 @@ proxy gRPC requests to it.
 | `CURL_CA_BUNDLE` | — | Shared CA bundle for curl/libcurl consumers in the gateway and Galaxy Proxy |
 | `GIT_SSL_CAINFO` | — | Shared CA bundle for `git ls-remote`, `git clone`, and `ansible-galaxy` git fetches |
 
-Abbenay uses `containers/abbenay/config.yaml` volume-mounted at runtime. The config defines LLM providers and models. API keys are injected from environment variables — never committed to the config file. To add providers or models, edit the `providers` section of the config.
+Abbenay uses `containers/abbenay/config/` as a **writable** hostPath mount
+(`abbenay-config` → `/home/abbenay/.config/abbenay`). The config defines LLM
+providers and models. API keys are injected from environment variables —
+never committed to the config file. To add providers or models, edit
+`containers/abbenay/config/config.yaml` or POST via the Gateway admin proxy
+(`/api/v1/ai/provider/{id}/configure`); writes survive Abbenay restarts.
 
 The Abbenay daemon exposes a gRPC API on port 50057. Primary connects to it for AI model listing (`ListAIModels`) and batch remediation requests.
 
@@ -226,6 +239,7 @@ The Settings page (`/settings`) provides a model picker that queries available A
 | `sessions` | `apme-sessions/` | `/sessions` | Primary (rw), Ansible, Collection Health, Dep Audit (ro) | rw / ro |
 | `proxy-cache` | `<cache>/proxy/` | `/cache` | Galaxy Proxy | rw |
 | `gateway-data` | `<cache>/gateway/` | `/data` | Gateway | rw |
+| `abbenay-config` | `containers/abbenay/config/` | `/home/abbenay/.config/abbenay` | Abbenay | rw |
 | `workspace` | CWD (CLI only) | `/workspace` | CLI | rw |
 
 #### Observability (Podman pod only)

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -149,6 +149,10 @@ assert_template_contains "Abbenay HTTP args ordered (ADR-070)" "${RENDER}" \
 assert_template_contains "Gateway Abbenay HTTP URL (ADR-070)" "${RENDER}" 'value: "http://127.0.0.1:8787"'
 assert_template_lacks "no Abbenay HTTP Service port" "${RENDER}" "name: abbenay-http"
 assert_template_lacks "no Abbenay HTTP hostPort" "${RENDER}" $'containerPort: 8787\n          hostPort:'
+assert_template_contains "init-abbenay-config init container (#498)" "${RENDER}" $'- name: init-abbenay-config\n'
+assert_template_contains "abbenay-config-seed volume (#498)" "${RENDER}" 'abbenay-config-seed'
+assert_template_contains "abbenay-config emptyDir by default (#498)" "${RENDER}" $'name: abbenay-config\n          emptyDir'
+assert_template_lacks "abbenay-config data mount not readOnly (#498)" "${RENDER}" $'name: abbenay-config\n              readOnly: true'
 assert_template_contains "reporting localhost" "${RENDER}" 'value: "127.0.0.1:50060"'
 assert_template_contains "abbenay addr localhost" "${RENDER}" 'value: "127.0.0.1:50057"'
 assert_template_contains "gateway primary addr localhost" "${RENDER}" 'value: "127.0.0.1:50051"'


### PR DESCRIPTION
## Summary
- Seeds Abbenay config from ConfigMap/hostPath into a writable emptyDir (optional PVC) so Gateway ADR-070 `/configure` changes persist across the container lifetime (and across restarts when PVC is enabled).
- Updates Helm Simple topology (ADR-069) volumes/init, Podman RW config dir via `up.sh`, and docs/ADR-070 for the writable-config contract.
- Closes the gap where Abbenay config was read-only, blocking runtime admin configure (#498).
- Review follow-ups (`4a697e52`, `98a4023b`): recursive SELinux relabel before seed and again after seed *before* `podman unshare chown 1001:1001` (no world-writable chmod); CA-injection markers updated for the RW config mount.

Fixes #498

Related: [ADR-070](https://github.com/ansible/apme/blob/main/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md)

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e helm` passes (lint + Simple template assertions + package)
- [x] `tox -e unit -- tests/test_podman_up_script.py` passes (CA/GCP injection markers)
- [ ] Helm install / template: Abbenay mounts writable runtime config; optional PVC when enabled
- [ ] Podman `tox -e up`: Abbenay config dir is RW and seeded; configure via Gateway ADR-070 proxy persists
- [ ] Confirm no secrets (`.env`, API keys) are committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added writable Abbenay runtime configuration storage for Helm and Podman deployments.
  * Added optional Helm persistence through a configurable PVC, with `emptyDir` used by default.
  * Configuration is seeded automatically and preserved across restarts when persistence is enabled.
  * Podman deployments now initialize and maintain a writable host configuration directory.

* **Documentation**
  * Updated deployment and configuration guides with storage, initialization, permissions, and persistence details.

* **Tests**
  * Added Helm validation checks for configuration initialization, volumes, and writable mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->