### PR TITLE
fix(galaxy): temporarily ignore TLS certs for Hub downloads

### DIFF
--- a/src/galaxy_proxy/collection_downloader.py
+++ b/src/galaxy_proxy/collection_downloader.py
@@ -69,7 +69,9 @@ def write_temp_ansible_cfg(
 
     The generated config uses a ``[galaxy]`` section with ``server_list``
     pointing to per-server ``[galaxy_server.<name>]`` sections — the same
-    format ``ansible-galaxy`` reads natively.
+    format ``ansible-galaxy`` reads natively.  It currently also sets
+    ``ignore_certs = true`` so private Hub installs work with self-signed
+    certificates (temporary; should become configurable).
 
     Args:
         servers: Ordered list of Galaxy server configurations.
@@ -96,6 +98,9 @@ def write_temp_ansible_cfg(
 
     cfg.add_section("galaxy")
     cfg.set("galaxy", "server_list", ",".join(server_names))
+    # Temporary: allow Hub/Galaxy pulls against self-signed lab CAs.
+    # Track making this configurable: do not leave always-on for production trust models.
+    cfg.set("galaxy", "ignore_certs", "true")
 
     for srv in servers:
         section = f"galaxy_server.{srv.name}"
@@ -261,6 +266,9 @@ async def download_collections(
     status = "error"
 
     try:
+        # Temporary default: ansible-galaxy must reach private Hub with self-signed TLS.
+        # Prefer an explicit operator override when present.
+        env.setdefault("ANSIBLE_GALAXY_IGNORE", "true")
         if servers:
             try:
                 _inject_galaxy_env(env, servers)

--- a/src/galaxy_proxy/collection_downloader.py
+++ b/src/galaxy_proxy/collection_downloader.py
@@ -99,7 +99,7 @@ def write_temp_ansible_cfg(
     cfg.add_section("galaxy")
     cfg.set("galaxy", "server_list", ",".join(server_names))
     # Temporary: allow Hub/Galaxy pulls against self-signed lab CAs.
-    # Track making this configurable: do not leave always-on for production trust models.
+    # CA bundle injection is too hard in the current lab path; flip via #526.
     cfg.set("galaxy", "ignore_certs", "true")
 
     for srv in servers:
@@ -266,9 +266,11 @@ async def download_collections(
     status = "error"
 
     try:
-        # Temporary default: ansible-galaxy must reach private Hub with self-signed TLS.
-        # Prefer an explicit operator override when present.
-        env.setdefault("ANSIBLE_GALAXY_IGNORE", "true")
+        # Temporary lab default for Hub/self-signed TLS. Env vars outrank INI, so
+        # only inject when the caller did not supply ansible.cfg (their
+        # galaxy.ignore_certs must win). Track flipping the default: #526.
+        if ansible_cfg_path is None:
+            env.setdefault("ANSIBLE_GALAXY_IGNORE", "true")
         if servers:
             try:
                 _inject_galaxy_env(env, servers)

--- a/tests/test_collection_downloader.py
+++ b/tests/test_collection_downloader.py
@@ -61,6 +61,7 @@ class TestWriteTempAnsibleCfg:
         parser = configparser.ConfigParser()
         parser.read(cfg_path)
         assert parser.get("galaxy", "server_list") == "galaxy"
+        assert parser.get("galaxy", "ignore_certs") == "true"
         assert parser.get("galaxy_server.galaxy", "url") == "https://galaxy.ansible.com"
 
     def test_multiple_servers_with_auth(self, tmp_path: Path) -> None:
@@ -337,6 +338,7 @@ class TestDownloadCollections:
             )
 
         assert captured_env.get("ANSIBLE_CONFIG") == str(cfg_path)
+        assert captured_env.get("ANSIBLE_GALAXY_IGNORE") == "true"
 
     @pytest.mark.asyncio  # type: ignore[untyped-decorator]
     async def test_uses_servers_injects_env_vars(self, tmp_path: Path) -> None:
@@ -371,6 +373,7 @@ class TestDownloadCollections:
         assert captured_env.get("ANSIBLE_GALAXY_SERVER_LIST") == "hub"
         assert captured_env.get("ANSIBLE_GALAXY_SERVER_HUB_URL") == "https://hub.example.com"
         assert captured_env.get("ANSIBLE_GALAXY_SERVER_HUB_TOKEN") == "tok"
+        assert captured_env.get("ANSIBLE_GALAXY_IGNORE") == "true"
         assert "ANSIBLE_CONFIG" not in captured_env
 
     @pytest.mark.asyncio  # type: ignore[untyped-decorator]

--- a/tests/test_collection_downloader.py
+++ b/tests/test_collection_downloader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import configparser
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -330,7 +331,11 @@ class TestDownloadCollections:
                 captured_env.update(env)
             return mock_process
 
-        with patch("galaxy_proxy.collection_downloader.asyncio.create_subprocess_exec", side_effect=capture_exec):
+        with (
+            patch("galaxy_proxy.collection_downloader.asyncio.create_subprocess_exec", side_effect=capture_exec),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop("ANSIBLE_GALAXY_IGNORE", None)
             await download_collections(
                 ["a.b"],
                 download_dir,
@@ -338,7 +343,8 @@ class TestDownloadCollections:
             )
 
         assert captured_env.get("ANSIBLE_CONFIG") == str(cfg_path)
-        assert captured_env.get("ANSIBLE_GALAXY_IGNORE") == "true"
+        # Env would override the caller's INI galaxy.ignore_certs — do not inject.
+        assert "ANSIBLE_GALAXY_IGNORE" not in captured_env
 
     @pytest.mark.asyncio  # type: ignore[untyped-decorator]
     async def test_uses_servers_injects_env_vars(self, tmp_path: Path) -> None:
@@ -363,7 +369,11 @@ class TestDownloadCollections:
                 captured_env.update(env)
             return mock_process
 
-        with patch("galaxy_proxy.collection_downloader.asyncio.create_subprocess_exec", side_effect=capture_exec):
+        with (
+            patch("galaxy_proxy.collection_downloader.asyncio.create_subprocess_exec", side_effect=capture_exec),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop("ANSIBLE_GALAXY_IGNORE", None)
             await download_collections(
                 ["a.b"],
                 download_dir,


### PR DESCRIPTION
## Summary

Private Automation Hub collection downloads were failing TLS verification against self-signed lab AAP certs, so scans missed Hub-backed dependencies. This temporarily defaults Galaxy downloads to ignore cert verification so Hub pulls succeed.

**Why default-ignore stays:** loading CA certs into the pod is too hard in the current lab path. Flip later via #526.

## Changes

- Set `ignore_certs = true` on generated temp `ansible.cfg`
- Default `ANSIBLE_GALAXY_IGNORE=true` for `ansible-galaxy collection download` when no caller `ansible_cfg_path` is supplied (env would otherwise override INI)
- Preserve an explicit caller `ansible.cfg` `galaxy.ignore_certs` setting

## Follow-up

Tracked in #526 — make ignore-certs opt-in / config-driven and prefer CA-bundle trust for production.

## Test plan

- [x] Confirmed on `apme-ea` that `ANSIBLE_GALAXY_IGNORE=true` allows `ansible-galaxy collection download` against Hub with a self-signed cert
- [x] Unit coverage for generated `ansible.cfg` `ignore_certs`
- [x] Unit coverage: env default when no `ansible_cfg_path`; no inject when `ansible_cfg_path` is set
- [x] `tox -e lint` / `tox -e unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection downloads now work with servers using self-signed certificates by default.
  * Generated Ansible configuration automatically enables certificate verification bypass for Galaxy downloads.
  * Existing `ANSIBLE_GALAXY_IGNORE` environment settings are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->