### PR TITLE
docs(specs): add REQ-019 scan attestation specification

### DIFF
--- a/.sdlc/specs/README.md
+++ b/.sdlc/specs/README.md
@@ -27,7 +27,7 @@ Specs answer "What does this feature do?" They provide:
 | REQ-015 | Detect Debug Sensitive Variables | PHASE-001 | Implemented |
 | REQ-016 | Phase 2 SCM Providers (GitLab + Bitbucket) | PHASE-003 | In Progress |
 | REQ-017 | Python Import Deprecations | PHASE-001 | Draft |
-| REQ-018 | Python AST Validator | PHASE-001 | Draft |
+| REQ-018 | Python AST Validator | PHASE-002 | Draft |
 | REQ-019 | Scan Attestation | Unassigned | Draft |
 
 ## Directory Structure

--- a/.sdlc/specs/README.md
+++ b/.sdlc/specs/README.md
@@ -52,7 +52,10 @@ specs/
 ├── REQ-013-opa-policy-inputs/
 ├── REQ-014-policy-permissive-mode/
 ├── REQ-015-debug-sensitive-vars/
-└── REQ-016-scm-providers-phase2/
+├── REQ-016-scm-providers-phase2/
+├── REQ-017-python-import-deprecations/
+├── REQ-018-python-ast-validator/
+└── REQ-019-scan-attestation/
 ```
 
 ## Phase Relationship
@@ -62,10 +65,12 @@ Requirements are grouped by delivery phase:
 ```
 PHASE-001: CLI Scanner (In Progress)
 ├── REQ-001: Core Scanning Engine (In Progress)
-└── REQ-015: Detect Debug Sensitive Variables (Implemented)
+├── REQ-015: Detect Debug Sensitive Variables (Implemented)
+└── REQ-017: Python Import Deprecations (Draft)
 
 PHASE-002: Rewrite Engine (Implemented)
-└── REQ-002: Automated Remediation (Implemented)
+├── REQ-002: Automated Remediation (Implemented)
+└── REQ-018: Python AST Validator (Draft)
 
 PHASE-003: Enterprise Dashboard (In Progress)
 ├── REQ-003: Security & Compliance (Draft)
@@ -80,6 +85,9 @@ PHASE-003: Enterprise Dashboard (In Progress)
 
 PHASE-004: AI Remediation (Implemented)
 └── DR-005: AI-Assisted Remediation (Decided)
+
+Unassigned
+└── REQ-019: Scan Attestation (Draft)
 ```
 
 See [phases/README.md](../phases/README.md) for phase details.

--- a/.sdlc/specs/README.md
+++ b/.sdlc/specs/README.md
@@ -26,6 +26,9 @@ Specs answer "What does this feature do?" They provide:
 | REQ-014 | Policy Permissive Mode | PHASE-003 | Draft |
 | REQ-015 | Detect Debug Sensitive Variables | PHASE-001 | Implemented |
 | REQ-016 | Phase 2 SCM Providers (GitLab + Bitbucket) | PHASE-003 | In Progress |
+| REQ-017 | Python Import Deprecations | PHASE-001 | Draft |
+| REQ-018 | Python AST Validator | PHASE-001 | Draft |
+| REQ-019 | Scan Attestation | Unassigned | Draft |
 
 ## Directory Structure
 

--- a/.sdlc/specs/REQ-019-scan-attestation/contract.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/contract.md
@@ -25,7 +25,7 @@ Scans are created through the existing project operation endpoint (ADR-052), not
 }
 ```
 
-Gateway generates `scan_id` internally at operation creation. Clients obtain it from `GET /api/v1/projects/{project_id}/operation` (or the operation SSE stream), which includes `scan_id` in the snapshot once the operation exists. The scan record stores initial attestation state `not_requested` or `pending` when `options.attest=true`.
+Gateway generates `scan_id` internally at operation creation. Clients obtain it from `GET /api/v1/projects/{project_id}/operation` (or the operation SSE stream), which includes `scan_id` in the snapshot once the operation exists. The scan record stores initial attestation state `not_requested` or `scan_in_progress` when `options.attest=true`. `pending` is set only after the completed scan is persisted and Gateway begins signing.
 
 When `options.attest=true`, Gateway assembles and signs the attestation after the scan completes. Signing is idempotent: repeated `GET .../attestation` requests for the same `scan_id` return the same envelope once signing succeeds.
 
@@ -85,9 +85,17 @@ Verify a signed attestation.
 **Request**:
 ```json
 {
-  "envelope": { ... }
+  "envelope": { ... },
+  "sourceManifest": {
+    "files": [
+      {"path": "playbooks/site.yml", "sha256": "<hex>"},
+      {"path": "roles/common/tasks/main.yml", "sha256": "<hex>"}
+    ]
+  }
 }
 ```
+
+`sourceManifest` is optional. When omitted, Gateway verifies signature and trust policy only (same semantics as CLI without `--path`). When present, Gateway recomputes the Subject Digest from the manifest using the same canonicalization rules as AC-1 and compares it to `subject[].digest.sha256` in the attestation.
 
 **Response** (200):
 ```json
@@ -95,9 +103,12 @@ Verify a signed attestation.
   "valid": true,
   "signer": "<identity>",
   "attestedAt": "<RFC3339>",
+  "digestVerified": false,
   "reason": null
 }
 ```
+
+`digestVerified` is `true` when `sourceManifest` was supplied and the recomputed Subject Digest matches the attestation; `false` when `sourceManifest` was omitted or the digest does not match. When `sourceManifest` is supplied and the digest mismatches, `valid` is `false` and `reason` is `SUBJECT_DIGEST_MISMATCH`.
 
 When verification fails, `valid` is `false` and `reason` is a stable machine-readable code:
 
@@ -109,7 +120,8 @@ When verification fails, `valid` is `false` and `reason` is a stable machine-rea
 | `INVALID_AUDIENCE` | OIDC audience mismatch |
 | `REKOR_ENTRY_MISSING` | No matching Rekor transparency-log entry |
 | `TRUST_SERVICE_UNAVAILABLE` | Required verification inputs missing (no persisted bundle, no local trust root, or live lookup required but unavailable) |
-| `EXPIRED_CERTIFICATE` | Signing certificate outside validity window at verification time (see [design.md](design.md) for historical validation) |
+| `EXPIRED_CERTIFICATE` | **Keyless**: signing certificate outside validity window at the authenticated Rekor `integratedTime` or bundled SET timestamp (not the verifier's current clock). **Keyed**: signature verification uses the configured trust-set public keys only; certificate expiry checks do not apply (see [design.md](design.md)) |
+| `SUBJECT_DIGEST_MISMATCH` | `sourceManifest` supplied but recomputed Subject Digest does not match attestation |
 | `UNTRUSTED_KEYID` | Keyed attestation: `keyid` not in configured trust set |
 | `MALFORMED_ENVELOPE` | Envelope structure, Base64, or JSON invalid |
 
@@ -121,9 +133,18 @@ When verification fails, `valid` is `false` and `reason` is a stable machine-rea
 | `401` | Unauthenticated |
 | `403` | Authenticated but not authorized to invoke verification |
 
-Malformed requests return `400` with `{"detail": "<human-readable>"}`; they do not return the 200 verification body above.
+Malformed requests return `400` with a stable machine-readable reason and human-readable detail:
 
-`signer` and `attestedAt` are populated only when `valid` is `true`.
+```json
+{
+  "reason": "MALFORMED_ENVELOPE",
+  "detail": "<human-readable>"
+}
+```
+
+They do not return the 200 verification body above.
+
+`signer` and `attestedAt` are populated only when `valid` is `true`. `digestVerified` is populated only in the 200 verification body.
 
 Verification applies the Sigstore trust policy defined in AC-5 of [requirement.md](requirement.md). **Keyed attestations**: signature is valid only when `keyid` resolves to a public key in the Gateway trust set; unknown `keyid` returns `valid: false` with reason `UNTRUSTED_KEYID`.
 
@@ -140,8 +161,8 @@ Private key material is loaded **only by Gateway**. CLI and Primary never read s
 
 | Source | Resolved by | Notes |
 |--------|-------------|-------|
-| `--signing-key <path>` | Gateway | CLI forwards the path as an opaque reference in the scan request metadata |
-| `APME_SIGNING_KEY` | Gateway | Filesystem path to PEM key; evaluated on Gateway only |
+| `--signing-key <id-or-path>` | Gateway | CLI forwards an opaque key reference in scan request metadata. Gateway resolves **only** (a) a configured allowlisted key identifier (`keyid`) or (b) a path under its configured signing-key directory. Reject path traversal, symlinks escaping the directory, and references outside the allowlist. |
+| `APME_SIGNING_KEY` | Gateway | Default signing key path or `keyid` on Gateway only; same resolution rules as `--signing-key` |
 | (none) | Gateway | Sigstore keyless signing per AC-5 trust policy |
 
 **Precedence** (highest wins): `--signing-key` → `APME_SIGNING_KEY` → keyless Sigstore.
@@ -178,7 +199,8 @@ When attestation is unavailable, the CLI must not write a truncated or placehold
 | State | Meaning |
 |-------|---------|
 | `not_requested` | Scan created without `attest=true` |
-| `pending` | Scan complete; Gateway signing in progress |
+| `scan_in_progress` | Attestation requested; scan not yet complete (`GET .../attestation` returns `202` with `{"status": "scan_in_progress"}`) |
+| `pending` | Scan complete and persisted; Gateway signing in progress (`GET .../attestation` returns `202` with `{"status": "signing_pending"}`) |
 | `ready` | Signed attestation persisted and retrievable |
 | `failed` | Signing failed; `reason` field set per Gateway failure reporting above |
 

--- a/.sdlc/specs/REQ-019-scan-attestation/contract.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/contract.md
@@ -25,15 +25,17 @@ Scans are created through the existing project operation endpoint (ADR-052), not
 }
 ```
 
-Gateway generates `scan_id` internally at operation creation. Clients obtain it from `GET /api/v1/projects/{project_id}/operation` (or the operation SSE stream), which includes `scan_id` in the snapshot once the operation exists. The scan record stores initial attestation state `not_requested` or `scan_in_progress` when `options.attest=true`. `pending` is set only after the completed scan is persisted and Gateway begins signing.
+Gateway generates `scan_id` internally at operation creation. Clients obtain it from `GET /api/v1/projects/{project_id}/operation` (or the operation SSE stream), which includes `scan_id` in the snapshot once the operation exists. In the REST activity API, that same UUID is the `activity_id` (`GET /api/v1/activity/{activity_id}` — `activity_id` ≡ `scans.scan_id`).
 
-When `options.attest=true`, Gateway assembles and signs the attestation after the scan completes. Signing is idempotent: repeated `GET .../attestation` requests for the same `scan_id` return the same envelope once signing succeeds.
+The scan record stores initial attestation state `not_requested` or `scan_in_progress` when `options.attest=true`. `pending` is set only after the completed scan is persisted and Gateway claims the signing job (see Signing idempotency below).
 
-### GET /api/v1/scans/{scan_id}/attestation
+When `options.attest=true`, Gateway assembles and signs the attestation after the scan completes. Retrieval is stable: repeated `GET .../attestation` requests for the same `activity_id` return the same persisted envelope once signing succeeds.
 
-Returns signed attestation for a completed scan.
+### GET /api/v1/activity/{activity_id}/attestation
 
-**Authorization**: Requires an authenticated session (same mechanism as other scan read endpoints). Caller must have read access to the scan's tenant/project.
+Returns the signed attestation for a completed scan. `activity_id` is the scan UUID (`scans.scan_id`); this nests under the existing activity API rather than inventing a `/api/v1/scans/` namespace.
+
+**Authorization**: Requires an authenticated session (same mechanism as other activity read endpoints). Caller must have read access to the scan's tenant/project.
 
 **Responses**:
 
@@ -42,13 +44,50 @@ Returns signed attestation for a completed scan.
 | `200` | Attestation ready (body below) |
 | `202` | Scan still running. Include `Retry-After: 5`. Body: `{"status": "scan_in_progress"}` |
 | `202` | Scan complete; Gateway signing still in progress. Include `Retry-After: 5`. Body: `{"status": "signing_pending"}` |
-| `404` | Unknown `scan_id` |
+| `404` | Unknown `activity_id` |
 | `403` | Authenticated but not authorized for this scan |
-| `409` | Scan exists but attestation was not requested (`attest=false` or absent), or signing failed (see Gateway failure reporting) |
+| `422` | Scan exists but attestation was not requested (`attest=false` or absent). Body: `{"status": "not_requested"}` |
+| `409` | Attestation was requested but signing failed. Body: `{"status": "signing_failed", "reason": "<code>"}` (see Gateway failure reporting) |
+
+`GET` is read-only with respect to signing: it never starts a second signing attempt. It only returns the current attestation state and, when `ready`, the immutable persisted record.
 
 **Response** (200):
 
-Returns the in-toto DSSE envelope plus Sigstore verification material required by AC-5. For keyless attestations, Gateway persists and returns a [Sigstore Bundle v0.3](https://docs.sigstore.dev/about/bundle/) (`mediaType`: `application/vnd.dev.sigstore.bundle.v0.3+json`) containing the DSSE envelope, Fulcio certificate chain, and Rekor Signed Entry Timestamp (SET). For keyed attestations, the envelope includes the configured `keyid` and signature only; `verificationMaterial` is omitted.
+Returns a [Sigstore Bundle v0.3](https://docs.sigstore.dev/about/bundle/) for keyless attestations, or a DSSE envelope for keyed attestations.
+
+**Keyless (Bundle v0.3)** — `Content-Type: application/vnd.dev.sigstore.bundle.v0.3+json`:
+
+```json
+{
+  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+  "verificationMaterial": {
+    "certificate": { "rawBytes": "<base64-der>" },
+    "tlogEntries": [
+      {
+        "logIndex": "<string>",
+        "logId": { "keyId": "<base64>" },
+        "kindVersion": { "kind": "dsse", "version": "0.0.1" },
+        "integratedTime": "<string>",
+        "inclusionPromise": { "signedEntryTimestamp": "<base64>" }
+      }
+    ]
+  },
+  "dsseEnvelope": {
+    "payloadType": "application/vnd.in-toto+json",
+    "payload": "<base64-encoded-statement>",
+    "signatures": [
+      {
+        "keyid": "<cert-fingerprint-or-empty>",
+        "sig": "<base64-signature>"
+      }
+    ]
+  }
+}
+```
+
+Gateway persists the full Bundle (including the `trustedRoot` metadata version used at signing) so later retrieval does not depend on live Rekor/Fulcio availability.
+
+**Keyed** — DSSE envelope only (`verificationMaterial` / Bundle wrapper omitted):
 
 ```json
 {
@@ -56,27 +95,30 @@ Returns the in-toto DSSE envelope plus Sigstore verification material required b
   "payload": "<base64-encoded-statement>",
   "signatures": [
     {
-      "keyid": "<key-id>",
+      "keyid": "<trust-set-key-id>",
       "sig": "<base64-signature>"
     }
-  ],
-  "verificationMaterial": {
-    "x509CertificateChain": ["<base64-cert>"],
-    "tlogEntries": ["<rekor-entry>"]
-  }
+  ]
 }
 ```
 
-`verificationMaterial` is present for keyless attestations and omitted for keyed attestations signed with a configured trust-set key. Gateway stores the full bundle at signing time so later retrieval does not depend on live Rekor/Fulcio availability.
-
 **Wire format** (DSSE v1 + Sigstore Bundle binding):
 
-- **Statement bytes**: UTF-8 JSON of the in-toto Statement (see [requirement.md](requirement.md)); no pretty-printing; keys sorted lexicographically where the serializer supports canonical ordering.
+- **Statement bytes**: UTF-8 JSON of the in-toto Statement (see [requirement.md](requirement.md)). Canonicalization is **mandatory and fixed** for both signer and verifier: RFC 8785 (JSON Canonicalization Scheme) over the Statement object, then UTF-8 encode. No pretty-printing; no alternate serializer layouts.
 - **DSSE envelope**: `payloadType` is always `application/vnd.in-toto+json`; `payload` is standard Base64 (no URL-safe alphabet) of the Statement bytes; exactly one entry in `signatures`.
 - **PAE (Pre-Authentication Encoding)**: Signatures cover DSSE v1 PAE over `(payloadType, payload)` per [DSSE protocol v1.0.0](https://github.com/secure-systems-lab/dsse/blob/v1.0.0/protocol.md): `DSSEv1` + SP + LEN(type) + SP + type + SP + LEN(body) + SP + body, where LEN is decimal byte length and body is the raw Statement bytes (before Base64).
-- **Keyless signature algorithm**: ECDSA P-256 SHA-256 over the PAE bytes; Fulcio-issued X.509 certificate binds the signature. `keyid` in the envelope is the certificate fingerprint (SHA-256 of DER, hex-encoded) or empty when implied by `verificationMaterial`.
+- **Keyless signature algorithm**: ECDSA P-256 SHA-256 over the PAE bytes; Fulcio-issued X.509 certificate binds the signature. `keyid` in the envelope is the certificate fingerprint (SHA-256 of DER, hex-encoded) or empty when implied by Bundle `verificationMaterial`.
 - **Keyed signature algorithm**: ECDSA P-256 SHA-256 or Ed25519 over the PAE bytes; `keyid` is the stable public-key fingerprint registered in the Gateway trust set (see [design.md](design.md)).
-- **Sigstore Bundle binding**: Bundle `messageSignature` matches the DSSE `signatures[0].sig`; bundle `verificationMaterial` (certificate chain + Rekor SET) validates against the same PAE input. Gateway persists the bundle `trustedRoot` metadata version alongside `verificationMaterial` for historical verification within the retention window.
+- **Sigstore Bundle binding**: For keyless attestations the Bundle content is the **`dsseEnvelope`** oneof (not `messageSignature`). Bundle `dsseEnvelope.signatures[0].sig` is the DSSE signature over the PAE bytes; Bundle `verificationMaterial` (certificate + Rekor SET) validates against that same PAE input. Gateway persists the Bundle `trustedRoot` metadata version alongside the Bundle for historical verification within the retention window.
+
+### Signing idempotency and crash recovery
+
+Signing must be **enforceably** idempotent per `scan_id` / `activity_id`, not merely stable after success:
+
+1. **Atomic claim**: After the completed scan is persisted, exactly one worker transitions attestation state from `scan_in_progress` to `pending` via compare-and-swap (or an equivalent unique claim). Losers observe `pending` / `ready` / `failed` and do not call Fulcio/Rekor again.
+2. **Immutable record**: Once state is `ready`, the persisted attestation blob (Bundle or keyed DSSE) is immutable. Further signing attempts must no-op and return that record.
+3. **Crash recovery**: If a prior attempt completed signing (Fulcio/Rekor succeeded) but failed to persist the Bundle, the claim owner must recover by persisting the in-memory / staging Bundle bytes already obtained for that claim — **not** by submitting a new Rekor entry. If recovery is impossible (claim lost with no staging bytes), mark `failed` with a stable reason (`SIGNING_RECOVERY_FAILED`) and do not silently produce a second winning envelope for the same `scan_id`.
+4. **GET never signs**: Retrieval endpoints only read state; they do not claim or re-enter the signing path.
 
 ### POST /api/v1/attestations/verify
 
@@ -95,7 +137,7 @@ Verify a signed attestation.
 }
 ```
 
