### PR TITLE
fix(ci): supply-chain job outputs and nested Podman hardening

### DIFF
--- a/.agents/skills/pr-address-feedback/SKILL.md
+++ b/.agents/skills/pr-address-feedback/SKILL.md
@@ -112,10 +112,12 @@ accepts — gets flagged.
 
 **Information exposure.** The reviewer asks "should this data be visible
 here?" for every piece of information that escapes internal scope:
-logged data, error messages, API responses, documentation examples.
+logged data, error messages, API responses, documentation examples,
+and credentials left in local Git config by `actions/checkout`.
 User content in info-level logs, credentials on CLI examples, internal
-paths in error messages — all get flagged because the reviewer assumes
-the minimum-exposure principle.
+paths in error messages, and a write-capable `GITHUB_TOKEN` persisted
+into `.git/config` for later job steps — all get flagged because the
+reviewer assumes the minimum-exposure principle.
 
 **Caller safety.** The reviewer reads every public interface from the
 caller's perspective and asks "could this surprise me?" Nullable
@@ -191,7 +193,11 @@ above should catch novel issues these don't cover.
   `prek` directly in docs, scripts, or CI (ADR-047). Always use
   `tox -e <env>`.
 - **GitHub Actions pinning**: pin to commit SHAs with a tag comment
-  (`actions/checkout@SHA # v4`), not mutable tags.
+  (`actions/checkout@SHA # v4`), not mutable tags. On workflows with
+  `packages: write` (or other write scopes) that run untrusted
+  scripts after checkout—especially `workflow_dispatch`—set
+  `persist-credentials: false` on `actions/checkout` so
+  `GITHUB_TOKEN` is not left in local Git config (zizmor artipacked).
 - **OPA is subprocess, not REST**: the OPA validator invokes `opa eval`
   via subprocess — do not introduce httpx or HTTP client dependencies
   for OPA (verified in code, documented in AGENTS.md invariant 9).
@@ -210,6 +216,19 @@ note the original tag:
 ```yaml
 - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 ```
+
+When a job (or workflow-level `permissions`) grants write scopes and later
+steps run repo scripts, disable checkout credential persistence:
+
+```yaml
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+  with:
+    persist-credentials: false
+```
+
+Check sibling jobs in the same workflow for consistency — if supply-chain
+or attest already set `persist-credentials: false`, merge/build jobs that
+share `packages: write` should match.
 
 ### Inaccurate documentation
 

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -131,7 +131,11 @@ artifact type, translate it:
 
 5. **Are dependencies and versions pinned to intent?** Check every
    version range, action tag, and base image. Does each one express
-   what you actually mean — not tighter, not looser?
+   what you actually mean — not tighter, not looser? For workflow
+   checkouts: if the job has write scopes (`packages: write`, etc.)
+   or runs untrusted/repo scripts after checkout, is
+   `persist-credentials: false` set so `GITHUB_TOKEN` is not left
+   in local Git config? Match sibling jobs in the same workflow.
 
 6. **Is there dead weight?** Check for unused imports, unreachable
    branches, written-but-never-read variables, parameters accepted
@@ -354,7 +358,9 @@ critical/high/medium/low.
 - Test gaps for behaviors the code/docs claim
 - Silent no-ops, dead branches, wrong defaults
 - **Dependencies pinned to intent** — version ranges, GitHub Action
-  tags, base images, pip/uv specs (not tighter, not looser)
+  tags, base images, pip/uv specs (not tighter, not looser);
+  checkout `persist-credentials: false` when write-scoped tokens
+  must not remain in local Git config for later steps
 - **Dead weight** — unused imports/params; paid-for-but-wasteful work:
   double JSON parse, list.pop(0)/insert(0,…) vs deque, len(list(seq)),
   O(P×V) nested scans that should be O(P+V)

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -124,27 +124,30 @@ jobs:
     timeout-minutes: 30
     outputs:
       consumer_tags: ${{ steps.tags.outputs.tags }}
-      owner_lc: ${{ steps.owner.outputs.lc }}
+      # Do not export owner_lc or quay_ns — GitHub may skip outputs that match
+      # masked secrets (e.g. Quay org name). Downstream jobs compute these locally.
       quay_enabled: ${{ steps.quay-check.outputs.enabled }}
