### PR TITLE
fix(helm): allow nginx conf init copy under OpenShift SCC

### DIFF
--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -29,7 +29,8 @@ helm repo add apme https://ansible.github.io/apme
 helm repo update
 helm install apme apme/apme \
   --namespace apme --create-namespace \
-  --set route.enabled=true   # OpenShift
+  --set route.enabled=true \
+  --set route.host=apme.apps.ocp.example.com  # Openshift, fix URL to match domain
 ```
 
 Defaults pull from `quay.io/ansible` with image tag `2026.7.3` (`Chart.appVersion`).

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -30,8 +30,12 @@ helm repo update
 helm install apme apme/apme \
   --namespace apme --create-namespace \
   --set route.enabled=true \
-  --set route.host=apme.apps.ocp.example.com  # Openshift, fix URL to match domain
+  --set route.host=apme.apps.ocp.example.com
 ```
+
+Replace `route.host` with a hostname under your cluster's OpenShift
+ingress domain (for example `apme.apps.<cluster-domain>`) before installing —
+`example.com` will not resolve.
 
 Defaults pull from `quay.io/ansible` with image tag `2026.7.3` (`Chart.appVersion`).
 For unreleased SHA builds, set `--set image.tag=sha-<commit>`.

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -108,11 +108,14 @@ helm repo update
 helm install apme apme/apme \
   --namespace apme --create-namespace \
   -f https://ansible.github.io/apme/values-standalone.yaml \
-  --set route.enabled=true   # OpenShift
+  --set route.enabled=true \
+  --set route.host=apme.apps.ocp.example.com
 ```
 
 Omit `-f values-standalone.yaml` if you want the same UI-on default without an
-explicit profile (the file is equivalent to chart defaults).
+explicit profile (the file is equivalent to chart defaults). Replace
+`route.host` with a hostname under your cluster ingress domain — required
+whenever Routes are enabled with the standalone UI.
 
 ### Portal / backend-only
 
@@ -204,6 +207,7 @@ Gateway DB and Abbenay down together.
 | `abbenay.aiModel` | `""` | Default AI model ID |
 | `ingress.enabled` | `false` | Create Kubernetes Ingress |
 | `route.enabled` | `false` | Create OpenShift Route |
+| `route.host` | `""` | Shared Route hostname; **required** when `route.enabled` and `ui.enabled` |
 | `autoscaling.enabled` | `false` | Must stay `false` (ADR-069) |
 | `networkPolicy.enabled` | `false` | Enable NetworkPolicy |
 | `podDisruptionBudget.enabled` | `false` | Enable PDB |
@@ -249,7 +253,10 @@ route:
     insecureEdgeTerminationPolicy: Redirect
 ```
 
-When `host` is empty, OpenShift auto-assigns separate hosts per Route.
+When `ui.enabled=true`, `route.host` is **required** so the UI (`/`) and
+Gateway (`/api`) Routes share one hostname. When `ui.enabled=false`
+(portal), leave `host` empty to let OpenShift auto-assign the API Route
+hostname.
 
 ### Portal / external UI (backend only)
 

--- a/deploy/helm/apme/templates/engine-deployment.yaml
+++ b/deploy/helm/apme/templates/engine-deployment.yaml
@@ -75,7 +75,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          command: ["sh", "-c", "cp -a /etc/nginx/conf.d/. /mnt/conf.d/"]
+          command: ["sh", "-c", "cp -a -r --no-preserve=mode,ownership,timestamps /etc/nginx/conf.d/. /mnt/conf.d/"]
           volumeMounts:
             - name: nginx-conf
               mountPath: /mnt/conf.d