-`sourceManifest` is optional. When omitted, Gateway verifies signature and trust policy only (same semantics as CLI without `--path`). When present, Gateway recomputes the Subject Digest from the manifest using the same canonicalization rules as AC-1 and compares it to `subject[].digest.sha256` in the attestation.
+`envelope` is either a Sigstore Bundle v0.3 (keyless) or a DSSE envelope (keyed). `sourceManifest` is optional. When omitted, Gateway verifies signature and trust policy only (same semantics as CLI without `--path`). When present, Gateway recomputes the Subject Digest from the manifest using the same canonicalization rules as AC-1 and compares it to `subject[].digest.sha256` in the attestation.
 
 **Response** (200):
 ```json
@@ -103,12 +145,16 @@ Verify a signed attestation.
   "valid": true,
   "signer": "<identity>",
   "attestedAt": "<RFC3339>",
-  "digestVerified": false,
+  "digestVerified": null,
   "reason": null
 }
 ```
 
-`digestVerified` is `true` when `sourceManifest` was supplied and the recomputed Subject Digest matches the attestation; `false` when `sourceManifest` was omitted or the digest does not match. When `sourceManifest` is supplied and the digest mismatches, `valid` is `false` and `reason` is `SUBJECT_DIGEST_MISMATCH`.
+| `digestVerified` | Meaning |
+|------------------|---------|
+| `true` | `sourceManifest` supplied and recomputed Subject Digest matches |
+| `false` | `sourceManifest` supplied and digest does not match (`valid` is `false`, `reason` is `SUBJECT_DIGEST_MISMATCH`) |
+| `null` | `sourceManifest` omitted; digest check skipped |
 
 When verification fails, `valid` is `false` and `reason` is a stable machine-readable code:
 
@@ -144,7 +190,7 @@ Malformed requests return `400` with a stable machine-readable reason and human-
 
 They do not return the 200 verification body above.
 
-`signer` and `attestedAt` are populated only when `valid` is `true`. `digestVerified` is populated only in the 200 verification body.
+`signer` and `attestedAt` are populated only when `valid` is `true`. `digestVerified` is populated only in the 200 verification body (`true` / `false` / `null` as above).
 
 Verification applies the Sigstore trust policy defined in AC-5 of [requirement.md](requirement.md). **Keyed attestations**: signature is valid only when `keyid` resolves to a public key in the Gateway trust set; unknown `keyid` returns `valid: false` with reason `UNTRUSTED_KEYID`.
 
@@ -161,22 +207,29 @@ Private key material is loaded **only by Gateway**. CLI and Primary never read s
 
 | Source | Resolved by | Notes |
 |--------|-------------|-------|
-| `--signing-key <id-or-path>` | Gateway | CLI forwards an opaque key reference in scan request metadata. Gateway resolves **only** (a) a configured allowlisted key identifier (`keyid`) or (b) a path under its configured signing-key directory. Reject path traversal, symlinks escaping the directory, and references outside the allowlist. |
+| `--signing-key <id-or-path>` | Gateway | CLI forwards an opaque key reference in scan request metadata. Gateway resolves **only** (a) a configured allowlisted key identifier (`keyid`) or (b) a path under its configured signing-key directory (in-container path, not a client host path). Reject path traversal, symlinks escaping the directory, and references outside the allowlist. |
 | `APME_SIGNING_KEY` | Gateway | Default signing key path or `keyid` on Gateway only; same resolution rules as `--signing-key` |
-| (none) | Gateway | Sigstore keyless signing per AC-5 trust policy |
+| (none) | Gateway | Sigstore keyless signing using Gateway workload identity (see [design.md](design.md)) |
 
 **Precedence** (highest wins): `--signing-key` → `APME_SIGNING_KEY` → keyless Sigstore.
+
+**CLI sequence** (`apme check --attest`):
+
+1. Start check with attestation requested (flag forwarded to Gateway via existing scan-driver metadata).
+2. Wait for scan persistence, then poll attestation state until `ready` or `failed` (same semantics as `GET .../attestation` `200` / `409`).
+3. Emit scan results and attestation per AC-2 output rules.
 
 **Gateway failure reporting**:
 - Missing or unreadable key path at Gateway: scan completes but attestation status is `failed`; `GET .../attestation` returns `409` with `{"status": "signing_failed", "reason": "KEY_NOT_FOUND"}` (or `KEY_UNREADABLE`)
 - Sigstore unavailable with no keyed fallback: `{"status": "signing_failed", "reason": "SIGSTORE_UNAVAILABLE"}`
+- Claim/recovery failure after external signing succeeded without recoverable staging bytes: `{"status": "signing_failed", "reason": "SIGNING_RECOVERY_FAILED"}`
 
 **CLI failure reporting** (`apme check --attest`):
 
 | Condition | Exit code | Behavior |
 |-----------|-----------|----------|
 | Scan succeeds; attestation signed | `0` (or scan exit code if violations) | Attestation written per AC-2 output rules |
-| Scan succeeds; Gateway signing fails | `1` | No partial attestation file; stderr reports stable reason (`KEY_NOT_FOUND`, `KEY_UNREADABLE`, `SIGSTORE_UNAVAILABLE`) |
+| Scan succeeds; Gateway signing fails | `1` | No partial attestation file; stderr reports stable reason (`KEY_NOT_FOUND`, `KEY_UNREADABLE`, `SIGSTORE_UNAVAILABLE`, `SIGNING_RECOVERY_FAILED`) |
 | Attestation output path unwritable | `2` | Scan results still emitted per normal rules; no partial attestation file |
 | `--json` and attestation unavailable | non-zero | Single JSON document: `{"scan": <results>, "attestation": null, "attestationError": {"reason": "<code>", "message": "<human-readable>"}}` |
 
@@ -186,24 +239,26 @@ When attestation is unavailable, the CLI must not write a truncated or placehold
 
 **v1 is REST-only.** Attestation signing, storage, and retrieval are Gateway responsibilities; Primary and FixSession remain unchanged for v1. No new Primary RPC or FixSession fields are required in the initial release.
 
+**Subject digest handoff (no proto change)**: Gateway — not Primary — computes the Subject Digest. After `ReportFixCompleted`, Gateway uses (a) the project working tree it already cloned for the operation and (b) the set of source file paths present in the persisted `content_graph_json` (same graph Primary already emits today). Gateway hashes those files from the clone using AC-1 canonicalization rules. Primary does **not** emit per-file SHA-256 digests over the wire. If a path in the graph is missing from the clone at signing time, signing fails with `SUBJECT_TREE_INCOMPLETE` (attestation state `failed`).
+
 **Gateway handoff**:
 1. Client sets `options.attest=true` on `POST /api/v1/projects/{project_id}/operation` (REST) or forwards the flag through the existing Gateway→Primary scan driver metadata path (CLI `--attest`).
-2. Primary completes the scan and returns SARIF/results to Gateway as today, plus attestation inputs persisted on the scan record:
-   - `scanCompletedAt` (UTC RFC 3339, from Primary completion timestamp)
-   - Subject digest manifest inputs: relative paths and per-file SHA-256 of all content-graph source files (same rules as AC-1 Subject Digest)
-   - `toolVersion`, `verdict`, `violationCount`
-3. Gateway computes the Subject Digest from the manifest, assembles the in-toto Statement, signs the DSSE envelope, persists the full Sigstore bundle (including `trustedRoot` metadata version), and exposes completion via `GET /api/v1/scans/{scan_id}/attestation`.
+2. Primary completes the scan and returns results to Gateway as today. Gateway persists the scan record including:
+   - `scanCompletedAt` (UTC RFC 3339, from Primary completion timestamp / reporting event)
+   - `content_graph_json` (existing field; supplies the file-path set for digest computation)
+   - `toolVersion`, `verdict`, `violationCount`, and SARIF/results already persisted for the scan
+3. The exclusive claim owner transitions to `pending`, computes the Subject Digest from clone + graph paths, assembles the in-toto Statement (RFC 8785), signs the DSSE envelope, persists the full Sigstore Bundle (keyless) or keyed DSSE plus `trustedRoot` metadata version, sets state `ready`, and exposes the record via `GET /api/v1/activity/{activity_id}/attestation`.
 
 **Completion states** (stored on the scan record):
 
 | State | Meaning |
 |-------|---------|
-| `not_requested` | Scan created without `attest=true` |
+| `not_requested` | Scan created without `attest=true` (`GET .../attestation` returns `422`) |
 | `scan_in_progress` | Attestation requested; scan not yet complete (`GET .../attestation` returns `202` with `{"status": "scan_in_progress"}`) |
-| `pending` | Scan complete and persisted; Gateway signing in progress (`GET .../attestation` returns `202` with `{"status": "signing_pending"}`) |
-| `ready` | Signed attestation persisted and retrievable |
-| `failed` | Signing failed; `reason` field set per Gateway failure reporting above |
+| `pending` | Scan complete and persisted; exclusive signing claim held (`GET .../attestation` returns `202` with `{"status": "signing_pending"}`) |
+| `ready` | Signed attestation persisted and retrievable (immutable) |
+| `failed` | Signing failed; `reason` field set per Gateway failure reporting above (`GET .../attestation` returns `409`) |
 
-**Backward compatibility**: Existing FixSession clients that do not send `attest=true` behave unchanged. Attestation is opt-in via REST scan creation or CLI `--attest`; no proto version bump is required for v1.
+**Backward compatibility**: Existing FixSession clients that do not send `attest=true` behave unchanged. Attestation is opt-in via REST operation creation or CLI `--attest`; no proto version bump is required for v1.
 
 A future ADR may extend FixSession with typed attestation events if inline delivery becomes necessary.

--- a/.sdlc/specs/REQ-019-scan-attestation/contract.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/contract.md
@@ -4,17 +4,19 @@
 
 ### POST /api/v1/projects/{project_id}/operation (attestation request)
 
-Scans are created through the existing project operation endpoint (ADR-052), not a separate `/api/v1/scans` route. To request attestation, set `options.attest=true` in the operation body:
+Scans are created through the existing project operation endpoint (ADR-052), not a separate `/api/v1/scans` route. To request attestation, set `options.attest=true` in the operation body. **v1: `action` must be `check`.** If `options.attest=true` and `action` is `remediate` (or any non-check action), Gateway returns `400` with reason `ATTEST_CHECK_ONLY`.
 
 ```json
 {
   "action": "check",
   "options": {
-    "attest": true
+    "attest": true,
+    "signing_key": "<keyid-or-path>"
   }
 }
 ```
 
+`options.signing_key` is optional; when present it uses the unified `<keyid-or-path>` grammar (see Signing key resolution). Host paths from the client are rejected.
 **Authorization**: Same authentication and project authorization as other `/api/v1/projects/{project_id}/operation` endpoints. Caller must have permission to start a check on the project.
 
 **Response** (201):
@@ -27,10 +29,37 @@ Scans are created through the existing project operation endpoint (ADR-052), not
 
 Gateway generates `scan_id` internally at operation creation. Clients obtain it from `GET /api/v1/projects/{project_id}/operation` (or the operation SSE stream), which includes `scan_id` in the snapshot once the operation exists. In the REST activity API, that same UUID is the `activity_id` (`GET /api/v1/activity/{activity_id}` — `activity_id` ≡ `scans.scan_id`).
 
-The scan record stores initial attestation state `not_requested` or `scan_in_progress` when `options.attest=true`. `pending` is set only after the completed scan is persisted and Gateway claims the signing job (see Signing idempotency below).
+When `options.attest=true`, the scan record's attestation state is initialized to **`scan_in_progress`**. When `options.attest` is absent or `false`, attestation state is **`not_requested`**. `not_requested` must never be stored for an attestation-requested scan (otherwise `GET .../attestation` would permanently return `422`). `pending` is set only after the completed scan is persisted and Gateway claims the signing job (see Signing idempotency below).
 
-When `options.attest=true`, Gateway assembles and signs the attestation after the scan completes. Retrieval is stable: repeated `GET .../attestation` requests for the same `activity_id` return the same persisted envelope once signing succeeds.
+**Pollable stub at operate-time**: Today `Scan` rows are created at `ReportFixCompleted`. For attestation, Gateway **must** insert a durable stub `scans` row (minimal columns + `attestation_state=scan_in_progress`) when the operation is accepted and `scan_id` is allocated — **before** Primary starts — so `GET /api/v1/activity/{activity_id}` and `GET .../attestation` return `202` / `scan_in_progress` instead of `404` while the scan runs. `ReportFixCompleted` updates the stub in place.
 
+When `options.attest=true`, Gateway stages an immutable source snapshot for the `scan_id` before Primary begins, disables format-rewrite for that check session, assembles and signs the attestation after the scan completes, and defers snapshot cleanup until attestation reaches `ready` or `failed`. Retrieval is stable: repeated `GET .../attestation` requests for the same `activity_id` return the same persisted envelope once signing succeeds.
+
+### POST /api/v1/operations/local-check (CLI / local tree)
+
+Creates a Gateway-orchestrated check with optional attestation for a local source tree (used by `apme check --attest <dir>`).
+
+**Authorization**: Authenticated caller; co-located daemon may additionally restrict to local clients.
+
+**Request** (JSON, co-located path mode):
+
+```json
+{
+  "path": "/allowed/root/my-project",
+  "options": {
+    "attest": true,
+    "signing_key": "<keyid-or-path>"
+  }
+}
+```
+
+**Request** (multipart, remote Gateway): field `archive` = tar of the project tree; field `options` = JSON object with `attest` / `signing_key` as above.
+
+**Rules**:
+- Same `attest` state machine and check-only rule as project operate.
+- Co-located `path` must resolve under a configured allowlist of roots; Gateway **copies** into an immutable snapshot (never hashes the live client directory).
+- Remote mode requires the uploaded archive; path mode is rejected.
+- **Response** (201): `{"operation_id": "<uuid>", "scan_id": "<uuid>"}` — `scan_id` is immediately pollable via `GET /api/v1/activity/{scan_id}/attestation`.
 ### GET /api/v1/activity/{activity_id}/attestation
 
 Returns the signed attestation for a completed scan. `activity_id` is the scan UUID (`scans.scan_id`); this nests under the existing activity API rather than inventing a `/api/v1/scans/` namespace.
@@ -48,6 +77,8 @@ Returns the signed attestation for a completed scan. `activity_id` is the scan U
 | `403` | Authenticated but not authorized for this scan |
 | `422` | Scan exists but attestation was not requested (`attest=false` or absent). Body: `{"status": "not_requested"}` |
 | `409` | Attestation was requested but signing failed. Body: `{"status": "signing_failed", "reason": "<code>"}` (see Gateway failure reporting) |
+
+Clients **must** branch on the JSON `status` field when handling `202` responses; both pending states share HTTP `202` by design.
 
 `GET` is read-only with respect to signing: it never starts a second signing attempt. It only returns the current attestation state and, when `ready`, the immutable persisted record.
 
