### PR TITLE
feat(gateway): proxy Abbenay secrets API for memory store support

### DIFF
--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -66,7 +66,8 @@ Abbenay surfaces (ADR-046 inference stays Primary). Reject path traversal
 (`..` / encoded forms). Abbenay remains the source of truth for config.
 
 Allowlist: `GET/POST /config`, `GET /engines`, `GET /providers`,
-`POST /provider/{id}/configure`, `DELETE /provider/{id}`.
+`POST /provider/{id}/configure`, `DELETE /provider/{id}`,
+`GET/POST /secrets`, `DELETE /secrets/{key}`.
 
 **3. Enable Abbenay HTTP on loopback when Abbenay is enabled.**  
 In addition to gRPC `:50057` (Primary), start Abbenay’s HTTP admin surface on
@@ -208,8 +209,9 @@ runtime admin API.
 - **OpenAPI**: proxy routes `include_in_schema=False` (Abbenay owns schemas);
   Gateway `info.description` references ADR-070.
 - **Tests**: path rewrite, Bearer inject, Cookie strip, 502, models/chat not
-  proxied, traversal rejected, missing token 503, Set-Cookie stripped; helm
-  asserts ordered `--host`/`127.0.0.1`/`--port`/`8787` and Gateway HTTP URL.
+  proxied, traversal rejected, missing token 503, Set-Cookie stripped; secrets
+  GET/POST/DELETE proxy tests; helm asserts ordered
+  `--host`/`127.0.0.1`/`--port`/`8787` and Gateway HTTP URL.
 - **Portal UI**: out of scope for the first implementation PR; catalog proxy +
   Quality settings follow in a later change.
 - **Config durability** ([#498](https://github.com/ansible/apme/issues/498)):
@@ -245,3 +247,4 @@ runtime admin API.
 | 2026-08-03 | cidrblock | Accepted — Simple in-pod Abbenay; Gateway HTTP admin proxy |
 | 2026-08-03 | bthornto | Amended allowlist: added `GET /engines` for read-only engine discovery |
 | 2026-08-03 | bthornto | §6 Config durability implemented (#498): seed→RW emptyDir/PVC; Podman RW config dir |
+| 2026-08-13 | bthornto | Amended allowlist: added `GET/POST /secrets`, `DELETE /secrets/{key}` for Abbenay ≥ v2026.8.5 memory secret store |

--- a/containers/abbenay/config.yaml.example
+++ b/containers/abbenay/config.yaml.example
@@ -1,7 +1,8 @@
 # Abbenay dev configuration for the APME pod.
 #
-# Models: configure one or more LLM providers below. API keys are read
-# from environment variables (set in containers/abbenay/.env).
+# Models: configure one or more LLM providers below. API keys are
+# referenced via secret_name + secret_store (env | memory | keychain).
+# For env-var-based keys, set values in containers/abbenay/.env.
 #
 # Consumers: the "apme" consumer uses a well-known dev token so the
 # Primary container can authenticate without per-dev setup.
@@ -20,7 +21,8 @@ providers:
       anthropic/claude-sonnet-4: {}
       anthropic/claude-opus-4.6: {}
       x-ai/grok-4.5: {}
-    api_key_env: OPENROUTER_API_KEY
+    secret_name: OPENROUTER_API_KEY
+    secret_store: env
 
   # Direct Vertex AI Claude (GCP ADC — no API key).
   # Set ABBENAY_GCP_CREDENTIALS + GOOGLE_VERTEX_PROJECT in .env (see .env.example).
@@ -36,7 +38,8 @@ providers:
   # vertex-anthropic-proxy:
   #   engine: vertex-anthropic
   #   base_url: "https://your-proxy.example.com:443/models"
-  #   api_key_env: "VERTEX_ANTHROPIC_API_KEY"
+  #   secret_name: "VERTEX_ANTHROPIC_API_KEY"
+  #   secret_store: env
   #   models:
   #     claude-sonnet-4@20250514: {}
 

--- a/containers/podman/build.sh
+++ b/containers/podman/build.sh
@@ -16,7 +16,7 @@ echo "==> Building base image (shared dependencies)..."
 podman build "${BUILD_ARGS[@]}" -t localhost/apme-base:latest -f containers/base/Dockerfile .
 
 echo "==> Pulling Abbenay AI image..."
-podman pull ghcr.io/redhat-developer/abbenay:v2026.8.2
+podman pull ghcr.io/redhat-developer/abbenay:v2026.8.5
 
 echo "==> Building service images..."
 podman build "${BUILD_ARGS[@]}" -t apme-primary:latest -f containers/primary/Dockerfile .

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -216,7 +216,7 @@ spec:
         - containerPort: 8081
           hostPort: 8081
     - name: abbenay
-      image: ghcr.io/redhat-developer/abbenay:v2026.8.2
+      image: ghcr.io/redhat-developer/abbenay:v2026.8.5
       # ADR-070: HTTP + gRPC on loopback (pod-shared netns). No hostPort for
       # Abbenay — matches Helm Simple and avoids plaintext host exposure.
       args:

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -202,7 +202,7 @@ Gateway DB and Abbenay down together.
 | `ui.replicas` | `1` | Must be `1` when UI enabled |
 | `abbenay.enabled` | `false` | Enable AI provider sidecar |
 | `abbenay.token` | `""` | Abbenay gRPC + HTTP admin token (required when `abbenay.enabled=true`) |
-| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:v2026.8.2` | Abbenay image |
+| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:v2026.8.5` | Abbenay image |
 | `abbenay.providers` | `{}` | LLM provider map (see [ABBENAY_AI.md](../../../docs/guides/ABBENAY_AI.md)) |
 | `abbenay.aiModel` | `""` | Default AI model ID |
 | `ingress.enabled` | `false` | Create Kubernetes Ingress |

--- a/deploy/helm/apme/templates/abbenay-configmap.yaml
+++ b/deploy/helm/apme/templates/abbenay-configmap.yaml
@@ -20,7 +20,8 @@ data:
         base_url: {{ $provider.baseUrl | quote }}
       {{- end }}
       {{- if or $provider.apiKey $provider.apiKeySecret }}
-        api_key_env_var_name: {{ printf "ABBENAY_PROVIDER_%s" (upper (replace "-" "_" $name)) | quote }}
+        secret_name: {{ printf "ABBENAY_PROVIDER_%s" (upper (replace "-" "_" $name)) | quote }}
+        secret_store: env
       {{- end }}
       {{- if and (eq $provider.engine "vertex-anthropic") (not $provider.baseUrl) }}
       {{- with $.Values.abbenay.gcp }}

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -154,7 +154,7 @@ ui:
 # See docs/guides/ABBENAY_AI.md for GCP-specific setup.
 abbenay:
   enabled: false
-  image: ghcr.io/redhat-developer/abbenay:v2026.8.2
+  image: ghcr.io/redhat-developer/abbenay:v2026.8.5
   # -- Token APME uses to authenticate with Abbenay (required when enabled)
   token: ""
   # -- Override the default model APME selects (e.g. "vertex-claude/claude-sonnet-4-6")

--- a/docs/design/DESIGN_AI_ESCALATION.md
+++ b/docs/design/DESIGN_AI_ESCALATION.md
@@ -576,14 +576,14 @@ Install with: pip install apme-engine[ai]
 Pre-built multi-arch Abbenay images (amd64 + arm64) are available on GHCR:
 
 ```bash
-podman pull ghcr.io/redhat-developer/abbenay:v2026.8.2
+podman pull ghcr.io/redhat-developer/abbenay:v2026.8.5
 ```
 
 | Tag | Meaning |
 |-----|---------|
 | `:main` | Latest merged code |
 | `:sha-<short>` | Specific commit |
-| `:v2026.8.2` | Release (`v` prefix; APME pin) |
+| `:v2026.8.5` | Release (`v` prefix; APME pin) |
 | `:latest` | Latest stable release |
 
 ```

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -20,11 +20,51 @@ Gateway reach Abbenay at `127.0.0.1`. The Gateway reverse-proxies an
 | `GET /api/v1/ai/providers` | `/api/providers` |
 | `POST /api/v1/ai/provider/{id}/configure` | `/api/provider/{id}/configure` |
 | `DELETE /api/v1/ai/provider/{id}` | `/api/provider/{id}` |
+| `GET/POST /api/v1/ai/secrets` | `/api/secrets` |
+| `DELETE /api/v1/ai/secrets/{key}` | `/api/secrets/{key}` |
 
 `GET /api/v1/ai/models` remains Primary → Abbenay gRPC (`ListAIModels`). Chat
 is **not** proxied. Set `APME_ABBENAY_HTTP_URL` (default
 `http://127.0.0.1:8787`) and `APME_ABBENAY_HTTP_TOKEN` on the Gateway (same
 secret as `ABBENAY_API_TOKEN` / `abbenay.token` in Helm).
+
+### Memory secret store (Abbenay >= v2026.8.5)
+
+Abbenay supports a process-lifetime in-memory secret store for containerized
+environments where a system keychain is unavailable. Secrets (API keys) can be
+injected at runtime via the Gateway proxy instead of requiring env vars or Helm
+Secrets at deploy time.
+
+**Inject a secret at runtime:**
+
+```bash
+curl -X POST http://gateway:8080/api/v1/ai/secrets \
+  -H "Content-Type: application/json" \
+  -d '{"key": "OPENROUTER_API_KEY", "value": "sk-or-...", "secretStore": "memory"}'
+```
+
+**List stored secret names:**
+
+```bash
+curl http://gateway:8080/api/v1/ai/secrets
+```
+
+**Remove a secret:**
+
+```bash
+curl -X DELETE http://gateway:8080/api/v1/ai/secrets/OPENROUTER_API_KEY
+```
+
+After injecting a secret, configure a provider to use it via
+`POST /api/v1/ai/provider/{id}/configure` with `secretName` and
+`secretStore: memory`. Memory-stored secrets do not survive pod restarts;
+re-inject after a restart or use Helm Secrets / env vars for persistence.
+
+> **Security note:** `GET /api/v1/ai/secrets` returns stored key **names**
+> (not values) to any client that can reach Gateway `:8080`. The Gateway REST
+> API relies on network-isolation auth (ADR-048) — operators must ensure an
+> outer auth layer (Ingress, Route, reverse proxy) before exposing `:8080`
+> outside the cluster.
 
 ### Writable config volume (#498)
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -53,7 +53,7 @@ This builds a shared base image, eleven service images, and pulls one official i
 | `apme-gateway:latest` | `containers/gateway/Dockerfile` | REST API + gRPC Reporting service (SQLite) |
 | `apme-ui:latest` | `containers/ui/Dockerfile` | React SPA served by nginx (proxies API to Gateway) |
 | `apme-cli:latest` | `containers/cli/Dockerfile` | CLI client |
-| `ghcr.io/redhat-developer/abbenay:v2026.8.2` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
+| `ghcr.io/redhat-developer/abbenay:v2026.8.5` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
 
 ### Configure Abbenay AI (optional)
 

--- a/src/apme_gateway/api/abbenay_proxy.py
+++ b/src/apme_gateway/api/abbenay_proxy.py
@@ -201,7 +201,8 @@ def _filter_response_headers(upstream: httpx.Response) -> dict[str, str]:
     "/ai/{path:path}",
     methods=["GET", "POST", "DELETE"],
     # Transparent proxy — Abbenay owns the admin schema (ADR-070).
-    # Omit HEAD: Starlette derives it from GET without a response body.
+    # HEAD is intentionally omitted: with an explicit methods list FastAPI
+    # returns 405 for HEAD (it is not auto-derived from GET here).
     include_in_schema=False,
 )
 async def proxy_abbenay_admin(path: str, request: Request) -> Response:

--- a/src/apme_gateway/api/abbenay_proxy.py
+++ b/src/apme_gateway/api/abbenay_proxy.py
@@ -6,6 +6,8 @@ through caller ``Authorization``. Inference (``GET /api/v1/ai/models`` and
 Abbenay chat) is **not** proxied — chat stays Primary → Abbenay gRPC.
 ``GET /api/v1/ai/engines`` proxies Abbenay's engine registry (read-only
 discovery path, ADR-070 amendment 2026-08-03).
