### PR TITLE
chore(helm): pin APME 2026.8.6 and Abbenay v2026.8.2

### DIFF
--- a/containers/podman/build.sh
+++ b/containers/podman/build.sh
@@ -16,7 +16,7 @@ echo "==> Building base image (shared dependencies)..."
 podman build "${BUILD_ARGS[@]}" -t localhost/apme-base:latest -f containers/base/Dockerfile .
 
 echo "==> Pulling Abbenay AI image..."
-podman pull ghcr.io/redhat-developer/abbenay:v2026.8.1
+podman pull ghcr.io/redhat-developer/abbenay:v2026.8.2
 
 echo "==> Building service images..."
 podman build "${BUILD_ARGS[@]}" -t apme-primary:latest -f containers/primary/Dockerfile .

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -216,7 +216,7 @@ spec:
         - containerPort: 8081
           hostPort: 8081
     - name: abbenay
-      image: ghcr.io/redhat-developer/abbenay:v2026.8.1
+      image: ghcr.io/redhat-developer/abbenay:v2026.8.2
       # ADR-070: HTTP + gRPC on loopback (pod-shared netns). No hostPort for
       # Abbenay — matches Helm Simple and avoids plaintext host exposure.
       args:

--- a/deploy/helm/apme/Chart.yaml
+++ b/deploy/helm/apme/Chart.yaml
@@ -3,11 +3,11 @@ name: apme
 description: Ansible Policy & Modernization Engine — policy enforcement and modernization for Ansible content
 type: application
 # Chart semver — bump whenever the packaged chart changes (templates, values, deps).
-version: 0.1.3
+version: 0.1.4
 # Must match image.tag in values.yaml (CalVer release tag without leading "v",
-# e.g. git tag v2026.7.3 → image tag 2026.7.3). Empty image.tag falls back to
+# e.g. git tag v2026.8.6 → image tag 2026.8.6). Empty image.tag falls back to
 # this field via the apme.image helper.
-appVersion: "2026.7.3"
+appVersion: "2026.8.6"
 home: https://github.com/ansible/apme
 icon: https://raw.githubusercontent.com/ansible/apme/main/docs/images/apme.png
 sources:

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -37,7 +37,7 @@ Replace `route.host` with a hostname under your cluster's OpenShift
 ingress domain (for example `apme.apps.<cluster-domain>`) before installing —
 `example.com` will not resolve.
 
-Defaults pull from `quay.io/ansible` with image tag `2026.7.3` (`Chart.appVersion`).
+Defaults pull from `quay.io/ansible` with image tag `2026.8.6` (`Chart.appVersion`).
 For unreleased SHA builds, set `--set image.tag=sha-<commit>`.
 
 > **Observability:** The reference Podman pod includes an OpenTelemetry Collector
@@ -82,7 +82,7 @@ spec:
 - Helm 3.x
 - Access to `quay.io/ansible` (default pull registry) or a mirror. CI always
   publishes to `ghcr.io/ansible` and publishes to Quay when credentials are set
