### PR TITLE
feat(gateway): store AI providers in DB and push to Abbenay memory

### DIFF
--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -309,6 +309,35 @@
         "title": "AiAcceptanceEntry",
         "type": "object"
       },
+      "AiEngineInfo": {
+        "description": "Abbenay engine descriptor for the provider wizard.\n\nAttributes:\n    id: Abbenay engine id (e.g. ``openrouter``).\n    requires_key: Whether the engine needs an API key.\n    default_base_url: Suggested API root when none is configured.\n    default_env_var: Legacy env-var name hint (informational only).",
+        "properties": {
+          "default_base_url": {
+            "default": "",
+            "title": "Default Base Url",
+            "type": "string"
+          },
+          "default_env_var": {
+            "default": "",
+            "title": "Default Env Var",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "requires_key": {
+            "default": true,
+            "title": "Requires Key",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "AiEngineInfo",
+        "type": "object"
+      },
       "AiEscalateTargetBody": {
         "description": "One AI escalation target (path + optional rule_ids).\n\nAttributes:\n    path: Content-graph location path (empty rule_ids = entire path).\n    rule_ids: Optional rule filter; omit or empty for the whole path.",
         "properties": {
@@ -352,6 +381,63 @@
           "name"
         ],
         "title": "AiModelInfo",
+        "type": "object"
+      },
+      "AiProviderSchema": {
+        "description": "A portal-managed Abbenay LLM provider (API key never exposed).\n\nAttributes:\n    id: Auto-increment primary key.\n    name: Virtual Abbenay provider name (slug).\n    engine: Abbenay engine id.\n    base_url: Optional custom API base URL.\n    models: Model id \u2192 params map.\n    has_api_key: Whether an API key is stored (value never exposed).\n    extra: Optional engine-specific metadata.\n    created_at: ISO 8601 creation timestamp.\n    updated_at: ISO 8601 last-update timestamp.",
+        "properties": {
+          "base_url": {
+            "default": "",
+            "title": "Base Url",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "engine": {
+            "title": "Engine",
+            "type": "string"
+          },
+          "extra": {
+            "additionalProperties": true,
+            "title": "Extra",
+            "type": "object"
+          },
+          "has_api_key": {
+            "default": false,
+            "title": "Has Api Key",
+            "type": "boolean"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "models": {
+            "additionalProperties": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Models",
+            "type": "object"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "engine",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "AiProviderSchema",
         "type": "object"
       },
       "ApproveRequest": {
@@ -576,6 +662,48 @@
         "title": "ComponentHealth",
         "type": "object"
       },
+      "CreateAiProviderRequest": {
+        "description": "Request body for creating an AI provider.\n\nAttributes:\n    name: Virtual Abbenay provider name (slug).\n    engine: Abbenay engine id.\n    base_url: Optional custom API base URL.\n    api_key: Provider API key (may be empty for keyless engines).\n    models: Model id \u2192 params map.\n    extra: Optional engine-specific metadata.",
+        "properties": {
+          "api_key": {
+            "default": "",
+            "title": "Api Key",
+            "type": "string"
+          },
+          "base_url": {
+            "default": "",
+            "title": "Base Url",
+            "type": "string"
+          },
+          "engine": {
+            "title": "Engine",
+            "type": "string"
+          },
+          "extra": {
+            "additionalProperties": true,
+            "title": "Extra",
+            "type": "object"
+          },
+          "models": {
+            "additionalProperties": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Models",
+            "type": "object"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "engine"
+        ],
+        "title": "CreateAiProviderRequest",
+        "type": "object"
+      },
       "CreateGalaxyServerRequest": {
         "description": "Request body for creating a Galaxy server.\n\nAttributes:\n    name: Short label.\n    url: Base API URL.\n    token: API token (optional, empty for public Galaxy).\n    auth_url: SSO/Keycloak token endpoint (optional).",
         "properties": {
@@ -779,6 +907,59 @@
           }
         },
         "title": "DepHealthSummary",
+        "type": "object"
+      },
+      "DiscoverAiModelsRequest": {
+        "description": "Discover models from an engine API (wizard helper).\n\nAttributes:\n    engine: Abbenay engine id to query.\n    api_key: Optional API key for authenticated discovery.\n    base_url: Optional custom API base URL.",
+        "properties": {
+          "api_key": {
+            "default": "",
+            "title": "Api Key",
+            "type": "string"
+          },
+          "base_url": {
+            "default": "",
+            "title": "Base Url",
+            "type": "string"
+          },
+          "engine": {
+            "title": "Engine",
+            "type": "string"
+          }
+        },
+        "required": [
+          "engine"
+        ],
+        "title": "DiscoverAiModelsRequest",
+        "type": "object"
+      },
+      "DiscoveredAiModel": {
+        "description": "Model discovered from an engine API.\n\nAttributes:\n    id: Engine model id.\n    name: Human-readable model name.\n    provider: Upstream provider label from Abbenay.\n    engine: Abbenay engine id used for discovery.",
+        "properties": {
+          "engine": {
+            "default": "",
+            "title": "Engine",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "default": "",
+            "title": "Name",
+            "type": "string"
+          },
+          "provider": {
+            "default": "",
+            "title": "Provider",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "DiscoveredAiModel",
         "type": "object"
       },
       "DraftProposalUpdate": {
@@ -2376,6 +2557,84 @@
           "scan_type"
         ],
         "title": "TrendPoint",
+        "type": "object"
+      },
+      "UpdateAiProviderRequest": {
+        "description": "Partial update for an AI provider.\n\nAttributes:\n    name: New virtual provider name, or None to leave unchanged.\n    engine: New engine id, or None to leave unchanged.\n    base_url: New base URL, or None to leave unchanged.\n    api_key: New API key, or None/empty to leave unchanged.\n    models: New models map, or None to leave unchanged.\n    extra: New metadata, or None to leave unchanged.",
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url"
+          },
+          "engine": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Engine"
+          },
+          "extra": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extra"
+          },
+          "models": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Models"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "UpdateAiProviderRequest",
         "type": "object"
       },
       "UpdateGalaxyServerRequest": {
@@ -4911,6 +5170,251 @@
           }
         },
         "summary": "Session Trend Endpoint"
+      }
+    },
+    "/api/v1/settings/ai-engines": {
+      "get": {
+        "description": "Return Abbenay engine types for the provider wizard.\n\nReturns:\n    Engine descriptors (empty when Abbenay is unavailable).",
+        "operationId": "list_ai_engines_api_v1_settings_ai_engines_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AiEngineInfo"
+                  },
+                  "title": "Response List Ai Engines Api V1 Settings Ai Engines Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Ai Engines"
+      }
+    },
+    "/api/v1/settings/ai-providers": {
+      "get": {
+        "description": "Return all portal-managed AI providers (secrets masked).\n\nReturns:\n    Provider definitions with ``has_api_key`` instead of raw secrets.",
+        "operationId": "list_ai_providers_api_v1_settings_ai_providers_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AiProviderSchema"
+                  },
+                  "title": "Response List Ai Providers Api V1 Settings Ai Providers Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Ai Providers"
+      },
+      "post": {
+        "description": "Create a new AI provider definition (Gateway SoT).\n\nArgs:\n    body: Provider creation payload (including optional API key).\n\nReturns:\n    Newly created provider (API key masked).\n\nRaises:\n    HTTPException: 400 on invalid name/engine; 409 on duplicate name.",
+        "operationId": "create_ai_provider_api_v1_settings_ai_providers_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAiProviderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiProviderSchema"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Ai Provider"
+      }
+    },
+    "/api/v1/settings/ai-providers/discover-models": {
+      "post": {
+        "description": "Discover models from an engine API (wizard helper).\n\nArgs:\n    body: Engine id plus optional credentials for discovery.\n\nReturns:\n    Discovered model descriptors from Abbenay.\n\nRaises:\n    HTTPException: 400 when engine is missing; 503 when Abbenay is down;\n        502 when discovery fails.",
+        "operationId": "discover_ai_models_api_v1_settings_ai_providers_discover_models_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverAiModelsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DiscoveredAiModel"
+                  },
+                  "title": "Response Discover Ai Models Api V1 Settings Ai Providers Discover Models Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Discover Ai Models"
+      }
+    },
+    "/api/v1/settings/ai-providers/{provider_id}": {
+      "delete": {
+        "description": "Delete an AI provider definition and remove it from Abbenay.\n\nArgs:\n    provider_id: Gateway primary key.\n\nRaises:\n    HTTPException: 404 if not found.",
+        "operationId": "delete_ai_provider_api_v1_settings_ai_providers__provider_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider_id",
+            "required": true,
+            "schema": {
+              "title": "Provider Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Ai Provider"
+      },
+      "get": {
+        "description": "Fetch a single AI provider by ID.\n\nArgs:\n    provider_id: Gateway primary key.\n\nReturns:\n    Provider definition (API key masked).\n\nRaises:\n    HTTPException: 404 if not found.",
+        "operationId": "get_ai_provider_api_v1_settings_ai_providers__provider_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider_id",
+            "required": true,
+            "schema": {
+              "title": "Provider Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiProviderSchema"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Ai Provider"
+      },
+      "patch": {
+        "description": "Update an AI provider definition.\n\nArgs:\n    provider_id: Gateway primary key.\n    body: Partial update payload.\n\nReturns:\n    Updated provider (API key masked).\n\nRaises:\n    HTTPException: 400 when no fields are provided or validation fails;\n        404 if not found; 409 on duplicate name.",
+        "operationId": "update_ai_provider_api_v1_settings_ai_providers__provider_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider_id",
+            "required": true,
+            "schema": {
+              "title": "Provider Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAiProviderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiProviderSchema"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Ai Provider"
       }
     },
     "/api/v1/settings/galaxy-servers": {

--- a/src/apme_gateway/_abbenay_admin.py
+++ b/src/apme_gateway/_abbenay_admin.py
@@ -1,0 +1,341 @@
+"""Low-level Abbenay gRPC admin helpers for Gateway AI settings.
+
+Uses ``ListEngines``, ``DiscoverModels``, ``ConfigureProvider``,
+``RemoveProvider``, and ``UpdateConfig`` so Portal-managed providers are
+applied to the running Abbenay daemon (consumed by Primary at job time).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import grpc.aio
+
+logger = logging.getLogger(__name__)
+
+_ADDR_ENV = "APME_ABBENAY_ADDR"
+_DEFAULT_ADDR = "127.0.0.1:50057"
+
+
+@dataclass(frozen=True)
+class AbbenayEngineInfo:
+    """Engine metadata returned by Abbenay ``ListEngines``.
+
+    Attributes:
+        id: Abbenay engine id.
+        requires_key: Whether the engine needs an API key.
+        default_base_url: Suggested API root.
+        default_env_var: Legacy env-var name hint.
+    """
+
+    id: str
+    requires_key: bool
+    default_base_url: str
+    default_env_var: str
+
+
+@dataclass(frozen=True)
+class AbbenayDiscoveredModel:
+    """Model descriptor returned by Abbenay ``DiscoverModels``.
+
+    Attributes:
+        id: Engine model id.
+        name: Human-readable model name.
+        provider: Upstream provider label.
+        engine: Abbenay engine id.
+    """
+
+    id: str
+    name: str
+    provider: str
+    engine: str
+
+
+def _resolve_addr() -> str:
+    """Return the Abbenay gRPC listen address from env or the default.
+
+    Returns:
+        Host:port or ``unix://`` path for the Abbenay admin channel.
+    """
+    return os.environ.get(_ADDR_ENV, "").strip() or _DEFAULT_ADDR
+
+
+def _grpc_target(addr: str) -> str:
+    """Normalize an Abbenay address for ``grpc.aio.insecure_channel``.
+
+    Args:
+        addr: Host:port or ``unix://`` path.
+
+    Returns:
+        Channel target string.
+    """
+    if addr.startswith("unix://"):
+        return addr
+    return addr
+
+
+class AbbenayAdminClient:
+    """Async admin client over the Abbenay gRPC API."""
+
+    def __init__(self, addr: str | None = None) -> None:
+        """Create a client bound to ``addr`` or the process default.
+
+        Args:
+            addr: Optional Abbenay gRPC address override.
+        """
+        self._addr = addr or _resolve_addr()
+        self._channel: grpc.aio.Channel | None = None
+        self._stub: Any = None
+
+    async def connect(self) -> None:
+        """Open the insecure gRPC channel and stub."""
+        from abbenay_grpc.abbenay.v1 import service_pb2_grpc  # noqa: PLC0415
+
+        target = _grpc_target(self._addr)
+        self._channel = grpc.aio.insecure_channel(target)
+        self._stub = service_pb2_grpc.AbbenayStub(self._channel)
+
+    async def close(self) -> None:
+        """Close the gRPC channel if open."""
+        if self._channel is not None:
+            await self._channel.close(grace=None)
+            self._channel = None
+            self._stub = None
+
+    async def __aenter__(self) -> AbbenayAdminClient:
+        """Connect on context-manager enter.
+
+        Returns:
+            Connected admin client.
+        """
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        """Close on context-manager exit.
+
+        Args:
+            *_args: Unused exception context from the context manager protocol.
+        """
+        await self.close()
+
+    async def list_engines(self) -> list[AbbenayEngineInfo]:
+        """List engines advertised by Abbenay.
+
+        Returns:
+            Engine descriptors from ``ListEngines``.
+        """
+        from abbenay_grpc.abbenay.v1 import service_pb2 as proto  # noqa: PLC0415
+
+        resp = await self._stub.ListEngines(proto.ListEnginesRequest(), timeout=10)
+        return [
+            AbbenayEngineInfo(
+                id=e.id,
+                requires_key=bool(e.requires_key),
+                default_base_url=e.default_base_url or "",
+                default_env_var=e.default_env_var or "",
+            )
+            for e in resp.engines
+        ]
+
+    async def discover_models(
+        self,
+        *,
+        engine_id: str,
+        api_key: str = "",
+        base_url: str = "",
+    ) -> list[AbbenayDiscoveredModel]:
+        """Discover models for an engine.
+
+        Args:
+            engine_id: Abbenay engine id.
+            api_key: Optional API key for authenticated discovery.
+            base_url: Optional custom API base URL.
+
+        Returns:
+            Discovered model descriptors.
+        """
+        from abbenay_grpc.abbenay.v1 import service_pb2 as proto  # noqa: PLC0415
+
+        req = proto.DiscoverModelsRequest(engine_id=engine_id)
+        if api_key:
+            req.api_key = api_key
+        if base_url:
+            req.base_url = base_url
+        resp = await self._stub.DiscoverModels(req, timeout=60)
+        return [
+            AbbenayDiscoveredModel(
+                id=m.id or m.engine_model_id or "",
+                name=m.name or m.id or "",
+                provider=m.provider or engine_id,
+                engine=m.engine or engine_id,
+            )
+            for m in resp.models
+            if m.id or m.engine_model_id
+        ]
+
+    async def configure_provider(
+        self,
+        *,
+        provider_id: str,
+        engine: str,
+        api_key: str = "",
+        base_url: str = "",
+    ) -> None:
+        """Configure provider credentials via Abbenay gRPC.
+
+        Args:
+            provider_id: Virtual provider name.
+            engine: Abbenay engine id.
+            api_key: Provider API key (may be empty).
+            base_url: Optional custom API base URL.
+
+        Raises:
+            RuntimeError: When Abbenay reports configure failure.
+        """
+        from abbenay_grpc.abbenay.v1 import service_pb2 as proto  # noqa: PLC0415
+
+        req = proto.ConfigureProviderRequest(
+            provider_id=provider_id,
+            engine=engine,
+            api_key=api_key,
+            base_url=base_url,
+        )
+        resp = await self._stub.ConfigureProvider(req, timeout=30)
+        if not resp.success:
+            msg = f"Abbenay ConfigureProvider failed for '{provider_id}'"
+            raise RuntimeError(msg)
+
+    async def remove_provider(self, provider_id: str) -> None:
+        """Remove a virtual provider from Abbenay.
+
+        Args:
+            provider_id: Virtual provider name.
+        """
+        from abbenay_grpc.abbenay.v1 import service_pb2 as proto  # noqa: PLC0415
+
+        await self._stub.RemoveProvider(
+            proto.RemoveProviderRequest(provider_id=provider_id),
+            timeout=30,
+        )
+
+    async def get_config(self) -> Any:
+        """Fetch the live Abbenay configuration object.
+
+        Returns:
+            Abbenay ``GetConfig`` response payload.
+        """
+        from abbenay_grpc.abbenay.v1 import service_pb2 as proto  # noqa: PLC0415
+
+        return await self._stub.GetConfig(proto.GetConfigRequest(), timeout=10)
+
+    async def update_config(self, config: Any) -> None:
+        """Replace the live Abbenay configuration.
+
+        Args:
+            config: Abbenay config object from ``get_config``.
+        """
+        from abbenay_grpc.abbenay.v1 import service_pb2 as proto  # noqa: PLC0415
+
+        await self._stub.UpdateConfig(
+            proto.UpdateConfigRequest(config=config),
+            timeout=30,
+        )
+
+    async def sync_provider_models(
+        self,
+        *,
+        provider_id: str,
+        engine: str,
+        base_url: str,
+        models: dict[str, dict[str, Any]],
+        api_key: str = "",
+    ) -> None:
+        """Configure credentials and publish the model allow-list to Abbenay.
+
+        Args:
+            provider_id: Virtual provider name.
+            engine: Abbenay engine id.
+            base_url: Optional custom API base URL.
+            models: Model id → params map.
+            api_key: Provider API key (may be empty).
+        """
+        from abbenay_grpc.abbenay.v1 import service_pb2 as proto  # noqa: PLC0415
+
+        await self.configure_provider(
+            provider_id=provider_id,
+            engine=engine,
+            api_key=api_key,
+            base_url=base_url,
+        )
+
+        config = await self.get_config()
+        provider_cfg = proto.FullProviderConfig(
+            engine=engine,
+            base_url=base_url,
+        )
+        for model_id in models:
+            provider_cfg.models[model_id].CopyFrom(proto.ModelParamConfig(model_id=model_id))
+
+        config.providers[provider_id].CopyFrom(provider_cfg)
+        await self.update_config(config)
+
+
+async def open_abbenay_admin() -> AbbenayAdminClient | None:
+    """Connect to Abbenay, returning None when the client library is missing.
+
+    Returns:
+        Connected client, or ``None`` when gRPC/client setup fails.
+    """
+    try:
+        client = AbbenayAdminClient()
+        await client.connect()
+        return client
+    except ImportError:
+        logger.warning("abbenay_grpc is not installed — AI provider sync skipped")
+        return None
+    except Exception:
+        logger.warning("Failed to connect to Abbenay at %s", _resolve_addr(), exc_info=True)
+        return None
+
+
+def models_json_to_dict(raw: str) -> dict[str, dict[str, Any]]:
+    """Parse stored models JSON, returning an empty dict on invalid input.
+
+    Args:
+        raw: JSON string from the Gateway DB.
+
+    Returns:
+        Model id → params map.
+    """
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(k): v if isinstance(v, dict) else {} for k, v in parsed.items()}
+
+
+def extra_json_to_dict(raw: str) -> dict[str, Any]:
+    """Parse stored extra JSON, returning an empty dict on invalid input.
+
+    Args:
+        raw: JSON string from the Gateway DB.
+
+    Returns:
+        Extra metadata object.
+    """
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}

--- a/src/apme_gateway/_abbenay_sync.py
+++ b/src/apme_gateway/_abbenay_sync.py
@@ -1,0 +1,205 @@
+"""Push AI provider configs from the Gateway DB to Abbenay.
+
+Durable SoT is the Gateway ``ai_providers`` table. Abbenay receives a
+just-in-time push into its process-lifetime ``memory`` secret store
+(DR-047) — used before AI-enabled scans and after settings CRUD.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+
+from apme_gateway.api.abbenay_proxy import abbenay_http_base_url, abbenay_http_token
+
+logger = logging.getLogger(__name__)
+
+_pending_sync: asyncio.Task[None] | None = None
+_PROXY_TIMEOUT_S = 60.0
+
+
+def _secret_name_for(provider_name: str) -> str:
+    """Derive the Abbenay memory secret name for a provider.
+
+    Args:
+        provider_name: Virtual Abbenay provider name (slug).
+
+    Returns:
+        Upper-snake secret name used with ``secretStore=memory``.
+    """
+    return f"{provider_name.upper().replace('-', '_')}_API_KEY"
+
+
+async def _configure_provider_http(
+    client: httpx.AsyncClient,
+    *,
+    provider_id: str,
+    engine: str,
+    base_url: str,
+    api_key: str,
+    models: dict[str, dict[str, object]],
+) -> None:
+    """Push one provider+cred into Abbenay memory and publish models.
+
+    Args:
+        client: Shared HTTP client.
+        provider_id: Abbenay virtual provider name.
+        engine: Abbenay engine id.
+        base_url: Optional custom API base URL.
+        api_key: Provider API key (may be empty for keyless engines).
+        models: Model id → params map to publish into Abbenay config.
+
+    Raises:
+        RuntimeError: When the Abbenay token is missing or HTTP calls fail.
+    """
+    base = abbenay_http_base_url()
+    token = abbenay_http_token()
+    if not token:
+        msg = "Abbenay HTTP admin token not configured"
+        raise RuntimeError(msg)
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    secret_name = _secret_name_for(provider_id)
+    configure_body: dict[str, object] = {
+        "engine": engine,
+        "secretName": secret_name,
+        "secretStore": "memory",
+    }
+    if api_key:
+        configure_body["apiKey"] = api_key
+    if base_url:
+        configure_body["baseUrl"] = base_url
+
+    resp = await client.post(
+        f"{base}/api/provider/{provider_id}/configure",
+        headers=headers,
+        json=configure_body,
+    )
+    if resp.status_code >= 400:
+        msg = f"Abbenay configure {provider_id} failed: {resp.status_code} {resp.text[:200]}"
+        raise RuntimeError(msg)
+
+    # Merge models into persisted config (secret_* already set by configure).
+    cfg_resp = await client.get(f"{base}/api/config", headers=headers)
+    if cfg_resp.status_code >= 400:
+        msg = f"Abbenay get config failed: {cfg_resp.status_code}"
+        raise RuntimeError(msg)
+    raw = cfg_resp.json()
+    config = raw.get("config") if isinstance(raw, dict) and "config" in raw else raw
+    if not isinstance(config, dict):
+        config = {}
+    providers = dict(config.get("providers") or {})
+    prev = dict(providers.get(provider_id) or {})
+    prev["engine"] = engine
+    prev["secret_name"] = secret_name
+    prev["secret_store"] = "memory"
+    if base_url:
+        prev["base_url"] = base_url
+    prev["models"] = {mid: (opts if isinstance(opts, dict) else {}) for mid, opts in models.items()}
+    providers[provider_id] = prev
+    put = await client.post(
+        f"{base}/api/config",
+        headers=headers,
+        json={"location": "user", "config": {**config, "providers": providers}},
+    )
+    if put.status_code >= 400:
+        msg = f"Abbenay update config failed: {put.status_code} {put.text[:200]}"
+        raise RuntimeError(msg)
+
+
+async def push_ai_providers() -> bool:
+    """Load AI providers from the DB and reconcile them with Abbenay memory.
+
+    Returns:
+        bool: ``True`` on success, ``False`` on any failure (logged, never raised).
+
+    Raises:
+        asyncio.CancelledError: Re-raised if the task is cancelled.
+    """
+    from apme_gateway._abbenay_admin import (  # noqa: PLC0415
+        models_json_to_dict,
+        open_abbenay_admin,
+    )
+    from apme_gateway.db import get_session  # noqa: PLC0415
+    from apme_gateway.db import queries as q  # noqa: PLC0415
+
+    try:
+        async with get_session() as db:
+            providers = await q.list_ai_providers(db)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning("Failed to load AI providers from DB for Abbenay sync", exc_info=True)
+        return False
+
+    if not abbenay_http_token():
+        logger.warning("Abbenay HTTP token unset — AI provider push skipped")
+        return False
+
+    desired_names = {p.name for p in providers}
+
+    # Prune removed providers via gRPC when available.
+    client = await open_abbenay_admin()
+    if client is not None:
+        try:
+            existing = await client.get_config()
+            for provider_id in list(existing.providers.keys()):
+                if provider_id not in desired_names:
+                    await client.remove_provider(provider_id)
+        except Exception:
+            logger.debug("Could not prune removed Abbenay providers", exc_info=True)
+        finally:
+            await client.close()
+
+    try:
+        async with httpx.AsyncClient(timeout=_PROXY_TIMEOUT_S) as http:
+            for provider in providers:
+                models = models_json_to_dict(provider.models_json)
+                await _configure_provider_http(
+                    http,
+                    provider_id=provider.name,
+                    engine=provider.engine,
+                    base_url=provider.base_url or "",
+                    api_key=provider.api_key or "",
+                    models=models,
+                )
+        logger.info("Synced %d AI provider(s) to Abbenay (memory)", len(providers))
+        return True
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning("Failed to push AI providers to Abbenay", exc_info=True)
+        return False
+
+
+def schedule_sync() -> None:
+    """Schedule a background Abbenay sync (fire-and-forget, coalesced)."""
+    global _pending_sync  # noqa: PLW0603
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.debug("No running event loop; skipping Abbenay sync")
+        return
+
+    if _pending_sync is not None and not _pending_sync.done():
+        logger.debug("Abbenay sync already in flight; skipping duplicate")
+        return
+
+    async def _bg_sync() -> None:
+        global _pending_sync  # noqa: PLW0603
+        try:
+            await push_ai_providers()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Background Abbenay sync failed", exc_info=True)
+        finally:
+            _pending_sync = None
+
+    _pending_sync = loop.create_task(_bg_sync())

--- a/src/apme_gateway/api/ai_providers.py
+++ b/src/apme_gateway/api/ai_providers.py
@@ -1,0 +1,95 @@
+"""Validation and serialization helpers for portal-managed AI providers."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException
+
+from apme_gateway.api.schemas import AiProviderSchema
+
+if TYPE_CHECKING:
+    from apme_gateway.db.models import AiProvider
+
+_PROVIDER_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+def validate_provider_name(name: str) -> str:
+    """Validate Abbenay virtual provider name.
+
+    Args:
+        name: Candidate provider id.
+
+    Returns:
+        Stripped valid name.
+
+    Raises:
+        HTTPException: 400 when the name is invalid.
+    """
+    trimmed = name.strip()
+    if not trimmed or not _PROVIDER_NAME_RE.match(trimmed):
+        raise HTTPException(
+            status_code=400,
+            detail="Provider name must match ^[a-z][a-z0-9-]*$",
+        )
+    return trimmed
+
+
+def to_ai_provider_schema(row: AiProvider) -> AiProviderSchema:
+    """Convert ORM row to API schema (API key masked).
+
+    Args:
+        row: AiProvider ORM instance.
+
+    Returns:
+        Pydantic response schema without secret values.
+    """
+    try:
+        models = json.loads(row.models_json or "{}")
+    except json.JSONDecodeError:
+        models = {}
+    if not isinstance(models, dict):
+        models = {}
+    try:
+        extra = json.loads(row.extra_json or "{}")
+    except json.JSONDecodeError:
+        extra = {}
+    if not isinstance(extra, dict):
+        extra = {}
+    return AiProviderSchema(
+        id=row.id,
+        name=row.name,
+        engine=row.engine,
+        base_url=row.base_url or "",
+        models=models,
+        has_api_key=bool(row.api_key),
+        extra=extra,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def dump_models(models: dict[str, dict[str, object]]) -> str:
+    """Serialize models map for DB storage.
+
+    Args:
+        models: Model id → params map.
+
+    Returns:
+        JSON string suitable for ``models_json``.
+    """
+    return json.dumps(models or {})
+
+
+def dump_extra(extra: dict[str, object]) -> str:
+    """Serialize extra metadata for DB storage.
+
+    Args:
+        extra: Engine-specific metadata object.
+
+    Returns:
+        JSON string suitable for ``extra_json``.
+    """
+    return json.dumps(extra or {})

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -1270,6 +1270,17 @@ async def _drive_operation(
         bridge_task: asyncio.Task[None] | None = None
         enable_ai = coerce_option_bool(options.get("enable_ai", False))
 
+        if enable_ai:
+            from apme_gateway._abbenay_sync import push_ai_providers  # noqa: PLC0415
+
+            pushed = await push_ai_providers()
+            if not pushed:
+                logger.warning(
+                    "AI provider push to Abbenay failed before operation %s — "
+                    "continuing; inference may fail if Abbenay has no memory creds",
+                    operation_id[:12],
+                )
+
         if remediate or assess_pause:
             approval_queue = asyncio.Queue()
             if assess_pause:

--- a/src/apme_gateway/api/router.py
+++ b/src/apme_gateway/api/router.py
@@ -23,23 +23,34 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 
 from apme_engine.graph.severity import severity_from_proto, severity_to_label
+from apme_gateway.api.ai_providers import (
+    dump_extra,
+    dump_models,
+    to_ai_provider_schema,
+    validate_provider_name,
+)
 from apme_gateway.api.schemas import (
     ActiveOperationSummary,
     ActivityDetail,
     ActivitySummary,
     AiAcceptanceEntry,
+    AiEngineInfo,
     AiModelInfo,
+    AiProviderSchema,
     CollectionDetail,
     CollectionHealthSummary,
     CollectionProjectRef,
     CollectionRefSchema,
     CollectionSummary,
     ComponentHealth,
+    CreateAiProviderRequest,
     CreateGalaxyServerRequest,
     CreateProjectRequest,
     CreateSuppressionRequest,
     DashboardSummary,
     DepHealthSummary,
+    DiscoverAiModelsRequest,
+    DiscoveredAiModel,
     GalaxyServerSchema,
     HealthStatus,
     LogEntry,
@@ -62,6 +73,7 @@ from apme_gateway.api.schemas import (
     SuppressionSchema,
     TopViolation,
     TrendPoint,
+    UpdateAiProviderRequest,
     UpdateGalaxyServerRequest,
     UpdateProjectRequest,
     ViolationDetail,
@@ -448,6 +460,250 @@ async def delete_galaxy_server(server_id: int) -> None:
     from apme_gateway._galaxy_proxy_sync import schedule_push  # noqa: PLC0415
 
     schedule_push()
+
+
+# ── AI provider settings (portal-managed Abbenay) ────────────────────
+
+
+@router.get("/settings/ai-engines")  # type: ignore[untyped-decorator]
+async def list_ai_engines() -> list[AiEngineInfo]:
+    """Return Abbenay engine types for the provider wizard.
+
+    Returns:
+        Engine descriptors (empty when Abbenay is unavailable).
+    """
+    from apme_gateway._abbenay_admin import open_abbenay_admin  # noqa: PLC0415
+
+    client = await open_abbenay_admin()
+    if client is None:
+        return []
+    try:
+        engines = await client.list_engines()
+        return [
+            AiEngineInfo(
+                id=e.id,
+                requires_key=e.requires_key,
+                default_base_url=e.default_base_url,
+                default_env_var=e.default_env_var,
+            )
+            for e in engines
+            if e.id != "mock"
+        ]
+    except Exception:
+        logger.warning("Failed to list Abbenay engines", exc_info=True)
+        return []
+    finally:
+        await client.close()
+
+
+@router.post("/settings/ai-providers/discover-models")  # type: ignore[untyped-decorator]
+async def discover_ai_models(body: DiscoverAiModelsRequest) -> list[DiscoveredAiModel]:
+    """Discover models from an engine API (wizard helper).
+
+    Args:
+        body: Engine id plus optional credentials for discovery.
+
+    Returns:
+        Discovered model descriptors from Abbenay.
+
+    Raises:
+        HTTPException: 400 when engine is missing; 503 when Abbenay is down;
+            502 when discovery fails.
+    """
+    if not body.engine.strip():
+        raise HTTPException(status_code=400, detail="engine is required")
+    from apme_gateway._abbenay_admin import open_abbenay_admin  # noqa: PLC0415
+
+    client = await open_abbenay_admin()
+    if client is None:
+        raise HTTPException(status_code=503, detail="Abbenay admin unavailable")
+    try:
+        models = await client.discover_models(
+            engine_id=body.engine.strip(),
+            api_key=body.api_key,
+            base_url=body.base_url,
+        )
+        return [
+            DiscoveredAiModel(
+                id=m.id,
+                name=m.name,
+                provider=m.provider,
+                engine=m.engine,
+            )
+            for m in models
+        ]
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Model discovery failed: {exc}",
+        ) from exc
+    finally:
+        await client.close()
+
+
+@router.get("/settings/ai-providers")  # type: ignore[untyped-decorator]
+async def list_ai_providers() -> list[AiProviderSchema]:
+    """Return all portal-managed AI providers (secrets masked).
+
+    Returns:
+        Provider definitions with ``has_api_key`` instead of raw secrets.
+    """
+    async with get_session() as db:
+        rows = await q.list_ai_providers(db)
+    return [to_ai_provider_schema(r) for r in rows]
+
+
+@router.post("/settings/ai-providers", status_code=201)  # type: ignore[untyped-decorator]
+async def create_ai_provider(body: CreateAiProviderRequest) -> AiProviderSchema:
+    """Create a new AI provider definition (Gateway SoT).
+
+    Args:
+        body: Provider creation payload (including optional API key).
+
+    Returns:
+        Newly created provider (API key masked).
+
+    Raises:
+        HTTPException: 400 on invalid name/engine; 409 on duplicate name.
+    """
+    from sqlalchemy.exc import IntegrityError  # noqa: PLC0415
+
+    name = validate_provider_name(body.name)
+    engine = body.engine.strip()
+    if not engine:
+        raise HTTPException(status_code=400, detail="engine is required")
+
+    try:
+        async with get_session() as db:
+            row = await q.create_ai_provider(
+                db,
+                name=name,
+                engine=engine,
+                base_url=body.base_url.strip(),
+                api_key=body.api_key,
+                models_json=dump_models(body.models),
+                extra_json=dump_extra(body.extra),
+            )
+    except IntegrityError:
+        raise HTTPException(
+            status_code=409,
+            detail=f"AI provider named '{name}' already exists",
+        ) from None
+
+    from apme_gateway._abbenay_sync import schedule_sync  # noqa: PLC0415
+
+    schedule_sync()
+    return to_ai_provider_schema(row)
+
+
+@router.get("/settings/ai-providers/{provider_id}")  # type: ignore[untyped-decorator]
+async def get_ai_provider(provider_id: int) -> AiProviderSchema:
+    """Fetch a single AI provider by ID.
+
+    Args:
+        provider_id: Gateway primary key.
+
+    Returns:
+        Provider definition (API key masked).
+
+    Raises:
+        HTTPException: 404 if not found.
+    """
+    async with get_session() as db:
+        row = await q.get_ai_provider(db, provider_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="AI provider not found")
+    return to_ai_provider_schema(row)
+
+
+@router.patch("/settings/ai-providers/{provider_id}")  # type: ignore[untyped-decorator]
+async def update_ai_provider(
+    provider_id: int,
+    body: UpdateAiProviderRequest,
+) -> AiProviderSchema:
+    """Update an AI provider definition.
+
+    Args:
+        provider_id: Gateway primary key.
+        body: Partial update payload.
+
+    Returns:
+        Updated provider (API key masked).
+
+    Raises:
+        HTTPException: 400 when no fields are provided or validation fails;
+            404 if not found; 409 on duplicate name.
+    """
+    from sqlalchemy.exc import IntegrityError  # noqa: PLC0415
+
+    updates: dict[str, str] = {}
+    if body.name is not None:
+        updates["name"] = validate_provider_name(body.name)
+    if body.engine is not None:
+        engine = body.engine.strip()
+        if not engine:
+            raise HTTPException(status_code=400, detail="engine cannot be empty")
+        updates["engine"] = engine
+    if body.base_url is not None:
+        updates["base_url"] = body.base_url.strip()
+    if body.api_key is not None and body.api_key != "":
+        updates["api_key"] = body.api_key
+    if body.models is not None:
+        updates["models_json"] = dump_models(body.models)
+    if body.extra is not None:
+        updates["extra_json"] = dump_extra(body.extra)
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    try:
+        async with get_session() as db:
+            row = await q.update_ai_provider(db, provider_id, **updates)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=409,
+            detail=f"AI provider named '{updates.get('name', '')}' already exists",
+        ) from None
+    if row is None:
+        raise HTTPException(status_code=404, detail="AI provider not found")
+
+    from apme_gateway._abbenay_sync import schedule_sync  # noqa: PLC0415
+
+    schedule_sync()
+    return to_ai_provider_schema(row)
+
+
+@router.delete("/settings/ai-providers/{provider_id}", status_code=204)  # type: ignore[untyped-decorator]
+async def delete_ai_provider(provider_id: int) -> None:
+    """Delete an AI provider definition and remove it from Abbenay.
+
+    Args:
+        provider_id: Gateway primary key.
+
+    Raises:
+        HTTPException: 404 if not found.
+    """
+    async with get_session() as db:
+        row = await q.get_ai_provider(db, provider_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="AI provider not found")
+        provider_name = row.name
+        ok = await q.delete_ai_provider(db, provider_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="AI provider not found")
+
+    from apme_gateway._abbenay_admin import open_abbenay_admin  # noqa: PLC0415
+    from apme_gateway._abbenay_sync import schedule_sync  # noqa: PLC0415
+
+    client = await open_abbenay_admin()
+    if client is not None:
+        try:
+            await client.remove_provider(provider_name)
+        except Exception:
+            logger.debug("Abbenay remove_provider(%s) failed", provider_name, exc_info=True)
+        finally:
+            await client.close()
+
+    schedule_sync()
 
 
 # ── Project CRUD (ADR-037) ───────────────────────────────────────────

--- a/src/apme_gateway/api/schemas.py
+++ b/src/apme_gateway/api/schemas.py
@@ -815,6 +815,121 @@ class UpdateGalaxyServerRequest(BaseModel):  # type: ignore[misc]
     auth_url: str | None = None
 
 
+# ── AI provider settings (portal-managed Abbenay) ────────────────────
+
+
+class AiEngineInfo(BaseModel):  # type: ignore[misc]
+    """Abbenay engine descriptor for the provider wizard.
+
+    Attributes:
+        id: Abbenay engine id (e.g. ``openrouter``).
+        requires_key: Whether the engine needs an API key.
+        default_base_url: Suggested API root when none is configured.
+        default_env_var: Legacy env-var name hint (informational only).
+    """
+
+    id: str
+    requires_key: bool = True
+    default_base_url: str = ""
+    default_env_var: str = ""
+
+
+class AiProviderSchema(BaseModel):  # type: ignore[misc]
+    """A portal-managed Abbenay LLM provider (API key never exposed).
+
+    Attributes:
+        id: Auto-increment primary key.
+        name: Virtual Abbenay provider name (slug).
+        engine: Abbenay engine id.
+        base_url: Optional custom API base URL.
+        models: Model id → params map.
+        has_api_key: Whether an API key is stored (value never exposed).
+        extra: Optional engine-specific metadata.
+        created_at: ISO 8601 creation timestamp.
+        updated_at: ISO 8601 last-update timestamp.
+    """
+
+    id: int
+    name: str
+    engine: str
+    base_url: str = ""
+    models: dict[str, dict[str, object]] = Field(default_factory=dict)
+    has_api_key: bool = False
+    extra: dict[str, object] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str
+
+
+class CreateAiProviderRequest(BaseModel):  # type: ignore[misc]
+    """Request body for creating an AI provider.
+
+    Attributes:
+        name: Virtual Abbenay provider name (slug).
+        engine: Abbenay engine id.
+        base_url: Optional custom API base URL.
+        api_key: Provider API key (may be empty for keyless engines).
+        models: Model id → params map.
+        extra: Optional engine-specific metadata.
+    """
+
+    name: str
+    engine: str
+    base_url: str = ""
+    api_key: str = ""
+    models: dict[str, dict[str, object]] = Field(default_factory=dict)
+    extra: dict[str, object] = Field(default_factory=dict)
+
+
+class UpdateAiProviderRequest(BaseModel):  # type: ignore[misc]
+    """Partial update for an AI provider.
+
+    Attributes:
+        name: New virtual provider name, or None to leave unchanged.
+        engine: New engine id, or None to leave unchanged.
+        base_url: New base URL, or None to leave unchanged.
+        api_key: New API key, or None/empty to leave unchanged.
+        models: New models map, or None to leave unchanged.
+        extra: New metadata, or None to leave unchanged.
+    """
+
+    name: str | None = None
+    engine: str | None = None
+    base_url: str | None = None
+    api_key: str | None = None
+    models: dict[str, dict[str, object]] | None = None
+    extra: dict[str, object] | None = None
+
+
+class DiscoverAiModelsRequest(BaseModel):  # type: ignore[misc]
+    """Discover models from an engine API (wizard helper).
+
+    Attributes:
+        engine: Abbenay engine id to query.
+        api_key: Optional API key for authenticated discovery.
+        base_url: Optional custom API base URL.
+    """
+
+    engine: str
+    api_key: str = ""
+    base_url: str = ""
+
+
+class DiscoveredAiModel(BaseModel):  # type: ignore[misc]
+    """Model discovered from an engine API.
+
+    Attributes:
+        id: Engine model id.
+        name: Human-readable model name.
+        provider: Upstream provider label from Abbenay.
+        engine: Abbenay engine id used for discovery.
+    """
+
+    id: str
+    name: str = ""
+    provider: str = ""
+    engine: str = ""
+
+
 class DashboardSummary(BaseModel):  # type: ignore[misc]
     """Cross-project aggregate statistics (ADR-037).
 

--- a/src/apme_gateway/db/models.py
+++ b/src/apme_gateway/db/models.py
@@ -576,6 +576,39 @@ class GalaxyServer(Base):
     updated_at: Mapped[str] = mapped_column(Text, nullable=False)
 
 
+class AiProvider(Base):
+    """A portal-managed Abbenay LLM provider (Gateway SoT for scan-time push).
+
+    API keys are stored as plaintext in this release; application-layer
+    encryption is a documented follow-up (same pattern as Galaxy ADR-045).
+    At AI-enabled scan time the Gateway pushes these rows into Abbenay's
+    process-lifetime ``memory`` secret store (DR-047).
+
+    Attributes:
+        id: Auto-increment primary key.
+        name: Virtual provider name (Abbenay config key).
+        engine: Abbenay engine id (e.g. ``openrouter``, ``ollama``).
+        base_url: Optional custom API base URL.
+        api_key: Provider API key (may be empty for keyless engines).
+        models_json: JSON object mapping model id → params (usually ``{}``).
+        extra_json: Optional engine-specific metadata.
+        created_at: ISO 8601 creation timestamp.
+        updated_at: ISO 8601 last-update timestamp.
+    """
+
+    __tablename__ = "ai_providers"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    engine: Mapped[str] = mapped_column(Text, nullable=False)
+    base_url: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    api_key: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    models_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+    extra_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+    created_at: Mapped[str] = mapped_column(Text, nullable=False)
+    updated_at: Mapped[str] = mapped_column(Text, nullable=False)
+
+
 # ── ContentGraph visualization table ──────────────────────────────────
 
 

--- a/src/apme_gateway/db/queries.py
+++ b/src/apme_gateway/db/queries.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from apme_gateway.db.models import (
+    AiProvider,
     GalaxyServer,
     Notification,
     PatchedFile,
@@ -1798,6 +1799,125 @@ async def update_galaxy_server(
     await db.commit()
     await db.refresh(server)
     return server
+
+
+# ---------------------------------------------------------------------------
+# AI provider settings (portal-managed Abbenay)
+# ---------------------------------------------------------------------------
+
+
+async def list_ai_providers(db: AsyncSession) -> list[AiProvider]:
+    """Return all configured AI providers ordered by name.
+
+    Args:
+        db: Async database session.
+
+    Returns:
+        List of AiProvider rows.
+    """
+    result = await db.execute(select(AiProvider).order_by(AiProvider.name))
+    return list(result.scalars().all())
+
+
+async def get_ai_provider(db: AsyncSession, provider_id: int) -> AiProvider | None:
+    """Fetch a single AI provider by ID.
+
+    Args:
+        db: Async database session.
+        provider_id: Primary key.
+
+    Returns:
+        AiProvider or None if not found.
+    """
+    row: AiProvider | None = await db.get(AiProvider, provider_id)
+    return row
+
+
+async def create_ai_provider(
+    db: AsyncSession,
+    *,
+    name: str,
+    engine: str,
+    base_url: str = "",
+    api_key: str = "",
+    models_json: str = "{}",
+    extra_json: str = "{}",
+) -> AiProvider:
+    """Insert a new AI provider definition.
+
+    Args:
+        db: Async database session.
+        name: Virtual provider name.
+        engine: Abbenay engine id.
+        base_url: Optional custom API base URL.
+        api_key: Provider API key (may be empty).
+        models_json: JSON models map.
+        extra_json: Optional metadata JSON.
+
+    Returns:
+        The newly created AiProvider row.
+    """
+    now = datetime.now(tz=UTC).isoformat()
+    row = AiProvider(
+        name=name,
+        engine=engine,
+        base_url=base_url,
+        api_key=api_key,
+        models_json=models_json,
+        extra_json=extra_json,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def update_ai_provider(
+    db: AsyncSession,
+    provider_id: int,
+    **fields: str,
+) -> AiProvider | None:
+    """Update mutable fields on an AI provider.
+
+    Args:
+        db: Async database session.
+        provider_id: Primary key.
+        **fields: Allowed keys name/engine/base_url/api_key/models_json/extra_json.
+
+    Returns:
+        Updated AiProvider or None if not found.
+    """
+    row: AiProvider | None = await db.get(AiProvider, provider_id)
+    if row is None:
+        return None
+    allowed = {"name", "engine", "base_url", "api_key", "models_json", "extra_json"}
+    for key, value in fields.items():
+        if key in allowed:
+            setattr(row, key, value)
+    row.updated_at = datetime.now(tz=UTC).isoformat()
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def delete_ai_provider(db: AsyncSession, provider_id: int) -> bool:
+    """Delete an AI provider by ID.
+
+    Args:
+        db: Async database session.
+        provider_id: Primary key.
+
+    Returns:
+        True if a row was deleted.
+    """
+    row = await db.get(AiProvider, provider_id)
+    if row is None:
+        return False
+    await db.delete(row)
+    await db.commit()
+    return True
 
 
 async def delete_galaxy_server(db: AsyncSession, server_id: int) -> bool:

--- a/tests/test_gateway_ai_providers.py
+++ b/tests/test_gateway_ai_providers.py
@@ -1,0 +1,209 @@
+"""Unit tests for the AI provider settings REST API."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from apme_gateway._abbenay_admin import AbbenayDiscoveredModel, AbbenayEngineInfo
+from apme_gateway.app import create_app
+from apme_gateway.db import close_db, init_db
+
+
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
+async def _db(tmp_path: Path) -> AsyncIterator[None]:
+    """Initialise a fresh DB per test.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Yields:
+        None: Test runs between setup and teardown.
+    """
+    await init_db(str(tmp_path / "test.db"))
+    yield
+    await close_db()
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+async def client() -> AsyncIterator[AsyncClient]:
+    """Build an async test client for the gateway app.
+
+    Yields:
+        AsyncClient: Client bound to the ASGI app.
+    """
+    app = create_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def test_list_ai_providers_empty(client: AsyncClient) -> None:
+    """GET /settings/ai-providers returns empty list when none configured.
+
+    Args:
+        client: Async HTTP test client.
+    """
+    resp = await client.get("/api/v1/settings/ai-providers")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_create_ai_provider(client: AsyncClient) -> None:
+    """POST /settings/ai-providers creates a provider and masks the API key.
+
+    Args:
+        client: Async HTTP test client.
+    """
+    body = {
+        "name": "openrouter",
+        "engine": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "sk-test",
+        "models": {"anthropic/claude-sonnet-4-6": {}},
+    }
+    with patch("apme_gateway._abbenay_sync.schedule_sync") as mock_sync:
+        resp = await client.post("/api/v1/settings/ai-providers", json=body)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "openrouter"
+    assert data["engine"] == "openrouter"
+    assert data["has_api_key"] is True
+    assert "sk-test" not in resp.text
+    assert data["models"]["anthropic/claude-sonnet-4-6"] == {}
+    mock_sync.assert_called_once()
+
+
+async def test_create_ai_provider_duplicate_name(client: AsyncClient) -> None:
+    """POST /settings/ai-providers returns 409 for duplicate names.
+
+    Args:
+        client: Async HTTP test client.
+    """
+    body = {
+        "name": "openrouter",
+        "engine": "openrouter",
+        "models": {"gpt-4o": {}},
+    }
+    resp1 = await client.post("/api/v1/settings/ai-providers", json=body)
+    assert resp1.status_code == 201
+    resp2 = await client.post("/api/v1/settings/ai-providers", json=body)
+    assert resp2.status_code == 409
+
+
+async def test_update_ai_provider(client: AsyncClient) -> None:
+    """PATCH /settings/ai-providers/{id} updates mutable fields.
+
+    Args:
+        client: Async HTTP test client.
+    """
+    create_resp = await client.post(
+        "/api/v1/settings/ai-providers",
+        json={"name": "ollama", "engine": "ollama", "models": {"llama3": {}}},
+    )
+    provider_id = create_resp.json()["id"]
+    with patch("apme_gateway._abbenay_sync.schedule_sync"):
+        resp = await client.patch(
+            f"/api/v1/settings/ai-providers/{provider_id}",
+            json={"base_url": "http://localhost:11434", "models": {"llama3.2": {}}},
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["base_url"] == "http://localhost:11434"
+    assert "llama3.2" in data["models"]
+
+
+async def test_delete_ai_provider(client: AsyncClient) -> None:
+    """DELETE /settings/ai-providers/{id} removes DB row and Abbenay provider.
+
+    Args:
+        client: Async HTTP test client.
+    """
+    create_resp = await client.post(
+        "/api/v1/settings/ai-providers",
+        json={"name": "temp", "engine": "mock", "models": {"mock-model": {}}},
+    )
+    provider_id = create_resp.json()["id"]
+    mock_admin = AsyncMock()
+    mock_admin.remove_provider = AsyncMock()
+    mock_admin.close = AsyncMock()
+    with (
+        patch("apme_gateway._abbenay_admin.open_abbenay_admin", return_value=mock_admin),
+        patch("apme_gateway._abbenay_sync.schedule_sync"),
+    ):
+        resp = await client.delete(f"/api/v1/settings/ai-providers/{provider_id}")
+    assert resp.status_code == 204
+    mock_admin.remove_provider.assert_called_once_with("temp")
+
+    list_resp = await client.get("/api/v1/settings/ai-providers")
+    assert list_resp.json() == []
+
+
+async def test_list_ai_engines_from_abbenay(client: AsyncClient) -> None:
+    """GET /settings/ai-engines returns Abbenay engine descriptors.
+
+    Args:
+        client: Async HTTP test client.
+    """
+    mock_admin = AsyncMock()
+    mock_admin.list_engines = AsyncMock(
+        return_value=[
+            AbbenayEngineInfo(
+                id="openrouter",
+                requires_key=True,
+                default_base_url="https://openrouter.ai/api/v1",
+                default_env_var="OPENROUTER_API_KEY",
+            ),
+            AbbenayEngineInfo(
+                id="anthropic",
+                requires_key=True,
+                default_base_url="",
+                default_env_var="ANTHROPIC_API_KEY",
+            ),
+        ],
+    )
+    mock_admin.close = AsyncMock()
+    with patch("apme_gateway._abbenay_admin.open_abbenay_admin", return_value=mock_admin):
+        resp = await client.get("/api/v1/settings/ai-engines")
+    assert resp.status_code == 200
+    engines = resp.json()
+    assert len(engines) == 2
+    assert engines[0]["id"] == "openrouter"
+    assert engines[0]["requires_key"] is True
+
+
+async def test_discover_ai_models(client: AsyncClient) -> None:
+    """POST /settings/ai-providers/discover-models proxies Abbenay discovery.
+
+    Args:
+        client: Async HTTP test client.
+    """
+    mock_admin = AsyncMock()
+    mock_admin.discover_models = AsyncMock(
+        return_value=[
+            AbbenayDiscoveredModel(
+                id="gpt-4o",
+                name="gpt-4o",
+                provider="openai",
+                engine="openai",
+            ),
+        ],
+    )
+    mock_admin.close = AsyncMock()
+    with patch("apme_gateway._abbenay_admin.open_abbenay_admin", return_value=mock_admin):
+        resp = await client.post(
+            "/api/v1/settings/ai-providers/discover-models",
+            json={"engine": "openai", "api_key": "sk-test"},
+        )
+    assert resp.status_code == 200
+    models = resp.json()
+    assert models[0]["id"] == "gpt-4o"
+    mock_admin.discover_models.assert_called_once_with(
+        engine_id="openai",
+        api_key="sk-test",
+        base_url="",
+    )


### PR DESCRIPTION
## Summary
- Add Gateway `ai_providers` SoT with CRUD at `/api/v1/settings/ai-providers` (API keys masked on read).
- Push provider + `apiKey` into Abbenay `secretStore: memory` before AI-enabled scans (and after settings CRUD).
- Builds on the Abbenay v2026.8.5 memory-store proxy work so Portal no longer needs env/mount secrets for scan-time creds.

## Test plan
- [ ] `tox -e py` (or targeted `tests/test_gateway_ai_providers.py`) passes
- [ ] Create/update/delete a provider via Gateway settings API; confirm key is never returned
- [ ] Start an AI-enabled scan and confirm Abbenay receives the provider in memory before the job
- [ ] Restart Abbenay, re-run an AI scan, and confirm push-before-scan restores the provider


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI provider management through the settings API, including provider creation, updates, deletion, and listing.
  * Added AI engine listing and model discovery capabilities.
  * Added validation for provider names and engines, with clear handling for duplicates and missing providers.
  * Provider API keys are securely masked in responses.
  * Provider settings automatically synchronize with the AI service before operations.

* **Tests**
  * Added coverage for provider management, synchronization, engine listing, model discovery, validation, and secure key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->