### PR TITLE
build(deps): batch Dependabot updates

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -57,15 +57,15 @@ jobs:
       - id: owner
         run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: containers/base/Dockerfile
@@ -96,15 +96,15 @@ jobs:
       - id: owner
         run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ${{ matrix.image.file }}
@@ -153,15 +153,15 @@ jobs:
           QUAY_PASS: ${{ secrets.QUAY_PASSWORD }}
           QUAY_ORG: ${{ vars.QUAY_NAMESPACE }}
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         if: steps.quay-check.outputs.enabled == 'true'
         with:
           registry: ${{ env.QUAY_REGISTRY }}
@@ -170,7 +170,7 @@ jobs:
 
       # Tag list only — image name is a placeholder; merge script applies tags per image.
       - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ steps.owner.outputs.lc }}/apme-gateway
           tags: |
@@ -241,15 +241,15 @@ jobs:
           echo "Consumer tags:"
           cat /tmp/consumer-tags.txt
 
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         if: needs.merge-manifests.outputs.quay_enabled == 'true'
         with:
           registry: ${{ env.QUAY_REGISTRY }}
@@ -336,13 +336,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         if: needs.merge-manifests.outputs.quay_enabled == 'true'
         with:
           registry: ${{ env.QUAY_REGISTRY }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,11 @@ repos:
           - types-PyYAML
           - grpc-stubs
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.25
+    rev: 0.11.27
     hooks:
       - id: uv-lock
   - repo: https://github.com/jsh9/pydoclint
-    rev: 0.9.0
+    rev: 0.9.1
     hooks:
       - id: pydoclint
         args: [--exclude=src/apme/v1/, src/, tests/, scripts/]

--- a/action.yml
+++ b/action.yml
@@ -193,7 +193,7 @@ runs:
     # ── Upload results ────────────────────────────────────────────────
     - name: Upload SARIF to Code Scanning
       if: inputs.sarif == 'true' && steps.scan.outputs.sarif-path != ''
-      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
       with:
         sarif_file: ${{ steps.scan.outputs.sarif-path }}
         category: apme

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,6 @@
         "@types/dagre": "^0.7.52",
         "@types/debounce": "^1.2.4",
         "@types/get-value": "^3.0.5",
-        "@types/js-yaml": "^4.0.9",
         "@types/luxon": "^3.7.2",
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.0",
@@ -1343,12 +1342,6 @@
       "dependencies": {
         "@types/unist": "*"
       }
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true
     },
     "node_modules/@types/luxon": {
       "version": "3.7.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,10 +14,10 @@
         "@ansible/ansible-ui-framework": "file:./vendor/ansible-ui-framework",
         "@apme/ui-workflow": "workspace:*",
         "@patternfly/patternfly": "6.3.1",
-        "@patternfly/react-charts": "8.5.1",
+        "@patternfly/react-charts": "8.6.0",
         "@patternfly/react-core": "6.5.1",
         "@patternfly/react-icons": "6.5.1",
-        "@patternfly/react-table": "6.5.1",
+        "@patternfly/react-table": "6.6.0",
         "@react-hook/resize-observer": "^2.0.2",
         "d3": "^7.9.0",
         "dagre": "^0.8.5",
@@ -28,7 +28,7 @@
         "react-i18next": "^17.0.11",
         "react-router": "^8.3.0",
         "react-syntax-highlighter": "^16.1.1",
-        "styled-components": "^6.1.13",
+        "styled-components": "^6.4.3",
         "swr": "^2.2.5",
         "undici": "7.28.0"
       },
@@ -50,7 +50,7 @@
         "debounce": "^3.0.0",
         "fast-deep-equal": "^3.1.3",
         "get-value": "^4.1.0",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^5.2.1",
         "jsdom": "^29.0.1",
         "luxon": "^3.7.2",
         "p-limit": "^7.3.0",
@@ -59,7 +59,7 @@
         "typescript": "^5.7.2",
         "vite": "^8.2.0",
         "vitest": "^4.1.9",
-        "zustand": "^5.0.12"
+        "zustand": "^5.0.14"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -417,13 +417,13 @@
       "integrity": "sha512-O/lTo5EHKzer/HNzqMQOQEAMG7izDDkEHpAeJ5+sGaeQ/maB3RK7sQsOPS4DjrnMxt4/cC6LogK2mowlbf1j5Q=="
     },
     "node_modules/@patternfly/react-charts": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-8.5.1.tgz",