@@ -87,7 +118,7 @@ Returns a [Sigstore Bundle v0.3](https://docs.sigstore.dev/about/bundle/) for ke
 
 Gateway persists the full Bundle (including the `trustedRoot` metadata version used at signing) so later retrieval does not depend on live Rekor/Fulcio availability.
 
-**Keyed** — DSSE envelope only (`verificationMaterial` / Bundle wrapper omitted):
+**Keyed** — DSSE envelope only (`verificationMaterial` / Bundle wrapper omitted). `Content-Type: application/vnd.in-toto.dsse+json` (or `application/json` when clients cannot negotiate; verifiers detect keyed vs keyless by presence/absence of Bundle `mediaType` / `verificationMaterial`):
 
 ```json
 {
@@ -107,8 +138,12 @@ Gateway persists the full Bundle (including the `trustedRoot` metadata version u
 - **Statement bytes**: UTF-8 JSON of the in-toto Statement (see [requirement.md](requirement.md)). Canonicalization is **mandatory and fixed** for both signer and verifier: RFC 8785 (JSON Canonicalization Scheme) over the Statement object, then UTF-8 encode. No pretty-printing; no alternate serializer layouts.
 - **DSSE envelope**: `payloadType` is always `application/vnd.in-toto+json`; `payload` is standard Base64 (no URL-safe alphabet) of the Statement bytes; exactly one entry in `signatures`.
 - **PAE (Pre-Authentication Encoding)**: Signatures cover DSSE v1 PAE over `(payloadType, payload)` per [DSSE protocol v1.0.0](https://github.com/secure-systems-lab/dsse/blob/v1.0.0/protocol.md): `DSSEv1` + SP + LEN(type) + SP + type + SP + LEN(body) + SP + body, where LEN is decimal byte length and body is the raw Statement bytes (before Base64).
-- **Keyless signature algorithm**: ECDSA P-256 SHA-256 over the PAE bytes; Fulcio-issued X.509 certificate binds the signature. `keyid` in the envelope is the certificate fingerprint (SHA-256 of DER, hex-encoded) or empty when implied by Bundle `verificationMaterial`.
-- **Keyed signature algorithm**: ECDSA P-256 SHA-256 or Ed25519 over the PAE bytes; `keyid` is the stable public-key fingerprint registered in the Gateway trust set (see [design.md](design.md)).
+- **Keyless signature algorithm**: ECDSA P-256 with SHA-256 over the PAE bytes; signature bytes are **ASN.1 DER** encoded (`SEQUENCE { r INTEGER, s INTEGER }`) then standard Base64 in `sig`. Fulcio-issued X.509 certificate binds the signature. `keyid` in the envelope is the certificate fingerprint — SHA-256 of the certificate DER bytes, **lowercase hex** — or empty when implied by Bundle `verificationMaterial`.
+- **Keyed signature algorithms**:
+  - **ECDSA P-256 SHA-256**: signature bytes are ASN.1 DER (same as keyless), then Base64 in `sig`.
+  - **Ed25519**: signature bytes are the raw 64-byte PureEd25519 signature (R ‖ S), then Base64 in `sig`. No ASN.1 wrapping.
+- **Keyed `keyid` fingerprint**: SHA-256 over the public key's SubjectPublicKeyInfo (SPKI) DER bytes, encoded as **lowercase hex** (64 hex chars). That value is the stable trust-set key identifier.
+- **Cross-language test vector** (implementation TASK must ship golden vectors covering): RFC 8785 Statement bytes, DSSE PAE bytes, ECDSA DER `sig` Base64, Ed25519 raw `sig` Base64, and keyed `keyid` derivation from a fixed SPKI. Vectors live under `tests/fixtures/attestation/` when implementation lands.
 - **Sigstore Bundle binding**: For keyless attestations the Bundle content is the **`dsseEnvelope`** oneof (not `messageSignature`). Bundle `dsseEnvelope.signatures[0].sig` is the DSSE signature over the PAE bytes; Bundle `verificationMaterial` (certificate + Rekor SET) validates against that same PAE input. Gateway persists the Bundle `trustedRoot` metadata version alongside the Bundle for historical verification within the retention window.
 
 ### Signing idempotency and crash recovery
@@ -116,9 +151,12 @@ Gateway persists the full Bundle (including the `trustedRoot` metadata version u
 Signing must be **enforceably** idempotent per `scan_id` / `activity_id`, not merely stable after success:
 
 1. **Atomic claim**: After the completed scan is persisted, exactly one worker transitions attestation state from `scan_in_progress` to `pending` via compare-and-swap (or an equivalent unique claim). Losers observe `pending` / `ready` / `failed` and do not call Fulcio/Rekor again.
-2. **Immutable record**: Once state is `ready`, the persisted attestation blob (Bundle or keyed DSSE) is immutable. Further signing attempts must no-op and return that record.
-3. **Crash recovery**: If a prior attempt completed signing (Fulcio/Rekor succeeded) but failed to persist the Bundle, the claim owner must recover by persisting the in-memory / staging Bundle bytes already obtained for that claim — **not** by submitting a new Rekor entry. If recovery is impossible (claim lost with no staging bytes), mark `failed` with a stable reason (`SIGNING_RECOVERY_FAILED`) and do not silently produce a second winning envelope for the same `scan_id`.
-4. **GET never signs**: Retrieval endpoints only read state; they do not claim or re-enter the signing path.
+2. **Digest then Statement**: Claim owner confines owned-scope graph paths, hashes the immutable snapshot, then assembles the in-toto Statement (RFC 8785) including `subject[].digest` and `contentEpoch: "submitted_snapshot"`.
+3. **Durable staging before external writes**: Before any Fulcio/Rekor network call, durably stage claim metadata and the assembled Statement/PAE bytes for that `scan_id`. After a successful external signing response, Bundle/envelope bytes are staged durably before marking `ready`. Recovery only flushes staged bytes — it never opens a second Rekor entry.
+4. **Immutable record**: Once state is `ready`, the persisted attestation blob (Bundle or keyed DSSE) is immutable. Further signing attempts must no-op and return that record.
+5. **Crash recovery**: If a prior attempt completed signing (Fulcio/Rekor succeeded) but failed to persist the Bundle, the claim owner must recover by persisting the staged Bundle bytes already obtained for that claim — **not** by submitting a new Rekor entry. If recovery is impossible (claim lost with no staging bytes), mark `failed` with a stable reason (`SIGNING_RECOVERY_FAILED`) and do not silently produce a second winning envelope for the same `scan_id`.
+6. **Snapshot lifetime**: Retain the immutable snapshot until attestation is `ready` or `failed`, then delete. Do not delete after hashing alone.
+7. **GET never signs**: Retrieval endpoints only read state; they do not claim or re-enter the signing path.
 
 ### POST /api/v1/attestations/verify
 
@@ -137,7 +175,7 @@ Verify a signed attestation.
 }
 ```
 
-`envelope` is either a Sigstore Bundle v0.3 (keyless) or a DSSE envelope (keyed). `sourceManifest` is optional. When omitted, Gateway verifies signature and trust policy only (same semantics as CLI without `--path`). When present, Gateway recomputes the Subject Digest from the manifest using the same canonicalization rules as AC-1 and compares it to `subject[].digest.sha256` in the attestation.
+`envelope` is either a Sigstore Bundle v0.3 (keyless) or a DSSE envelope (keyed). `sourceManifest` is optional. When omitted, Gateway verifies signature and trust policy only (same semantics as CLI without `--path`). When present, Gateway recomputes the Subject Digest from the manifest using the same path-confinement and canonicalization rules as AC-1 and compares it to `subject[].digest.sha256` in the attestation. Manifest paths that fail confinement yield `valid: false` with reason `SUBJECT_PATH_INVALID`.
 
 **Response** (200):
 ```json
@@ -165,9 +203,10 @@ When verification fails, `valid` is `false` and `reason` is a stable machine-rea
 | `UNTRUSTED_IDENTITY` | Certificate subject does not match configured pattern |
 | `INVALID_AUDIENCE` | OIDC audience mismatch |
 | `REKOR_ENTRY_MISSING` | No matching Rekor transparency-log entry |
-| `TRUST_SERVICE_UNAVAILABLE` | Required verification inputs missing (no persisted bundle, no local trust root, or live lookup required but unavailable) |
+| `TRUST_SERVICE_UNAVAILABLE` | Required verification inputs missing (no persisted bundle, no local trust root). Under `APME_SIGSTORE_OFFLINE=true`, also returned immediately for incomplete envelopes without live lookup. When online, returned if live lookup is required but unavailable |
 | `EXPIRED_CERTIFICATE` | **Keyless**: signing certificate outside validity window at the authenticated Rekor `integratedTime` or bundled SET timestamp (not the verifier's current clock). **Keyed**: signature verification uses the configured trust-set public keys only; certificate expiry checks do not apply (see [design.md](design.md)) |
 | `SUBJECT_DIGEST_MISMATCH` | `sourceManifest` supplied but recomputed Subject Digest does not match attestation |
+| `SUBJECT_PATH_INVALID` | Manifest or graph path failed confinement rules |
 | `UNTRUSTED_KEYID` | Keyed attestation: `keyid` not in configured trust set |
 | `MALFORMED_ENVELOPE` | Envelope structure, Base64, or JSON invalid |
 
@@ -197,7 +236,7 @@ Verification applies the Sigstore trust policy defined in AC-5 of [requirement.m
 ## CLI Commands
 
 ```bash
-apme check --attest [--attest-output <path>] [--signing-key <path>]
+apme check --attest [--attest-output <path>] [--signing-key <keyid-or-path>]
 apme verify-attestation [--path <source-tree>] <file>
 ```
 
@@ -205,31 +244,42 @@ apme verify-attestation [--path <source-tree>] <file>
 
 Private key material is loaded **only by Gateway**. CLI and Primary never read signing keys.
 
+**Grammar** (identical for every entry point): `<keyid-or-path>` is either (a) an allowlisted trust-set key identifier, or (b) an absolute or relative path that Gateway resolves **only** under its configured in-container signing-key directory. Client host paths are rejected.
+
 | Source | Resolved by | Notes |
 |--------|-------------|-------|
-| `--signing-key <id-or-path>` | Gateway | CLI forwards an opaque key reference in scan request metadata. Gateway resolves **only** (a) a configured allowlisted key identifier (`keyid`) or (b) a path under its configured signing-key directory (in-container path, not a client host path). Reject path traversal, symlinks escaping the directory, and references outside the allowlist. |
-| `APME_SIGNING_KEY` | Gateway | Default signing key path or `keyid` on Gateway only; same resolution rules as `--signing-key` |
+| `--signing-key <keyid-or-path>` | Gateway | CLI forwards as `options.signing_key` on the Gateway operate / local-check request. Gateway resolves per the grammar above. Reject path traversal, symlinks escaping the directory, and references outside the allowlist. |
+| `APME_SIGNING_KEY=<keyid-or-path>` | Gateway | Default signing key on Gateway only; same grammar and resolution rules as `--signing-key` |
 | (none) | Gateway | Sigstore keyless signing using Gateway workload identity (see [design.md](design.md)) |
 
 **Precedence** (highest wins): `--signing-key` → `APME_SIGNING_KEY` → keyless Sigstore.
 
 **CLI sequence** (`apme check --attest`):
 
-1. Start check with attestation requested (flag forwarded to Gateway via existing scan-driver metadata).
-2. Wait for scan persistence, then poll attestation state until `ready` or `failed` (same semantics as `GET .../attestation` `200` / `409`).
-3. Emit scan results and attestation per AC-2 output rules.
+1. Call Gateway: registered project → `POST /api/v1/projects/{project_id}/operation`; local tree → `POST /api/v1/operations/local-check`. Body includes `options.attest=true` and optional `options.signing_key`. Direct Primary-only FixSession cannot attest in v1.
+2. Read `scan_id` from the 201 response (local-check) or operation snapshot (project operate). Stub scan row already exists with `attestation_state=scan_in_progress`.
+3. Poll `GET /api/v1/activity/{activity_id}/attestation` until `ready` or `failed` (`200` / `409`). Branch on JSON `status` for `202` bodies.
+4. Emit scan results and attestation per AC-2 output rules.
 
-**Gateway failure reporting**:
-- Missing or unreadable key path at Gateway: scan completes but attestation status is `failed`; `GET .../attestation` returns `409` with `{"status": "signing_failed", "reason": "KEY_NOT_FOUND"}` (or `KEY_UNREADABLE`)
-- Sigstore unavailable with no keyed fallback: `{"status": "signing_failed", "reason": "SIGSTORE_UNAVAILABLE"}`
-- Claim/recovery failure after external signing succeeded without recoverable staging bytes: `{"status": "signing_failed", "reason": "SIGNING_RECOVERY_FAILED"}`
+**Gateway failure reporting** (`GET .../attestation` → `409`):
+
+| `reason` | Meaning |
+|----------|---------|
+| `KEY_NOT_FOUND` | Missing or unknown signing key reference at Gateway |
+| `KEY_UNREADABLE` | Signing key path exists but cannot be read/parsed |
+| `SIGSTORE_UNAVAILABLE` | Fulcio/Rekor/OIDC unreachable and no keyed fallback |
+| `SIGNING_RECOVERY_FAILED` | External signing succeeded but staged bytes were lost |
+| `SUBJECT_TREE_INCOMPLETE` | Owned-scope path set empty after extraction, or a confined owned path missing from the immutable snapshot |
+| `SUBJECT_PATH_INVALID` | Graph path failed confinement (absolute, `..`, NUL, duplicate, symlink escape) or referenced/out-of-snapshot path included |
+| `STATEMENT_INPUTS_MISSING` | Required Statement inputs absent after scan persistence (see persistence map) |
+| `ATTEST_CHECK_ONLY` | Returned on operate/local-check `400` when `attest=true` with non-check action (not a `409` signing failure) |
 
 **CLI failure reporting** (`apme check --attest`):
 
 | Condition | Exit code | Behavior |
 |-----------|-----------|----------|
 | Scan succeeds; attestation signed | `0` (or scan exit code if violations) | Attestation written per AC-2 output rules |
-| Scan succeeds; Gateway signing fails | `1` | No partial attestation file; stderr reports stable reason (`KEY_NOT_FOUND`, `KEY_UNREADABLE`, `SIGSTORE_UNAVAILABLE`, `SIGNING_RECOVERY_FAILED`) |
+| Scan succeeds; Gateway signing fails | `1` | No partial attestation file; stderr reports stable reason (`KEY_NOT_FOUND`, `KEY_UNREADABLE`, `SIGSTORE_UNAVAILABLE`, `SIGNING_RECOVERY_FAILED`, `SUBJECT_TREE_INCOMPLETE`, `SUBJECT_PATH_INVALID`, `STATEMENT_INPUTS_MISSING`) |
 | Attestation output path unwritable | `2` | Scan results still emitted per normal rules; no partial attestation file |
 | `--json` and attestation unavailable | non-zero | Single JSON document: `{"scan": <results>, "attestation": null, "attestationError": {"reason": "<code>", "message": "<human-readable>"}}` |
 
@@ -239,16 +289,49 @@ When attestation is unavailable, the CLI must not write a truncated or placehold
 
 **v1 is REST-only.** Attestation signing, storage, and retrieval are Gateway responsibilities; Primary and FixSession remain unchanged for v1. No new Primary RPC or FixSession fields are required in the initial release.
 
-**Subject digest handoff (no proto change)**: Gateway — not Primary — computes the Subject Digest. After `ReportFixCompleted`, Gateway uses (a) the project working tree it already cloned for the operation and (b) the set of source file paths present in the persisted `content_graph_json` (same graph Primary already emits today). Gateway hashes those files from the clone using AC-1 canonicalization rules. Primary does **not** emit per-file SHA-256 digests over the wire. If a path in the graph is missing from the clone at signing time, signing fails with `SUBJECT_TREE_INCOMPLETE` (attestation state `failed`).
+### Statement input persistence map
 
-**Gateway handoff**:
-1. Client sets `options.attest=true` on `POST /api/v1/projects/{project_id}/operation` (REST) or forwards the flag through the existing Gateway→Primary scan driver metadata path (CLI `--attest`).
-2. Primary completes the scan and returns results to Gateway as today. Gateway persists the scan record including:
-   - `scanCompletedAt` (UTC RFC 3339, from Primary completion timestamp / reporting event)
-   - `content_graph_json` (existing field; supplies the file-path set for digest computation)
-   - `toolVersion`, `verdict`, `violationCount`, and SARIF/results already persisted for the scan
-3. The exclusive claim owner transitions to `pending`, computes the Subject Digest from clone + graph paths, assembles the in-toto Statement (RFC 8785), signs the DSSE envelope, persists the full Sigstore Bundle (keyless) or keyed DSSE plus `trustedRoot` metadata version, sets state `ready`, and exposes the record via `GET /api/v1/activity/{activity_id}/attestation`.
+`FixCompletedEvent` today carries `content_graph_json`, violations, summary counts, and diagnostics — **not** SARIF, `toolVersion`, `verdict`, or `scanCompletedAt`. Implementers must not invent those as existing event fields. Normative sources:
 
+| Statement / control field | Authoritative source at signing time | Notes / migration |
+|---------------------------|--------------------------------------|-------------------|
+| `scanId` | `scans.scan_id` | Stub row created at operate/local-check accept |
+| `attestation_state` | New column `scans.attestation_state` (`not_requested` \| `scan_in_progress` \| `pending` \| `ready` \| `failed`) | Migration required |
+| `attestation_reason` | New nullable column `scans.attestation_reason` | Set on `failed` |
+| `attestation_blob` | New nullable column or side table `scan_attestations` holding Bundle/DSSE JSON | Immutable once `ready` |
+| `attestation_trusted_root_version` | New nullable text column | Keyless only |
+| Durable Statement/PAE staging | Side table or filesystem WAL keyed by `scan_id` (`attestation_staging`) | Written before Fulcio/Rekor; purged after `ready`/`failed` |
+| Snapshot path | Gateway runtime/metadata (not required in Statement); retain until terminal | Implementation detail |
+| `scanCompletedAt` | New nullable column `scans.completed_at` (UTC RFC 3339) set when Gateway commits `ReportFixCompleted` persistence | Migration required; do not reuse `created_at` (operate/stub time) |
+| `attestedAt` | Generated at envelope assembly | Wall clock UTC |
+| `toolVersion` | New nullable column `scans.tool_version` populated from Gateway-known APME package/engine version at completion | Migration required; empty → `STATEMENT_INPUTS_MISSING` |
+| `contentEpoch` | Constant `"submitted_snapshot"` in Statement | Not a DB column |
+| `verdict` | Derived: `"pass"` iff `scans.total_violations == 0`, else `"fail"` | Not stored separately |
+| `violationCount` | `scans.total_violations` | Existing; set from `FixCompletedEvent.summary` |
+| `sarif` | Assembled by Gateway from persisted **remaining** violation rows only (exclude fixed) — same selection as CLI SARIF export | Do not require a SARIF blob on `FixCompletedEvent` |
+| `subject[].name` | Project display name when `project_id` set; else basename of snapshot root | Deterministic |
+| `subject[].digest.sha256` | Computed from immutable snapshot + confined **owned** graph paths | See below |
+| Path set | `scan_graphs.graph_json` nodes with `scope == "owned"` and non-empty `file_path` (`ContentGraph.to_dict()`) | Empty owned set or empty `content_graph_json` when `attest=true` → `SUBJECT_TREE_INCOMPLETE` (single code; do not use `STATEMENT_INPUTS_MISSING` for empty graph) |
+
+Empty `content_graph_json` on `ReportFixCompleted` must not be treated as a successful empty path set for attestation-requested scans.
+
+### Subject digest handoff (no proto change)
+
+Gateway — not Primary — computes the Subject Digest:
+
+1. Retain the immutable snapshot for `scan_id` until attestation is terminal.
+2. After `ReportFixCompleted` persists `scan_graphs.graph_json`, extract `file_path` values from `ContentGraph.to_dict()` nodes where `scope == "owned"` and `file_path` is non-empty.
+3. If the pre-unique multiset contains duplicate normalized paths → `SUBJECT_PATH_INVALID`. Apply path confinement (relative POSIX, NFC, no `..`/NUL; symlink targets stay under snapshot root). Failures → `SUBJECT_PATH_INVALID`.
+4. Hash each surviving path's raw bytes from the snapshot; missing files → `SUBJECT_TREE_INCOMPLETE`.
+5. Canonicalize per AC-1 and set `subject[].digest.sha256` (lowercase hex). Statement includes `contentEpoch: "submitted_snapshot"`.
+
+Primary does **not** emit per-file SHA-256 digests over the wire.
+
+### Gateway handoff
+
+1. Client sets `options.attest=true` on `POST /api/v1/projects/{project_id}/operation` or `POST /api/v1/operations/local-check` (CLI `--attest`). Gateway rejects non-check actions (`ATTEST_CHECK_ONLY`), initializes stub `scans` row with `attestation_state=scan_in_progress`, and stages the immutable snapshot before Primary reads sources. Format-rewrite is disabled for the attest check session.
+2. Primary completes the scan and emits `ReportFixCompleted` as today. Gateway updates the stub scan row using the persistence map above (including new columns via migration).
+3. The exclusive claim owner transitions to `pending`, confines/hashes owned paths, assembles the Statement (RFC 8785), durably stages Statement/PAE bytes, signs the DSSE envelope, persists the Bundle/DSSE plus `trustedRoot` metadata version, sets state `ready`, deletes the snapshot, and exposes the record via `GET /api/v1/activity/{activity_id}/attestation`.
 **Completion states** (stored on the scan record):
 
 | State | Meaning |
@@ -259,6 +342,6 @@ When attestation is unavailable, the CLI must not write a truncated or placehold
 | `ready` | Signed attestation persisted and retrievable (immutable) |
 | `failed` | Signing failed; `reason` field set per Gateway failure reporting above (`GET .../attestation` returns `409`) |
 
-**Backward compatibility**: Existing FixSession clients that do not send `attest=true` behave unchanged. Attestation is opt-in via REST operation creation or CLI `--attest`; no proto version bump is required for v1.
+**Backward compatibility**: Existing FixSession clients that do not request attestation behave unchanged. Attestation is opt-in via REST operation creation or CLI `--attest` (Gateway-mediated); no proto version bump is required for v1.
 
 A future ADR may extend FixSession with typed attestation events if inline delivery becomes necessary.

--- a/.sdlc/specs/REQ-019-scan-attestation/contract.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/contract.md
@@ -2,9 +2,35 @@
 
 ## REST Endpoints
 
+### POST /api/v1/scans (attestation request)
+
+Scan creation accepts an optional boolean field to request attestation:
+
+```json
+{
+  "project_id": "<uuid>",
+  "path": "<scan-path>",
+  "attest": true
+}
+```
+
+When `attest=true`, Gateway assembles and signs the attestation after the scan completes. Signing is idempotent: repeated requests for the same `scan_id` return the same envelope once signing succeeds.
+
 ### GET /api/v1/scans/{scan_id}/attestation
 
 Returns signed attestation for a completed scan.
+
+**Authorization**: Requires authenticated session (same mechanism as other `/api/v1/scans` endpoints). Caller must have read access to the scan's tenant/project.
+
+**Responses**:
+
+| Status | Condition |
+|--------|-----------|
+| `200` | Attestation ready (body below) |
+| `202` | Scan complete; Gateway signing still in progress. Include `Retry-After` header. Body: `{"status": "pending"}` |
+| `404` | Unknown `scan_id` |
+| `403` | Authenticated but not authorized for this scan |
+| `409` | Scan exists but attestation was not requested (`attest=false` or absent) |
 
 **Response** (200):
 ```json
@@ -36,16 +62,49 @@ Verify a signed attestation.
 {
   "valid": true,
   "signer": "<identity>",
-  "timestamp": "<RFC3339>"
+  "attestedAt": "<RFC3339>",
+  "reason": null
 }
 ```
+
+When verification fails, `valid` is `false` and `reason` is a stable machine-readable code:
+
+| `reason` | Meaning |
+|----------|---------|
+| `INVALID_SIGNATURE` | Signature does not match payload |
+| `UNTRUSTED_ISSUER` | OIDC issuer not in allowlist |
+| `UNTRUSTED_IDENTITY` | Certificate subject does not match configured pattern |
+| `INVALID_AUDIENCE` | OIDC audience mismatch |
+| `REKOR_ENTRY_MISSING` | No matching Rekor transparency-log entry |
+| `TRUST_SERVICE_UNAVAILABLE` | Fulcio/Rekor/OIDC unreachable |
+| `EXPIRED_CERTIFICATE` | Signing certificate outside validity window |
+
+`signer` and `attestedAt` are populated only when `valid` is `true`.
+
+Verification applies the Sigstore trust policy defined in AC-5 of [requirement.md](requirement.md).
 
 ## CLI Commands
 
 ```bash
-apme check --attest [--signing-key <path>]
+apme check --attest [--attest-output <path>] [--signing-key <path>]
 apme verify-attestation <file>
 ```
+
+### Signing key resolution (Gateway-owned)
+
+Private key material is loaded **only by Gateway**. CLI and Primary never read signing keys.
+
+| Source | Resolved by | Notes |
+|--------|-------------|-------|
+| `--signing-key <path>` | Gateway | CLI forwards the path as an opaque reference in the scan request metadata |
+| `APME_SIGNING_KEY` | Gateway | Filesystem path to PEM key; evaluated on Gateway only |
+| (none) | Gateway | Sigstore keyless signing per AC-5 trust policy |
+
+**Precedence** (highest wins): `--signing-key` → `APME_SIGNING_KEY` → keyless Sigstore.
+
+**Failure reporting**:
+- Missing or unreadable key path at Gateway: scan completes but attestation status is `failed`; `GET .../attestation` returns `409` with `{"status": "signing_failed", "reason": "KEY_NOT_FOUND"}` (or `KEY_UNREADABLE`)
+- Sigstore unavailable with no keyed fallback: `{"status": "signing_failed", "reason": "SIGSTORE_UNAVAILABLE"}`
 
 ## Proto Extensions
 

--- a/.sdlc/specs/REQ-019-scan-attestation/contract.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/contract.md
@@ -1,0 +1,52 @@
+# REQ-019: Scan Attestation — API Contract
+
+## REST Endpoints
+
+### GET /api/v1/scans/{scan_id}/attestation
+
+Returns signed attestation for a completed scan.
+
+**Response** (200):
+```json
+{
+  "payloadType": "application/vnd.in-toto+json",
+  "payload": "<base64-encoded-statement>",
+  "signatures": [
+    {
+      "keyid": "<key-id>",
+      "sig": "<base64-signature>"
+    }
+  ]
+}
+```
+
+### POST /api/v1/attestations/verify
+
+Verify a signed attestation.
+
+**Request**:
+```json
+{
+  "envelope": { ... }
+}
+```
+
+**Response** (200):
+```json
+{
+  "valid": true,
+  "signer": "<identity>",
+  "timestamp": "<RFC3339>"
+}
+```
+
+## CLI Commands
+
+```bash
+apme check --attest [--signing-key <path>]
+apme verify-attestation <file>
+```
+
+## Proto Extensions
+
+TBD — may extend FixSession response or add separate RPC.

--- a/.sdlc/specs/REQ-019-scan-attestation/contract.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/contract.md
@@ -60,6 +60,7 @@ Creates a Gateway-orchestrated check with optional attestation for a local sourc
 - Co-located `path` must resolve under a configured allowlist of roots; Gateway **copies** into an immutable snapshot (never hashes the live client directory).
 - Remote mode requires the uploaded archive; path mode is rejected.
 - **Response** (201): `{"operation_id": "<uuid>", "scan_id": "<uuid>"}` — `scan_id` is immediately pollable via `GET /api/v1/activity/{scan_id}/attestation`.
+
 ### GET /api/v1/activity/{activity_id}/attestation
 
 Returns the signed attestation for a completed scan. `activity_id` is the scan UUID (`scans.scan_id`); this nests under the existing activity API rather than inventing a `/api/v1/scans/` namespace.
@@ -144,7 +145,10 @@ Gateway persists the full Bundle (including the `trustedRoot` metadata version u
   - **Ed25519**: signature bytes are the raw 64-byte PureEd25519 signature (R ‖ S), then Base64 in `sig`. No ASN.1 wrapping.
 - **Keyed `keyid` fingerprint**: SHA-256 over the public key's SubjectPublicKeyInfo (SPKI) DER bytes, encoded as **lowercase hex** (64 hex chars). That value is the stable trust-set key identifier.
 - **Cross-language test vector** (implementation TASK must ship golden vectors covering): RFC 8785 Statement bytes, DSSE PAE bytes, ECDSA DER `sig` Base64, Ed25519 raw `sig` Base64, and keyed `keyid` derivation from a fixed SPKI. Vectors live under `tests/fixtures/attestation/` when implementation lands.
-- **Sigstore Bundle binding**: For keyless attestations the Bundle content is the **`dsseEnvelope`** oneof (not `messageSignature`). Bundle `dsseEnvelope.signatures[0].sig` is the DSSE signature over the PAE bytes; Bundle `verificationMaterial` (certificate + Rekor SET) validates against that same PAE input. Gateway persists the Bundle `trustedRoot` metadata version alongside the Bundle for historical verification within the retention window.
+- **Sigstore Bundle binding**: For keyless attestations the Bundle content is the **`dsseEnvelope`** oneof (not `messageSignature`).
+- **DSSE verification** (independent of Rekor): Verify `dsseEnvelope.signatures[0].sig` over DSSE v1 PAE of `(payloadType, decoded payload)`. This check does **not** use the Rekor SET.
+- **Rekor SET / inclusion proof** (independent of PAE): Authenticate the canonical Rekor log entry and its inclusion proof. The logged entry **must bind** to the exact `dsseEnvelope` tuple (`payloadType`, `payload`, signature bytes). SET verification proves that this envelope/signature pair was included in Rekor; it does **not** re-validate PAE.
+- Gateway persists the Bundle `trustedRoot` metadata version alongside the Bundle for historical verification within the retention window.
 
 ### Signing idempotency and crash recovery
 
@@ -183,16 +187,22 @@ Verify a signed attestation.
   "valid": true,
   "signer": "<identity>",
   "attestedAt": "<RFC3339>",
+  "subjectDigest": "<sha256-hex>",
   "digestVerified": null,
   "reason": null
 }
 ```
 
+| Field | Presence | Encoding |
+|-------|----------|----------|
+| `subjectDigest` | Always in the 200 body once the Statement is parsed (including `valid: false` after a successful parse). Omitted only when the request is rejected as `400` / `MALFORMED_ENVELOPE`. | Lowercase hex SHA-256; **must equal** `subject[0].digest.sha256` from the signed Statement |
+| `digestVerified` | Always in the 200 body | See table below |
+
 | `digestVerified` | Meaning |
 |------------------|---------|
 | `true` | `sourceManifest` supplied and recomputed Subject Digest matches |
 | `false` | `sourceManifest` supplied and digest does not match (`valid` is `false`, `reason` is `SUBJECT_DIGEST_MISMATCH`) |
-| `null` | `sourceManifest` omitted; digest check skipped |
+| `null` | `sourceManifest` omitted; digest check skipped; `subjectDigest` is still the signed value |
 
 When verification fails, `valid` is `false` and `reason` is a stable machine-readable code:
 
@@ -229,7 +239,7 @@ Malformed requests return `400` with a stable machine-readable reason and human-
 
 They do not return the 200 verification body above.
 
-`signer` and `attestedAt` are populated only when `valid` is `true`. `digestVerified` is populated only in the 200 verification body (`true` / `false` / `null` as above).
+`signer` and `attestedAt` are populated only when `valid` is `true`. `subjectDigest` and `digestVerified` are populated on every 200 verification body as specified above.
 
 Verification applies the Sigstore trust policy defined in AC-5 of [requirement.md](requirement.md). **Keyed attestations**: signature is valid only when `keyid` resolves to a public key in the Gateway trust set; unknown `keyid` returns `valid: false` with reason `UNTRUSTED_KEYID`.
 
@@ -239,6 +249,21 @@ Verification applies the Sigstore trust policy defined in AC-5 of [requirement.m
 apme check --attest [--attest-output <path>] [--signing-key <keyid-or-path>]
 apme verify-attestation [--path <source-tree>] <file>
 ```
+
+**`apme verify-attestation` stdout** (JSON object, even without `--json`):
+
+```json
+{
+  "valid": true,
+  "signer": "<identity>",
+  "attestedAt": "<RFC3339>",
+  "subjectDigest": "<sha256-hex>",
+  "digestVerified": null,
+  "reason": null
+}
+```
+
+Field semantics match `POST /api/v1/attestations/verify`. `subjectDigest` is always present after a successful parse (the signed digest), including when `--path` is omitted (`digestVerified` is then `null`).
 
 ### Signing key resolution (Gateway-owned)
 

--- a/.sdlc/specs/REQ-019-scan-attestation/contract.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/contract.md
@@ -2,39 +2,53 @@
 
 ## REST Endpoints
 
-### POST /api/v1/scans (attestation request)
+### POST /api/v1/projects/{project_id}/operation (attestation request)
 
-Scan creation accepts an optional boolean field to request attestation:
+Scans are created through the existing project operation endpoint (ADR-052), not a separate `/api/v1/scans` route. To request attestation, set `options.attest=true` in the operation body:
 
 ```json
 {
-  "project_id": "<uuid>",
-  "path": "<scan-path>",
-  "attest": true
+  "action": "check",
+  "options": {
+    "attest": true
+  }
 }
 ```
 
-When `attest=true`, Gateway assembles and signs the attestation after the scan completes. Signing is idempotent: repeated requests for the same `scan_id` return the same envelope once signing succeeds.
+**Authorization**: Same authentication and project authorization as other `/api/v1/projects/{project_id}/operation` endpoints. Caller must have permission to start a check on the project.
+
+**Response** (201):
+
+```json
+{
+  "operation_id": "<uuid>"
+}
+```
+
+Gateway generates `scan_id` internally at operation creation. Clients obtain it from `GET /api/v1/projects/{project_id}/operation` (or the operation SSE stream), which includes `scan_id` in the snapshot once the operation exists. The scan record stores initial attestation state `not_requested` or `pending` when `options.attest=true`.
+
+When `options.attest=true`, Gateway assembles and signs the attestation after the scan completes. Signing is idempotent: repeated `GET .../attestation` requests for the same `scan_id` return the same envelope once signing succeeds.
 
 ### GET /api/v1/scans/{scan_id}/attestation
 
 Returns signed attestation for a completed scan.
 
-**Authorization**: Requires an authenticated session (same mechanism as other `/api/v1/scans` endpoints). Caller must have read access to the scan's tenant/project.
+**Authorization**: Requires an authenticated session (same mechanism as other scan read endpoints). Caller must have read access to the scan's tenant/project.
 
 **Responses**:
 
 | Status | Condition |
 |--------|-----------|
 | `200` | Attestation ready (body below) |
-| `202` | Scan complete; Gateway signing still in progress. Include `Retry-After` header. Body: `{"status": "pending"}` |
+| `202` | Scan still running. Include `Retry-After: 5`. Body: `{"status": "scan_in_progress"}` |
+| `202` | Scan complete; Gateway signing still in progress. Include `Retry-After: 5`. Body: `{"status": "signing_pending"}` |
 | `404` | Unknown `scan_id` |
 | `403` | Authenticated but not authorized for this scan |
-| `409` | Scan exists but attestation was not requested (`attest=false` or absent) |
+| `409` | Scan exists but attestation was not requested (`attest=false` or absent), or signing failed (see Gateway failure reporting) |
 
 **Response** (200):
 
-Returns the in-toto envelope plus Sigstore verification material required by AC-5. For keyless attestations, Gateway persists and returns a [Sigstore Bundle](https://docs.sigstore.dev/about/bundle/) (or equivalent) containing the Fulcio certificate chain, OIDC claims, and Rekor inclusion proof alongside the signed statement. For keyed attestations, the envelope includes the configured `keyid` and signature only.
+Returns the in-toto DSSE envelope plus Sigstore verification material required by AC-5. For keyless attestations, Gateway persists and returns a [Sigstore Bundle v0.3](https://docs.sigstore.dev/about/bundle/) (`mediaType`: `application/vnd.dev.sigstore.bundle.v0.3+json`) containing the DSSE envelope, Fulcio certificate chain, and Rekor Signed Entry Timestamp (SET). For keyed attestations, the envelope includes the configured `keyid` and signature only; `verificationMaterial` is omitted.
 
 ```json
 {
@@ -54,6 +68,15 @@ Returns the in-toto envelope plus Sigstore verification material required by AC-
 ```
 
 `verificationMaterial` is present for keyless attestations and omitted for keyed attestations signed with a configured trust-set key. Gateway stores the full bundle at signing time so later retrieval does not depend on live Rekor/Fulcio availability.
+
+**Wire format** (DSSE v1 + Sigstore Bundle binding):
+
+- **Statement bytes**: UTF-8 JSON of the in-toto Statement (see [requirement.md](requirement.md)); no pretty-printing; keys sorted lexicographically where the serializer supports canonical ordering.
+- **DSSE envelope**: `payloadType` is always `application/vnd.in-toto+json`; `payload` is standard Base64 (no URL-safe alphabet) of the Statement bytes; exactly one entry in `signatures`.
+- **PAE (Pre-Authentication Encoding)**: Signatures cover DSSE v1 PAE over `(payloadType, payload)` per [DSSE protocol v1.0.0](https://github.com/secure-systems-lab/dsse/blob/v1.0.0/protocol.md): `DSSEv1` + SP + LEN(type) + SP + type + SP + LEN(body) + SP + body, where LEN is decimal byte length and body is the raw Statement bytes (before Base64).
+- **Keyless signature algorithm**: ECDSA P-256 SHA-256 over the PAE bytes; Fulcio-issued X.509 certificate binds the signature. `keyid` in the envelope is the certificate fingerprint (SHA-256 of DER, hex-encoded) or empty when implied by `verificationMaterial`.
+- **Keyed signature algorithm**: ECDSA P-256 SHA-256 or Ed25519 over the PAE bytes; `keyid` is the stable public-key fingerprint registered in the Gateway trust set (see [design.md](design.md)).
+- **Sigstore Bundle binding**: Bundle `messageSignature` matches the DSSE `signatures[0].sig`; bundle `verificationMaterial` (certificate chain + Rekor SET) validates against the same PAE input. Gateway persists the bundle `trustedRoot` metadata version alongside `verificationMaterial` for historical verification within the retention window.
 
 ### POST /api/v1/attestations/verify
 
@@ -85,12 +108,24 @@ When verification fails, `valid` is `false` and `reason` is a stable machine-rea
 | `UNTRUSTED_IDENTITY` | Certificate subject does not match configured pattern |
 | `INVALID_AUDIENCE` | OIDC audience mismatch |
 | `REKOR_ENTRY_MISSING` | No matching Rekor transparency-log entry |
-| `TRUST_SERVICE_UNAVAILABLE` | Fulcio/Rekor/OIDC unreachable |
-| `EXPIRED_CERTIFICATE` | Signing certificate outside validity window |
+| `TRUST_SERVICE_UNAVAILABLE` | Required verification inputs missing (no persisted bundle, no local trust root, or live lookup required but unavailable) |
+| `EXPIRED_CERTIFICATE` | Signing certificate outside validity window at verification time (see [design.md](design.md) for historical validation) |
+| `UNTRUSTED_KEYID` | Keyed attestation: `keyid` not in configured trust set |
+| `MALFORMED_ENVELOPE` | Envelope structure, Base64, or JSON invalid |
+
+**HTTP errors** (malformed request — distinct from verification failure):
+
+| Status | Condition |
+|--------|-----------|
+| `400` | Missing `envelope`, invalid JSON, or envelope fails structural validation before cryptographic checks |
+| `401` | Unauthenticated |
+| `403` | Authenticated but not authorized to invoke verification |
+
+Malformed requests return `400` with `{"detail": "<human-readable>"}`; they do not return the 200 verification body above.
 
 `signer` and `attestedAt` are populated only when `valid` is `true`.
 
-Verification applies the Sigstore trust policy defined in AC-5 of [requirement.md](requirement.md).
+Verification applies the Sigstore trust policy defined in AC-5 of [requirement.md](requirement.md). **Keyed attestations**: signature is valid only when `keyid` resolves to a public key in the Gateway trust set; unknown `keyid` returns `valid: false` with reason `UNTRUSTED_KEYID`.
 
 ## CLI Commands
 
@@ -131,9 +166,12 @@ When attestation is unavailable, the CLI must not write a truncated or placehold
 **v1 is REST-only.** Attestation signing, storage, and retrieval are Gateway responsibilities; Primary and FixSession remain unchanged for v1. No new Primary RPC or FixSession fields are required in the initial release.
 
 **Gateway handoff**:
-1. Client sets `attest=true` on scan creation (REST) or forwards the flag through the existing Gateway→Primary scan driver metadata path.
-2. Primary completes the scan and returns SARIF/results to Gateway as today.
-3. Gateway assembles the in-toto statement, signs it, persists the full Sigstore bundle, and exposes completion via `GET /api/v1/scans/{scan_id}/attestation`.
+1. Client sets `options.attest=true` on `POST /api/v1/projects/{project_id}/operation` (REST) or forwards the flag through the existing Gateway→Primary scan driver metadata path (CLI `--attest`).
+2. Primary completes the scan and returns SARIF/results to Gateway as today, plus attestation inputs persisted on the scan record:
+   - `scanCompletedAt` (UTC RFC 3339, from Primary completion timestamp)
+   - Subject digest manifest inputs: relative paths and per-file SHA-256 of all content-graph source files (same rules as AC-1 Subject Digest)
+   - `toolVersion`, `verdict`, `violationCount`
+3. Gateway computes the Subject Digest from the manifest, assembles the in-toto Statement, signs the DSSE envelope, persists the full Sigstore bundle (including `trustedRoot` metadata version), and exposes completion via `GET /api/v1/scans/{scan_id}/attestation`.
 
 **Completion states** (stored on the scan record):
 

--- a/.sdlc/specs/REQ-019-scan-attestation/contract.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/contract.md
@@ -20,7 +20,7 @@ When `attest=true`, Gateway assembles and signs the attestation after the scan c
 
 Returns signed attestation for a completed scan.
 
-**Authorization**: Requires authenticated session (same mechanism as other `/api/v1/scans` endpoints). Caller must have read access to the scan's tenant/project.
+**Authorization**: Requires an authenticated session (same mechanism as other `/api/v1/scans` endpoints). Caller must have read access to the scan's tenant/project.
 
 **Responses**:
 
@@ -33,6 +33,9 @@ Returns signed attestation for a completed scan.
 | `409` | Scan exists but attestation was not requested (`attest=false` or absent) |
 
 **Response** (200):
+
+Returns the in-toto envelope plus Sigstore verification material required by AC-5. For keyless attestations, Gateway persists and returns a [Sigstore Bundle](https://docs.sigstore.dev/about/bundle/) (or equivalent) containing the Fulcio certificate chain, OIDC claims, and Rekor inclusion proof alongside the signed statement. For keyed attestations, the envelope includes the configured `keyid` and signature only.
+
 ```json
 {
   "payloadType": "application/vnd.in-toto+json",
@@ -42,9 +45,15 @@ Returns signed attestation for a completed scan.
       "keyid": "<key-id>",
       "sig": "<base64-signature>"
     }
-  ]
+  ],
+  "verificationMaterial": {
+    "x509CertificateChain": ["<base64-cert>"],
+    "tlogEntries": ["<rekor-entry>"]
+  }
 }
 ```
+
+`verificationMaterial` is present for keyless attestations and omitted for keyed attestations signed with a configured trust-set key. Gateway stores the full bundle at signing time so later retrieval does not depend on live Rekor/Fulcio availability.
 
 ### POST /api/v1/attestations/verify
 
@@ -87,7 +96,7 @@ Verification applies the Sigstore trust policy defined in AC-5 of [requirement.m
 
 ```bash
 apme check --attest [--attest-output <path>] [--signing-key <path>]
