### PR TITLE
build(ai): pin abbenay-client 2026.8.5 from PyPI

### DIFF
--- a/.sdlc/context/dependencies.md
+++ b/.sdlc/context/dependencies.md
@@ -136,7 +136,7 @@ with open(path, "w") as f:
 
 | Package | Purpose |
 |---------|---------|
-| `abbenay-client==2026.8.5` | gRPC client for the Abbenay AI provider (Tier 2 remediation); PyPI, CalVer-aligned with daemon image `v2026.8.5`. Prefer `uv sync --extra ai` (hashes in `uv.lock`); `pip install apme-engine[ai]` is version-pin only. |
+| `abbenay-client==2026.8.5` | gRPC client for the Abbenay AI provider (Tier 2 remediation); PyPI, CalVer-aligned with daemon image `v2026.8.5`. Local/dev: `uv sync --extra ai`. Production/containers: `uv sync --frozen --extra ai` (hashes in `uv.lock`). `pip install apme-engine[ai]` is version-pin only. |
 
 ### Gateway (`[project.optional-dependencies.gateway]`)
 

--- a/.sdlc/context/dependencies.md
+++ b/.sdlc/context/dependencies.md
@@ -136,7 +136,7 @@ with open(path, "w") as f:
 
 | Package | Purpose |
 |---------|---------|
-| `abbenay-client` | gRPC client for the Abbenay AI provider (Tier 2 remediation) |
+| `abbenay-client==2026.8.5` | gRPC client for the Abbenay AI provider (Tier 2 remediation); PyPI, CalVer-aligned with daemon image `v2026.8.5` |
 
 ### Gateway (`[project.optional-dependencies.gateway]`)
 

--- a/.sdlc/context/dependencies.md
+++ b/.sdlc/context/dependencies.md
@@ -136,7 +136,7 @@ with open(path, "w") as f:
 
 | Package | Purpose |
 |---------|---------|
-| `abbenay-client==2026.8.5` | gRPC client for the Abbenay AI provider (Tier 2 remediation); PyPI, CalVer-aligned with daemon image `v2026.8.5` |
+| `abbenay-client==2026.8.5` | gRPC client for the Abbenay AI provider (Tier 2 remediation); PyPI, CalVer-aligned with daemon image `v2026.8.5`. Prefer `uv sync --extra ai` (hashes in `uv.lock`); `pip install apme-engine[ai]` is version-pin only. |
 
 ### Gateway (`[project.optional-dependencies.gateway]`)
 

--- a/docs/design/DESIGN_AI_ESCALATION.md
+++ b/docs/design/DESIGN_AI_ESCALATION.md
@@ -543,21 +543,14 @@ Future MCP integration (when implemented) would allow the LLM to autonomously ca
 
 ## Optional Dependency
 
-`abbenay-client` is an optional dependency:
-
-Currently pinned via direct wheel URL with SHA256 verification:
+`abbenay-client` is an optional dependency, published on PyPI. Pin it to
+the same CalVer as the Abbenay daemon image (currently `v2026.8.5`):
 
 ```toml
 [project.optional-dependencies]
 ai = [
-    "abbenay-client @ https://github.com/redhat-developer/abbenay/releases/download/v2026.4.1-alpha/abbenay_client-2026.4.1a0-py3-none-any.whl#sha256=8a4730...",
+    "abbenay-client==2026.8.5",
 ]
-```
-
-Once `abbenay-client` is published to PyPI, this can be simplified to:
-
-```toml
-ai = ["abbenay-client>=2026.4.1a0"]
 ```
 
 Install with: `pip install apme-engine[ai]`

--- a/docs/design/DESIGN_AI_ESCALATION.md
+++ b/docs/design/DESIGN_AI_ESCALATION.md
@@ -553,13 +553,32 @@ ai = [
 ]
 ```
 
-Install with: `pip install apme-engine[ai]`
+**Install (preferred — hashed via ``uv.lock``):**
+
+```bash
+uv sync --extra ai
+```
+
+Container images use ``uv sync --frozen --extra ai`` (see
+``containers/base/Dockerfile``), so deployed builds verify wheel/sdist
+digests from the lockfile.
+
+**Install (pip — version pin only):**
+
+```bash
+pip install apme-engine[ai]
+```
+
+``pip`` does not consume ``uv.lock`` hashes. That matches other optional
+extras (``gateway``, ``dev``): the version pin is the contract; artifact
+integrity for production comes from ``uv sync --frozen``.
 
 If `--ai` is set but `abbenay-client` is not installed:
 
 ```
 Error: AI escalation requires the 'ai' extra.