+``GET/POST /api/v1/ai/secrets`` and ``DELETE /api/v1/ai/secrets/{key}`` proxy
+Abbenay's memory secret store (ADR-070 amendment 2026-08-13, Abbenay ≥ v2026.8.5).
 """
 
 from __future__ import annotations
@@ -63,12 +65,13 @@ _RESPONSE_DROP: Final = frozenset(
 )
 
 # Admin-only path allowlist (decoded, no leading slash). Matches ADR-070 /
-# ABBENAY_AI.md — no chat/sessions/secrets/templates.
-_GET_PATHS: Final = frozenset({"config", "engines", "providers"})
+# ABBENAY_AI.md — no chat/sessions/templates.
+_GET_PATHS: Final = frozenset({"config", "engines", "providers", "secrets"})
 _GET_PROVIDER_RE: Final = re.compile(r"^provider/[^/]+$")
-_POST_PATHS: Final = frozenset({"config"})
+_POST_PATHS: Final = frozenset({"config", "secrets"})
 _POST_CONFIGURE_RE: Final = re.compile(r"^provider/[^/]+/configure$")
 _DELETE_PROVIDER_RE: Final = re.compile(r"^provider/[^/]+$")
+_DELETE_SECRET_RE: Final = re.compile(r"^secrets/[^/]+$")
 
 router = APIRouter(prefix="/api/v1", tags=["abbenay-admin"])
 
@@ -134,7 +137,7 @@ def _method_allows_path(method: str, admin_path: str) -> bool:
     if method == "POST":
         return admin_path in _POST_PATHS or bool(_POST_CONFIGURE_RE.fullmatch(admin_path))
     if method == "DELETE":
-        return bool(_DELETE_PROVIDER_RE.fullmatch(admin_path))
+        return bool(_DELETE_PROVIDER_RE.fullmatch(admin_path)) or bool(_DELETE_SECRET_RE.fullmatch(admin_path))
     return False
 
 
@@ -206,7 +209,8 @@ async def proxy_abbenay_admin(path: str, request: Request) -> Response:
 
     Allowed (examples): ``GET/POST /ai/config``, ``GET /ai/engines``,
     ``GET /ai/providers``, ``POST /ai/provider/{id}/configure``,
-    ``DELETE /ai/provider/{id}``.
+    ``DELETE /ai/provider/{id}``, ``GET/POST /ai/secrets``,
+    ``DELETE /ai/secrets/{key}``.
     ``GET /api/v1/ai/models`` remains on the main router (Primary). Chat and
     other Abbenay surfaces are not proxied.
 

--- a/tests/test_gateway_abbenay_proxy.py
+++ b/tests/test_gateway_abbenay_proxy.py
@@ -199,18 +199,59 @@ async def test_chat_path_not_proxied(app_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
-async def test_secrets_path_not_proxied(app_client: AsyncClient) -> None:
-    """GET /api/v1/ai/secrets is outside the documented admin allowlist.
+async def test_get_secrets_proxied(app_client: AsyncClient) -> None:
+    """GET /api/v1/ai/secrets proxies to Abbenay /api/secrets (memory store).
 
     Args:
         app_client: Async HTTP test client.
     """