-apme verify-attestation <file>
+apme verify-attestation [--path <source-tree>] <file>
 ```
 
 ### Signing key resolution (Gateway-owned)
@@ -102,10 +111,39 @@ Private key material is loaded **only by Gateway**. CLI and Primary never read s
 
 **Precedence** (highest wins): `--signing-key` → `APME_SIGNING_KEY` → keyless Sigstore.
 
-**Failure reporting**:
+**Gateway failure reporting**:
 - Missing or unreadable key path at Gateway: scan completes but attestation status is `failed`; `GET .../attestation` returns `409` with `{"status": "signing_failed", "reason": "KEY_NOT_FOUND"}` (or `KEY_UNREADABLE`)
 - Sigstore unavailable with no keyed fallback: `{"status": "signing_failed", "reason": "SIGSTORE_UNAVAILABLE"}`
 
+**CLI failure reporting** (`apme check --attest`):
+
+| Condition | Exit code | Behavior |
+|-----------|-----------|----------|
+| Scan succeeds; attestation signed | `0` (or scan exit code if violations) | Attestation written per AC-2 output rules |
+| Scan succeeds; Gateway signing fails | `1` | No partial attestation file; stderr reports stable reason (`KEY_NOT_FOUND`, `KEY_UNREADABLE`, `SIGSTORE_UNAVAILABLE`) |
+| Attestation output path unwritable | `2` | Scan results still emitted per normal rules; no partial attestation file |
+| `--json` and attestation unavailable | non-zero | Single JSON document: `{"scan": <results>, "attestation": null, "attestationError": {"reason": "<code>", "message": "<human-readable>"}}` |
+
+When attestation is unavailable, the CLI must not write a truncated or placeholder attestation file to `--attest-output`.
+
 ## Proto Extensions
 
-TBD — may extend FixSession response or add separate RPC.
+**v1 is REST-only.** Attestation signing, storage, and retrieval are Gateway responsibilities; Primary and FixSession remain unchanged for v1. No new Primary RPC or FixSession fields are required in the initial release.
+
+**Gateway handoff**:
+1. Client sets `attest=true` on scan creation (REST) or forwards the flag through the existing Gateway→Primary scan driver metadata path.
+2. Primary completes the scan and returns SARIF/results to Gateway as today.
+3. Gateway assembles the in-toto statement, signs it, persists the full Sigstore bundle, and exposes completion via `GET /api/v1/scans/{scan_id}/attestation`.
+
+**Completion states** (stored on the scan record):
+
+| State | Meaning |
+|-------|---------|
+| `not_requested` | Scan created without `attest=true` |
+| `pending` | Scan complete; Gateway signing in progress |
+| `ready` | Signed attestation persisted and retrievable |
+| `failed` | Signing failed; `reason` field set per Gateway failure reporting above |
+
+**Backward compatibility**: Existing FixSession clients that do not send `attest=true` behave unchanged. Attestation is opt-in via REST scan creation or CLI `--attest`; no proto version bump is required for v1.
+
+A future ADR may extend FixSession with typed attestation events if inline delivery becomes necessary.

--- a/.sdlc/specs/REQ-019-scan-attestation/design.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/design.md
@@ -6,6 +6,42 @@ Draft — provisional decisions recorded below; final ADR may follow during impl
 
 ## Design Decisions
 
+### Keyless signer identity (Gateway workload)
+
+Keyless Sigstore signing is performed **only by Gateway**. The OIDC identity presented to Fulcio is the **Gateway workload identity**, not an ambient identity from the caller's CI job unless that job identity is explicitly configured as the Gateway signing identity.
+
+**Default (recommended for Helm / OpenShift)**:
+- Gateway obtains a short-lived OIDC token from its platform workload identity (Kubernetes service account token projected for Fulcio, cloud workload identity, or equivalent).
+- Trust policy issuer allowlist + issuer-to-identity mapping are configured to match that Gateway service account / workload subject (see AC-5).
+- CI pipelines request attestation via REST or `apme check --attest`; they verify that the returned Bundle was signed by the **trusted Gateway identity**, not by the CI job itself.
+
+**Optional CI-bound identity**:
+- Operators may configure Gateway to exchange or accept a short-lived OIDC token whose subject matches a dedicated CI identity pattern **only when** that pattern is registered in the Gateway trust policy and Gateway is the component that performs Fulcio/Rekor calls.
+- CLI/`--attest` never sends private keys; any token handoff is non-secret and Gateway-validated.
+
+**Forbidden ambiguity**:
+- Do not document or implement "keyless with no identity path."
+- Do not default trust policy to broad CI issuer wildcards that would accept any GitHub Actions / GitLab job while Gateway actually signs as a cluster SA (or vice versa).
+
+Air-gapped deployments **must** use keyed signing (`APME_SIGNING_KEY`); keyless requires outbound OIDC, Fulcio, and Rekor.
+
+### Signing idempotency and recovery
+
+Rekor writes are not naturally idempotent. Gateway must enforce one logical attestation per `scan_id`:
+
+1. Persist scan completion first.
+2. Atomically claim signing (`scan_in_progress` → `pending`) for exactly one worker.
+3. Stage Bundle/envelope bytes before marking `ready`.
+4. On retry after Fulcio/Rekor success + persist failure: flush staged bytes; never open a second Rekor entry for the same claim.
+5. If staging is lost: `failed` / `SIGNING_RECOVERY_FAILED` — do not invent a second winner.
+6. `ready` records are immutable; GET endpoints never sign.
+
+See [contract.md](contract.md) for the normative API wording.
+
+### Subject digest ownership
+
+Gateway owns Subject Digest computation (clone working tree + paths from persisted `content_graph_json`). This preserves "no FixSession / Primary proto change" for v1 while keeping digest binding over actual scanned sources. Missing graph paths at signing time fail closed (`SUBJECT_TREE_INCOMPLETE`).
+
 ### Offline / air-gapped mode
 
 Keyless Sigstore signing requires outbound OIDC, Fulcio, and Rekor access. Air-gapped deployments **must** configure keyed signing via `APME_SIGNING_KEY` (Helm Secret mount).
@@ -25,6 +61,8 @@ Signing keys live in a Kubernetes Secret mounted read-only into the Gateway cont
 
 Each keyed signer has a stable **key ID** (`keyid` in the envelope) derived from the public key fingerprint. Gateway persists the public key material in a verifier **trust set** keyed by `keyid`.
 
+**CLI `--signing-key`**: opaque reference resolved only on Gateway — allowlisted `keyid` or path under the configured in-container signing-key directory. Client host paths are not accepted.
+
 **Rotation procedure**:
 1. Add the new private key to the Secret (or a parallel Secret) and configure Gateway to sign with the new key.
 2. Register the new public key in the trust set with its `keyid`.
@@ -36,6 +74,12 @@ Retired keys remain trusted for verification only; they are not used for new sig
 ### Attestation retention
 
 Attestations are stored alongside scan records in Gateway persistence. Retention follows the scan retention policy (default: 90 days, configurable via Gateway settings — exact setting TBD in implementation task). Purging a scan deletes its attestation.
+
+### Wire format
+
+- Keyless: Sigstore Bundle v0.3 with `dsseEnvelope` (not `messageSignature`).
+- Keyed: DSSE envelope only.
+- Statement bytes: RFC 8785 (JCS) before Base64 into DSSE `payload`.
 
 ## Open Questions
 

--- a/.sdlc/specs/REQ-019-scan-attestation/design.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/design.md
@@ -12,8 +12,12 @@ Keyless Sigstore signing requires outbound OIDC, Fulcio, and Rekor access. Air-g
 
 Verification when `APME_SIGSTORE_OFFLINE=true`:
 - **Keyed attestations**: verify signature against the configured trust-set public keys only; Rekor checks are skipped.
-- **Keyless attestations**: Rekor verification is **never** bypassed. Verifiers require the persisted `verificationMaterial` bundle (Fulcio chain + Rekor proof) captured at signing time. If the bundle is missing or incomplete, verification returns `valid: false` with reason `REKOR_ENTRY_MISSING` or `TRUST_SERVICE_UNAVAILABLE` — not a silent pass.
-- **Live keyless verification without embedded bundle**: requires Rekor/Fulcio/OIDC reachability; returns `TRUST_SERVICE_UNAVAILABLE` when offline.
+- **Keyless attestations with persisted bundle**: verify using embedded certificate, OIDC claims, Rekor SET, and the persisted `trustedRoot` metadata — **no live OIDC, Fulcio, or Rekor network access required**. If the bundle is missing or incomplete, verification returns `valid: false` with reason `REKOR_ENTRY_MISSING` or `TRUST_SERVICE_UNAVAILABLE` — not a silent pass.
+- **Live keyless verification without embedded bundle**: requires Rekor/Fulcio reachability to fetch missing proof material; returns `TRUST_SERVICE_UNAVAILABLE` when required inputs cannot be obtained.
+
+**Historical certificate validation** (retained keyless attestations):
+- Fulcio signing certificates are short-lived. For attestations within the retention window, `EXPIRED_CERTIFICATE` checks use the authenticated Rekor `integratedTime` (or bundled SET timestamp), **not** the verifier's current clock.
+- Gateway persists the Sigstore `trustedRoot` version used at signing alongside `verificationMaterial`. Retired Fulcio roots remain available for verification until all attestations signed under that root pass the retention window (default: 90 days).
 
 ### Key management (Helm)
 

--- a/.sdlc/specs/REQ-019-scan-attestation/design.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/design.md
@@ -1,0 +1,15 @@
+# REQ-019: Scan Attestation — Design
+
+## Status
+
+Pending design review.
+
+## Open Questions
+
+1. **Offline mode**: How to handle air-gapped environments without Sigstore access?
+2. **Key management**: Where does the signing key live in Helm deployments?
+3. **Retention**: How long to store attestations in Gateway DB?
+
+## Design Decisions
+
+TBD after requirements approval.

--- a/.sdlc/specs/REQ-019-scan-attestation/design.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/design.md
@@ -8,11 +8,26 @@ Draft — provisional decisions recorded below; final ADR may follow during impl
 
 ### Offline / air-gapped mode
 
-Keyless Sigstore signing requires outbound OIDC, Fulcio, and Rekor access. Air-gapped deployments **must** configure keyed signing via `APME_SIGNING_KEY` (Helm Secret mount). Verification in air-gapped mode validates the local signature and configured trust roots only; Rekor checks are skipped when `APME_SIGSTORE_OFFLINE=true`.
+Keyless Sigstore signing requires outbound OIDC, Fulcio, and Rekor access. Air-gapped deployments **must** configure keyed signing via `APME_SIGNING_KEY` (Helm Secret mount).
+
+Verification when `APME_SIGSTORE_OFFLINE=true`:
+- **Keyed attestations**: verify signature against the configured trust-set public keys only; Rekor checks are skipped.
+- **Keyless attestations**: Rekor verification is **never** bypassed. Verifiers require the persisted `verificationMaterial` bundle (Fulcio chain + Rekor proof) captured at signing time. If the bundle is missing or incomplete, verification returns `valid: false` with reason `REKOR_ENTRY_MISSING` or `TRUST_SERVICE_UNAVAILABLE` — not a silent pass.
+- **Live keyless verification without embedded bundle**: requires Rekor/Fulcio/OIDC reachability; returns `TRUST_SERVICE_UNAVAILABLE` when offline.
 
 ### Key management (Helm)
 
-Signing keys live in a Kubernetes Secret mounted read-only into the Gateway container (e.g., `/etc/apme/secrets/signing-key.pem`). Gateway reads the path from `APME_SIGNING_KEY`. Keys are never mounted into engine containers. Rotation: update Secret and rolling-restart Gateway; new attestations use the new key, verifiers accept keys in the configured trust set.
+Signing keys live in a Kubernetes Secret mounted read-only into the Gateway container (e.g., `/etc/apme/secrets/signing-key.pem`). Gateway reads the path from `APME_SIGNING_KEY`. Keys are never mounted into engine containers.
+
+Each keyed signer has a stable **key ID** (`keyid` in the envelope) derived from the public key fingerprint. Gateway persists the public key material in a verifier **trust set** keyed by `keyid`.
+
+**Rotation procedure**:
+1. Add the new private key to the Secret (or a parallel Secret) and configure Gateway to sign with the new key.
+2. Register the new public key in the trust set with its `keyid`.
+3. Rolling-restart Gateway; new attestations use the new key.
+4. **Do not remove** the previous public key from the trust set until all attestations signed with that `keyid` have passed the configured retention window (default: 90 days — see Attestation retention below).
+
+Retired keys remain trusted for verification only; they are not used for new signatures.
 
 ### Attestation retention
 
@@ -21,4 +36,3 @@ Attestations are stored alongside scan records in Gateway persistence. Retention
 ## Open Questions
 
 1. Whether to expose a dedicated `APME_ATTESTATION_RETENTION_DAYS` setting or inherit scan retention only
-2. Whether FixSession should carry attestation inline or remain REST-only for v1

--- a/.sdlc/specs/REQ-019-scan-attestation/design.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/design.md
@@ -2,14 +2,23 @@
 
 ## Status
 
-Pending design review.
-
-## Open Questions
-
-1. **Offline mode**: How to handle air-gapped environments without Sigstore access?
-2. **Key management**: Where does the signing key live in Helm deployments?
-3. **Retention**: How long to store attestations in Gateway DB?
+Draft — provisional decisions recorded below; final ADR may follow during implementation.
 
 ## Design Decisions
 
-TBD after requirements approval.
+### Offline / air-gapped mode
+
+Keyless Sigstore signing requires outbound OIDC, Fulcio, and Rekor access. Air-gapped deployments **must** configure keyed signing via `APME_SIGNING_KEY` (Helm Secret mount). Verification in air-gapped mode validates the local signature and configured trust roots only; Rekor checks are skipped when `APME_SIGSTORE_OFFLINE=true`.
+
+### Key management (Helm)
+
+Signing keys live in a Kubernetes Secret mounted read-only into the Gateway container (e.g., `/etc/apme/secrets/signing-key.pem`). Gateway reads the path from `APME_SIGNING_KEY`. Keys are never mounted into engine containers. Rotation: update Secret and rolling-restart Gateway; new attestations use the new key, verifiers accept keys in the configured trust set.
+
+### Attestation retention
+
+Attestations are stored alongside scan records in Gateway persistence. Retention follows the scan retention policy (default: 90 days, configurable via Gateway settings — exact setting TBD in implementation task). Purging a scan deletes its attestation.
+
+## Open Questions
+
+1. Whether to expose a dedicated `APME_ATTESTATION_RETENTION_DAYS` setting or inherit scan retention only
+2. Whether FixSession should carry attestation inline or remain REST-only for v1

--- a/.sdlc/specs/REQ-019-scan-attestation/design.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/design.md
@@ -86,6 +86,7 @@ Attestations are stored alongside scan records in Gateway persistence. Retention
 - Keyless: Sigstore Bundle v0.3 with `dsseEnvelope` (not `messageSignature`).
 - Keyed: DSSE envelope only.
 - Statement bytes: RFC 8785 (JCS) before Base64 into DSSE `payload`.
+- Verification splits DSSE PAE signature check from Rekor SET/inclusion-proof check (see contract wire format). The SET binds the logged entry to the exact envelope/signature; it does not re-validate PAE.
 
 ## Open Questions
 

--- a/.sdlc/specs/REQ-019-scan-attestation/design.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/design.md
@@ -15,9 +15,9 @@ Keyless Sigstore signing is performed **only by Gateway**. The OIDC identity pre
 - Trust policy issuer allowlist + issuer-to-identity mapping are configured to match that Gateway service account / workload subject (see AC-5).
 - CI pipelines request attestation via REST or `apme check --attest`; they verify that the returned Bundle was signed by the **trusted Gateway identity**, not by the CI job itself.
 
-**Optional CI-bound identity**:
-- Operators may configure Gateway to exchange or accept a short-lived OIDC token whose subject matches a dedicated CI identity pattern **only when** that pattern is registered in the Gateway trust policy and Gateway is the component that performs Fulcio/Rekor calls.
-- CLI/`--attest` never sends private keys; any token handoff is non-secret and Gateway-validated.
+**Optional CI-bound identity** (out of v1 scope):
+- v1 does **not** accept client-supplied OIDC tokens. Gateway obtains its workload identity token itself.
+- Any future token-accept path requires a separate ADR covering TLS-only transport, issuer/audience/subject validation, log redaction, memory-only handling, and threat model. Until then, CLI/`--attest` never sends private keys or OIDC bearer tokens.
 
 **Forbidden ambiguity**:
 - Do not document or implement "keyless with no identity path."
@@ -31,16 +31,20 @@ Rekor writes are not naturally idempotent. Gateway must enforce one logical atte
 
 1. Persist scan completion first.
 2. Atomically claim signing (`scan_in_progress` → `pending`) for exactly one worker.
-3. Stage Bundle/envelope bytes before marking `ready`.
-4. On retry after Fulcio/Rekor success + persist failure: flush staged bytes; never open a second Rekor entry for the same claim.
-5. If staging is lost: `failed` / `SIGNING_RECOVERY_FAILED` — do not invent a second winner.
-6. `ready` records are immutable; GET endpoints never sign.
+3. Confine paths and compute Subject Digest from the immutable snapshot.
+4. Assemble the in-toto Statement (RFC 8785) including that digest.
+5. **Durable write-ahead before any Fulcio/Rekor network write**: persist claim metadata and Statement/PAE bytes keyed by `scan_id` **before** calling Rekor.
+6. After external signing succeeds, stage Bundle/envelope bytes durably before marking `ready`.
+7. On retry after Fulcio/Rekor success + persist failure: flush staged bytes; never open a second Rekor entry for the same claim.
+8. If staging is lost after an external write: `failed` / `SIGNING_RECOVERY_FAILED` — do not invent a second winner.
+9. Retain the snapshot until attestation is terminal (`ready`/`failed`); then delete.
+10. `ready` records are immutable; GET endpoints never sign.
 
 See [contract.md](contract.md) for the normative API wording.
 
 ### Subject digest ownership
 
-Gateway owns Subject Digest computation (clone working tree + paths from persisted `content_graph_json`). This preserves "no FixSession / Primary proto change" for v1 while keeping digest binding over actual scanned sources. Missing graph paths at signing time fail closed (`SUBJECT_TREE_INCOMPLETE`).
+Gateway owns Subject Digest computation against an **immutable snapshot** it staged for the `scan_id`, using **owned-scope** paths from persisted `content_graph_json` after path confinement. Digest epoch is **`submitted_snapshot`** (Gateway staged bytes), with format-rewrite disabled for attest sessions so Primary analysis aligns with those bytes. Missing owned paths at signing time fail closed (`SUBJECT_TREE_INCOMPLETE`). Invalid/escaping/referenced-out-of-tree paths fail closed (`SUBJECT_PATH_INVALID`).
 
 ### Offline / air-gapped mode
 
@@ -48,8 +52,10 @@ Keyless Sigstore signing requires outbound OIDC, Fulcio, and Rekor access. Air-g
 
 Verification when `APME_SIGSTORE_OFFLINE=true`:
 - **Keyed attestations**: verify signature against the configured trust-set public keys only; Rekor checks are skipped.
-- **Keyless attestations with persisted bundle**: verify using embedded certificate, OIDC claims, Rekor SET, and the persisted `trustedRoot` metadata — **no live OIDC, Fulcio, or Rekor network access required**. If the bundle is missing or incomplete, verification returns `valid: false` with reason `REKOR_ENTRY_MISSING` or `TRUST_SERVICE_UNAVAILABLE` — not a silent pass.
-- **Live keyless verification without embedded bundle**: requires Rekor/Fulcio reachability to fetch missing proof material; returns `TRUST_SERVICE_UNAVAILABLE` when required inputs cannot be obtained.
+- **Keyless attestations with persisted bundle**: verify using embedded certificate, OIDC claims, Rekor SET, and the persisted `trustedRoot` metadata — **no live OIDC, Fulcio, or Rekor network access**. If the bundle is missing or incomplete, verification returns `valid: false` with reason `REKOR_ENTRY_MISSING` or `TRUST_SERVICE_UNAVAILABLE` immediately — **without attempting network calls**.
+- **Keyless without embedded bundle under offline mode**: return `valid: false` with `TRUST_SERVICE_UNAVAILABLE` immediately; do not attempt live trust-service lookup.
+
+Live Rekor/Fulcio fetch for incomplete envelopes is allowed **only** when `APME_SIGSTORE_OFFLINE` is unset/false (explicitly online verification).
 
 **Historical certificate validation** (retained keyless attestations):
 - Fulcio signing certificates are short-lived. For attestations within the retention window, `EXPIRED_CERTIFICATE` checks use the authenticated Rekor `integratedTime` (or bundled SET timestamp), **not** the verifier's current clock.
@@ -59,9 +65,9 @@ Verification when `APME_SIGSTORE_OFFLINE=true`:
 
 Signing keys live in a Kubernetes Secret mounted read-only into the Gateway container (e.g., `/etc/apme/secrets/signing-key.pem`). Gateway reads the path from `APME_SIGNING_KEY`. Keys are never mounted into engine containers.
 
-Each keyed signer has a stable **key ID** (`keyid` in the envelope) derived from the public key fingerprint. Gateway persists the public key material in a verifier **trust set** keyed by `keyid`.
+Each keyed signer has a stable **key ID** (`keyid` in the envelope) derived from the public key fingerprint (see contract wire-format section for exact algorithm). Gateway persists the public key material in a verifier **trust set** keyed by `keyid`.
 
-**CLI `--signing-key`**: opaque reference resolved only on Gateway — allowlisted `keyid` or path under the configured in-container signing-key directory. Client host paths are not accepted.
+**CLI `--signing-key <keyid-or-path>`** and **`APME_SIGNING_KEY`**: same grammar — allowlisted `keyid` or path under the configured in-container signing-key directory. Client host paths are not accepted. Resolved only on Gateway.
 
 **Rotation procedure**:
 1. Add the new private key to the Secret (or a parallel Secret) and configure Gateway to sign with the new key.

--- a/.sdlc/specs/REQ-019-scan-attestation/requirement.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/requirement.md
@@ -30,40 +30,60 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 ### AC-1: Signed SARIF Attestation
 
 **Given** a completed scan with violations or clean result
-**When** attestation output is requested (`--attest` flag or API parameter)
+**When** attestation output is requested (`--attest` CLI flag or `attest=true` on scan creation)
 **Then** APME produces an in-toto attestation envelope containing:
 - SARIF payload as the predicate
-- Timestamp (RFC 3339)
-- Subject (scanned content SHA-256)
+- `attestedAt` timestamp (RFC 3339) recording Gateway envelope creation time (UTC system clock)
+- `scanCompletedAt` timestamp (RFC 3339) recording when Primary finished the scan
+- Subject (scanned project content fingerprint — see Subject Digest below)
 - Cosign signature (keyless via Sigstore or local key)
+
+**Subject Digest** (`subject[].digest.sha256`):
+- Covers all source files parsed into the content graph for the scan (not build artifacts or SARIF output)
+- Canonicalization: relative paths sorted lexicographically (POSIX `/`, NFC Unicode), each entry contributes `path + "\0" + sha256(raw_file_bytes) + "\n"`; project digest is SHA-256 of the UTF-8 manifest string (hex-encoded in the envelope)
+- Verifiers reproduce the digest from the same scanned tree to bind the attestation to scanned content
 
 ### AC-2: CLI Integration
 
 **Given** the CLI check command
 **When** `apme check --attest` is invoked
-**Then** output includes the signed attestation JSON alongside normal output
+**Then** scan results and attestation use a single, unambiguous output container:
+- With `--json`: one JSON document on stdout shaped as `{"scan": <scan-results>, "attestation": <signed-envelope>}`
+- Without `--json`: scan results go to stdout as today; the signed attestation is written to `--attest-output <path>` (default: `attestation.json` in the working directory)
+- The CLI never concatenates two independent JSON documents on stdout
 
 ### AC-3: Gateway REST Endpoint
 
 **Given** a completed scan stored in Gateway
-**When** `GET /api/v1/scans/{scan_id}/attestation` is called
-**Then** returns the signed attestation for that scan
+**When** `GET /api/v1/scans/{scan_id}/attestation` is called by an authenticated caller authorized for that scan
+**Then** returns the signed attestation for that scan (see contract for error and pending states)
 
 ### AC-4: Verification Command
 
 **Given** a signed attestation file
 **When** `apme verify-attestation <file>` is invoked
-**Then** validates signature and outputs verification status
+**Then** validates signature and trust policy, prints verification status to stdout, and exits:
+- `0` when valid
+- `1` when signature or trust policy checks fail
+- `2` on file read or parse errors
 
 ### AC-5: Keyless and Keyed Signing
 
 **Given** attestation is requested
 **When** no signing key is configured
-**Then** use Sigstore keyless signing (OIDC identity)
+**Then** use Sigstore keyless signing (OIDC identity) subject to the trust policy below
 
 **Given** attestation is requested
-**When** `APME_SIGNING_KEY` environment variable is set
-**Then** use the provided key for signing
+**When** `APME_SIGNING_KEY` environment variable is set on Gateway (or `--signing-key <path>` forwarded as a non-secret path reference — see contract)
+**Then** use the provided key for signing; CLI and Primary never load private key material
+
+**Sigstore trust policy** (applies to keyless signing and verification):
+- **OIDC issuer**: configurable allowlist; default includes CI OIDC issuers (`https://token.actions.githubusercontent.com`, GitLab, Azure Pipelines). Reject signatures whose certificate OIDC issuer is not allowlisted.
+- **Workload identity**: certificate `subject` (OIDC `sub`) must match a configured identity pattern for the deployment.
+- **Audience**: certificate OIDC audience must match configured value (default: `sigstore`).
+- **Fulcio roots**: verify against bundled Sigstore public root certificates; roots are versioned and updatable via Gateway configuration.
+- **Rekor policy**: keyless attestations must have a verifiable Rekor transparency-log entry in the configured Rekor instance (default: public Sigstore Rekor).
+- **Unavailable services**: when Rekor/Fulcio/OIDC are unreachable and no keyed fallback is configured, signing fails with `SIGSTORE_UNAVAILABLE`; verification reports `valid: false` with reason `TRUST_SERVICE_UNAVAILABLE`. Air-gapped deployments use keyed signing only (see design.md).
 
 ## Technical Approach
 