-      "integrity": "sha512-3PUeicoG1dAcAP0TW425H0rPML3MP3DHkWH4WkguOLQgmpgRfDdRWa+ePKc2K7U1cOLl8hpQm1CVMhyamePBQw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-8.6.0.tgz",
+      "integrity": "sha512-ReHg/zwPlPjP78RbjurbhHxA4BrAZnj3Z0OjBp9wLZTq3dX78d/uHW+BeEHOYT4NJwSbHfLbW/cqxhJQ4dzLLg==",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-styles": "^6.5.1",
-        "@patternfly/react-tokens": "^6.5.1",
+        "@patternfly/react-styles": "^6.6.0",
+        "@patternfly/react-tokens": "^6.6.0",
         "hoist-non-react-statics": "^3.3.2",
         "lodash": "^4.17.23",
         "tslib": "^2.8.1"
@@ -542,15 +542,15 @@
       "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.5.1.tgz",
-      "integrity": "sha512-JpX66ctLsg5snRRheDhuF2fHvXDG4UDKYfP5403kCAQ4Dz2dPu3PhlHi4AJol+egEBD2HfS/U37j7noQ1Y7mpA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.6.0.tgz",
+      "integrity": "sha512-aOVSAbtXagey1xRI8oIkK3I/csh6S00p42qqOkh6G1s5vMZM7oVQH/Nvvq8gIwx4lZ3f1m7IkdD7My8nml0Bsw==",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-core": "^6.5.1",
-        "@patternfly/react-icons": "^6.5.1",
-        "@patternfly/react-styles": "^6.5.1",
-        "@patternfly/react-tokens": "^6.5.1",
+        "@patternfly/react-core": "^6.6.0",
+        "@patternfly/react-icons": "^6.6.0",
+        "@patternfly/react-styles": "^6.6.0",
+        "@patternfly/react-tokens": "^6.6.0",
         "lodash": "^4.18.1",
         "tslib": "^2.8.1"
       },
@@ -2559,9 +2559,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "dev": true,
       "funding": [
         {
@@ -2578,7 +2578,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsdom": {
@@ -3530,9 +3530,9 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.2.tgz",
-      "integrity": "sha512-xZBhBJsMtGqb+aKcwKgaT+BtuFums9VynX2JRvXJGTx5UfZzN12rk5r4nVdhXYvRw+hE7yiYxVrOqJZaK2+Txg==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.3.tgz",
+      "integrity": "sha512-wYXrhu+JmDjZ1Tv7O0OopGTfztbzun43Pjjhh2H+xc0h5A09dwpZ5FJbrifJDcL8g5TA9btpWOX2+iSRuJTExw==",
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
@@ -4021,10 +4021,11 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
-      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
       },
@@ -4051,7 +4052,7 @@
     },
     "packages/ui-workflow": {
       "name": "@apme/ui-workflow",
-      "version": "0.1.1",
+      "version": "0.0.0-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,10 +18,10 @@
     "@ansible/ansible-ui-framework": "file:./vendor/ansible-ui-framework",
     "@apme/ui-workflow": "workspace:*",
     "@patternfly/patternfly": "6.3.1",
-    "@patternfly/react-charts": "8.5.1",
+    "@patternfly/react-charts": "8.6.0",
     "@patternfly/react-core": "6.5.1",
     "@patternfly/react-icons": "6.5.1",
-    "@patternfly/react-table": "6.5.1",
+    "@patternfly/react-table": "6.6.0",
     "@react-hook/resize-observer": "^2.0.2",
     "d3": "^7.9.0",
     "dagre": "^0.8.5",
@@ -32,7 +32,7 @@
     "react-i18next": "^17.0.11",
     "react-router": "^8.3.0",
     "react-syntax-highlighter": "^16.1.1",
-    "styled-components": "^6.1.13",
+    "styled-components": "^6.4.3",
     "swr": "^2.2.5",
     "undici": "7.28.0"
   },
@@ -54,7 +54,7 @@
     "debounce": "^3.0.0",
     "fast-deep-equal": "^3.1.3",
     "get-value": "^4.1.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^5.2.1",
     "jsdom": "^29.0.1",
     "luxon": "^3.7.2",
     "p-limit": "^7.3.0",
@@ -63,7 +63,7 @@
     "typescript": "^5.7.2",
     "vite": "^8.2.0",
     "vitest": "^4.1.9",