-Install with: pip install apme-engine[ai]
+Install with: uv sync --extra ai
+# or: pip install apme-engine[ai]
 ```
 
 ---

--- a/docs/design/DESIGN_AI_ESCALATION.md
+++ b/docs/design/DESIGN_AI_ESCALATION.md
@@ -553,17 +553,22 @@ ai = [
 ]
 ```
 
-**Install (preferred — hashed via ``uv.lock``):**
+**Install (local / development):**
 
 ```bash
 uv sync --extra ai
 ```
 
-Container images use ``uv sync --frozen --extra ai`` (see
-``containers/base/Dockerfile``), so deployed builds verify wheel/sdist
-digests from the lockfile.
+**Install (production / containers — hashed via ``uv.lock``):**
 
-**Install (pip — version pin only):**
+```bash
+uv sync --frozen --extra ai
+```
+
+Container images use the frozen form (see ``containers/base/Dockerfile``)
+so deployed builds verify wheel/sdist digests from the lockfile.
+
+**Install (pip — version pin only, not for production):**
 
 ```bash
 pip install apme-engine[ai]
@@ -575,10 +580,11 @@ integrity for production comes from ``uv sync --frozen``.
 
 If `--ai` is set but `abbenay-client` is not installed:
 
-```
+```text
 Error: AI escalation requires the 'ai' extra.
 Install with: uv sync --extra ai
 # or: pip install apme-engine[ai]
+# Production/containers: uv sync --frozen --extra ai
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
 
 [project.optional-dependencies]
 ai = [
-    "abbenay-client @ https://github.com/redhat-developer/abbenay/releases/download/v2026.4.1-alpha/abbenay_client-2026.4.1a0-py3-none-any.whl#sha256=8a473016b6b2d06c0620abb3d03f583b2b2c958654e293e8e66da70516e5dd33",
+    # Pin to the same CalVer as the Abbenay daemon image (deploy pins).
+    "abbenay-client==2026.8.5",
 ]
 gateway = [
     "sqlalchemy>=2.0",

--- a/src/apme_engine/remediation/abbenay_provider.py
+++ b/src/apme_engine/remediation/abbenay_provider.py
@@ -1,7 +1,8 @@
 """AbbenayProvider — default AIProvider implementation using abbenay_grpc.
 
 This is the sole file in the codebase that imports abbenay_grpc.
-Install with: pip install apme-engine[ai]
+Install with: ``uv sync --extra ai`` (preferred; hashes via ``uv.lock``)
+or ``pip install apme-engine[ai]`` (version pin only).
 """
 
 from __future__ import annotations
@@ -656,7 +657,9 @@ class AbbenayProvider:
             from abbenay_grpc import AbbenayClient  # noqa: PLC0415
         except ImportError:
             raise ImportError(
-                "AI escalation requires the 'ai' extra.\nInstall with: pip install apme-engine[ai]"
+                "AI escalation requires the 'ai' extra.\n"
+                "Install with: uv sync --extra ai\n"
+                "or: pip install apme-engine[ai]"
             ) from None
 
         if addr.startswith("unix://"):

--- a/src/apme_engine/remediation/abbenay_provider.py
+++ b/src/apme_engine/remediation/abbenay_provider.py
@@ -1,8 +1,9 @@
 """AbbenayProvider — default AIProvider implementation using abbenay_grpc.
 
 This is the sole file in the codebase that imports abbenay_grpc.
-Install with: ``uv sync --extra ai`` (preferred; hashes via ``uv.lock``)
-or ``pip install apme-engine[ai]`` (version pin only).
+Install (local/dev): ``uv sync --extra ai``.
+Install (production/containers): ``uv sync --frozen --extra ai``.
+Alternate (version pin only): ``pip install apme-engine[ai]``.
 """
 
 from __future__ import annotations
@@ -658,7 +659,8 @@ class AbbenayProvider:
         except ImportError:
             raise ImportError(
                 "AI escalation requires the 'ai' extra.\n"
-                "Install with: uv sync --extra ai\n"
+                "Install (local/dev): uv sync --extra ai\n"
+                "Install (production/containers): uv sync --frozen --extra ai\n"
                 "or: pip install apme-engine[ai]"
             ) from None
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -20,25 +20,16 @@ constraints = [
 
 [[package]]
 name = "abbenay-client"
-version = "2026.4.1a0"
-source = { url = "https://github.com/redhat-developer/abbenay/releases/download/v2026.4.1-alpha/abbenay_client-2026.4.1a0-py3-none-any.whl" }
+version = "2026.8.5"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/84/1e/30227da7b62ef1981056f86a31a31aeffec44781b9f34022b9eeb864227d/abbenay_client-2026.8.5.tar.gz", hash = "sha256:87b305ed62fcab4f4204b3cf59f4bbe5e5949bfb38e19db04be6b82f1bb2ff97", size = 36609, upload-time = "2026-08-13T17:06:47.471Z" }
 wheels = [
-    { url = "https://github.com/redhat-developer/abbenay/releases/download/v2026.4.1-alpha/abbenay_client-2026.4.1a0-py3-none-any.whl", hash = "sha256:8a473016b6b2d06c0620abb3d03f583b2b2c958654e293e8e66da70516e5dd33" },
+    { url = "https://files.pythonhosted.org/packages/49/3c/e4e3218675c9943698ab9845e7285930f5f0a5f27c6c5403db6033d533c2/abbenay_client-2026.8.5-py3-none-any.whl", hash = "sha256:693bf3e86836f855a25e4df30aa027b3e70ff3a855fc2ab8ebcf9d43f2c0fa2b", size = 38443, upload-time = "2026-08-13T17:06:46.108Z" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "grpcio", specifier = ">=1.60.0" },
-    { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.60.0" },
-    { name = "protobuf", specifier = ">=4.25.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
-]
-provides-extras = ["dev"]
 
 [[package]]
 name = "aiosqlite"
@@ -312,7 +303,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "abbenay-client", marker = "extra == 'ai'", url = "https://github.com/redhat-developer/abbenay/releases/download/v2026.4.1-alpha/abbenay_client-2026.4.1a0-py3-none-any.whl" },
+    { name = "abbenay-client", marker = "extra == 'ai'", specifier = "==2026.8.5" },
     { name = "aiosqlite", marker = "extra == 'gateway'", specifier = ">=0.20" },
     { name = "ansible-core", specifier = ">=2.20.7" },
     { name = "fastapi", specifier = ">=0.100" },


### PR DESCRIPTION
## Summary

- Bump optional `abbenay-client` from GitHub alpha wheel `2026.4.1a0` to PyPI `==2026.8.5`, matching the Abbenay daemon image pin from #558
- Refresh `uv.lock` (registry + hashes) and design/SDLC docs that described the old direct-URL install
- Document install integrity: local/dev `uv sync --extra ai`; production/containers `uv sync --frozen --extra ai` (hashes in `uv.lock`); pip path is version-pin only

## Changes

- `pyproject.toml`: `ai` extra → `abbenay-client==2026.8.5`
- `uv.lock`: resolve from `https://pypi.org/simple` with published wheel/sdist hashes
- `DESIGN_AI_ESCALATION.md`: PyPI pin + local vs frozen install guidance
- `.sdlc/context/dependencies.md`: note PyPI pin, daemon alignment, install paths
- `abbenay_provider.py`: install guidance matches docs

## Test plan

- [x] `tox -e lint` passes (including `uv-lock`)
- [x] Full `tox -e unit` — 2945 passed; 3 pre-existing OPA failures (external binary)
- [x] Spot-checked `AbbenayClient` 2026.8.5 API still matches `abbenay_provider.py` usage
- [x] CI green including `test-ai-extra`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the optional AI integration to version 2026.8.5.
  - Switched installation to the published package distribution.

- **Documentation**
  - Clarified installation guidance for local and production `uv` environments, as well as pip.
  - Added guidance for locked production installations.
  - Updated missing-dependency messages with recommended installation commands.
  - Removed outdated instructions for the previous distribution method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->