@@ -71,7 +91,7 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 
 Signing requires outbound calls (Sigstore Rekor transparency log). Per ADR-020/ADR-029, this belongs in **Gateway**, not engine:
 
-```
+```text
 ┌─────────┐      ┌─────────┐      ┌─────────────┐
 │  CLI    │─────▶│ Primary │─────▶│  Gateway    │
 │ --attest│      │ (SARIF) │      │ (sign+store)│
@@ -96,7 +116,8 @@ in-toto Statement (SLSA Provenance):
   "predicateType": "https://apme.io/attestations/scan/v1",
   "predicate": {
     "scanId": "<uuid>",
-    "timestamp": "<RFC3339>",
+    "scanCompletedAt": "<RFC3339>",
+    "attestedAt": "<RFC3339>",
     "toolVersion": "<apme-version>",
     "sarif": { ... },
     "verdict": "pass|fail",
@@ -105,11 +126,14 @@ in-toto Statement (SLSA Provenance):
 }
 ```
 
+- `scanCompletedAt`: UTC timestamp when Primary finished the scan (from scan metadata)
+- `attestedAt`: UTC timestamp when Gateway assembled and signed the envelope (authoritative audit time for the attestation record)
+
 ### Dependencies
 
 - `sigstore-python` for keyless signing
 - `cosign` binary for keyed signing (optional)
-- Architectural compatibility: Verified (signing in Gateway per invariant 11)
+- Architectural compatibility: Gateway-side signing aligns with invariant 11 (engine never queries out); open operational decisions (offline mode, key storage, retention) are recorded in [design.md](design.md)
 
 ## Out of Scope
 
@@ -119,9 +143,9 @@ in-toto Statement (SLSA Provenance):
 
 ## References
 
-- [Industry Gap Analysis](../../.sdlc/research/industry-gap-analysis.md) — identifies artifact signing as high-priority gap
-- [ADR-020: Event Sink Abstraction](../../.sdlc/adrs/ADR-020-event-sink-abstraction.md)
-- [ADR-029: Gateway Persistence](../../.sdlc/adrs/ADR-029-gateway-persistence.md)
+- [Industry Gap Analysis](../../research/industry-gap-analysis.md) — identifies artifact signing as high-priority gap
+- [ADR-020: Event Sink Abstraction](../../adrs/ADR-020-event-sink-abstraction.md)
+- [ADR-029: Gateway Persistence](../../adrs/ADR-029-gateway-persistence.md)
 - [in-toto Specification](https://github.com/in-toto/attestation)
 - [Sigstore](https://www.sigstore.dev/)
 - [SLSA](https://slsa.dev/)

--- a/.sdlc/specs/REQ-019-scan-attestation/requirement.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/requirement.md
@@ -3,9 +3,9 @@
 ## Metadata
 
 - **Phase**: Unassigned (Enterprise feature)
-- **Status**: Draft
 - **Created**: 2026-08-13
 - **Origin**: Bank of America field engagement (Edward Quail → Richard Henshall)
+- **Status**: Draft
 
 ## Problem Statement
 
@@ -32,18 +32,41 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 **Given** a completed scan with violations or clean result
 **When** attestation output is requested (`--attest` CLI flag or `options.attest=true` on operation creation)
 **Then** APME produces an in-toto Statement inside a DSSE envelope containing:
-- SARIF payload as the predicate
+- SARIF payload as the predicate (Gateway-assembled from persisted scan violations — see contract persistence map)
 - `attestedAt` timestamp (RFC 3339) recording Gateway envelope creation time (UTC system clock)
-- `scanCompletedAt` timestamp (RFC 3339) recording when Primary finished the scan
+- `scanCompletedAt` timestamp (RFC 3339) recording when Gateway persisted scan completion for that `scan_id`
 - Subject (scanned project content fingerprint — see Subject Digest below)
 - A DSSE signature over the Statement (Sigstore keyless via Gateway workload identity, or a configured Gateway signing key). Implementation may use `sigstore-python` and/or `cosign`; the wire contract is DSSE (+ Sigstore Bundle v0.3 for keyless), not a Cosign-specific blob format.
 
 **Subject Digest** (`subject[].digest.sha256`):
-- Covers all source files present in the content graph for the scan (not build artifacts or SARIF output)
-- File set and digests are computed by **Gateway** from its project clone using paths from persisted `content_graph_json` (see contract — no Primary per-file hash RPC)
-- Canonicalization: relative paths sorted lexicographically (POSIX `/`, NFC Unicode), each entry contributes `path + "\0" + sha256(raw_file_bytes) + "\n"`; project digest is SHA-256 of the UTF-8 manifest string (hex-encoded in the envelope)
+- Covers **owned project source files** present in the content graph for the scan (not build artifacts, SARIF output, or referenced/external dependency paths)
+- File set and digests are computed by **Gateway** from an **immutable source snapshot** it owns for the `scan_id` (see Immutable source snapshot below), using paths extracted from persisted `content_graph_json` (see contract — no Primary per-file hash RPC)
+- **Content epoch (normative)**: the digest binds to **submitted snapshot bytes** Gateway staged for the `scan_id`, not to Primary's post-format in-memory temp tree. Predicate field `contentEpoch` is always `"submitted_snapshot"`. When `options.attest=true`, the Gateway-driven check session **disables the format-rewrite phase** so Primary analyzes the same bytes as the snapshot (implementation TASK documents the session hook; if unavailable, still attest `submitted_snapshot` and do not claim post-format identity).
+- **Path confinement** (fail closed before any file open/hash):
+  - Paths are relative, NFC-normalized POSIX (`/` separators), with no leading `/`
+  - Reject absolute paths, `..` segments, empty segments, NUL bytes (`\0`), and duplicate paths after normalization (duplicates before uniquing → `SUBJECT_PATH_INVALID`; do not silently unique)
+  - When resolving a path under the snapshot root, do not follow a symlink whose final target escapes the snapshot root; reject with `SUBJECT_PATH_INVALID`
+  - Any confinement failure → signing fails with `SUBJECT_PATH_INVALID` (attestation state `failed`); do not hash outside the snapshot
+- **File-set extraction**: from `ContentGraph.to_dict()` nodes where `scope == "owned"`, take non-empty `file_path` values under `nodes[].data` (or equivalent node dict shape). Exclude `scope == "referenced"` (collections/modules/roles outside the project tree). Paths that do not resolve under the snapshot root after confinement → `SUBJECT_PATH_INVALID`. An empty path set after extraction → `SUBJECT_TREE_INCOMPLETE`.
+- Canonicalization: confined relative paths sorted lexicographically (POSIX `/`, NFC Unicode), each entry contributes `path + "\0" + sha256(raw_file_bytes) + "\n"`; project digest is SHA-256 of the UTF-8 manifest string (hex-encoded lowercase in the envelope)
 - Statement JSON bytes for signing use RFC 8785 (JCS) canonicalization (see contract)
-- Verifiers reproduce the digest from the same scanned tree to bind the attestation to scanned content (see AC-4)
+- Verifiers reproduce the digest from the same submitted tree (AC-4 `--path`) to bind the attestation to attested content
+
+**Immutable source snapshot**:
+- Gateway never hashes a live, mutable working tree after Primary returns, and never assumes a clone still exists after operation cleanup.
+- For each attestation-requested scan, Gateway stages an immutable snapshot directory keyed by `scan_id` **before** Primary begins reading sources, and **retains it until attestation reaches `ready` or `failed`**. Early deletion after hashing alone is forbidden (recovery may need the tree until terminal).
+- **REST SCM operations** (`POST .../operation` on a registered project): the shallow clone used for the operation **is** that snapshot when `options.attest=true`. Cleanup (`rmtree`) is deferred until attestation terminal state; if attest is false, cleanup remains as today.
+- **CLI** (`apme check --attest`): attestation requires Gateway orchestration via the concrete control plane in AC-2 / contract (registered-project operate **or** local-check staging). No Primary-only attest path.
+- Hashing runs only against that snapshot after `content_graph_json` is persisted. A confined owned path missing from the snapshot → `SUBJECT_TREE_INCOMPLETE`.
+
+**Predicate field derivation** (normative; see contract persistence map for storage sources):
+- `subject[].name`: the Gateway project display name when `project_id` is set; otherwise the basename of the staged snapshot root. Never a free-form client string.
+- `contentEpoch`: always `"submitted_snapshot"` (see above).
+- `verdict`: `"pass"` when persisted `total_violations == 0`, otherwise `"fail"`.
+- `violationCount`: persisted `total_violations` (integer ≥ 0).
+- `toolVersion`: Gateway-recorded APME engine/tool version string persisted at scan completion (see contract).
+- `scanCompletedAt`: UTC RFC 3339 timestamp Gateway records when the scan completion row is committed.
+- `sarif`: SARIF document Gateway assembles from **remaining** violation rows only for that `scan_id` (same selection as CLI SARIF export — exclude `fixed_violations`). Missing required inputs → signing fails with `STATEMENT_INPUTS_MISSING`.
 
 ### AC-2: CLI Integration
 
@@ -53,6 +76,13 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 - With `--json`: one JSON document on stdout shaped as `{"scan": <scan-results>, "attestation": <signed-envelope>}`
 - Without `--json`: scan results go to stdout as today; the signed attestation is written to `--attest-output <path>` (default: `attestation.json` in the working directory)
 - The CLI never concatenates two independent JSON documents on stdout
+
+**CLI attest control plane** (required):
+- `--attest` is Gateway-mediated. Direct Primary-only FixSession without Gateway cannot produce a signed attestation in v1.
+- CLI obtains `scan_id` / `activity_id` from Gateway, then polls `GET /api/v1/activity/{activity_id}/attestation` until `ready` or `failed`.
+- **Registered SCM project**: `POST /api/v1/projects/{project_id}/operation` with `action=check` and `options.attest=true` (and optional `options.signing_key`).
+- **Local path** (typical `apme check --attest <dir>`): `POST /api/v1/operations/local-check` (see contract) — Gateway copies the target tree into an immutable snapshot, creates the scan stub, drives Primary, then signs. Co-located daemons may accept a server-local absolute path under an allowlisted root; remote Gateways require an uploaded archive (tar) of the tree. No bind-mount of a mutable client working tree as the hash root.
+- Co-located daemon deployments expose Gateway on localhost; CLI uses that Gateway base URL (existing `--gateway-url` / default).
 
 ### AC-3: Gateway REST Endpoint
 
@@ -70,8 +100,9 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 - `2` on file read or parse errors
 
 **Subject digest verification**:
-- With `--path <source-tree>`: recompute the Subject Digest using the same file-selection and canonicalization rules as AC-1 and compare to `subject[].digest.sha256` in the attestation. Mismatch fails with exit `1`.
+- With `--path <source-tree>`: recompute the Subject Digest using the same owned-scope file-selection, path confinement, and canonicalization rules as AC-1 and compare to `subject[].digest.sha256` in the attestation. Mismatch fails with exit `1`. Confinement failures during verify also fail with exit `1`.
 - Without `--path`: verify signature and trust policy only; report the signed digest value but do not assert it matches local content (stdout includes `"digestVerified": null`).
+- Offline trust policy matches Gateway: when `APME_SIGSTORE_OFFLINE=true` (or CLI equivalent flag documented in the TASK), keyless verify uses embedded Bundle material and local trust roots only — no live OIDC/Fulcio/Rekor calls.
 
 ### AC-5: Keyless and Keyed Signing
 
@@ -80,7 +111,7 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 **Then** use Sigstore keyless signing with **Gateway workload identity** (see design.md), subject to the trust policy below. The attested signer identity is the Gateway's configured OIDC identity — not an ambient CI job identity unless that identity is explicitly configured as the Gateway signing identity.
 
 **Given** attestation is requested
-**When** `APME_SIGNING_KEY` environment variable is set on Gateway (or `--signing-key <id-or-path>` forwarded as a non-secret Gateway key reference — see contract)
+**When** `APME_SIGNING_KEY` environment variable is set on Gateway (or `--signing-key <keyid-or-path>` forwarded as a non-secret Gateway key reference — see contract)
 **Then** use the provided key for signing; CLI and Primary never load private key material
 
 **Sigstore trust policy** (applies to keyless signing and verification):
@@ -90,7 +121,7 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 - **Fulcio roots**: verify against bundled Sigstore public root certificates; roots are versioned and updatable via Gateway configuration.
 - **Rekor policy**: keyless attestations must have a verifiable Rekor transparency-log entry in the configured Rekor instance (default: public Sigstore Rekor).
 - **Signing availability**: when Rekor/Fulcio/OIDC are unreachable and no keyed fallback is configured, signing fails with `SIGSTORE_UNAVAILABLE`. Air-gapped deployments use keyed signing only (see design.md).
-- **Verification availability**: keyless verification of a persisted Sigstore Bundle uses embedded certificate, claims, and Rekor proof with local trust roots — **independent of live OIDC, Fulcio, or Rekor reachability**. `TRUST_SERVICE_UNAVAILABLE` applies only when required verification inputs are missing (no bundle, no local trust root, or live lookup required for an incomplete envelope) — not merely because external services are unreachable.
+- **Verification availability**: keyless verification of a persisted Sigstore Bundle uses embedded certificate, claims, and Rekor proof with local trust roots — **independent of live OIDC, Fulcio, or Rekor reachability**. When `APME_SIGSTORE_OFFLINE=true`, verification never performs live trust-service calls; missing/incomplete bundle material returns `TRUST_SERVICE_UNAVAILABLE` or `REKOR_ENTRY_MISSING`. Live lookup is allowed only when offline mode is explicitly disabled.
 
 ## Technical Approach
 
@@ -101,8 +132,8 @@ Signing requires outbound calls (Sigstore Rekor transparency log). Per ADR-020/A
 ```text
 ┌─────────┐     REST / CLI      ┌─────────────┐     gRPC      ┌─────────┐
 │  Client │────────────────────▶│   Gateway   │──────────────▶│ Primary │