-    client = _mock_upstream()
+    secrets_body = b'{"secrets":["OPENROUTER_API_KEY"]}'
+    client = _mock_upstream(content=secrets_body)
     with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
         resp = await app_client.get("/api/v1/ai/secrets")
 
-    assert resp.status_code == 404
-    client.request.assert_not_awaited()
+    assert resp.status_code == 200
+    assert resp.content == secrets_body
+    assert client.request.await_args is not None
+    assert client.request.await_args.args[1] == "http://127.0.0.1:8787/api/secrets"
+    assert client.request.await_args.kwargs["headers"]["Authorization"] == "Bearer admin-http-token"
+    assert "Cookie" not in client.request.await_args.kwargs["headers"]
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_post_secrets_proxied(app_client: AsyncClient) -> None:
+    """POST /api/v1/ai/secrets proxies to Abbenay /api/secrets (set secret).
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = _mock_upstream(content=b'{"ok":true}')
+    body = {"key": "OPENROUTER_API_KEY", "value": "sk-or-test"}
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.post("/api/v1/ai/secrets", json=body)
+
+    assert resp.status_code == 200
+    assert client.request.await_args is not None
+    assert client.request.await_args.args[1] == "http://127.0.0.1:8787/api/secrets"
+    assert client.request.await_args.kwargs["headers"]["Authorization"] == "Bearer admin-http-token"
+    assert b"sk-or-test" in (client.request.await_args.kwargs.get("content") or b"")
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_delete_secret_by_key_proxied(app_client: AsyncClient) -> None:
+    """DELETE /api/v1/ai/secrets/{key} proxies to Abbenay /api/secrets/{key}.
+
+    Args:
+        app_client: Async HTTP test client.
+    """
+    client = _mock_upstream(content=b'{"deleted":true}')
+    with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
+        resp = await app_client.delete("/api/v1/ai/secrets/OPENROUTER_API_KEY")
+
+    assert resp.status_code == 200
+    assert client.request.await_args is not None
+    assert client.request.await_args.args[1] == ("http://127.0.0.1:8787/api/secrets/OPENROUTER_API_KEY")
+    assert client.request.await_args.kwargs["headers"]["Authorization"] == "Bearer admin-http-token"
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]

--- a/tests/test_gateway_abbenay_proxy.py
+++ b/tests/test_gateway_abbenay_proxy.py
@@ -226,15 +226,27 @@ async def test_post_secrets_proxied(app_client: AsyncClient) -> None:
         app_client: Async HTTP test client.
     """
     client = _mock_upstream(content=b'{"ok":true}')