--- a/deploy/helm/apme/templates/route.yaml
+++ b/deploy/helm/apme/templates/route.yaml
@@ -2,6 +2,9 @@
 {{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
 {{- fail "route.enabled is true but the cluster does not provide the route.openshift.io/v1 API (not an OpenShift cluster?)" }}
 {{- end }}
+{{- if and .Values.ui.enabled (not .Values.route.host) }}
+{{- fail "route.host is required when route.enabled=true and ui.enabled=true (UI and Gateway must share one OpenShift Route host for /api path routing). Portal/backend-only installs (ui.enabled=false) may omit host for OpenShift auto-assignment." }}
+{{- end }}
 {{- if .Values.ui.enabled }}
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -279,10 +279,9 @@ ingress:
   tls: []
 
 # -- OpenShift Route (alternative to Ingress for OCP clusters)
-# Set route.host to serve the UI and API on the same domain (e.g.
-# "apme.apps.ocp.example.com").  When host is empty, OpenShift
-# auto-assigns a different host per Route and the UI/API will be on
-# separate domains.
+# When ui.enabled=true, route.host is required so the UI (/) and Gateway
+# (/api) Routes share one hostname. When ui.enabled=false (portal), leave
+# host empty to let OpenShift auto-assign the API Route hostname.
 route:
   enabled: false
   host: ""

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -448,8 +448,12 @@ helm repo add apme https://ansible.github.io/apme
 helm repo update
 helm install apme apme/apme \
   --namespace apme --create-namespace \
-  --set route.enabled=true
+  --set route.enabled=true \
+  --set route.host=apme.apps.ocp.example.com
 ```
+
+Replace `route.host` with a hostname under your cluster OpenShift ingress
+domain. It is required whenever Routes are enabled with the standalone UI.
 
 #### Portal / backend-only
 
@@ -503,6 +507,7 @@ SHA or release tag (and Quay only when that publish included Quay credentials).
 | `ui.enabled` | Deploy standalone UI (default: `true`; use `values-portal.yaml` for portal) |
 | `ingress.enabled` | Create Ingress resource (default: false) |
 | `route.enabled` | Create OpenShift Route (default: false) |
+| `route.host` | Shared Route hostname; required when `route.enabled` and `ui.enabled` |
 
 See [deploy/helm/apme/README.md](../../deploy/helm/apme/README.md) for the
 full values reference and architecture details.

--- a/scripts/helm_chart.sh
+++ b/scripts/helm_chart.sh
@@ -178,6 +178,14 @@ HPA_ERR="$("${HELM_BIN}" template test-release "${CHART_DIR}" \
 }
 assert_fail_message "HPA rejected" "${HPA_ERR}" "autoscaling.enabled must be false"
 
+ROUTE_HOST_ERR="$("${HELM_BIN}" template test-release "${CHART_DIR}" \
+  --set route.enabled=true \
+  --api-versions route.openshift.io/v1 2>&1 >/dev/null)" && {
+  echo "FAIL: expected helm template to fail when route.enabled=true without route.host (ui enabled)" >&2
+  exit 1
+}
+assert_fail_message "route.host required" "${ROUTE_HOST_ERR}" "route.host is required"
+
 # Confirm Service selectors + no Abbenay Service / extra Deployments
 RENDER_FILE="$(mktemp)"
 trap 'rm -f "${RENDER_FILE}"' EXIT


### PR DESCRIPTION
## Summary
- Fix the UI `init-nginx-conf` container so `cp` into the shared emptyDir works under OpenShift's restricted SCC (arbitrary non-root UID).
- Require `route.host` when OpenShift Routes are enabled together with the standalone UI, so UI (`/`) and Gateway (`/api`) share one hostname.
- Document the shared-host requirement and remind installers to replace the placeholder ingress hostname.

## Changes
- `engine-deployment.yaml`: use `cp -a -r --no-preserve=mode,ownership,timestamps` when seeding `/mnt/conf.d` from the UI image.
- `route.yaml`: fail render when `route.enabled=true` and `ui.enabled=true` but `route.host` is empty (portal/`ui.enabled=false` may omit host for auto-assignment).
- `values.yaml`, chart README, and `DEPLOYMENT.md`: document the requirement and update standalone install examples.

## Test plan
- [ ] `helm template` / install on OpenShift with `route.enabled=true` and a shared `route.host`
- [ ] Confirm `helm template ... --set route.enabled=true` (UI on, no host) fails with a clear error
- [ ] Confirm portal install (`values-portal.yaml` + `route.enabled=true`, no host) still renders
- [ ] Confirm `init-nginx-conf` completes without permission errors on restricted-v2 SCC
- [ ] Confirm UI Route `/` and API Route `/api` resolve on the same host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified OpenShift Route hostname requirements for standalone UI deployments.
  * Added examples showing how to configure a hostname matching the cluster ingress domain.
  * Documented automatic hostname assignment when the UI is disabled.

* **Bug Fixes**
  * Added validation to prevent UI-enabled deployments from proceeding without a shared Route hostname.
  * Improved configuration handling during UI deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->