-      quay_ns: ${{ steps.quay-check.outputs.ns }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - id: owner
         run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
+      # Namespace is public (image paths); use a repo variable, not a secret.
+      # A secret-derived ns would mask subjects.json and drop the job output.
       - id: quay-check
         run: |
           if [ -n "$QUAY_USER" ] && [ -n "$QUAY_PASS" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
-            echo "ns=${QUAY_ORG:-${{ steps.owner.outputs.lc }}}" >> "$GITHUB_OUTPUT"
+            echo "ns=${QUAY_ORG:-$OWNER_LC}" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
         env:
+          OWNER_LC: ${{ steps.owner.outputs.lc }}
           QUAY_USER: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASS: ${{ secrets.QUAY_PASSWORD }}
-          QUAY_ORG: ${{ secrets.QUAY_NAMESPACE }}
+          QUAY_ORG: ${{ vars.QUAY_NAMESPACE }}
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
@@ -255,13 +258,31 @@ jobs:
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      - id: owner
+        run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      # Same as merge-manifests: public ns via vars (not a masked secret).
+      - id: quay-check
+        run: |
+          if [ -n "$QUAY_USER" ] && [ -n "$QUAY_PASS" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "ns=${QUAY_ORG:-$OWNER_LC}" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          OWNER_LC: ${{ steps.owner.outputs.lc }}
+          QUAY_USER: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASS: ${{ secrets.QUAY_PASSWORD }}
+          QUAY_ORG: ${{ vars.QUAY_NAMESPACE }}
+
       - name: Sign images and generate container SBOMs
         env:
           GHCR_REGISTRY: ${{ env.GHCR_REGISTRY }}
           QUAY_REGISTRY: ${{ env.QUAY_REGISTRY }}
-          OWNER_LC: ${{ needs.merge-manifests.outputs.owner_lc }}
-          QUAY_ENABLED: ${{ needs.merge-manifests.outputs.quay_enabled }}
-          QUAY_NS: ${{ needs.merge-manifests.outputs.quay_ns }}
+          OWNER_LC: ${{ steps.owner.outputs.lc }}
+          QUAY_ENABLED: ${{ steps.quay-check.outputs.enabled }}
+          QUAY_NS: ${{ steps.quay-check.outputs.ns }}
         run: |
           args=(
             --owner "$OWNER_LC"

--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -129,6 +129,10 @@ jobs:
       quay_enabled: ${{ steps.quay-check.outputs.enabled }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          # workflow_dispatch + packages:write — do not leave GITHUB_TOKEN in
+          # local git config for merge-manifests.sh (zizmor artipacked).
+          persist-credentials: false
 
       - id: owner
         run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -99,11 +99,14 @@ admin writes persist there as the source of truth after first configure:
   volume **once** (only if the file is absent). Default volume is `emptyDir`
   (pod lifetime). Optional PVC via `persistence.abbenay.enabled=true` survives
   restarts. Abbenay mounts the writable dir at `/etc/abbenay-config`.
-- **Podman**: `containers/abbenay/config/` is a hostPath RW mount at
-  `/home/abbenay/.config/abbenay`. `up.sh` seeds `config.yaml` from the legacy
-  `containers/abbenay/config.yaml` (or `.example`) when the dir is empty, then
-  `podman unshare chown -R 1001:1001` so UID 1001 can write under rootless
-  Podman host-UID mapping.
+- **Podman**: Writable hostPath is
+  `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` (override via
+  `APME_CACHE_HOST_PATH`), mounted at `/home/abbenay/.config/abbenay`.
+  `up.sh` seeds `config.yaml` from `containers/abbenay/config/` (or legacy
+  `config.yaml` / `.example`) when the cache file is absent, applies
+  `0700`/`0600`, then grants container UID 1001 access on the **cache copy**
+  (rootful: chown; rootless: POSIX ACL so the host user can still edit). The
+  git checkout is never chowned.
 
 After the first successful configure, the writable file is SoT — Helm value /
 ConfigMap changes do not overwrite an existing runtime config.
@@ -211,7 +214,8 @@ runtime admin API.
   Quality settings follow in a later change.
 - **Config durability** ([#498](https://github.com/ansible/apme/issues/498)):
   implemented — seed ConfigMap → writable emptyDir (default) / optional PVC
-  (`persistence.abbenay`); Podman RW `containers/abbenay/config/`; seed-once;
+  (`persistence.abbenay`); Podman RW cache
+  (`${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/`); seed-once;
   runtime SoT after first configure.
 
 ## Related Decisions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -120,10 +120,12 @@ USER 1001
 ```
 
 #### Image Scanning
+
+Container image vulnerability scanning runs in the `container-images` GitHub
+Actions workflow on each release. For local Python supply-chain artifacts, use:
+
 ```bash
-# Scan images for vulnerabilities
-trivy image apme-primary:latest
-grype apme-primary:latest
+tox -e release-supply-chain
 ```
 
 ### Dependency Security
@@ -200,8 +202,7 @@ bandit -r src/
 # Dependency vulnerabilities
 pip-audit
 
-# Container scanning
-trivy image apme-primary:latest
+# Container image scanning — see container-images GitHub Actions workflow
 ```
 
 ---

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -23,9 +23,12 @@ RUN --mount=type=cache,target=/tmp/uv-cache \
             --extra ai --extra gateway
 
 # Full source; install the project itself (deps already cached).
+# Normalize modes after COPY: some hosts/filesystems (e.g. virtiofs) present
+# git-tracked 0644 files as 0600, which breaks non-root UID 1001 at runtime.
 COPY . /app
 RUN --mount=type=cache,target=/tmp/uv-cache \
-    uv sync --frozen --no-dev --extra ai --extra gateway
+    chmod -R a+rX /app \
+    && uv sync --frozen --no-dev --extra ai --extra gateway
 
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/containers/opa/Dockerfile
+++ b/containers/opa/Dockerfile
@@ -10,7 +10,8 @@ COPY --from=opa-bin /opa /usr/local/bin/opa
 
 RUN cp -r /app/src/apme_engine/validators/opa/bundle /bundle \
     && cp /app/containers/opa/entrypoint.sh /entrypoint.sh \
-    && chmod +x /entrypoint.sh
+    && chmod -R a+rX /bundle \
+    && chmod a+rx /entrypoint.sh
 
 USER 1001
 

--- a/containers/podman/check-volume-permissions.sh
+++ b/containers/podman/check-volume-permissions.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Verify UBI service images can write to mounted volume paths as UID 1001 (ADR-061).
+# Also verify UID 1001 can read application source (host COPY may preserve 0600).
 # Run after image build; invoked from containers/podman/build.sh.
 set -euo pipefail
 
@@ -38,6 +39,24 @@ check_write() {
     -c "touch '${mount_path}/.write-test' && test -f '${mount_path}/.write-test' && rm -f '${mount_path}/.write-test'"
 }
 
+# Ensure non-root can read packaged source (editable install path).
+check_app_readable() {
+  local image=$1
+  local probe=$2
+
+  if ! podman image exists "$image" 2>/dev/null; then
+    echo "==> Skip app-read check for $image (image not built)"
+    return 0
+  fi
+
+  echo "==> App read check: $image (UID $RUNTIME_UID) -> $probe"
+  podman run --rm \
+    --user "${RUNTIME_UID}" \
+    --entrypoint sh \
+    "$image" \
+    -c "test -r '${probe}'"
+}
+
 prep_dir "${PROBE_ROOT}/sessions"
 prep_dir "${PROBE_ROOT}/data"
 prep_dir "${PROBE_ROOT}/cache"
@@ -45,5 +64,13 @@ prep_dir "${PROBE_ROOT}/cache"
 check_write apme-primary:latest /sessions "${PROBE_ROOT}/sessions"
 check_write apme-gateway:latest /data "${PROBE_ROOT}/data"
 check_write apme-galaxy-proxy:latest /cache "${PROBE_ROOT}/cache"
+
+check_app_readable apme-primary:latest /app/src/apme_engine/__init__.py
+check_app_readable apme-gateway:latest /app/src/apme_gateway/__init__.py
+check_app_readable apme-galaxy-proxy:latest /app/src/galaxy_proxy/__init__.py
+check_app_readable apme-opa:latest /entrypoint.sh
+check_app_readable apme-ui:latest /entrypoint.sh
+check_app_readable apme-ui:latest /etc/nginx/nginx.conf
+check_app_readable apme-ui:latest /etc/nginx/conf.d/default.conf.template
 
 echo "Volume permission checks passed (UID ${RUNTIME_UID})."

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -158,18 +158,44 @@ _owned_by_container_uid() {
 }
 
 # Host UID that corresponds to a container UID (rootless subordinate map).
+# Resolve from the live user-namespace uid_map: rootless Podman maps container
+# UID 0 to the host user and UID 1..N onto /etc/subuid, so container 1001 is
+# subuid_start+1000 — not subuid_start+1001. Arithmetic on /etc/subuid alone
+# is off-by-one for non-zero container UIDs.
 _host_uid_for_container_uid() {
   local container_uid="$1"
   if ! _podman_is_rootless; then
     echo "$container_uid"
     return 0
   fi
-  local start
-  start=$(awk -F: -v u="$(id -un)" '$1 == u { print $2; exit }' /etc/subuid)
-  if [[ -z "$start" ]]; then
+  local mapped
+  mapped=$(podman unshare awk -v uid="$container_uid" '
+    uid >= $1 && uid < $1 + $3 {
+      print $2 + uid - $1
+      found = 1
+      exit
+    }
+    END { exit !found }
+  ' /proc/self/uid_map) || return 1
+  if [[ -z "$mapped" ]]; then
     return 1
   fi
-  echo $((start + container_uid))
+  echo "$mapped"
+}
+
+# Return 0 when container UID can open path (rootless user-namespace probe).
+_container_uid_can_read() {
+  local container_uid="$1"
+  local path="$2"
+  podman unshare python3 -c '
+import os, sys
+uid = int(sys.argv[1])
+path = sys.argv[2]
+os.setgid(uid)
+os.setuid(uid)
+with open(path, "rb"):
+    pass
+' "$container_uid" "$path"
 }
 
 # Make Abbenay cache config usable by the host user and container UID 1001.
@@ -205,6 +231,10 @@ _ensure_abbenay_config_access() {
     setfacl -d -m "u:${mapped}:rwx" "$path" || return 1
     if [[ -f "$path/config.yaml" ]]; then
       setfacl -m "u:${mapped}:rw" "$path/config.yaml" || return 1
+      if ! _container_uid_can_read "$cuid" "$path/config.yaml"; then
+        echo "ERROR: container UID $cuid cannot read $path/config.yaml after ACL grant" >&2
+        return 1
+      fi
     fi
     return 0
   fi

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -9,17 +9,32 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
 # Return SELinux mode: disabled, Permissive, Enforcing, or unknown (fail closed).
+# A bare /sys/fs/selinux directory without enforce is a stub (common in nested
+# containers / Podman-in-Podman) — treat as disabled, not unknown.
 _selinux_mode() {
-  if [[ ! -d /sys/fs/selinux ]]; then
+  if [[ ! -e /sys/fs/selinux/enforce ]]; then
     echo "disabled"
     return 0
   fi
   local mode
-  if ! mode=$(getenforce 2>/dev/null) || [[ -z "$mode" ]]; then
+  if mode=$(getenforce 2>/dev/null) && [[ -n "$mode" ]]; then
+    echo "$mode"
+    return 0
+  fi
+  # Fallback when getenforce is missing but selinuxfs is mounted.
+  local enforce
+  if ! enforce=$(cat /sys/fs/selinux/enforce 2>/dev/null); then
     echo "unknown"
     return 1
   fi
-  echo "$mode"
+  case "$enforce" in
+    1) echo "Enforcing" ;;
+    0) echo "Permissive" ;;
+    *)
+      echo "unknown"
+      return 1
+      ;;
+  esac
   return 0
 }
 
@@ -71,22 +86,163 @@ _selinux_marker_exists() {
   [[ -f "$(_selinux_repair_marker_path "$1")" ]]
 }
 
+# Return 0 when Podman is running rootless.
+_podman_is_rootless() {
+  podman info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -qx true
+}
+
+# Create a file after volume chown. Rootless mounts are often mode 1755 owned by
+# the subordinate UID for container 1001, so the host user cannot touch(1) them.
+_touch_in_volume_namespace() {
+  local path="$1"
+  if _podman_is_rootless; then
+    podman unshare touch "$path" 2>/dev/null || return 1
+  elif ! touch "$path" 2>/dev/null; then
+    return 1
+  fi
+}
+
 _write_selinux_marker() {
   local mountpoint="$1"
   local marker
   marker=$(_selinux_repair_marker_path "$mountpoint")
-  if ! touch "$marker" 2>/dev/null; then
+  if ! _touch_in_volume_namespace "$marker"; then
     return 1
   fi
   chcon -l s0 -t container_file_t "$marker" 2>/dev/null || true
 }
 
+_CHOWN_REPAIR_MARKER=".apme-chown-repair-v1"
+
+_chown_repair_marker_path() {
+  echo "$1/${_CHOWN_REPAIR_MARKER}"
+}
+
+_chown_marker_exists() {
+  [[ -f "$(_chown_repair_marker_path "$1")" ]]
+}
+
+_write_chown_marker() {
+  local mountpoint="$1"
+  local marker
+  marker=$(_chown_repair_marker_path "$mountpoint")
+  if ! _touch_in_volume_namespace "$marker"; then
+    return 1
+  fi
+  chcon -l s0 -t container_file_t "$marker" 2>/dev/null || true
+}
+
+# Chown a host path so a container UID can write it.
+# Rootless: podman unshare (host subordinate UIDs). Rootful: direct chown.
+_chown_for_container_uid() {
+  local uid_gid="$1"
+  local path="$2"
+  if _podman_is_rootless; then
+    podman unshare chown -R "$uid_gid" "$path"
+  else
+    chown -R "$uid_gid" "$path"
+  fi
+}
+
+# Return 0 when path is owned by the given container UID.
+_owned_by_container_uid() {
+  local uid="$1"
+  local path="$2"
+  local actual
+  if _podman_is_rootless; then
+    actual=$(podman unshare stat -c '%u' "$path" 2>/dev/null) || return 1
+  else
+    actual=$(stat -c '%u' "$path" 2>/dev/null) || return 1
+  fi
+  [[ "$actual" == "$uid" ]]
+}
+
+# Host UID that corresponds to a container UID (rootless subordinate map).
+_host_uid_for_container_uid() {
+  local container_uid="$1"
+  if ! _podman_is_rootless; then
+    echo "$container_uid"
+    return 0
+  fi
+  local start
+  start=$(awk -F: -v u="$(id -un)" '$1 == u { print $2; exit }' /etc/subuid)
+  if [[ -z "$start" ]]; then
+    return 1
+  fi
+  echo $((start + container_uid))
+}
+
+# Make Abbenay cache config usable by the host user and container UID 1001.
+# Rootless: keep host ownership; grant a POSIX ACL to the subordinate UID so
+# the next tox -e up can still chmod/seed and developers can edit config.yaml.
+# Rootful: chown to 1001:1001. Migrates caches that were previously chowned
+# exclusively to the subordinate UID (which locked the host user out).
+_ensure_abbenay_config_access() {
+  local path="$1"
+  local cuid=1001
+
+  if _podman_is_rootless; then
+    if [[ -d "$path" ]] && [[ ! -w "$path" ]]; then
+      if _owned_by_container_uid "$cuid" "$path"; then
+        echo "Restoring host ownership of Abbenay config cache (prior rootless chown)..."
+        # Inside the user namespace, the host user is UID 0.
+        podman unshare chown -R 0:0 "$path" || return 1
+      else
+        echo "ERROR: Abbenay config cache is not writable: $path" >&2
+        return 1
+      fi
+    fi
+    if ! command -v setfacl >/dev/null 2>&1; then
+      echo "ERROR: setfacl is required for rootless Abbenay config (host edit + UID 1001)" >&2
+      return 1
+    fi
+    local mapped
+    mapped=$(_host_uid_for_container_uid "$cuid") || {
+      echo "ERROR: could not resolve subordinate UID for container UID $cuid" >&2
+      return 1
+    }
+    setfacl -m "u:${mapped}:rwx" "$path" || return 1
+    setfacl -d -m "u:${mapped}:rwx" "$path" || return 1
+    if [[ -f "$path/config.yaml" ]]; then
+      setfacl -m "u:${mapped}:rw" "$path/config.yaml" || return 1
+    fi
+    return 0
+  fi
+
+  if ! _chown_for_container_uid "${cuid}:${cuid}" "$path" \
+    || ! _owned_by_container_uid "$cuid" "$path"; then
+    return 1
+  fi
+}
+
+# Recursive chown only when the mountpoint needs migration or lacks a marker.
+# Large session/gateway volumes must not be walked on every tox -e up.
+_ensure_volume_owned_by_container_uid() {
+  local uid_gid="$1"
+  local uid="${uid_gid%%:*}"
+  local path="$2"
+  if _owned_by_container_uid "$uid" "$path" && _chown_marker_exists "$path"; then
+    return 0
+  fi
+  if ! _chown_for_container_uid "$uid_gid" "$path"; then
+    return 1
+  fi
+  if ! _owned_by_container_uid "$uid" "$path"; then
+    return 1
+  fi
+  if ! _write_chown_marker "$path"; then
+    return 1
+  fi
+}
+
 # Relabel named Podman volume mountpoints so pod containers can read/write under SELinux.
 # Standalone `podman run -v vol:path:Z` probes can stamp MCS categories the pod
 # cannot access, breaking gateway DB writes (project creation, scans, etc.).
-# Only relabel when the mountpoint context is wrong; avoid recursive walks on every
-# startup (large apme-sessions trees). Set APME_SELINUX_FULL_RELABEL=1 for a one-time
-# recursive repair of an existing volume.
+# Also ensure UID 1001 owns the mountpoint — pvc.yaml annotations are not always
+# applied to pre-existing volumes or rootful Podman (mode 1755 root-owned → EACCES).
+# Only relabel/chown when needed; avoid recursive walks on every startup (large
+# apme-sessions trees). Set APME_SELINUX_FULL_RELABEL=1 for a one-time recursive
+# SELinux repair of an existing volume.
 _relabel_podman_volumes() {
   local vol mountpoint
   for vol in apme-sessions apme-gateway-data apme-proxy-cache; do
@@ -96,6 +252,10 @@ _relabel_podman_volumes() {
     mountpoint=$(podman volume inspect "$vol" --format '{{.Mountpoint}}')
     if [[ -z "$mountpoint" || ! -d "$mountpoint" ]]; then
       continue
+    fi
+    if ! _ensure_volume_owned_by_container_uid 1001:0 "$mountpoint"; then
+      echo "ERROR: could not chown volume $vol ($mountpoint) to 1001:0" >&2
+      return 1
     fi
     local mode
     mode=$(_selinux_mode) || {
@@ -394,18 +554,35 @@ print(yaml)
   echo "Vertex AI project: $GOOGLE_VERTEX_PROJECT (location: $GOOGLE_VERTEX_LOCATION)"
 fi
 
-# Set up writable Abbenay config directory (seed from legacy config.yaml if present).
+# Set up writable Abbenay config directory (seed from repo / legacy files).
 # The hostPath Directory mount replaces the old read-only File mount so that
 # runtime admin writes (POST /api/v1/ai/provider/.../configure) survive restarts.
-# Rootless Podman maps host UID to root inside the user namespace; Abbenay runs
-# as UID 1001, so ownership must be 1001:1001 in that namespace (podman unshare
-# chown) or configure returns EACCES. Avoid world-writable chmod.
-ABBENAY_CONFIG_DIR="$ROOT/containers/abbenay/config"
+# Never chown the git checkout: rootless Podman maps UID 1001 to a subordinate
+# host UID and would lock the developer out of containers/abbenay/config.
+# Runtime config always lives under CACHE_PATH (mode 0700/0600; credentials).
+# Rootless: host keeps ownership; container UID 1001 gets a POSIX ACL.
+# Rootful: chown the cache copy to 1001:1001.
+ABBENAY_CONFIG_SEED="$ROOT/containers/abbenay/config"
+ABBENAY_CONFIG_REPO_PATH="$ABBENAY_CONFIG_SEED"
+ABBENAY_CONFIG_DIR="$CACHE_PATH/abbenay/config"
+if ! command -v podman >/dev/null 2>&1; then
+  echo "ERROR: podman is required to set Abbenay config ownership (UID 1001)" >&2
+  exit 1
+fi
+# Migrate prior exclusive subordinate-UID ownership before host chmod/seed.
+if [[ -d "$ABBENAY_CONFIG_DIR" ]] && [[ ! -w "$ABBENAY_CONFIG_DIR" ]]; then
+  if ! _ensure_abbenay_config_access "$ABBENAY_CONFIG_DIR"; then
+    echo "ERROR: could not restore host access to Abbenay config cache $ABBENAY_CONFIG_DIR" >&2
+    exit 1
+  fi
+fi
 mkdir -p "$ABBENAY_CONFIG_DIR"
-# Relabel the empty dir first so seed copies land on a container-readable parent.
-_relabel_host_path_for_podman "$ABBENAY_CONFIG_DIR"
+chmod 0700 "$ABBENAY_CONFIG_DIR"
 if [[ ! -f "$ABBENAY_CONFIG_DIR/config.yaml" ]]; then
-  if [[ -f "$ROOT/containers/abbenay/config.yaml" ]]; then
+  if [[ -f "$ABBENAY_CONFIG_SEED/config.yaml" ]]; then
+    cp "$ABBENAY_CONFIG_SEED/config.yaml" "$ABBENAY_CONFIG_DIR/config.yaml"
+    echo "Seeded Abbenay config from containers/abbenay/config/config.yaml"
+  elif [[ -f "$ROOT/containers/abbenay/config.yaml" ]]; then
     cp "$ROOT/containers/abbenay/config.yaml" "$ABBENAY_CONFIG_DIR/config.yaml"
     echo "Seeded Abbenay config from containers/abbenay/config.yaml (legacy location)"
   elif [[ -f "$ROOT/containers/abbenay/config.yaml.example" ]]; then
@@ -413,18 +590,30 @@ if [[ ! -f "$ABBENAY_CONFIG_DIR/config.yaml" ]]; then
     echo "Seeded Abbenay config from containers/abbenay/config.yaml.example"
   fi
 fi
-# Relabel seeded files while still host-owned; chcon after podman unshare
-# chown to a subordinate UID can fail on Enforcing hosts.
+if [[ -f "$ABBENAY_CONFIG_DIR/config.yaml" ]]; then
+  chmod 0600 "$ABBENAY_CONFIG_DIR/config.yaml"
+fi
 _relabel_host_path_for_podman "$ABBENAY_CONFIG_DIR"
-if command -v podman >/dev/null 2>&1; then
-  if ! podman unshare chown -R 1001:1001 "$ABBENAY_CONFIG_DIR"; then
-    echo "ERROR: could not chown Abbenay config dir to 1001:1001 via podman unshare" >&2
-    exit 1
-  fi
-else
-  echo "ERROR: podman is required to set Abbenay config ownership (UID 1001)" >&2
+if ! _ensure_abbenay_config_access "$ABBENAY_CONFIG_DIR"; then
+  echo "ERROR: could not grant Abbenay container UID 1001 access to $ABBENAY_CONFIG_DIR" >&2
   exit 1
 fi
+# POD_YAML still has the repo hostPath from envsubst; always mount the cache copy.
+if ! POD_YAML=$(ABBENAY_CONFIG_REPO_PATH="$ABBENAY_CONFIG_REPO_PATH" \
+  ABBENAY_CONFIG_DIR="$ABBENAY_CONFIG_DIR" python3 -c '
+import os, sys
+yaml = sys.stdin.read()
+old = "path: " + os.environ["ABBENAY_CONFIG_REPO_PATH"]
+new = "path: " + os.environ["ABBENAY_CONFIG_DIR"]
+if old not in yaml:
+    print("ERROR: abbenay-config hostPath not found in pod YAML", file=sys.stderr)
+    sys.exit(1)
+print(yaml.replace(old, new, 1), end="")
+' <<< "$POD_YAML"); then
+  echo "ERROR: could not retarget Abbenay config hostPath in pod YAML" >&2
+  exit 1
+fi
+echo "Abbenay config hostPath: $ABBENAY_CONFIG_DIR (seed sources remain under containers/abbenay/)"
 _relabel_host_path_for_podman "$ROOT/containers/otel-collector/config.yaml"
 if [[ -n "$ABBENAY_CA_BUNDLE" ]]; then
   _relabel_host_path_for_podman "$ABBENAY_CA_BUNDLE"

--- a/containers/ui/Dockerfile
+++ b/containers/ui/Dockerfile
@@ -29,10 +29,14 @@ RUN dnf install -y gettext && dnf clean all
 COPY containers/ui/nginx.conf /etc/nginx/nginx.conf
 COPY containers/ui/nginx.conf.template /etc/nginx/conf.d/default.conf.template
 COPY containers/ui/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+# Host checkouts on virtiofs may present git 0644 files as 0600; UID 1001 must
+# read nginx configs and the entrypoint (shell scripts need +r, not only +x).
+RUN chmod a+rx /entrypoint.sh \
+    && chmod a+r /etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
 
-RUN chmod -R g+w /etc/nginx/conf.d /var/log/nginx /run
+RUN chmod -R a+rX /usr/share/nginx/html \
+    && chmod -R g+w /etc/nginx/conf.d /var/log/nginx /run
 USER 1001
 
 EXPOSE 8081

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -35,7 +35,7 @@ the first write, the runtime file is the source of truth.
 | Deploy | Seed | Writable volume | Notes |
 |--------|------|-----------------|-------|
 | **Helm** | ConfigMap `*-abbenay-config` (from `abbenay.providers`) | `emptyDir` by default; optional PVC via `persistence.abbenay.enabled=true` | Init `init-abbenay-config` copies seed only if `config.yaml` is absent. Mount: `/etc/abbenay-config`. |
-| **Podman** | `containers/abbenay/config.yaml` (or `.example`) on first `tox -e up` | Host dir `containers/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds when the dir has no `config.yaml`, then `podman unshare chown -R 1001:1001` so UID 1001 can write under rootless Podman. Dir is gitignored. |
+| **Podman** | `containers/abbenay/config/` (or legacy `config.yaml` / `.example`) on first `tox -e up` | Cache dir `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds into the cache path (mode `0700`/`0600`). Rootful chowns the cache copy to UID 1001; rootless keeps host ownership and grants UID 1001 a POSIX ACL. The repo tree is never chowned. |
 
 Helm PVC knobs (`persistence.abbenay.*`):
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -64,16 +64,16 @@ cp containers/abbenay/.env.example containers/abbenay/.env
 # Edit .env and set your LLM provider API key (e.g., OPENROUTER_API_KEY)
 ```
 
-The `.env` file is gitignored. Abbenay config lives in the **writable** host
-directory `containers/abbenay/config/` (mounted RW at
-`/home/abbenay/.config/abbenay`). On first `tox -e up`, `up.sh` seeds
-`config.yaml` from `containers/abbenay/config.yaml` or
-`config.yaml.example` if the directory is empty, then runs
-`podman unshare chown -R 1001:1001` so the container UID 1001 can write under
-rootless Podman. Edit
-`containers/abbenay/config/config.yaml` (or use the Gateway admin proxy) to
-change providers/models — runtime configure writes persist across container
-restarts.
+The `.env` file is gitignored. Abbenay config is **seeded** from
+`containers/abbenay/config/` (or legacy `config.yaml` /
+`config.yaml.example`) into
+`${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` (override with
+`APME_CACHE_HOST_PATH`). That cache directory is the RW hostPath mount
+(`0700` / `0600`). Rootful Podman chowns the cache copy to UID 1001; rootless
+keeps host ownership and grants UID 1001 a POSIX ACL so you can still edit the
+file. The git checkout is never chowned. Edit the cache `config.yaml` (or use
+the Gateway admin proxy) to change providers/models — runtime configure writes
+persist across container restarts.
 
 If `.env` is missing or the key is empty, the Abbenay container starts but model queries return empty results. AI remediation gracefully degrades — Tier 1 deterministic fixes still work.
 
@@ -218,12 +218,14 @@ proxy gRPC requests to it.
 | `CURL_CA_BUNDLE` | — | Shared CA bundle for curl/libcurl consumers in the gateway and Galaxy Proxy |
 | `GIT_SSL_CAINFO` | — | Shared CA bundle for `git ls-remote`, `git clone`, and `ansible-galaxy` git fetches |
 
-Abbenay uses `containers/abbenay/config/` as a **writable** hostPath mount
-(`abbenay-config` → `/home/abbenay/.config/abbenay`). The config defines LLM
-providers and models. API keys are injected from environment variables —
-never committed to the config file. To add providers or models, edit
-`containers/abbenay/config/config.yaml` or POST via the Gateway admin proxy
-(`/api/v1/ai/provider/{id}/configure`); writes survive Abbenay restarts.
+Abbenay uses `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` as a
+**writable** hostPath mount (`abbenay-config` → `/home/abbenay/.config/abbenay`).
+`up.sh` seeds that cache dir from `containers/abbenay/config/` (or legacy
+files) and never chowns the git checkout. The config defines LLM providers and
+models. API keys are injected from environment variables — never committed to
+the config file. To add providers or models, edit the cache `config.yaml` or
+POST via the Gateway admin proxy (`/api/v1/ai/provider/{id}/configure`);
+writes survive Abbenay restarts.
 
 The Abbenay daemon exposes a gRPC API on port 50057. Primary connects to it for AI model listing (`ListAIModels`) and batch remediation requests.
 
@@ -240,7 +242,7 @@ The Settings page (`/settings`) provides a model picker that queries available A
 | `sessions` | `apme-sessions/` | `/sessions` | Primary (rw), Ansible, Collection Health, Dep Audit (ro) | rw / ro |
 | `proxy-cache` | `<cache>/proxy/` | `/cache` | Galaxy Proxy | rw |
 | `gateway-data` | `<cache>/gateway/` | `/data` | Gateway | rw |
-| `abbenay-config` | `containers/abbenay/config/` | `/home/abbenay/.config/abbenay` | Abbenay | rw |
+| `abbenay-config` | `<cache>/abbenay/config/` | `/home/abbenay/.config/abbenay` | Abbenay | rw |
 | `workspace` | CWD (CLI only) | `/workspace` | CLI | rw |
 
 #### Observability (Podman pod only)

--- a/tests/test_podman_up_script.py
+++ b/tests/test_podman_up_script.py
@@ -1,4 +1,4 @@
-"""Regression tests for CA bundle injection in ``containers/podman/up.sh``."""
+"""Regression tests for ``containers/podman/up.sh`` helpers and YAML injection."""
 
 from __future__ import annotations
 
@@ -163,3 +163,25 @@ def test_up_sh_injects_ca_bundle_into_galaxy_proxy() -> None:
     assert (
         f"    - name: galaxy-ca-bundle\n      hostPath:\n        path: {quoted_ca_path}\n        type: File\n"
     ) in rendered
+
+
+def test_up_sh_maps_rootless_acl_from_uid_map() -> None:
+    """Rootless ACL host UID comes from uid_map, with a UID 1001 read probe.
+
+    Rootless Podman maps container UID 0 to the host user and UID 1 onto
+    ``/etc/subuid`` start, so container 1001 is ``subuid_start+1000``. Adding
+    the container UID directly to ``/etc/subuid`` targets the wrong host UID.
+    """
+    script = UP_SH.read_text(encoding="utf-8")
+    helper_start = script.index("_host_uid_for_container_uid() {")
+    helper_end = script.index("\n}\n", helper_start) + 3
+    helper = script[helper_start:helper_end]
+
+    assert "podman unshare awk" in helper
+    assert "/proc/self/uid_map" in helper
+    assert "$2 + uid - $1" in helper
+    assert "start + container_uid" not in helper
+    assert "/etc/subuid" not in helper
+
+    assert "_container_uid_can_read() {" in script
+    assert '_container_uid_can_read "$cuid" "$path/config.yaml"' in script

--- a/tests/test_release_supply_chain.py
+++ b/tests/test_release_supply_chain.py
@@ -111,6 +111,50 @@ def test_python_sbom_builds_into_isolated_output_dir() -> None:
     assert "dist/*.whl" not in content
 
 
+def test_container_workflow_computes_owner_locally_in_supply_chain() -> None:
+    """owner_lc must not cross job outputs (GitHub may skip secret-matching values)."""
+    workflow = yaml.safe_load(CONTAINER_WORKFLOW.read_text(encoding="utf-8"))
+    merge_outputs = workflow["jobs"]["merge-manifests"]["outputs"]
+    assert "owner_lc" not in merge_outputs
+    assert "quay_ns" not in merge_outputs
+
+    supply_steps = workflow["jobs"]["supply-chain"]["steps"]
+    step_ids = [step.get("id", "") for step in supply_steps if isinstance(step, dict)]
+    assert "owner" in step_ids
+    assert "quay-check" in step_ids
+
+    sign_step = next(
+        step
+        for step in supply_steps
+        if isinstance(step, dict) and step.get("name") == "Sign images and generate container SBOMs"
+    )
+    assert sign_step["env"]["OWNER_LC"] == "${{ steps.owner.outputs.lc }}"
+    assert sign_step["env"]["QUAY_ENABLED"] == "${{ steps.quay-check.outputs.enabled }}"
+    assert sign_step["env"]["QUAY_NS"] == "${{ steps.quay-check.outputs.ns }}"
+
+
+def test_container_workflow_quay_namespace_is_repo_variable() -> None:
+    """Quay org is public image path data — must be vars, not secrets.
+
+    If QUAY_NAMESPACE is a secret, subjects.json embeds the masked value and
+    GitHub discards the subjects job output, breaking attest-provenance.
+    """
+    content = CONTAINER_WORKFLOW.read_text(encoding="utf-8")
+    assert "${{ secrets.QUAY_NAMESPACE }}" not in content
+    assert content.count("${{ vars.QUAY_NAMESPACE }}") >= 2
+
+    workflow = yaml.safe_load(content)
+    for job_name in ("merge-manifests", "supply-chain"):
+        quay_check = next(
+            step
+            for step in workflow["jobs"][job_name]["steps"]
+            if isinstance(step, dict) and step.get("id") == "quay-check"
+        )
+        assert quay_check["env"]["QUAY_ORG"] == "${{ vars.QUAY_NAMESPACE }}"
+        assert quay_check["env"]["QUAY_USER"] == "${{ secrets.QUAY_USERNAME }}"
+        assert quay_check["env"]["QUAY_PASS"] == "${{ secrets.QUAY_PASSWORD }}"
+
+
 def test_container_workflow_runs_supply_chain_after_merge() -> None:
     """Published images must be signed and SBOM'd after manifest merge."""
     workflow = yaml.safe_load(CONTAINER_WORKFLOW.read_text(encoding="utf-8"))
@@ -315,6 +359,78 @@ echo '{"bomFormat":"CycloneDX","specVersion":"1.5","version":1,"components":[]}'
     assert sorted(subjects, key=lambda item: item["name"]) == [
         {"name": "ghcr.io/ansible/apme-gateway", "digest": "sha256:bbb222"},
         {"name": "ghcr.io/ansible/apme-primary", "digest": "sha256:aaa111"},
+    ]
+
+
+def test_subjects_json_includes_configured_quay_namespace() -> None:
+    """Configured --quay-ns must appear in provenance subjects for attest matrix."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        bindir = root / "bin"
+        bindir.mkdir()
+        output_dir = root / "sboms"
+        subjects_file = root / "subjects.json"
+        images_file = root / "images.txt"
+        tags_file = root / "tags.txt"
+        images_file.write_text("primary\n", encoding="utf-8")
+        tags_file.write_text("v1.0.0\n", encoding="utf-8")
+
+        docker_stub = """\
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "buildx" && "${2:-}" == "imagetools" && "${3:-}" == "inspect" ]]; then
+  case "${4:-}" in
+    *ghcr.io/*/apme-primary*) echo "sha256:aaa111" ;;
+    *quay.io/private-org/apme-primary*) echo "sha256:ccc333" ;;
+    *)
+      echo "unexpected image ref: ${4:-}" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+echo "unexpected docker invocation: $*" >&2
+exit 1
+"""
+        syft_stub = """\
+#!/usr/bin/env bash
+set -euo pipefail
+echo '{"bomFormat":"CycloneDX","specVersion":"1.5","version":1,"components":[]}'
+"""
+        for name, body in (("docker", docker_stub), ("syft", syft_stub)):
+            script = bindir / name
+            script.write_text(body, encoding="utf-8")
+            script.chmod(0o755)
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"""
+                set -euo pipefail
+                export PATH="{bindir}:$PATH"
+                export SYFT_INSTALL_DIR="{bindir}"
+                export IMAGES_FILE="{images_file}"
+                export SUPPLY_CHAIN_PARALLELISM=1
+                {SUPPLY_CHAIN_SH} \\
+                  --owner ansible \\
+                  --tags-file {tags_file} \\
+                  --output-dir {output_dir} \\
+                  --quay-ns private-org \\
+                  --skip-sign \\
+                  --list-subjects {subjects_file}
+                """,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr or result.stdout
+        subjects = json.loads(subjects_file.read_text(encoding="utf-8"))
+    assert sorted(subjects, key=lambda item: item["name"]) == [
+        {"name": "ghcr.io/ansible/apme-primary", "digest": "sha256:aaa111"},
+        {"name": "quay.io/private-org/apme-primary", "digest": "sha256:ccc333"},
     ]
 
 


### PR DESCRIPTION
## Summary

- Fixes the `container-images` supply-chain job: GitHub Actions can skip `owner_lc` / `quay_ns` job outputs when they match masked secrets, leaving `--owner` empty. The supply-chain job now computes owner and Quay namespace locally (same pattern as merge-manifests signing).
- Moves the public Quay org from `secrets.QUAY_NAMESPACE` to `vars.QUAY_NAMESPACE` so the namespace can appear in `subjects.json` / the `subjects` job output without being discarded (which would break `attest-provenance` matrix expansion). Credentials remain secrets.
- Sets `persist-credentials: false` on the merge-manifests `actions/checkout` (matching supply-chain/attest) so a write-capable `GITHUB_TOKEN` is not left in local git config for `workflow_dispatch` runs (zizmor artipacked).
- Hardens local Podman for nested/rootful hosts: SELinux stub detection, volume UID 1001 chown with a one-time repair marker (`podman unshare touch` when rootless), and `chmod a+rX` after COPY so UID 1001 can read app files on virtiofs.
- Abbenay config: seed from the repo into `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` (`0700`/`0600`); never chown the git checkout. Rootless keeps host ownership and grants UID 1001 a POSIX ACL resolved from the live userns `uid_map` (not `/etc/subuid` + container UID), then probes `config.yaml` as UID 1001; rootful chowns the cache copy to 1001:1001.
- Documents local supply-chain checks via `tox -e release-supply-chain` in `SECURITY.md`.

Split out of #500 so that PR can stay Primary→Engine rename only.

**Ops note:** If `QUAY_NAMESPACE` was configured as a repository secret, move it to a repository/org **variable** (`vars.QUAY_NAMESPACE`). Username/password stay as secrets.

## Test plan

- [x] `tox -e unit -- tests/test_release_supply_chain.py`
- [x] `tox -e unit -- tests/test_podman_up_script.py`
- [x] `bash -n containers/podman/up.sh`
- [x] YAML parse of `.github/workflows/container-images.yml` after persist-credentials change
- [ ] Confirm `container-images` supply-chain job receives non-empty `--owner` on a release/workflow_dispatch run
- [ ] Confirm Quay publish uses `vars.QUAY_NAMESPACE` (not a secret) when dual-publishing
- [ ] On a nested or rootful Podman host: `tox -e build && tox -e up` (volume permission script + Abbenay cache config + Primary container start)
- [ ] On rootless Podman: second `tox -e up` after Abbenay cache exists still succeeds (ACL / no exclusive subuid lockout)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved container image scanning and supply-chain verification for releases.
  * Prevented checkout credentials from persisting in applicable workflows.

* **Bug Fixes**
  * Fixed container file permissions so non-root services can read required application, configuration, and static files.
  * Improved Podman startup handling for SELinux, volume ownership, rootless access, and container readability.
  * Added stronger validation so startup stops when required access or configuration checks fail.

* **Documentation**
  * Updated deployment and security guidance for cache-based configuration storage and automated scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->