-    "zustand": "^5.0.12"
+    "zustand": "^5.0.14"
   },
   "overrides": {
     "undici": "7.28.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,6 @@
     "@types/dagre": "^0.7.52",
     "@types/debounce": "^1.2.4",
     "@types/get-value": "^3.0.5",
-    "@types/js-yaml": "^4.0.9",
     "@types/luxon": "^3.7.2",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.0",

--- a/frontend/vendor/ansible-ui-framework/PageForm/Inputs/PageFormDataEditor.tsx
+++ b/frontend/vendor/ansible-ui-framework/PageForm/Inputs/PageFormDataEditor.tsx
@@ -2,7 +2,7 @@ import { Flex, FlexItem, Icon, ToggleGroup, ToggleGroupItem } from '@patternfly/
 import { CopyIcon, DownloadIcon, UploadIcon } from '@patternfly/react-icons';
 import isDeepEqual from 'fast-deep-equal';
 import getValue from 'get-value';
-import jsyaml, { YAMLException } from 'js-yaml';
+import { load, YAMLException } from 'js-yaml';
 import { ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { parseJSONPreservingLargeInts, stringifyPreservingLargeInts } from '../../utils/jsonUtils';
 import { safeDump, safeLoad } from '../../utils/yamlSchema';
@@ -228,7 +228,7 @@ export function PageFormDataEditor<
                   '__preserveYamlString' in valueAsObject
                 ) {
                   const preservedObj = valueAsObject as { __preserveYamlString: string };
-                  const actualObject = jsyaml.load(preservedObj.__preserveYamlString) as object;
+                  const actualObject = load(preservedObj.__preserveYamlString) as object;
                   onChange(actualObject);
                   return;
                 }

--- a/frontend/vendor/ansible-ui-framework/utils/codeEditorUtils.ts
+++ b/frontend/vendor/ansible-ui-framework/utils/codeEditorUtils.ts
@@ -1,4 +1,4 @@
-import jsyaml from 'js-yaml';
+import { dump, load } from 'js-yaml';
 
 export function jsonToYaml(jsonString: string) {
   if (jsonString.trim() === '') {
@@ -8,7 +8,7 @@ export function jsonToYaml(jsonString: string) {
   if (Object.entries(value).length === 0) {
     return '';
   }
-  return jsyaml.dump(value);
+  return dump(value);
 }
 export function isJsonString(jsonString: unknown) {
   if (typeof jsonString !== 'string') {
@@ -24,7 +24,7 @@ export function isJsonString(jsonString: unknown) {
   return typeof value === 'object' && value !== null;
 }
 export function yamlToJson(yamlString: string) {
-  const value: object = jsyaml.load(yamlString) as object;
+  const value: object = load(yamlString) as object;
   if (!value) {
     return '{}';
   }

--- a/frontend/vendor/ansible-ui-framework/utils/yamlSchema.ts
+++ b/frontend/vendor/ansible-ui-framework/utils/yamlSchema.ts
@@ -1,4 +1,4 @@
-import jsyaml from 'js-yaml';
+import { dump, load } from 'js-yaml';
 
 const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
 
@@ -59,7 +59,7 @@ export function safeLoad(input: string): unknown {
     }
   );
 
-  return jsyaml.load(processedYaml);
+  return load(processedYaml);
 }
 
 /**
@@ -88,7 +88,7 @@ export function safeLoad(input: string): unknown {
  * ```
  */
 export function safeDump(obj: unknown): string {
-  let yaml = jsyaml.dump(obj);
+  let yaml = dump(obj);
 
   const STRING_INT_PATTERN = /['"](-?\d{17,})['"]/g;
 


### PR DESCRIPTION
## Summary

Consolidates all 12 open Dependabot PRs into a single reviewable changeset:

- **GitHub Actions:** `docker/build-push-action` 7.3.0, `docker/login-action` 4.4.0, `docker/setup-buildx-action` 4.2.0, `docker/metadata-action` 6.2.0, `github/codeql-action/upload-sarif` 4.36.3
- **pre-commit:** `uv-pre-commit` 0.11.27, `pydoclint` 0.9.1
- **frontend npm:** `@patternfly/react-charts` 8.6.0, `@patternfly/react-table` 6.6.0, `styled-components` 6.4.3, `js-yaml` 5.2.1, `zustand` 5.0.14

Also updates vendored `ansible-ui-framework` consumers to use `js-yaml` named imports (`load`/`dump`) for v5 TypeScript compatibility and removes the redundant `@types/js-yaml` devDependency.

Closes #513
Closes #514
Closes #515
Closes #516
Closes #517
Closes #518
Closes #519
Closes #520
Closes #521
Closes #522
Closes #523
Closes #524

## Test plan

- [x] `tox -e lint`
- [x] CI green on PR (prek, test, ui)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend libraries to newer versions for improved compatibility, stability, and maintainability.
  * Refreshed automated code-quality and security tooling used during development and delivery.
  * Updated container build and publishing tools while preserving existing workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->