-│ --attest│                     │ (orchestrate│◀─────────────│ (SARIF / │
-└─────────┘                     │  persist)   │  ReportFix*  │  graph)  │
+│ --attest│                     │ (orchestrate│◀─────────────│ (violations│
+└─────────┘                     │  persist)   │  ReportFix*  │  / graph) │
                                 └──────┬──────┘               └─────────┘
                                        │ sign + store
                                        ▼
@@ -129,6 +160,7 @@ in-toto Statement (APME Scan Predicate):
     "scanCompletedAt": "<RFC3339>",
     "attestedAt": "<RFC3339>",
     "toolVersion": "<apme-version>",
+    "contentEpoch": "submitted_snapshot",
     "sarif": { ... },
     "verdict": "pass|fail",
     "violationCount": <n>
@@ -136,7 +168,7 @@ in-toto Statement (APME Scan Predicate):
 }
 ```
 
-- `scanCompletedAt`: UTC timestamp when Primary finished the scan (from scan metadata)
+- `scanCompletedAt`: UTC timestamp when Gateway committed scan completion for the `scan_id`
 - `attestedAt`: UTC timestamp when Gateway assembled and signed the envelope (authoritative audit time for the attestation record)
 
 ### Dependencies
@@ -151,6 +183,9 @@ in-toto Statement (APME Scan Predicate):
 - Custom attestation predicates (v1 ships with scan predicate only)
 - Hardware key support (HSM/YubiKey — future enhancement)
 - Binding attestation signer identity to an arbitrary caller CI job without configuring that identity as the Gateway signing identity
+- Direct Primary-only CLI attestation without Gateway (v1 requires Gateway orchestration)
+- Client-supplied OIDC token handoff for Fulcio (v1: Gateway obtains workload identity only; any accept-token path needs a separate ADR)
+- `action=remediate` with `options.attest=true` (v1: check-only)
 
 ## References
 

--- a/.sdlc/specs/REQ-019-scan-attestation/requirement.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/requirement.md
@@ -41,7 +41,7 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 **Subject Digest** (`subject[].digest.sha256`):
 - Covers all source files parsed into the content graph for the scan (not build artifacts or SARIF output)
 - Canonicalization: relative paths sorted lexicographically (POSIX `/`, NFC Unicode), each entry contributes `path + "\0" + sha256(raw_file_bytes) + "\n"`; project digest is SHA-256 of the UTF-8 manifest string (hex-encoded in the envelope)
-- Verifiers reproduce the digest from the same scanned tree to bind the attestation to scanned content
+- Verifiers reproduce the digest from the same scanned tree to bind the attestation to scanned content (see AC-4)
 
 ### AC-2: CLI Integration
 
@@ -61,11 +61,15 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 ### AC-4: Verification Command
 
 **Given** a signed attestation file
-**When** `apme verify-attestation <file>` is invoked
+**When** `apme verify-attestation [--path <source-tree>] <file>` is invoked
 **Then** validates signature and trust policy, prints verification status to stdout, and exits:
-- `0` when valid
-- `1` when signature or trust policy checks fail
+- `0` when valid (including subject digest match when `--path` is provided)
+- `1` when signature, trust policy, or subject digest checks fail
 - `2` on file read or parse errors
+
+**Subject digest verification**:
+- With `--path <source-tree>`: recompute the Subject Digest using the same file-selection and canonicalization rules as AC-1 and compare to `subject[].digest.sha256` in the attestation. Mismatch fails with exit `1`.
+- Without `--path`: verify signature and trust policy only; report the signed digest value but do not assert it matches local content (stdout includes `"digestVerified": false`).
 
 ### AC-5: Keyless and Keyed Signing
 
@@ -106,7 +110,7 @@ Signing requires outbound calls (Sigstore Rekor transparency log). Per ADR-020/A
 
 ### Attestation Format
 
-in-toto Statement (SLSA Provenance):
+in-toto Statement (APME Scan Predicate):
 ```json
 {
   "_type": "https://in-toto.io/Statement/v1",

--- a/.sdlc/specs/REQ-019-scan-attestation/requirement.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/requirement.md
@@ -1,0 +1,127 @@
+# REQ-019: Scan Attestation and Evidence Generation
+
+## Metadata
+
+- **Phase**: Unassigned (Enterprise feature)
+- **Status**: Draft
+- **Created**: 2026-08-13
+- **Origin**: Bank of America field engagement (Edward Quail → Richard Henshall)
+
+## Problem Statement
+
+Regulated enterprises require verifiable evidence that policy validation occurred before code is approved for execution. Current APME output (SARIF, JSON) provides scan results but lacks cryptographic attestation that would satisfy audit requirements for provenance and tamper-evidence.
+
+## User Stories
+
+**As a** platform owner in a regulated enterprise,
+**I want to** generate verifiable attestation records during automated CI/CD builds,
+**So that** only policy-compliant code is approved to execute and I have audit evidence for regulators.
+
+**As a** compliance officer,
+**I want to** verify that a specific scan result was produced by APME at a specific time,
+**So that** I can demonstrate to auditors that the validation pipeline was not bypassed.
+
+**As a** CI/CD pipeline operator,
+**I want to** store signed attestations alongside build artifacts,
+**So that** the evidence chain is preserved and queryable.
+
+## Acceptance Criteria
+
+### AC-1: Signed SARIF Attestation
+
+**Given** a completed scan with violations or clean result
+**When** attestation output is requested (`--attest` flag or API parameter)
+**Then** APME produces an in-toto attestation envelope containing:
+- SARIF payload as the predicate
+- Timestamp (RFC 3339)
+- Subject (scanned content SHA-256)
+- Cosign signature (keyless via Sigstore or local key)
+
+### AC-2: CLI Integration
+
+**Given** the CLI check command
+**When** `apme check --attest` is invoked
+**Then** output includes the signed attestation JSON alongside normal output
+
+### AC-3: Gateway REST Endpoint
+
+**Given** a completed scan stored in Gateway
+**When** `GET /api/v1/scans/{scan_id}/attestation` is called
+**Then** returns the signed attestation for that scan
+
+### AC-4: Verification Command
+
+**Given** a signed attestation file
+**When** `apme verify-attestation <file>` is invoked
+**Then** validates signature and outputs verification status
+
+### AC-5: Keyless and Keyed Signing
+
+**Given** attestation is requested
+**When** no signing key is configured
+**Then** use Sigstore keyless signing (OIDC identity)
+
+**Given** attestation is requested
+**When** `APME_SIGNING_KEY` environment variable is set
+**Then** use the provided key for signing
+
+## Technical Approach
+
+### Architecture (Invariant 11 Compliance)
+
+Signing requires outbound calls (Sigstore Rekor transparency log). Per ADR-020/ADR-029, this belongs in **Gateway**, not engine:
+
+```
+┌─────────┐      ┌─────────┐      ┌─────────────┐
+│  CLI    │─────▶│ Primary │─────▶│  Gateway    │
+│ --attest│      │ (SARIF) │      │ (sign+store)│
+└─────────┘      └─────────┘      └─────────────┘
+                                        │
+                                        ▼
+                                  ┌───────────┐
+                                  │ Sigstore  │
+                                  │ (Rekor)   │
+                                  └───────────┘
+```
+
+### Attestation Format
+
+in-toto Statement (SLSA Provenance):
+```json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {"name": "<project>", "digest": {"sha256": "<content-hash>"}}
+  ],
+  "predicateType": "https://apme.io/attestations/scan/v1",
+  "predicate": {
+    "scanId": "<uuid>",
+    "timestamp": "<RFC3339>",
+    "toolVersion": "<apme-version>",
+    "sarif": { ... },
+    "verdict": "pass|fail",
+    "violationCount": <n>
+  }
+}
+```
+
+### Dependencies
+
+- `sigstore-python` for keyless signing
+- `cosign` binary for keyed signing (optional)
+- Architectural compatibility: Verified (signing in Gateway per invariant 11)
+
+## Out of Scope
+
+- SLSA Build provenance (attestation of APME itself — separate concern)
+- Custom attestation predicates (v1 ships with scan predicate only)
+- Hardware key support (HSM/YubiKey — future enhancement)
+
+## References
+
+- [Industry Gap Analysis](../../.sdlc/research/industry-gap-analysis.md) — identifies artifact signing as high-priority gap
+- [ADR-020: Event Sink Abstraction](../../.sdlc/adrs/ADR-020-event-sink-abstraction.md)
+- [ADR-029: Gateway Persistence](../../.sdlc/adrs/ADR-029-gateway-persistence.md)
+- [in-toto Specification](https://github.com/in-toto/attestation)
+- [Sigstore](https://www.sigstore.dev/)
+- [SLSA](https://slsa.dev/)

--- a/.sdlc/specs/REQ-019-scan-attestation/requirement.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/requirement.md
@@ -83,7 +83,7 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 
 **Sigstore trust policy** (applies to keyless signing and verification):
 - **OIDC issuer**: configurable allowlist; default includes CI OIDC issuers (`https://token.actions.githubusercontent.com`, GitLab, Azure Pipelines). Reject signatures whose certificate OIDC issuer is not allowlisted.
-- **Workload identity**: certificate `subject` (OIDC `sub`) must match a configured identity pattern for the deployment.
+- **Issuer-to-identity mapping**: each allowed OIDC issuer must have a **non-empty** configured identity pattern (regex or glob on certificate `subject` / OIDC `sub`). Reject verification when an allowlisted issuer has no matching identity policy configured. Wildcards that trust every workload from an issuer (e.g., `*`) are forbidden.
 - **Audience**: certificate OIDC audience must match configured value (default: `sigstore`).
 - **Fulcio roots**: verify against bundled Sigstore public root certificates; roots are versioned and updatable via Gateway configuration.
 - **Rekor policy**: keyless attestations must have a verifiable Rekor transparency-log entry in the configured Rekor instance (default: public Sigstore Rekor).

--- a/.sdlc/specs/REQ-019-scan-attestation/requirement.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/requirement.md
@@ -101,7 +101,7 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 
 **Subject digest verification**:
 - With `--path <source-tree>`: recompute the Subject Digest using the same owned-scope file-selection, path confinement, and canonicalization rules as AC-1 and compare to `subject[].digest.sha256` in the attestation. Mismatch fails with exit `1`. Confinement failures during verify also fail with exit `1`.
-- Without `--path`: verify signature and trust policy only; report the signed digest value but do not assert it matches local content (stdout includes `"digestVerified": null`).
+- Without `--path`: verify signature and trust policy only; do not assert the digest matches local content. Stdout always includes `"subjectDigest": "<sha256-hex>"` (the signed `subject[0].digest.sha256`, lowercase hex) and `"digestVerified": null`.
 - Offline trust policy matches Gateway: when `APME_SIGSTORE_OFFLINE=true` (or CLI equivalent flag documented in the TASK), keyless verify uses embedded Bundle material and local trust roots only — no live OIDC/Fulcio/Rekor calls.
 
 ### AC-5: Keyless and Keyed Signing

--- a/.sdlc/specs/REQ-019-scan-attestation/requirement.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/requirement.md
@@ -30,7 +30,7 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 ### AC-1: Signed SARIF Attestation
 
 **Given** a completed scan with violations or clean result
-**When** attestation output is requested (`--attest` CLI flag or `attest=true` on scan creation)
+**When** attestation output is requested (`--attest` CLI flag or `options.attest=true` on operation creation)
 **Then** APME produces an in-toto attestation envelope containing:
 - SARIF payload as the predicate
 - `attestedAt` timestamp (RFC 3339) recording Gateway envelope creation time (UTC system clock)
@@ -87,7 +87,8 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 - **Audience**: certificate OIDC audience must match configured value (default: `sigstore`).
 - **Fulcio roots**: verify against bundled Sigstore public root certificates; roots are versioned and updatable via Gateway configuration.
 - **Rekor policy**: keyless attestations must have a verifiable Rekor transparency-log entry in the configured Rekor instance (default: public Sigstore Rekor).
-- **Unavailable services**: when Rekor/Fulcio/OIDC are unreachable and no keyed fallback is configured, signing fails with `SIGSTORE_UNAVAILABLE`; verification reports `valid: false` with reason `TRUST_SERVICE_UNAVAILABLE`. Air-gapped deployments use keyed signing only (see design.md).
+- **Signing availability**: when Rekor/Fulcio/OIDC are unreachable and no keyed fallback is configured, signing fails with `SIGSTORE_UNAVAILABLE`. Air-gapped deployments use keyed signing only (see design.md).
+- **Verification availability**: keyless verification of a persisted Sigstore Bundle uses embedded certificate, claims, and Rekor proof with local trust roots — **independent of live OIDC, Fulcio, or Rekor reachability**. `TRUST_SERVICE_UNAVAILABLE` applies only when required verification inputs are missing (no bundle, no local trust root, or live lookup required for an incomplete envelope) — not merely because external services are unreachable.
 
 ## Technical Approach
 

--- a/.sdlc/specs/REQ-019-scan-attestation/requirement.md
+++ b/.sdlc/specs/REQ-019-scan-attestation/requirement.md
@@ -27,20 +27,22 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 
 ## Acceptance Criteria
 
-### AC-1: Signed SARIF Attestation
+### AC-1: Signed Scan Attestation
 
 **Given** a completed scan with violations or clean result
 **When** attestation output is requested (`--attest` CLI flag or `options.attest=true` on operation creation)
-**Then** APME produces an in-toto attestation envelope containing:
+**Then** APME produces an in-toto Statement inside a DSSE envelope containing:
 - SARIF payload as the predicate
 - `attestedAt` timestamp (RFC 3339) recording Gateway envelope creation time (UTC system clock)
 - `scanCompletedAt` timestamp (RFC 3339) recording when Primary finished the scan
 - Subject (scanned project content fingerprint — see Subject Digest below)
-- Cosign signature (keyless via Sigstore or local key)
+- A DSSE signature over the Statement (Sigstore keyless via Gateway workload identity, or a configured Gateway signing key). Implementation may use `sigstore-python` and/or `cosign`; the wire contract is DSSE (+ Sigstore Bundle v0.3 for keyless), not a Cosign-specific blob format.
 
 **Subject Digest** (`subject[].digest.sha256`):
-- Covers all source files parsed into the content graph for the scan (not build artifacts or SARIF output)
+- Covers all source files present in the content graph for the scan (not build artifacts or SARIF output)
+- File set and digests are computed by **Gateway** from its project clone using paths from persisted `content_graph_json` (see contract — no Primary per-file hash RPC)
 - Canonicalization: relative paths sorted lexicographically (POSIX `/`, NFC Unicode), each entry contributes `path + "\0" + sha256(raw_file_bytes) + "\n"`; project digest is SHA-256 of the UTF-8 manifest string (hex-encoded in the envelope)
+- Statement JSON bytes for signing use RFC 8785 (JCS) canonicalization (see contract)
 - Verifiers reproduce the digest from the same scanned tree to bind the attestation to scanned content (see AC-4)
 
 ### AC-2: CLI Integration
@@ -55,7 +57,7 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 ### AC-3: Gateway REST Endpoint
 
 **Given** a completed scan stored in Gateway
-**When** `GET /api/v1/scans/{scan_id}/attestation` is called by an authenticated caller authorized for that scan
+**When** `GET /api/v1/activity/{activity_id}/attestation` is called by an authenticated caller authorized for that activity (`activity_id` ≡ `scan_id`)
 **Then** returns the signed attestation for that scan (see contract for error and pending states)
 
 ### AC-4: Verification Command
@@ -69,21 +71,21 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 
 **Subject digest verification**:
 - With `--path <source-tree>`: recompute the Subject Digest using the same file-selection and canonicalization rules as AC-1 and compare to `subject[].digest.sha256` in the attestation. Mismatch fails with exit `1`.
-- Without `--path`: verify signature and trust policy only; report the signed digest value but do not assert it matches local content (stdout includes `"digestVerified": false`).
+- Without `--path`: verify signature and trust policy only; report the signed digest value but do not assert it matches local content (stdout includes `"digestVerified": null`).
 
 ### AC-5: Keyless and Keyed Signing
 
 **Given** attestation is requested
-**When** no signing key is configured
-**Then** use Sigstore keyless signing (OIDC identity) subject to the trust policy below
+**When** no signing key is configured on Gateway
+**Then** use Sigstore keyless signing with **Gateway workload identity** (see design.md), subject to the trust policy below. The attested signer identity is the Gateway's configured OIDC identity — not an ambient CI job identity unless that identity is explicitly configured as the Gateway signing identity.
 
 **Given** attestation is requested
-**When** `APME_SIGNING_KEY` environment variable is set on Gateway (or `--signing-key <path>` forwarded as a non-secret path reference — see contract)
+**When** `APME_SIGNING_KEY` environment variable is set on Gateway (or `--signing-key <id-or-path>` forwarded as a non-secret Gateway key reference — see contract)
 **Then** use the provided key for signing; CLI and Primary never load private key material
 
 **Sigstore trust policy** (applies to keyless signing and verification):
-- **OIDC issuer**: configurable allowlist; default includes CI OIDC issuers (`https://token.actions.githubusercontent.com`, GitLab, Azure Pipelines). Reject signatures whose certificate OIDC issuer is not allowlisted.
-- **Issuer-to-identity mapping**: each allowed OIDC issuer must have a **non-empty** configured identity pattern (regex or glob on certificate `subject` / OIDC `sub`). Reject verification when an allowlisted issuer has no matching identity policy configured. Wildcards that trust every workload from an issuer (e.g., `*`) are forbidden.
+- **OIDC issuer**: configurable allowlist of issuers that may appear on Gateway signing certificates (defaults are environment-specific; production Helm documents the issuer for the Gateway service account / workload identity). Reject signatures whose certificate OIDC issuer is not allowlisted.
+- **Issuer-to-identity mapping**: each allowed OIDC issuer must have a **non-empty** configured identity pattern (regex or glob on certificate `subject` / OIDC `sub`) that matches the **Gateway signing identity** (for example a Kubernetes service account subject). Reject verification when an allowlisted issuer has no matching identity policy configured. Wildcards that trust every workload from an issuer (e.g., `*`) are forbidden.
 - **Audience**: certificate OIDC audience must match configured value (default: `sigstore`).
 - **Fulcio roots**: verify against bundled Sigstore public root certificates; roots are versioned and updatable via Gateway configuration.
 - **Rekor policy**: keyless attestations must have a verifiable Rekor transparency-log entry in the configured Rekor instance (default: public Sigstore Rekor).
@@ -97,17 +99,20 @@ Regulated enterprises require verifiable evidence that policy validation occurre
 Signing requires outbound calls (Sigstore Rekor transparency log). Per ADR-020/ADR-029, this belongs in **Gateway**, not engine:
 
 ```text
-┌─────────┐      ┌─────────┐      ┌─────────────┐
-│  CLI    │─────▶│ Primary │─────▶│  Gateway    │
-│ --attest│      │ (SARIF) │      │ (sign+store)│
-└─────────┘      └─────────┘      └─────────────┘
-                                        │
-                                        ▼
-                                  ┌───────────┐
-                                  │ Sigstore  │
-                                  │ (Rekor)   │
-                                  └───────────┘
+┌─────────┐     REST / CLI      ┌─────────────┐     gRPC      ┌─────────┐
+│  Client │────────────────────▶│   Gateway   │──────────────▶│ Primary │
+│ --attest│                     │ (orchestrate│◀─────────────│ (SARIF / │
+└─────────┘                     │  persist)   │  ReportFix*  │  graph)  │
+                                └──────┬──────┘               └─────────┘
+                                       │ sign + store
+                                       ▼
+                                 ┌───────────┐
+                                 │ Sigstore  │
+                                 │ (Rekor)   │
+                                 └───────────┘
 ```
+
+CLI and REST clients talk to Gateway (or a co-located daemon that includes Gateway). Primary remains emit-only; Gateway claims signing, talks to Sigstore, and stores the Bundle.
 
 ### Attestation Format
 
@@ -136,15 +141,16 @@ in-toto Statement (APME Scan Predicate):
 
 ### Dependencies
 
-- `sigstore-python` for keyless signing
-- `cosign` binary for keyed signing (optional)
-- Architectural compatibility: Gateway-side signing aligns with invariant 11 (engine never queries out); open operational decisions (offline mode, key storage, retention) are recorded in [design.md](design.md)
+- `sigstore-python` for keyless signing (and Bundle assembly)
+- `cosign` binary optional for keyed signing helpers
+- Architectural compatibility: Gateway-side signing aligns with invariant 11 (engine never queries out); operational decisions (offline mode, key storage, retention, signing identity, idempotency) are recorded in [design.md](design.md)
 
 ## Out of Scope
 
 - SLSA Build provenance (attestation of APME itself — separate concern)
 - Custom attestation predicates (v1 ships with scan predicate only)
 - Hardware key support (HSM/YubiKey — future enhancement)
+- Binding attestation signer identity to an arbitrary caller CI job without configuring that identity as the Gateway signing identity
 
 ## References
 


### PR DESCRIPTION
## Summary

- Add REQ-019: Scan Attestation and Evidence Generation specification
- Cryptographically signed attestations for regulatory compliance in enterprise CI/CD
- Addresses Bank of America field engagement (verifiable evidence that policy validation occurred)

## Key Design Points

- **in-toto + DSSE** — APME Scan Predicate; keyless returns Sigstore Bundle v0.3 with `dsseEnvelope` (not `messageSignature`)
- **Sigstore keyless** — Gateway workload identity by default; keyed optional (Gateway-owned keys only)
- **Sigstore bundle persistence** — Fulcio chain + Rekor proof stored and returned with keyless attestations
- **Gateway-side signing** — per invariant 11 (engine never queries out)
- **Enforceable signing idempotency** — atomic claim, immutable `ready` record, crash recovery without a second Rekor write; GET never signs
- **Subject digest** — Gateway computes from clone + `content_graph_json` paths (no Primary proto / FixSession change)
- **v1 REST-only transport** — no FixSession proto changes; Gateway handoff and completion states documented
- **Operation endpoint mapping** — attestation via `POST /api/v1/projects/{project_id}/operation` with `options.attest=true`
- **Attestation retrieval** — `GET /api/v1/activity/{activity_id}/attestation` (`activity_id` ≡ `scan_id`)
- **HTTP semantics** — `422 not_requested` vs `409 signing_failed`; dual `202` for scan vs signing pending
- **Canonical Statement bytes** — RFC 8785 (JCS) before DSSE PAE
- **CLI flags** — `apme check --attest` with JSON envelope or `--attest-output`; poll until ready/failed
- **Verification** — `apme verify-attestation [--path <source-tree>] <file>`; REST verify `digestVerified` is `true`/`false`/`null`
- **Trust policy** — per-issuer identity mapping for Gateway signing identity (no issuer-wide wildcards)
- **Historical validation** — `EXPIRED_CERTIFICATE` uses Rekor integratedTime or bundled SET timestamp
- **Key rotation** — stable key IDs, trust-set persistence through retention window

## Files Added/Updated

- `.sdlc/specs/REQ-019-scan-attestation/requirement.md`
- `.sdlc/specs/REQ-019-scan-attestation/design.md`
- `.sdlc/specs/REQ-019-scan-attestation/contract.md`
- `.sdlc/specs/README.md` — REQ-017/018/019 index rows

## References

- [Industry Gap Analysis](/.sdlc/research/industry-gap-analysis.md)
- ADR-020, ADR-029 — Gateway placement constraints

## Test plan

- [x] Review spec for completeness (CodeRabbit rounds + adversarial review fixes)
- [x] Validate architectural compatibility (invariant 11; no proto change for digest)
- [x] Confirm acceptance criteria are testable
- [x] Signing idempotency / Bundle wire format / workload identity documented
- [x] CodeRabbit: DSSE PAE vs Rekor SET, `subjectDigest` on verify outputs, encodings, persistence map, offline fail-closed, immutable snapshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added signed scan attestations for regulated CI/CD workflows.
  - Added optional attestation generation during scans, attestation retrieval, and offline verification.
  - Added CLI commands for creating and verifying attestations.
  - Added support for keyless and keyed signing, verification states, trust validation, and stable failure reporting.

- **Documentation**
  - Added specifications covering Python import deprecations, AST validation, and scan attestation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