-    body = {"key": "OPENROUTER_API_KEY", "value": "sk-or-test"}
+    body = {
+        "key": "OPENROUTER_API_KEY",
+        "value": "sk-or-test",
+        "secretStore": "memory",
+    }
     with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
-        resp = await app_client.post("/api/v1/ai/secrets", json=body)
+        resp = await app_client.post(
+            "/api/v1/ai/secrets",
+            json=body,
+            headers={"Cookie": "session=caller-cookie"},
+        )
 
     assert resp.status_code == 200
     assert client.request.await_args is not None
     assert client.request.await_args.args[1] == "http://127.0.0.1:8787/api/secrets"
     assert client.request.await_args.kwargs["headers"]["Authorization"] == "Bearer admin-http-token"
-    assert b"sk-or-test" in (client.request.await_args.kwargs.get("content") or b"")
+    assert "Cookie" not in client.request.await_args.kwargs["headers"]
+    content = client.request.await_args.kwargs.get("content") or b""
+    assert b"sk-or-test" in content
+    assert b"secretStore" in content
+    assert b"memory" in content
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]


### PR DESCRIPTION
## Summary

- Allowlist Abbenay's secrets HTTP endpoints (`GET/POST /secrets`,
  `DELETE /secrets/{key}`) through the Gateway admin proxy so portal and
  other clients can inject API keys into Abbenay's in-memory secret store
  at runtime (Abbenay >= v2026.8.5)
