### PR TITLE
chore(abbenay): bump image pin to v2026.8.1

### DIFF
--- a/containers/podman/build.sh
+++ b/containers/podman/build.sh
@@ -16,7 +16,7 @@ echo "==> Building base image (shared dependencies)..."
 podman build "${BUILD_ARGS[@]}" -t localhost/apme-base:latest -f containers/base/Dockerfile .
 
 echo "==> Pulling Abbenay AI image..."
-podman pull ghcr.io/redhat-developer/abbenay:v2026.8.0
+podman pull ghcr.io/redhat-developer/abbenay:v2026.8.1
 
 echo "==> Building service images..."
 podman build "${BUILD_ARGS[@]}" -t apme-primary:latest -f containers/primary/Dockerfile .

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -216,7 +216,7 @@ spec:
         - containerPort: 8081
           hostPort: 8081
     - name: abbenay
-      image: ghcr.io/redhat-developer/abbenay:v2026.8.0
+      image: ghcr.io/redhat-developer/abbenay:v2026.8.1
       # ADR-070: HTTP + gRPC on loopback (pod-shared netns). No hostPort for
       # Abbenay — matches Helm Simple and avoids plaintext host exposure.
       args:

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -194,7 +194,7 @@ Gateway DB and Abbenay down together.
 | `ui.replicas` | `1` | Must be `1` when UI enabled |
 | `abbenay.enabled` | `false` | Enable AI provider sidecar |
 | `abbenay.token` | `""` | Abbenay gRPC + HTTP admin token (required when `abbenay.enabled=true`) |
-| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:v2026.8.0` | Abbenay image |
+| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:v2026.8.1` | Abbenay image |
 | `abbenay.providers` | `{}` | LLM provider map (see [ABBENAY_AI.md](../../../docs/guides/ABBENAY_AI.md)) |
 | `abbenay.aiModel` | `""` | Default AI model ID |
 | `ingress.enabled` | `false` | Create Kubernetes Ingress |

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -154,7 +154,7 @@ ui:
 # See docs/guides/ABBENAY_AI.md for GCP-specific setup.
 abbenay:
   enabled: false
-  image: ghcr.io/redhat-developer/abbenay:v2026.8.0
+  image: ghcr.io/redhat-developer/abbenay:v2026.8.1
   # -- Token APME uses to authenticate with Abbenay (required when enabled)
   token: ""
   # -- Override the default model APME selects (e.g. "vertex-claude/claude-sonnet-4-6")

--- a/docs/design/DESIGN_AI_ESCALATION.md
+++ b/docs/design/DESIGN_AI_ESCALATION.md
@@ -576,7 +576,7 @@ Install with: pip install apme-engine[ai]
 Pre-built multi-arch Abbenay images (amd64 + arm64) are available on GHCR:
 
 ```bash
-podman pull ghcr.io/redhat-developer/abbenay:latest
+podman pull ghcr.io/redhat-developer/abbenay:v2026.8.1
 ```
 
 | Tag | Meaning |

--- a/docs/design/DESIGN_AI_ESCALATION.md
+++ b/docs/design/DESIGN_AI_ESCALATION.md
@@ -583,7 +583,7 @@ podman pull ghcr.io/redhat-developer/abbenay:latest
 |-----|---------|
 | `:main` | Latest merged code |
 | `:sha-<short>` | Specific commit |
-| `:v2026.8.0` | Release (`v` prefix; APME pin) |
+| `:v2026.8.1` | Release (`v` prefix; APME pin) |
 | `:latest` | Latest stable release |
 
 ```

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -53,7 +53,7 @@ This builds a shared base image, eleven service images, and pulls one official i
 | `apme-gateway:latest` | `containers/gateway/Dockerfile` | REST API + gRPC Reporting service (SQLite) |
 | `apme-ui:latest` | `containers/ui/Dockerfile` | React SPA served by nginx (proxies API to Gateway) |
 | `apme-cli:latest` | `containers/cli/Dockerfile` | CLI client |
-| `ghcr.io/redhat-developer/abbenay:v2026.8.0` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
+| `ghcr.io/redhat-developer/abbenay:v2026.8.1` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
 
 ### Configure Abbenay AI (optional)
 


### PR DESCRIPTION
## Summary
- Bump Abbenay image pin from `v2026.8.0` → `v2026.8.1` in Podman (`pod.yaml`, `build.sh`), Helm defaults, and docs.
- Aligns local/K8s deploys with [Abbenay v2026.8.1](https://github.com/redhat-developer/abbenay/releases/tag/v2026.8.1) (pairs with APME [v2026.8.5](https://github.com/ansible/apme/releases/tag/v2026.8.5)).

## Test plan
- [x] `tox -e lint`
- [x] `tox -e unit`
- [x] Rule of Five (Passes 1, 2, 5) — no ship-blockers; design pull example aligned with pin
- [x] Local: `podman pull` + `tox -e up` running `ghcr.io/redhat-developer/abbenay:v2026.8.1`; gateway `/api/v1/health` 200
- [ ] Helm template/install with `abbenay.enabled=true` pulls `v2026.8.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Abbenay AI provider component from v2026.8.0 to v2026.8.1 across build configurations, deployment manifests, and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->