### PR TITLE
fix(podman): grant ancestor traversal ACLs for rootless Abbenay config

### DIFF
--- a/containers/podman/down.sh
+++ b/containers/podman/down.sh
@@ -59,4 +59,36 @@ if [[ "${1:-}" == "--wipe" ]]; then
   else
     echo "No Abbenay secrets.json found at $ABBENAY_SECRETS"
   fi
+
+  # Revoke traversal ACLs granted on $HOME ancestors for rootless Abbenay
+  # config access (see up.sh _grant_ancestor_traversal / #528).
+  if command -v podman >/dev/null 2>&1 && command -v setfacl >/dev/null 2>&1; then
+    _host_uid_for_container_uid() {
+      local cuid="$1"
+      local mapped
+      mapped=$(podman unshare awk -v cuid="$cuid" '
+        BEGIN { found = 0 }
+        {
+          inside_ns = $1; count = $2; outside_ns = $3
+          if (cuid >= inside_ns && cuid < inside_ns + count) {
+            print outside_ns + (cuid - inside_ns)
+            found = 1
+            exit
+          }
+        }
+        END { exit !found }
+      ' /proc/self/uid_map) || return 1
+      echo "$mapped"
+    }
+    mapped=$(_host_uid_for_container_uid 1001 2>/dev/null) || mapped=""
+    if [[ -n "$mapped" ]]; then
+      home_real=$(cd "$HOME" && pwd -P)
+      for dir in "$home_real" "${XDG_CACHE_HOME:-$HOME/.cache}"; do
+        if getfacl -p "$dir" 2>/dev/null | grep -q "^user:${mapped}:"; then
+          setfacl -x "u:${mapped}" "$dir" 2>/dev/null && \
+            echo "Revoked traversal ACL for UID $mapped on $dir"
+        fi
+      done
+    fi
+  fi
 fi

--- a/containers/podman/down.sh
+++ b/containers/podman/down.sh
@@ -69,7 +69,7 @@ if [[ "${1:-}" == "--wipe" ]]; then
       mapped=$(podman unshare awk -v cuid="$cuid" '
         BEGIN { found = 0 }
         {
-          inside_ns = $1; count = $2; outside_ns = $3
+          inside_ns = $1; outside_ns = $2; count = $3
           if (cuid >= inside_ns && cuid < inside_ns + count) {
             print outside_ns + (cuid - inside_ns)
             found = 1
@@ -82,13 +82,17 @@ if [[ "${1:-}" == "--wipe" ]]; then
     }
     mapped=$(_host_uid_for_container_uid 1001 2>/dev/null) || mapped=""
     if [[ -n "$mapped" ]]; then
-      home_real=$(cd "$HOME" && pwd -P)
-      for dir in "$home_real" "${XDG_CACHE_HOME:-$HOME/.cache}"; do
-        if getfacl -p "$dir" 2>/dev/null | grep -q "^user:${mapped}:"; then
-          setfacl -x "u:${mapped}" "$dir" 2>/dev/null && \
-            echo "Revoked traversal ACL for UID $mapped on $dir"
-        fi
-      done
+      local state_file="${APME_CACHE_HOST_PATH:-${XDG_CACHE_HOME:-$HOME/.cache}/apme}/.traversal-acls"
+      if [[ -f "$state_file" ]]; then
+        while IFS= read -r dir; do
+          [[ -n "$dir" ]] || continue
+          if getfacl -p "$dir" 2>/dev/null | grep -q "^user:${mapped}:"; then
+            setfacl -x "u:${mapped}" "$dir" 2>/dev/null && \
+              echo "Revoked traversal ACL for UID $mapped on $dir"
+          fi
+        done < "$state_file"
+        rm -f "$state_file"
+      fi
     fi
   fi
 fi

--- a/containers/podman/down.sh
+++ b/containers/podman/down.sh
@@ -9,6 +9,59 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
+# Host UID for a container UID (rootless uid_map: ns_uid host_uid count).
+_host_uid_for_container_uid() {
+  local cuid="$1"
+  local mapped
+  mapped=$(podman unshare awk -v cuid="$cuid" '
+    BEGIN { found = 0 }
+    {
+      inside_ns = $1; outside_ns = $2; count = $3
+      if (cuid >= inside_ns && cuid < inside_ns + count) {
+        print outside_ns + (cuid - inside_ns)
+        found = 1
+        exit
+      }
+    }
+    END { exit !found }
+  ' /proc/self/uid_map) || return 1
+  echo "$mapped"
+}
+
+# Revoke traversal ACLs recorded by up.sh. Keep the state file (and fail) if
+# any entry still has the mapped-UID ACL after this pass.
+_revoke_traversal_acls() {
+  local state_file="$1"
+  local mapped="$2"
+  local dir acl failed=0 tmp
+  tmp="${state_file}.tmp"
+  : > "$tmp"
+  while IFS= read -r dir; do
+    [[ -n "$dir" ]] || continue
+    if ! acl=$(getfacl -np "$dir" 2>/dev/null); then
+      echo "ERROR: could not read ACL on $dir" >&2
+      printf '%s\n' "$dir" >> "$tmp"
+      failed=1
+      continue
+    fi
+    if ! grep -q "^user:${mapped}:" <<<"$acl"; then
+      continue
+    fi
+    if setfacl -x "u:${mapped}" "$dir" 2>/dev/null; then
+      echo "Revoked traversal ACL for UID $mapped on $dir"
+    else
+      echo "ERROR: could not revoke traversal ACL for UID $mapped on $dir" >&2
+      printf '%s\n' "$dir" >> "$tmp"
+      failed=1
+    fi
+  done < "$state_file"
+  if (( failed )); then
+    mv "$tmp" "$state_file"
+    return 1
+  fi
+  rm -f "$tmp" "$state_file"
+}
+
 echo "Stopping apme-pod..."
 podman pod stop apme-pod 2>/dev/null || true
 podman pod rm  apme-pod 2>/dev/null || true
@@ -62,36 +115,15 @@ if [[ "${1:-}" == "--wipe" ]]; then
 
   # Revoke traversal ACLs granted on $HOME ancestors for rootless Abbenay
   # config access (see up.sh _grant_ancestor_traversal / #528).
-  if command -v podman >/dev/null 2>&1 && command -v setfacl >/dev/null 2>&1; then
-    _host_uid_for_container_uid() {
-      local cuid="$1"
-      local mapped
-      mapped=$(podman unshare awk -v cuid="$cuid" '
-        BEGIN { found = 0 }
-        {
-          inside_ns = $1; outside_ns = $2; count = $3
-          if (cuid >= inside_ns && cuid < inside_ns + count) {
-            print outside_ns + (cuid - inside_ns)
-            found = 1
-            exit
-          }
-        }
-        END { exit !found }
-      ' /proc/self/uid_map) || return 1
-      echo "$mapped"
-    }
+  if command -v podman >/dev/null 2>&1 \
+    && command -v setfacl >/dev/null 2>&1 \
+    && command -v getfacl >/dev/null 2>&1; then
     mapped=$(_host_uid_for_container_uid 1001 2>/dev/null) || mapped=""
-    if [[ -n "$mapped" ]]; then
-      local state_file="${APME_CACHE_HOST_PATH:-${XDG_CACHE_HOME:-$HOME/.cache}/apme}/.traversal-acls"
-      if [[ -f "$state_file" ]]; then
-        while IFS= read -r dir; do
-          [[ -n "$dir" ]] || continue
-          if getfacl -p "$dir" 2>/dev/null | grep -q "^user:${mapped}:"; then
-            setfacl -x "u:${mapped}" "$dir" 2>/dev/null && \
-              echo "Revoked traversal ACL for UID $mapped on $dir"
-          fi
-        done < "$state_file"
-        rm -f "$state_file"
+    state_file="$CACHE_PATH/.traversal-acls"
+    if [[ -n "$mapped" && -f "$state_file" ]]; then
+      if ! _revoke_traversal_acls "$state_file" "$mapped"; then
+        echo "ERROR: traversal ACL cleanup incomplete; kept $state_file" >&2
+        exit 1
       fi
     fi
   fi

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -247,7 +247,8 @@ _grant_ancestor_traversal() {
       continue
     fi
     # Skip if the mapped UID already has effective execute via ACL.
-    if getfacl -ep "$dir" 2>/dev/null | grep -q "^user:${mapped_uid}:.*x"; then
+    # -e: effective perms (ACL mask); -n: numeric UID so name lookup cannot miss.
+    if getfacl -enp "$dir" 2>/dev/null | grep -q "^user:${mapped_uid}:.*x"; then
       continue
     fi
     setfacl -m "u:${mapped_uid}:x" "$dir" || {

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -224,7 +224,7 @@ _grant_ancestor_traversal() {
   target_path=$(realpath -m "$target_path")
   # If the target is outside $HOME, the container accesses it via a Podman
   # volume mount — no host-filesystem traversal ACLs are needed.
-  if [[ "$target_path" != "$home_real"* ]]; then
+  if [[ "$target_path" != "$home_real" && "$target_path" != "$home_real"/* ]]; then
     return 0
   fi
   local current
@@ -246,13 +246,16 @@ _grant_ancestor_traversal() {
     if (( (8#$perms & 8#001) != 0 )); then
       continue
     fi
-    # Skip if the mapped UID already has an ACL entry with 'x'.
-    if getfacl -p "$dir" 2>/dev/null | grep -q "^user:${mapped_uid}:.*x"; then
+    # Skip if the mapped UID already has effective execute via ACL.
+    if getfacl -ep "$dir" 2>/dev/null | grep -q "^user:${mapped_uid}:.*x"; then
       continue
     fi
     setfacl -m "u:${mapped_uid}:x" "$dir" || {
       echo "WARNING: could not grant traversal ACL on $dir for UID $mapped_uid" >&2
+      return 1
     }
+    # Record for later revocation by down.sh --wipe.
+    echo "$dir" >> "${APME_TRAVERSAL_STATE_FILE:-/dev/null}"
   done
 }
 
@@ -302,7 +305,7 @@ _ensure_abbenay_config_access() {
     # config path so the subordinate UID can reach the target.  Without this,
     # hosts with mode 700 on $HOME or $HOME/.cache block access at the first
     # path component (see #528).
-    _grant_ancestor_traversal "$mapped" "$path"
+    _grant_ancestor_traversal "$mapped" "$path" || return 1
     setfacl -m "u:${mapped}:rwx" "$path" || return 1
     setfacl -d -m "u:${mapped}:rwx" "$path" || return 1
     if [[ -f "$path/config.yaml" ]]; then
@@ -415,6 +418,7 @@ _relabel_podman_volumes() {
 
 # Default: XDG cache dir (persists across reboots); override with APME_CACHE_HOST_PATH
 CACHE_PATH="${APME_CACHE_HOST_PATH:-${XDG_CACHE_HOME:-$HOME/.cache}/apme}"
+APME_TRAVERSAL_STATE_FILE="$CACHE_PATH/.traversal-acls"
 
 if [[ "$CACHE_PATH" != /* ]]; then
   echo "ERROR: APME_CACHE_HOST_PATH must be an absolute path (got: $CACHE_PATH)" >&2
@@ -427,6 +431,8 @@ if [[ "$CACHE_PATH" == *$'\n'* ]]; then
 fi
 
 mkdir -p "$CACHE_PATH"
+# Reset traversal state for this run; down.sh --wipe reads this to undo ACLs.
+: > "$APME_TRAVERSAL_STATE_FILE"
 
 # Load Abbenay secrets (.env) if present.
 ABBENAY_ENV="$ROOT/containers/abbenay/.env"

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -212,6 +212,50 @@ with open(path, "rb"):
 ' "$container_uid" "$path"
 }
 
+# Grant execute-only (traversal) ACL to a mapped UID on each ancestor directory
+# between $HOME and the given path that lacks world-execute or an existing ACL
+# for that UID.  Prevents EACCES on mode-700 home directories (#528).
+# Only grants 'x' — never read or write — to minimise exposure.
+_grant_ancestor_traversal() {
+  local mapped_uid="$1"
+  local target_path="$2"
+  local home_real
+  home_real=$(cd "$HOME" && pwd -P)
+  target_path=$(realpath -m "$target_path")
+  # If the target is outside $HOME, the container accesses it via a Podman
+  # volume mount — no host-filesystem traversal ACLs are needed.
+  if [[ "$target_path" != "$home_real"* ]]; then
+    return 0
+  fi
+  local current
+  current=$(dirname "$target_path")
+  local -a ancestors=()
+  # Walk up from the target's parent to (and including) $HOME.
+  while [[ "$current" != "/" && "$current" != "$home_real" ]]; do
+    ancestors=("$current" "${ancestors[@]}")
+    current=$(dirname "$current")
+  done
+  # Include $HOME itself at the front.
+  if [[ "$current" == "$home_real" ]]; then
+    ancestors=("$home_real" "${ancestors[@]}")
+  fi
+  for dir in "${ancestors[@]}"; do
+    # Skip if world-executable — traversal already possible.
+    local perms
+    perms=$(stat -c '%a' "$dir" 2>/dev/null) || continue
+    if (( (8#$perms & 8#001) != 0 )); then
+      continue
+    fi
+    # Skip if the mapped UID already has an ACL entry with 'x'.
+    if getfacl -p "$dir" 2>/dev/null | grep -q "^user:${mapped_uid}:.*x"; then
+      continue
+    fi
+    setfacl -m "u:${mapped_uid}:x" "$dir" || {
+      echo "WARNING: could not grant traversal ACL on $dir for UID $mapped_uid" >&2
+    }
+  done
+}
+
 # Make Abbenay cache config usable by the host user and container UID 1001.
 # Rootless: keep host ownership; grant a POSIX ACL to the subordinate UID so
 # the next tox -e up can still chmod/seed and developers can edit config.yaml.
@@ -254,6 +298,11 @@ _ensure_abbenay_config_access() {
       echo "ERROR: could not resolve subordinate UID for container UID $cuid" >&2
       return 1
     }
+    # Grant execute-only traversal on ancestor directories between $HOME and the
+    # config path so the subordinate UID can reach the target.  Without this,
+    # hosts with mode 700 on $HOME or $HOME/.cache block access at the first
+    # path component (see #528).
+    _grant_ancestor_traversal "$mapped" "$path"
     setfacl -m "u:${mapped}:rwx" "$path" || return 1
     setfacl -d -m "u:${mapped}:rwx" "$path" || return 1
     if [[ -f "$path/config.yaml" ]]; then


### PR DESCRIPTION
## Summary

On hosts with mode-700 home directories (Fedora `useradd` default), the rootless container UID is blocked at `$HOME` before it can reach the Abbenay config cache. Grant execute-only POSIX ACLs on ancestor directories between `$HOME` and that cache, and revoke those ACLs on `down.sh --wipe`.

Closes #528.

## Changes

- `up.sh`: `_grant_ancestor_traversal()` walks `$HOME` → config path, skips world-executable dirs and existing effective `x` ACLs, records granted paths in `$CACHE_PATH/.traversal-acls`.
- Path check uses a component boundary (does not treat `/home/alice-other` as inside `/home/alice`).
- `down.sh --wipe`: revoke only ACLs listed in that state file. Fail and keep the file if `getfacl`/`setfacl` cannot drop an entry. No top-level `local` (that aborted `--wipe` under `set -e`).
- Numeric `getfacl -n` so UID matching does not depend on name lookup.

## Test plan

- [x] `bash -n containers/podman/up.sh containers/podman/down.sh`
- [x] `tox -e lint -- --skip skillmark`
- [x] `tox -e unit`
- [ ] Manual: Fedora/rootless host with `chmod 700 $HOME`; `tox -e up` then confirm container UID 1001 can read Abbenay config; `tox -e down -- --wipe` removes recorded traversal ACLs