- Bump the Abbenay image pin from v2026.8.2 to v2026.8.5 (memory store +
  consistent camelCase API)
- Migrate config vocabulary from legacy `api_key_env` / `api_key_env_var_name`
  to v2026.8.5's `secret_name` + `secret_store`

## Changes

- **Gateway proxy** (`abbenay_proxy.py`): added `secrets` to GET/POST
  allowlists, added `_DELETE_SECRET_RE` for `DELETE /secrets/{key}`,
  updated docstrings
- **Tests** (`test_gateway_abbenay_proxy.py`): replaced the blocking
  `test_secrets_path_not_proxied` with three positive tests covering
  GET list, POST set, and DELETE by key — each asserts path rewrite,
  Bearer token injection, and (where applicable) Cookie stripping
- **Abbenay image bump**: v2026.8.2 → v2026.8.5 in `values.yaml`,
  `pod.yaml`, `build.sh`, `README.md`, `DEPLOYMENT.md`,
  `DESIGN_AI_ESCALATION.md`
- **Config vocabulary**: `config.yaml.example` and Helm ConfigMap now
  use `secret_name` + `secret_store: env` instead of `api_key_env` /
  `api_key_env_var_name`
- **ADR-070**: amended allowlist and added revision history entry
- **ABBENAY_AI.md**: added secrets rows to proxy table, new "Memory
  secret store" section with curl examples, security note for key-name
  enumeration per ADR-048

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (3 pre-existing OPA failures unrelated)
- [x] All 14 Abbenay proxy tests pass (3 new + 11 existing)
- [x] Docs updated (ABBENAY_AI.md, DEPLOYMENT.md, Helm README, ADR-070)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gateway access for listing, creating, and deleting Abbenay in-memory secrets.
  * Added configurable secret-store settings for provider API keys.
* **Deployment**
  * Updated the default Abbenay image to v2026.8.5 across container and Helm deployment configurations.
* **Documentation**
  * Added runtime secret-management examples, configuration guidance, persistence details, and security notes.
  * Updated deployment and architecture references for the new Abbenay version.
* **Tests**
  * Added coverage for secret listing, creation, and deletion through the Gateway.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->