-- Default image tag is pinned to `2026.7.3` (GitHub release `v2026.7.3`; must
+- Default image tag is pinned to `2026.8.6` (GitHub release `v2026.8.6`; must
   match Chart.appVersion). Override with `--set image.tag=…` for another
   release or a SHA build (e.g. `sha-b7d1683`)
 - Cluster nodes on `linux/amd64` or `linux/arm64`. Tags published by CI after
@@ -192,7 +192,7 @@ Gateway DB and Abbenay down together.
 | Value | Default | Description |
 |-------|---------|-------------|
 | `image.registry` | `quay.io/ansible` | Container registry |
-| `image.tag` | `2026.7.3` | Image tag (GitHub release `v2026.7.3`; Quay omits the `v`) |
+| `image.tag` | `2026.8.6` | Image tag (GitHub release `v2026.8.6`; Quay omits the `v`) |
 | `engine.replicas` | `1` | Must be `1` (ADR-069) |
 | `gitleaks.enabled` | `true` | Enable Gitleaks validator |
 | `collectionHealth.enabled` | `true` | Enable Collection Health validator |
@@ -202,7 +202,7 @@ Gateway DB and Abbenay down together.
 | `ui.replicas` | `1` | Must be `1` when UI enabled |
 | `abbenay.enabled` | `false` | Enable AI provider sidecar |
 | `abbenay.token` | `""` | Abbenay gRPC + HTTP admin token (required when `abbenay.enabled=true`) |
-| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:v2026.8.1` | Abbenay image |
+| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:v2026.8.2` | Abbenay image |
 | `abbenay.providers` | `{}` | LLM provider map (see [ABBENAY_AI.md](../../../docs/guides/ABBENAY_AI.md)) |
 | `abbenay.aiModel` | `""` | Default AI model ID |
 | `ingress.enabled` | `false` | Create Kubernetes Ingress |

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -10,10 +10,10 @@ image:
   registry: quay.io/ansible
   # -- Image tag for all APME containers.
   # Pinned default shipped with this chart (must match Chart.yaml
-  # appVersion). Corresponds to GitHub release v2026.7.3; Quay/GHCR
+  # appVersion). Corresponds to GitHub release v2026.8.6; Quay/GHCR
   # release tags omit the leading "v". Override with a SHA tag
   # (e.g. "sha-b7d1683") for unreleased builds.
-  tag: "2026.7.3"
+  tag: "2026.8.6"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -154,7 +154,7 @@ ui:
 # See docs/guides/ABBENAY_AI.md for GCP-specific setup.
 abbenay:
   enabled: false
-  image: ghcr.io/redhat-developer/abbenay:v2026.8.1
+  image: ghcr.io/redhat-developer/abbenay:v2026.8.2
   # -- Token APME uses to authenticate with Abbenay (required when enabled)
   token: ""
   # -- Override the default model APME selects (e.g. "vertex-claude/claude-sonnet-4-6")

--- a/docs/design/DESIGN_AI_ESCALATION.md
+++ b/docs/design/DESIGN_AI_ESCALATION.md
@@ -576,14 +576,14 @@ Install with: pip install apme-engine[ai]
 Pre-built multi-arch Abbenay images (amd64 + arm64) are available on GHCR:
 
 ```bash
-podman pull ghcr.io/redhat-developer/abbenay:v2026.8.1
+podman pull ghcr.io/redhat-developer/abbenay:v2026.8.2
 ```
 
 | Tag | Meaning |
 |-----|---------|
 | `:main` | Latest merged code |
 | `:sha-<short>` | Specific commit |
-| `:v2026.8.1` | Release (`v` prefix; APME pin) |
+| `:v2026.8.2` | Release (`v` prefix; APME pin) |
 | `:latest` | Latest stable release |
 
 ```

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -53,7 +53,7 @@ This builds a shared base image, eleven service images, and pulls one official i
 | `apme-gateway:latest` | `containers/gateway/Dockerfile` | REST API + gRPC Reporting service (SQLite) |
 | `apme-ui:latest` | `containers/ui/Dockerfile` | React SPA served by nginx (proxies API to Gateway) |
 | `apme-cli:latest` | `containers/cli/Dockerfile` | CLI client |
-| `ghcr.io/redhat-developer/abbenay:v2026.8.1` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
+| `ghcr.io/redhat-developer/abbenay:v2026.8.2` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
 
 ### Configure Abbenay AI (optional)
 
@@ -501,7 +501,7 @@ SHA or release tag (and Quay only when that publish included Quay credentials).
 
 | Value | Description |
 |-------|-------------|
-| `image.tag` | Image tag (default `2026.7.3` / `Chart.appVersion`; override with SHA like `sha-b7d1683`) |
+| `image.tag` | Image tag (default `2026.8.6` / `Chart.appVersion`; override with SHA like `sha-b7d1683`) |
 | `engine.replicas` | Engine pod replicas (default: 1) |
 | `abbenay.enabled` | Enable AI provider (default: false) |
 | `abbenay.token` | Abbenay service token (required when `abbenay.enabled=true`) |


### PR DESCRIPTION
## Summary

- Pin Helm chart defaults to upcoming APME release **v2026.8.6** (`Chart.appVersion` / `image.tag`; chart version **0.1.4**)
- Bump Abbenay image pin to **v2026.8.2** in Helm, Podman, and docs
- APME images/tag will be published when v2026.8.6 is released after this lands

## Changes

- `deploy/helm/apme/Chart.yaml` — `appVersion: 2026.8.6`, `version: 0.1.4`
- `deploy/helm/apme/values.yaml` — `image.tag` + `abbenay.image`
- `deploy/helm/apme/README.md`, `docs/guides/DEPLOYMENT.md`, `docs/design/DESIGN_AI_ESCALATION.md`
- `containers/podman/pod.yaml`, `containers/podman/build.sh`

## Test plan

- [x] `tox -e helm` (lint + Simple template assertions + package `apme-0.1.4.tgz`)
- [x] `tox -e lint`
- [x] `tox -e unit`
- [ ] After APME v2026.8.6 images publish: Helm install pulls `quay.io/ansible/*:2026.8.6` and Abbenay `v2026.8.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Abbenay AI image to version `v2026.8.2`.
  * Updated the APME image to version `2026.8.6`.
  * Updated the Helm chart version to `0.1.4`.

* **Documentation**
  * Refreshed deployment instructions, installation guidance, and architecture documentation with the latest image versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->