### PR TITLE
build(ai): pin Abbenay v2026.8.6 and document file secret store

### DIFF
--- a/.agents/skills/tox/SKILL.md
+++ b/.agents/skills/tox/SKILL.md
@@ -88,7 +88,7 @@ directly. Every task maps to a `tox -e <env>` command.
 | `tox -e up -- --no-cache` | Full rebuild + start | When cached layers are stale. |
 | `tox -e build` | `containers/podman/build.sh` | Build images only (no start). |
 | `tox -e down` | `containers/podman/down.sh` | Stop the APME pod. |
-| `tox -e wipe` | Stop + wipe DB and sessions | Preserve images, wipe state. |
+| `tox -e wipe` | Stop + wipe DB, sessions, and Abbenay `secrets.json` | Preserve images, wipe state. |
 | `tox -e build-clean` | Wipe + rebuild `--no-cache` | Full clean rebuild (no start). |
 | `tox -e up-clean` | Wipe + rebuild `--no-cache` + start | Nuclear option — clean slate. |
 | `tox -e cli -- <args>` | `containers/podman/run-cli.sh` | Run CLI commands in the pod. |

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -120,7 +120,8 @@ provider keys. Durable keys in containers use Abbenay's filesystem store
 `<configDir>/secrets.json` (mode `0600` as written by Abbenay) on the same
 writable volume as `config.yaml`. On macOS Podman Machine, `up.sh` may set
 the file to `0644` so virtiofs can map container UID 1001 — treat the host
-cache directory as secret material. File-store keys survive a restart
+cache directory as secret material ([#562](https://github.com/ansible/apme/issues/562)
+for write access without world-open perms). File-store keys survive a restart
 **only** when that volume is durable:
 
 - **Helm**: `persistence.abbenay.enabled=true` (PVC). The chart default is

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -118,15 +118,27 @@ Abbenay. Gateway reverse-proxies the secrets API and does **not** persist
 provider keys. Durable keys in containers use Abbenay's filesystem store
 (`secretStore: "file"`, Abbenay ≥ v2026.8.6), which writes
 `<configDir>/secrets.json` (mode `0600`) on the same writable volume as
-`config.yaml` (Helm `persistence.abbenay`, Podman RW cache). The
-process-lifetime `memory` store remains available. Deploy-time Helm
-Secrets / env (`secret_store: env`) are unchanged.
+`config.yaml`. File-store keys survive a restart **only** when that volume
+is durable:
+
+- **Helm**: `persistence.abbenay.enabled=true` (PVC). The chart default is
+  `emptyDir` — file-store keys then last for the **pod** lifetime only
+  (lost on restart, OOM, drain, and Helm upgrade with `Recreate`).
+- **Podman**: RW host cache (survives `tox -e down`; `tox -e wipe` removes
+  `secrets.json`).
+
+The process-lifetime `memory` store remains available. Deploy-time Helm
+Secrets / env (`secret_store: env`) are unchanged. DELETE must pass
+`?secretStore=` (Abbenay defaults omitted store to **keychain**).
 
 Rejected: a Gateway `ai_providers` SQLite table as source of truth with
 push-into-Abbenay-memory
 ([#560](https://github.com/ansible/apme/pull/560)). That inverts this
 ADR's "Abbenay remains config SoT" (invariant 5) and makes Gateway a
-secrets vault it is not designed to be.
+secrets vault it is not designed to be. This amendment does **not**
+implement #560's Portal CRUD / push-before-scan UX; operators who need
+runtime keys to survive a Helm pod recycle must enable the Abbenay PVC
+(or keep using env / Helm Secrets).
 
 **We will use an allowlisted HTTP reverse-proxy on the Gateway for in-pod
 Abbenay admin, not a catch-all façade and not Gateway→Abbenay gRPC for chat.**
@@ -196,8 +208,10 @@ Abbenay `secretStore: memory` before AI-enabled scans (proposed in
 - Breaks "Abbenay remains config SoT" (this ADR / invariant 5)
 - Memory store is still ephemeral in Abbenay; durability is only in Gateway
 
-**Why not chosen**: Durable keys belong in Abbenay's file store on the
-existing config volume. Gateway stays a proxy.
+**Why not chosen**: Durable keys belong in Abbenay's file store on a
+**durable** config volume (Helm PVC / Podman cache), not in Gateway SQLite.
+Gateway stays a proxy. Default Helm `emptyDir` is still ephemeral — enable
+`persistence.abbenay.enabled` when file-store keys must survive pod recycle.
 
 ## Consequences
 
@@ -255,8 +269,10 @@ existing config volume. Gateway stays a proxy.
   (`${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/`); seed-once;
   runtime SoT after first configure.
 - **Secrets durability** (Abbenay ≥ v2026.8.6): `secretStore: "file"` writes
-  `<configDir>/secrets.json` on that same volume. Gateway does not parse
-  `secretStore`. Do not persist provider keys in Gateway SQLite.
+  `<configDir>/secrets.json` on that same volume. Durable only with Helm
+  `persistence.abbenay.enabled=true` or the Podman RW cache. Gateway does
+  not parse `secretStore`. Do not persist provider keys in Gateway SQLite.
+  DELETE requires `?secretStore=` (Abbenay defaults to keychain).
 
 ## Related Decisions
 
@@ -286,4 +302,4 @@ existing config volume. Gateway stays a proxy.
 | 2026-08-03 | bthornto | Amended allowlist: added `GET /engines` for read-only engine discovery |
 | 2026-08-03 | bthornto | §6 Config durability implemented (#498): seed→RW emptyDir/PVC; Podman RW config dir |
 | 2026-08-13 | bthornto | Amended allowlist: added `GET/POST /secrets`, `DELETE /secrets/{key}` for Abbenay ≥ v2026.8.5 memory secret store |
-| 2026-08-14 | bthornto | §7 secrets remain Abbenay SoT: file store (`secretStore: "file"`, ≥ v2026.8.6) on the config volume; Gateway stays proxy-only (not Gateway DB; closes #560) |
+| 2026-08-14 | bthornto | §7 secrets remain Abbenay SoT: file store (`secretStore: "file"`, ≥ v2026.8.6) on a durable config volume (Helm PVC / Podman cache); Gateway stays proxy-only (rejects Gateway DB SoT, #560) |

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -112,6 +112,22 @@ admin writes persist there as the source of truth after first configure:
 After the first successful configure, the writable file is SoT — Helm value /
 ConfigMap changes do not overwrite an existing runtime config.
 
+**7. Secrets source of truth remains Abbenay (not Gateway).**  
+Runtime API keys injected via `POST /api/v1/ai/secrets` are stored by
+Abbenay. Gateway reverse-proxies the secrets API and does **not** persist
+provider keys. Durable keys in containers use Abbenay's filesystem store
+(`secretStore: "file"`, Abbenay ≥ v2026.8.6), which writes
+`<configDir>/secrets.json` (mode `0600`) on the same writable volume as
+`config.yaml` (Helm `persistence.abbenay`, Podman RW cache). The
+process-lifetime `memory` store remains available. Deploy-time Helm
+Secrets / env (`secret_store: env`) are unchanged.
+
+Rejected: a Gateway `ai_providers` SQLite table as source of truth with
+push-into-Abbenay-memory
+([#560](https://github.com/ansible/apme/pull/560)). That inverts this
+ADR's "Abbenay remains config SoT" (invariant 5) and makes Gateway a
+secrets vault it is not designed to be.
+
 **We will use an allowlisted HTTP reverse-proxy on the Gateway for in-pod
 Abbenay admin, not a catch-all façade and not Gateway→Abbenay gRPC for chat.**
 
@@ -163,6 +179,25 @@ runtime admin API.
 - Slow feedback loop for EAP demos and day-2 model changes
 
 **Why not chosen**: Product needs runtime admin through the Gateway edge.
+
+### Alternative 4: Gateway SQLite as secrets SoT, push to Abbenay memory
+
+**Description**: Persist providers and API keys in Gateway DB; push into
+Abbenay `secretStore: memory` before AI-enabled scans (proposed in
+[#560](https://github.com/ansible/apme/pull/560)).
+
+**Pros**:
+- Survives Abbenay restart without a PVC
+- Portal CRUD can live next to other Gateway settings
+
+**Cons**:
+- Gateway becomes a secrets vault (SQLite is not designed for that)
+- Two sources of truth; push-before-scan races and restart windows
+- Breaks "Abbenay remains config SoT" (this ADR / invariant 5)
+- Memory store is still ephemeral in Abbenay; durability is only in Gateway
+
+**Why not chosen**: Durable keys belong in Abbenay's file store on the
+existing config volume. Gateway stays a proxy.
 
 ## Consequences
 
@@ -219,6 +254,9 @@ runtime admin API.
   (`persistence.abbenay`); Podman RW cache
   (`${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/`); seed-once;
   runtime SoT after first configure.
+- **Secrets durability** (Abbenay ≥ v2026.8.6): `secretStore: "file"` writes
+  `<configDir>/secrets.json` on that same volume. Gateway does not parse
+  `secretStore`. Do not persist provider keys in Gateway SQLite.
 
 ## Related Decisions
 
@@ -248,3 +286,4 @@ runtime admin API.
 | 2026-08-03 | bthornto | Amended allowlist: added `GET /engines` for read-only engine discovery |
 | 2026-08-03 | bthornto | §6 Config durability implemented (#498): seed→RW emptyDir/PVC; Podman RW config dir |
 | 2026-08-13 | bthornto | Amended allowlist: added `GET/POST /secrets`, `DELETE /secrets/{key}` for Abbenay ≥ v2026.8.5 memory secret store |
+| 2026-08-14 | bthornto | §7 secrets remain Abbenay SoT: file store (`secretStore: "file"`, ≥ v2026.8.6) on the config volume; Gateway stays proxy-only (not Gateway DB; closes #560) |

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -118,18 +118,21 @@ Abbenay. Gateway reverse-proxies the secrets API and does **not** persist
 provider keys. Durable keys in containers use Abbenay's filesystem store
 (`secretStore: "file"`, Abbenay ≥ v2026.8.6), which writes
 `<configDir>/secrets.json` (mode `0600` as written by Abbenay) on the same
-writable volume as `config.yaml`. On macOS Podman Machine, `up.sh` may set
-the file to `0644` so virtiofs can map container UID 1001 — treat the host
-cache directory as secret material ([#562](https://github.com/ansible/apme/issues/562)
-for write access without world-open perms). File-store keys survive a restart
+writable volume as `config.yaml`. On macOS Podman Machine, virtiofs cannot
+give container UID 1001 access without world-opening the file; `up.sh` does
+not chmod `secrets.json`. File store on Darwin hostPath is unsupported until
+[#562](https://github.com/ansible/apme/issues/562) (named volume or keep-id);
+use env or memory. File-store keys survive a restart
 **only** when that volume is durable:
 
 - **Helm**: `persistence.abbenay.enabled=true` (PVC). The chart default is
   `emptyDir` — file-store keys then last for the **pod** lifetime only
   (survive Abbenay container restart; lost on pod recycle, drain, and Helm
   upgrade with `Recreate`).
-- **Podman**: RW host cache (survives `tox -e down`; `tox -e wipe` removes
-  `secrets.json`).
+- **Podman (Linux)**: RW host cache (survives `tox -e down`; `tox -e wipe`
+  removes `secrets.json`). **macOS**: file store on the virtiofs hostPath is
+  unsupported until [#562](https://github.com/ansible/apme/issues/562); use
+  env or memory.
 
 The process-lifetime `memory` store remains available. Deploy-time Helm
 Secrets / env (`secret_store: env`) are unchanged. DELETE must pass

--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -43,7 +43,7 @@ Constraints and drivers:
 |-----------|--------|
 | 1. Validators read-only | Consistent |
 | 2. gRPC between backend services | Consistent — admin uses Abbenay’s existing HTTP API; inference stays gRPC via Primary |
-| 5. Stateless engine / persistence at Gateway | Consistent — Abbenay remains config SoT; Gateway does not persist Abbenay config |
+| 5. Stateless engine / persistence at Gateway | Consistent — Abbenay remains config and secrets SoT; Gateway does not persist Abbenay config or provider keys |
 | 11. Engine never queries out | Consistent — Gateway (not engine) reaches Abbenay admin |
 | 16. Helm Simple / Podman localhost | Consistent with ADR-069 |
 | 17. REST versioning (ADR-060) | Additive `/api/v1/ai/*` proxy mount |
@@ -117,13 +117,16 @@ Runtime API keys injected via `POST /api/v1/ai/secrets` are stored by
 Abbenay. Gateway reverse-proxies the secrets API and does **not** persist
 provider keys. Durable keys in containers use Abbenay's filesystem store
 (`secretStore: "file"`, Abbenay ≥ v2026.8.6), which writes
-`<configDir>/secrets.json` (mode `0600`) on the same writable volume as
-`config.yaml`. File-store keys survive a restart **only** when that volume
-is durable:
+`<configDir>/secrets.json` (mode `0600` as written by Abbenay) on the same
+writable volume as `config.yaml`. On macOS Podman Machine, `up.sh` may set
+the file to `0644` so virtiofs can map container UID 1001 — treat the host
+cache directory as secret material. File-store keys survive a restart
+**only** when that volume is durable:
 
 - **Helm**: `persistence.abbenay.enabled=true` (PVC). The chart default is
   `emptyDir` — file-store keys then last for the **pod** lifetime only
-  (lost on restart, OOM, drain, and Helm upgrade with `Recreate`).
+  (survive Abbenay container restart; lost on pod recycle, drain, and Helm
+  upgrade with `Recreate`).
 - **Podman**: RW host cache (survives `tox -e down`; `tox -e wipe` removes
   `secrets.json`).
 

--- a/.sdlc/context/dependencies.md
+++ b/.sdlc/context/dependencies.md
@@ -136,7 +136,7 @@ with open(path, "w") as f:
 
 | Package | Purpose |
 |---------|---------|
-| `abbenay-client==2026.8.5` | gRPC client for the Abbenay AI provider (Tier 2 remediation); PyPI, CalVer-aligned with daemon image `v2026.8.5`. Local/dev: `uv sync --extra ai`. Production/containers: `uv sync --frozen --extra ai` (hashes in `uv.lock`). `pip install apme-engine[ai]` is version-pin only. |
+| `abbenay-client==2026.8.6` | gRPC client for the Abbenay AI provider (Tier 2 remediation); PyPI, CalVer-aligned with daemon image `v2026.8.6`. Local/dev: `uv sync --extra ai`. Production/containers: `uv sync --frozen --extra ai` (hashes in `uv.lock`). `pip install apme-engine[ai]` is version-pin only. |
 
 ### Gateway (`[project.optional-dependencies.gateway]`)
 

--- a/.sdlc/context/deployment.md
+++ b/.sdlc/context/deployment.md
@@ -93,7 +93,7 @@ The **`remediate`** command uses a **bidirectional streaming RPC** (`FixSession`
 
 ```bash
 tox -e down                             # stop pod only
-tox -e wipe                             # stop pod and delete DB + session cache
+tox -e wipe                             # stop pod and delete DB, sessions, Abbenay secrets.json
 ```
 
 ### Health Check
@@ -270,7 +270,7 @@ See `PODMAN_OPA_ISSUES.md` for common Podman rootless issues:
 tox -e up                               # build + start
 tox -e cli                              # run a scan (check .)
 tox -e down                             # stop
-tox -e wipe                             # stop + wipe DB/sessions
+tox -e wipe                             # stop + wipe DB/sessions/Abbenay secrets.json
 ```
 
 ### Port Map

--- a/containers/abbenay/config.yaml.example
+++ b/containers/abbenay/config.yaml.example
@@ -1,7 +1,7 @@
 # Abbenay dev configuration for the APME pod.
 #
 # Models: configure one or more LLM providers below. API keys are
-# referenced via secret_name + secret_store (env | memory | keychain).
+# referenced via secret_name + secret_store (env | memory | keychain | file).
 # For env-var-based keys, set values in containers/abbenay/.env.
 #
 # Consumers: the "apme" consumer uses a well-known dev token so the

--- a/containers/podman/README.md
+++ b/containers/podman/README.md
@@ -68,7 +68,7 @@ The health check probes all validators via **gRPC** through the Primary orchestr
 
 ```bash
 tox -e down             # stop
-tox -e wipe             # stop + wipe DB and session cache
+tox -e wipe             # stop + wipe DB, session cache, and Abbenay secrets.json
 
 # Or directly
 podman pod stop apme-pod

--- a/containers/podman/build.sh
+++ b/containers/podman/build.sh
@@ -16,7 +16,7 @@ echo "==> Building base image (shared dependencies)..."
 podman build "${BUILD_ARGS[@]}" -t localhost/apme-base:latest -f containers/base/Dockerfile .
 
 echo "==> Pulling Abbenay AI image..."
-podman pull ghcr.io/redhat-developer/abbenay:v2026.8.5
+podman pull ghcr.io/redhat-developer/abbenay:v2026.8.6
 
 echo "==> Building service images..."
 podman build "${BUILD_ARGS[@]}" -t apme-primary:latest -f containers/primary/Dockerfile .

--- a/containers/podman/down.sh
+++ b/containers/podman/down.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Stop the APME pod and optionally wipe the database.
+# Stop the APME pod and optionally wipe local state (Gateway DB, sessions,
+# Abbenay secrets.json).
 #
 # Usage:
 #   ./down.sh          # stop pod only

--- a/containers/podman/down.sh
+++ b/containers/podman/down.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   ./down.sh          # stop pod only
-#   ./down.sh --wipe   # stop pod and delete the gateway database
+#   ./down.sh --wipe   # stop pod, delete gateway DB/sessions, and Abbenay secrets.json
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
@@ -49,5 +49,13 @@ if [[ "${1:-}" == "--wipe" ]]; then
     echo "Wiped session cache: $SESSIONS_DIR"
   else
     echo "No session cache found at $SESSIONS_DIR"
+  fi
+
+  ABBENAY_SECRETS="$CACHE_PATH/abbenay/config/secrets.json"
+  if [[ -f "$ABBENAY_SECRETS" ]]; then
+    rm -f "$ABBENAY_SECRETS"
+    echo "Wiped Abbenay file-store secrets: $ABBENAY_SECRETS"
+  else
+    echo "No Abbenay secrets.json found at $ABBENAY_SECRETS"
   fi
 fi

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -216,7 +216,7 @@ spec:
         - containerPort: 8081
           hostPort: 8081
     - name: abbenay
-      image: ghcr.io/redhat-developer/abbenay:v2026.8.5
+      image: ghcr.io/redhat-developer/abbenay:v2026.8.6
       # ADR-070: HTTP + gRPC on loopback (pod-shared netns). No hostPort for
       # Abbenay — matches Helm Simple and avoids plaintext host exposure.
       args:

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -235,6 +235,7 @@ _ensure_abbenay_config_access() {
       # so world-readable perms are sufficient for the container UID.
       chmod 755 "$path"
       [[ -f "$path/config.yaml" ]] && chmod 644 "$path/config.yaml"
+      [[ -f "$path/secrets.json" ]] && chmod 644 "$path/secrets.json"
       return 0
     fi
     if ! command -v setfacl >/dev/null 2>&1; then
@@ -252,6 +253,13 @@ _ensure_abbenay_config_access() {
       setfacl -m "u:${mapped}:rw" "$path/config.yaml" || return 1
       if ! _container_uid_can_read "$cuid" "$path/config.yaml"; then
         echo "ERROR: container UID $cuid cannot read $path/config.yaml after ACL grant" >&2
+        return 1
+      fi
+    fi
+    if [[ -f "$path/secrets.json" ]]; then
+      setfacl -m "u:${mapped}:rw" "$path/secrets.json" || return 1
+      if ! _container_uid_can_read "$cuid" "$path/secrets.json"; then
+        echo "ERROR: container UID $cuid cannot read $path/secrets.json after ACL grant" >&2
         return 1
       fi
     fi

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -232,7 +232,8 @@ _ensure_abbenay_config_access() {
     fi
     if [[ "$(uname -s)" == "Darwin" ]]; then
       # macOS: setfacl unavailable; Podman Machine VM shares files via virtiofs
-      # so world-readable perms are sufficient for the container UID.
+      # so other-readable perms are required for container UID 1001. Treat this
+      # cache dir as secret material (secrets.json may be 0644, not 0600).
       chmod 755 "$path"
       [[ -f "$path/config.yaml" ]] && chmod 644 "$path/config.yaml"
       [[ -f "$path/secrets.json" ]] && chmod 644 "$path/secrets.json"

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -231,9 +231,11 @@ _ensure_abbenay_config_access() {
       fi
     fi
     if [[ "$(uname -s)" == "Darwin" ]]; then
-      # macOS: setfacl unavailable; Podman Machine VM shares files via virtiofs
-      # so other-readable perms are required for container UID 1001. Treat this
-      # cache dir as secret material (secrets.json may be 0644, not 0600).
+      # macOS: setfacl unavailable; Podman Machine virtiofs presents the host
+      # user as owner and container UID 1001 as other, so other-read is required
+      # for config.yaml. Do not chmod 0666/0777 on secrets.json (world-writable
+      # keys). File-store persist without world access is #562 (named volume or
+      # keep-id). Treat this cache dir as secret material.
       chmod 755 "$path"
       [[ -f "$path/config.yaml" ]] && chmod 644 "$path/config.yaml"
       [[ -f "$path/secrets.json" ]] && chmod 644 "$path/secrets.json"

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -231,14 +231,16 @@ _ensure_abbenay_config_access() {
       fi
     fi
     if [[ "$(uname -s)" == "Darwin" ]]; then
-      # macOS: setfacl unavailable; Podman Machine virtiofs presents the host
-      # user as owner and container UID 1001 as other, so other-read is required
-      # for config.yaml. Do not chmod 0666/0777 on secrets.json (world-writable
-      # keys). File-store persist without world access is #562 (named volume or
-      # keep-id). Treat this cache dir as secret material.
+      # macOS: setfacl unavailable; virtiofs presents the host user as owner
+      # and container UID 1001 as other. config.yaml uses 0644 so UID 1001
+      # can read the seed. Do not chmod secrets.json: 0644 is other-readable
+      # and still not other-writable, so file-store persist cannot work.
+      # Named volume / keep-id: #562.
       chmod 755 "$path"
       [[ -f "$path/config.yaml" ]] && chmod 644 "$path/config.yaml"
-      [[ -f "$path/secrets.json" ]] && chmod 644 "$path/secrets.json"
+      if [[ -f "$path/secrets.json" ]]; then
+        echo "NOTE: Abbenay file secret store is unsupported on macOS virtiofs hostPath until #562. Leave secrets.json owner-only; use secret_store: env or memory. See https://github.com/ansible/apme/issues/562"
+      fi
       return 0
     fi
     if ! command -v setfacl >/dev/null 2>&1; then

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -343,10 +343,9 @@ Podman uses the same PVC definitions in
 helm uninstall apme
 ```
 
-PVCs are not deleted automatically. The Abbenay config PVC may contain
-plaintext `secrets.json` (file secret store) as well as runtime
-`config.yaml`. Remove PVCs when decommissioning or before reinstalling
-under the same release name (reinstall otherwise reattaches the old keys):
+Helm 3 deletes chart-managed PVCs on uninstall. If the StorageClass
+reclaim policy is Retain, orphaned PVs can still hold plaintext
+`secrets.json`. Delete leftover PVs/PVCs when decommissioning:
 
 ```bash
 kubectl delete pvc -l app.kubernetes.io/instance=apme

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -343,12 +343,32 @@ Podman uses the same PVC definitions in
 helm uninstall apme
 ```
 
-Helm 3 deletes chart-managed PVCs on uninstall. If the StorageClass
-reclaim policy is Retain, orphaned PVs can still hold plaintext
-`secrets.json`. Delete leftover PVs/PVCs when decommissioning:
+Helm 3 deletes chart-managed PVCs. The `kubectl delete pvc` command below is
+only needed if a claim was left behind (failed uninstall, or a PVC created
+outside the chart).
+
+If the StorageClass reclaim policy is **Delete**, the CSI driver typically
+removes the backing volume when the PVC is gone.
+
+If the reclaim policy is **Retain**, uninstall (and deleting the PVC) does
+**not** erase the disk. A PV in `Released` phase can still hold plaintext
+`secrets.json` (Abbenay file store) and runtime `config.yaml`. Identify it,
+destroy or crypto-erase the volume in the **storage provider**, then delete
+the PV object. `kubectl` cannot securely overwrite those bytes.
 
 ```bash
+# Find APME PVs (claims are <release>-abbenay-config, -gateway-data, …)
+kubectl get pv -o custom-columns=\
+NAME:.metadata.name,\
+RECLAIM:.spec.persistentVolumeReclaimPolicy,\
+STATUS:.status.phase,\
+CLAIM:.spec.claimRef.namespace/.spec.claimRef.name
+
+# Leftover chart PVCs (usually none after a clean helm uninstall)
 kubectl delete pvc -l app.kubernetes.io/instance=apme
+
+# After wiping/destroying a Retain volume in the storage provider:
+# kubectl delete pv <pv-name>
 ```
 
 ## Related

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -202,7 +202,7 @@ Gateway DB and Abbenay down together.
 | `ui.replicas` | `1` | Must be `1` when UI enabled |
 | `abbenay.enabled` | `false` | Enable AI provider sidecar |
 | `abbenay.token` | `""` | Abbenay gRPC + HTTP admin token (required when `abbenay.enabled=true`) |
-| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:v2026.8.5` | Abbenay image |
+| `abbenay.image` | `ghcr.io/redhat-developer/abbenay:v2026.8.6` | Abbenay image |
 | `abbenay.providers` | `{}` | LLM provider map (see [ABBENAY_AI.md](../../../docs/guides/ABBENAY_AI.md)) |
 | `abbenay.aiModel` | `""` | Default AI model ID |
 | `ingress.enabled` | `false` | Create Kubernetes Ingress |
@@ -213,8 +213,8 @@ Gateway DB and Abbenay down together.
 | `podDisruptionBudget.enabled` | `false` | Enable PDB |
 | `persistence.sessions.size` | `10Gi` | Session venv PVC size |
 | `persistence.gateway.size` | `5Gi` | Gateway DB PVC size |
-| `persistence.abbenay.enabled` | `false` | When `true` (and `abbenay.enabled`), PVC for Abbenay runtime config; otherwise `emptyDir` |
-| `persistence.abbenay.size` | `100Mi` | Abbenay config PVC size (seed-once from ConfigMap; runtime SoT after configure) |
+| `persistence.abbenay.enabled` | `false` | When `true` (and `abbenay.enabled`), PVC for Abbenay runtime config and file-store secrets (`secrets.json`); otherwise `emptyDir` |
+| `persistence.abbenay.size` | `100Mi` | Abbenay config PVC size (seed-once from ConfigMap; runtime SoT after configure; also holds `secrets.json` for `secretStore: file`) |
 
 See [`values.yaml`](values.yaml) for the complete reference with all resource
 limits, tolerations, affinity, and topology spread constraints.

--- a/deploy/helm/apme/README.md
+++ b/deploy/helm/apme/README.md
@@ -332,8 +332,9 @@ securityContext:
   runAsUser: 1001
 ```
 
-`fsGroup` ensures PVC mounts for `/sessions`, `/data`, and `/cache` are writable by
-the application UID. Local Podman uses the same PVC definitions in
+`fsGroup` ensures PVC mounts for `/sessions`, `/data`, `/cache`, and
+Abbenay `/etc/abbenay-config` are writable by the application UID. Local
+Podman uses the same PVC definitions in
 `containers/podman/pvc.yaml` (with `volume.podman.io/uid` annotations).
 
 ## Uninstall
@@ -342,7 +343,10 @@ the application UID. Local Podman uses the same PVC definitions in
 helm uninstall apme
 ```
 
-PVCs are not deleted automatically. Remove them manually if desired:
+PVCs are not deleted automatically. The Abbenay config PVC may contain
+plaintext `secrets.json` (file secret store) as well as runtime
+`config.yaml`. Remove PVCs when decommissioning or before reinstalling
+under the same release name (reinstall otherwise reattaches the old keys):
 
 ```bash
 kubectl delete pvc -l app.kubernetes.io/instance=apme

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -66,3 +66,12 @@ WARNING: image.tag is not set. Falling back to Chart.appVersion
 ({{ .Chart.AppVersion }}). Confirm that tag exists in the configured
 registry (or set --set image.tag=sha-<commit> for unreleased builds).
 {{- end }}
+
+{{- if and .Values.abbenay.enabled (not .Values.persistence.abbenay.enabled) }}
+
+NOTE: persistence.abbenay is disabled (emptyDir). Abbenay runtime
+config.yaml and file-store secrets.json last for the pod lifetime only
+(lost on restart, OOM, drain, or Helm upgrade). Set
+persistence.abbenay.enabled=true for durable keys, or keep using
+Helm Secrets / env (secret_store: env).
+{{- end }}

--- a/deploy/helm/apme/templates/NOTES.txt
+++ b/deploy/helm/apme/templates/NOTES.txt
@@ -70,8 +70,8 @@ registry (or set --set image.tag=sha-<commit> for unreleased builds).
 {{- if and .Values.abbenay.enabled (not .Values.persistence.abbenay.enabled) }}
 
 NOTE: persistence.abbenay is disabled (emptyDir). Abbenay runtime
-config.yaml and file-store secrets.json last for the pod lifetime only
-(lost on restart, OOM, drain, or Helm upgrade). Set
-persistence.abbenay.enabled=true for durable keys, or keep using
-Helm Secrets / env (secret_store: env).
+config.yaml and file-store secrets.json last for the pod lifetime
+(survive Abbenay container restart; lost on pod recycle, drain, or
+Helm Recreate upgrade). Set persistence.abbenay.enabled=true for
+durable keys, or keep using Helm Secrets / env (secret_store: env).
 {{- end }}

--- a/deploy/helm/apme/values.yaml
+++ b/deploy/helm/apme/values.yaml
@@ -154,7 +154,7 @@ ui:
 # See docs/guides/ABBENAY_AI.md for GCP-specific setup.
 abbenay:
   enabled: false
-  image: ghcr.io/redhat-developer/abbenay:v2026.8.5
+  image: ghcr.io/redhat-developer/abbenay:v2026.8.6
   # -- Token APME uses to authenticate with Abbenay (required when enabled)
   token: ""
   # -- Override the default model APME selects (e.g. "vertex-claude/claude-sonnet-4-6")
@@ -254,8 +254,9 @@ persistence:
     storageClass: ""
     accessMode: ReadWriteOnce
   # -- Writable config volume for Abbenay runtime admin (ADR-070 / #498).
-  # emptyDir by default (pod lifetime only — config resets on pod restart).
-  # Enable persistence for a PVC that survives restarts.
+  # emptyDir by default (pod lifetime only — config and file-store secrets
+  # reset on pod restart). Enable persistence for a PVC that survives
+  # restarts (config.yaml + secrets.json when secretStore is file).
   abbenay:
     enabled: false
     size: 100Mi

--- a/docs/design/DESIGN_AI_ESCALATION.md
+++ b/docs/design/DESIGN_AI_ESCALATION.md
@@ -531,7 +531,7 @@ Future MCP integration (when implemented) would allow the LLM to autonomously ca
 
 ### Secret Handling
 
-- API keys are managed by Abbenay (in its config or env vars), never passed through APME
+- API keys are managed by Abbenay (env, memory, keychain, or file store), never persisted by the Gateway
 - Consumer tokens are passed via gRPC metadata, not logged
 - File content sent to the LLM may contain sensitive data -- this is the user's responsibility (same as any LLM-assisted coding tool)
 
@@ -544,12 +544,12 @@ Future MCP integration (when implemented) would allow the LLM to autonomously ca
 ## Optional Dependency
 
 `abbenay-client` is an optional dependency, published on PyPI. Pin it to
-the same CalVer as the Abbenay daemon image (currently `v2026.8.5`):
+the same CalVer as the Abbenay daemon image (currently `v2026.8.6`):
 
 ```toml
 [project.optional-dependencies]
 ai = [
-    "abbenay-client==2026.8.5",
+    "abbenay-client==2026.8.6",
 ]
 ```
 
@@ -594,14 +594,14 @@ Install with: uv sync --extra ai
 Pre-built multi-arch Abbenay images (amd64 + arm64) are available on GHCR:
 
 ```bash
-podman pull ghcr.io/redhat-developer/abbenay:v2026.8.5
+podman pull ghcr.io/redhat-developer/abbenay:v2026.8.6
 ```
 
 | Tag | Meaning |
 |-----|---------|
 | `:main` | Latest merged code |
 | `:sha-<short>` | Specific commit |
-| `:v2026.8.5` | Release (`v` prefix; APME pin) |
+| `:v2026.8.6` | Release (`v` prefix; APME pin) |
 | `:latest` | Latest stable release |
 
 ```

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -57,14 +57,41 @@ curl -X DELETE http://gateway:8080/api/v1/ai/secrets/OPENROUTER_API_KEY
 
 After injecting a secret, configure a provider to use it via
 `POST /api/v1/ai/provider/{id}/configure` with `secretName` and
-`secretStore: memory`. Memory-stored secrets do not survive pod restarts;
-re-inject after a restart or use Helm Secrets / env vars for persistence.
+`secretStore: memory`. Memory-stored secrets do not survive Abbenay or pod
+restarts. For keys that must survive a restart, use the file store below,
+or Helm Secrets / env vars (`secret_store: env`).
+
+### File secret store (Abbenay >= v2026.8.6)
+
+For durable API keys in containers (no system keychain), Abbenay persists
+secrets to `<configDir>/secrets.json` (mode `0600`) on the **same writable
+volume** as `config.yaml`. Gateway reverse-proxies the JSON body unchanged
+and does **not** store keys (ADR-070). Pair file-store usage with a durable
+config volume:
+
+| Deploy | Durable volume | Lost on restart? |
+|--------|----------------|------------------|
+| **Helm** | `persistence.abbenay.enabled=true` (PVC) | `emptyDir` (the default) loses `secrets.json` |
+| **Podman** | RW cache `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` | Survives `tox -e down` / container restart |
+
+**Inject a secret into the file store:**
+
+```bash
+curl -X POST http://gateway:8080/api/v1/ai/secrets \
+  -H "Content-Type: application/json" \
+  -d '{"key": "OPENROUTER_API_KEY", "value": "sk-or-...", "secretStore": "file"}'
+```
+
+Then configure the provider with `secretName` and `secretStore: file` via
+`POST /api/v1/ai/provider/{id}/configure`. Deploy-time Helm Secrets / env
+(`secret_store: env` in the seed ConfigMap) are unchanged.
 
 > **Security note:** `GET /api/v1/ai/secrets` returns stored key **names**
 > (not values) to any client that can reach Gateway `:8080`. The Gateway REST
 > API relies on network-isolation auth (ADR-048) — operators must ensure an
 > outer auth layer (Ingress, Route, reverse proxy) before exposing `:8080`
-> outside the cluster.
+> outside the cluster. File-store `secrets.json` is mode `0600` on the
+> Abbenay config volume; treat that volume as secret material.
 
 ### Writable config volume (#498)
 
@@ -74,8 +101,8 @@ the first write, the runtime file is the source of truth.
 
 | Deploy | Seed | Writable volume | Notes |
 |--------|------|-----------------|-------|
-| **Helm** | ConfigMap `*-abbenay-config` (from `abbenay.providers`) | `emptyDir` by default; optional PVC via `persistence.abbenay.enabled=true` | Init `init-abbenay-config` copies seed only if `config.yaml` is absent. Mount: `/etc/abbenay-config`. |
-| **Podman** | `containers/abbenay/config/` (or legacy `config.yaml` / `.example`) on first `tox -e up` | Cache dir `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds into the cache path (mode `0700`/`0600`). Rootful chowns the cache copy to UID 1001; rootless keeps host ownership and grants UID 1001 a POSIX ACL. The repo tree is never chowned. |
+| **Helm** | ConfigMap `*-abbenay-config` (from `abbenay.providers`) | `emptyDir` by default; optional PVC via `persistence.abbenay.enabled=true` | Init `init-abbenay-config` copies seed only if `config.yaml` is absent. Mount: `/etc/abbenay-config`. The same volume holds file-store `secrets.json` (Abbenay ≥ v2026.8.6). |
+| **Podman** | `containers/abbenay/config/` (or legacy `config.yaml` / `.example`) on first `tox -e up` | Cache dir `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds into the cache path (mode `0700`/`0600`). Rootful chowns the cache copy to UID 1001; rootless keeps host ownership and grants UID 1001 a POSIX ACL. The repo tree is never chowned. File-store `secrets.json` is written here. |
 
 Helm PVC knobs (`persistence.abbenay.*`):
 

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -49,10 +49,17 @@ curl -X POST http://gateway:8080/api/v1/ai/secrets \
 curl http://gateway:8080/api/v1/ai/secrets
 ```
 
-**Remove a secret:**
+The response lists key **names** plus which store holds them (`secretStore`,
+`hasValue`). It does **not** return secret values. Env-injected Helm keys
+do not appear in this registry list.
+
+**Remove a secret:** Abbenay defaults omitted `secretStore` to **keychain**.
+Always pass the store you used when injecting, or the delete will no-op
+against the wrong backend (and still return success):
 
 ```bash
-curl -X DELETE http://gateway:8080/api/v1/ai/secrets/OPENROUTER_API_KEY
+curl -X DELETE 'http://gateway:8080/api/v1/ai/secrets/OPENROUTER_API_KEY?secretStore=memory'
+curl -X DELETE 'http://gateway:8080/api/v1/ai/secrets/OPENROUTER_API_KEY?secretStore=file'
 ```
 
 After injecting a secret, configure a provider to use it via
@@ -72,7 +79,7 @@ config volume:
 | Deploy | Durable volume | Lost on restart? |
 |--------|----------------|------------------|
 | **Helm** | `persistence.abbenay.enabled=true` (PVC) | `emptyDir` (the default) loses `secrets.json` |
-| **Podman** | RW cache `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` | Survives `tox -e down` / container restart |
+| **Podman** | RW cache `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` | Survives `tox -e down` / container restart. `tox -e wipe` deletes `secrets.json`. |
 
 **Inject a secret into the file store:**
 
@@ -83,8 +90,20 @@ curl -X POST http://gateway:8080/api/v1/ai/secrets \
 ```
 
 Then configure the provider with `secretName` and `secretStore: file` via
-`POST /api/v1/ai/provider/{id}/configure`. Deploy-time Helm Secrets / env
-(`secret_store: env` in the seed ConfigMap) are unchanged.
+`POST /api/v1/ai/provider/{id}/configure`. File-store keys and Helm env
+keys (`secret_store: env` in the seed ConfigMap) are **separate** backends:
+injecting `secretStore: file` does not override an env-backed provider until
+you reconfigure `secretStore`. Deploy-time Helm Secrets / env are unchanged.
+
+**Remove a file-store secret:**
+
+```bash
+curl -X DELETE 'http://gateway:8080/api/v1/ai/secrets/OPENROUTER_API_KEY?secretStore=file'
+```
+
+If `secrets.json` exists but is not valid JSON, Abbenay treats reads as empty
+and **refuses writes** (it will not overwrite a corrupt file). Fix or remove
+the file on the config volume, then re-inject.
 
 > **Security note:** `GET /api/v1/ai/secrets` returns stored key **names**
 > (not values) to any client that can reach Gateway `:8080`. The Gateway REST
@@ -102,7 +121,7 @@ the first write, the runtime file is the source of truth.
 | Deploy | Seed | Writable volume | Notes |
 |--------|------|-----------------|-------|
 | **Helm** | ConfigMap `*-abbenay-config` (from `abbenay.providers`) | `emptyDir` by default; optional PVC via `persistence.abbenay.enabled=true` | Init `init-abbenay-config` copies seed only if `config.yaml` is absent. Mount: `/etc/abbenay-config`. The same volume holds file-store `secrets.json` (Abbenay ≥ v2026.8.6). |
-| **Podman** | `containers/abbenay/config/` (or legacy `config.yaml` / `.example`) on first `tox -e up` | Cache dir `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds into the cache path (mode `0700`/`0600`). Rootful chowns the cache copy to UID 1001; rootless keeps host ownership and grants UID 1001 a POSIX ACL. The repo tree is never chowned. File-store `secrets.json` is written here. |
+| **Podman** | `containers/abbenay/config/` (or legacy `config.yaml` / `.example`) on first `tox -e up` | Cache dir `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds into the cache path (mode `0700`/`0600`). Rootful chowns the cache copy to UID 1001; rootless keeps host ownership and grants UID 1001 a POSIX ACL. The repo tree is never chowned. File-store `secrets.json` is written here; `tox -e wipe` deletes it. |
 
 Helm PVC knobs (`persistence.abbenay.*`):
 

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -74,10 +74,10 @@ or Helm Secrets / env vars (`secret_store: env`).
 For durable API keys in containers (no system keychain), Abbenay persists
 secrets to `<configDir>/secrets.json` on the **same writable volume** as
 `config.yaml`. Abbenay writes the file mode `0600`. On macOS Podman Machine,
-`up.sh` may relax it to `0644` so virtiofs can map container UID 1001 (the
-same workaround as `config.yaml`); treat
-`${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` as secret material.
-Granting UID 1001 write without world access is [#562](https://github.com/ansible/apme/issues/562).
+virtiofs cannot grant container UID 1001 read/write to that file without
+world-opening it; `up.sh` does **not** chmod `secrets.json`. Use
+`secret_store: env` or `memory` on Darwin until
+[#562](https://github.com/ansible/apme/issues/562) (named volume or keep-id).
 Gateway reverse-proxies the JSON body unchanged and does **not** store keys
 (ADR-070). Pair file-store usage with a durable config volume:
 
@@ -85,7 +85,8 @@ Gateway reverse-proxies the JSON body unchanged and does **not** store keys
 |--------|--------|----------|
 | **Helm (default)** | `emptyDir` | Abbenay **container** restart; lost on **pod** recycle (reschedule, drain, Helm `Recreate` upgrade) |
 | **Helm PVC** | `persistence.abbenay.enabled=true` | Pod recycle / upgrade (PVC may hold plaintext `secrets.json`) |
-| **Podman** | RW cache `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` | `tox -e down` / container restart. `tox -e wipe` deletes `secrets.json`. |
+| **Podman (Linux)** | RW cache `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` | `tox -e down` / container restart. `tox -e wipe` deletes `secrets.json`. |
+| **Podman (macOS)** | Same hostPath; virtiofs | File store unsupported until [#562](https://github.com/ansible/apme/issues/562). Use env or memory. |
 
 **Inject a secret into the file store:**
 
@@ -127,7 +128,7 @@ the first write, the runtime file is the source of truth.
 | Deploy | Seed | Writable volume | Notes |
 |--------|------|-----------------|-------|
 | **Helm** | ConfigMap `*-abbenay-config` (from `abbenay.providers`) | `emptyDir` by default; optional PVC via `persistence.abbenay.enabled=true` | Init `init-abbenay-config` copies seed only if `config.yaml` is absent. Mount: `/etc/abbenay-config`. The same volume holds file-store `secrets.json` (Abbenay ≥ v2026.8.6). |
-| **Podman** | `containers/abbenay/config/` (or legacy `config.yaml` / `.example`) on first `tox -e up` | Cache dir `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds into the cache path (mode `0700`/`0600`). Rootful chowns the cache copy to UID 1001; rootless keeps host ownership and grants UID 1001 a POSIX ACL. The repo tree is never chowned. File-store `secrets.json` is written here; `tox -e wipe` deletes it. |
+| **Podman** | `containers/abbenay/config/` (or legacy `config.yaml` / `.example`) on first `tox -e up` | Cache dir `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` → `/home/abbenay/.config/abbenay` | `up.sh` seeds into the cache path (mode `0700`/`0600`). Rootful chowns the cache copy to UID 1001; rootless Linux keeps host ownership and grants UID 1001 a POSIX ACL. macOS virtiofs cannot grant UID 1001 access to `secrets.json` without world-opening it — file store unsupported until [#562](https://github.com/ansible/apme/issues/562). The repo tree is never chowned. `tox -e wipe` deletes `secrets.json`. |
 
 Helm PVC knobs (`persistence.abbenay.*`):
 

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -77,6 +77,7 @@ secrets to `<configDir>/secrets.json` on the **same writable volume** as
 `up.sh` may relax it to `0644` so virtiofs can map container UID 1001 (the
 same workaround as `config.yaml`); treat
 `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` as secret material.
+Granting UID 1001 write without world access is [#562](https://github.com/ansible/apme/issues/562).
 Gateway reverse-proxies the JSON body unchanged and does **not** store keys
 (ADR-070). Pair file-store usage with a durable config volume:
 

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -49,9 +49,11 @@ curl -X POST http://gateway:8080/api/v1/ai/secrets \
 curl http://gateway:8080/api/v1/ai/secrets
 ```
 
-The response lists key **names** plus which store holds them (`secretStore`,
-`hasValue`). It does **not** return secret values. Env-injected Helm keys
-do not appear in this registry list.
+The response lists engine API-key slots (name, engine, `hasValue`, and
+`secretStore` when a registry backend holds the value). It does **not**
+return secret values. Helm env-injected keys typically show
+`hasValue: false` here because env is not a registry backend. Custom keys
+that are not an engine's default env var name are not listed.
 
 **Remove a secret:** Abbenay defaults omitted `secretStore` to **keychain**.
 Always pass the store you used when injecting, or the delete will no-op
@@ -59,7 +61,6 @@ against the wrong backend (and still return success):
 
 ```bash
 curl -X DELETE 'http://gateway:8080/api/v1/ai/secrets/OPENROUTER_API_KEY?secretStore=memory'
-curl -X DELETE 'http://gateway:8080/api/v1/ai/secrets/OPENROUTER_API_KEY?secretStore=file'
 ```
 
 After injecting a secret, configure a provider to use it via
@@ -71,15 +72,19 @@ or Helm Secrets / env vars (`secret_store: env`).
 ### File secret store (Abbenay >= v2026.8.6)
 
 For durable API keys in containers (no system keychain), Abbenay persists
-secrets to `<configDir>/secrets.json` (mode `0600`) on the **same writable
-volume** as `config.yaml`. Gateway reverse-proxies the JSON body unchanged
-and does **not** store keys (ADR-070). Pair file-store usage with a durable
-config volume:
+secrets to `<configDir>/secrets.json` on the **same writable volume** as
+`config.yaml`. Abbenay writes the file mode `0600`. On macOS Podman Machine,
+`up.sh` may relax it to `0644` so virtiofs can map container UID 1001 (the
+same workaround as `config.yaml`); treat
+`${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` as secret material.
+Gateway reverse-proxies the JSON body unchanged and does **not** store keys
+(ADR-070). Pair file-store usage with a durable config volume:
 
-| Deploy | Durable volume | Lost on restart? |
-|--------|----------------|------------------|
-| **Helm** | `persistence.abbenay.enabled=true` (PVC) | `emptyDir` (the default) loses `secrets.json` |
-| **Podman** | RW cache `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` | Survives `tox -e down` / container restart. `tox -e wipe` deletes `secrets.json`. |
+| Deploy | Volume | Survives |
+|--------|--------|----------|
+| **Helm (default)** | `emptyDir` | Abbenay **container** restart; lost on **pod** recycle (reschedule, drain, Helm `Recreate` upgrade) |
+| **Helm PVC** | `persistence.abbenay.enabled=true` | Pod recycle / upgrade (PVC may hold plaintext `secrets.json`) |
+| **Podman** | RW cache `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` | `tox -e down` / container restart. `tox -e wipe` deletes `secrets.json`. |
 
 **Inject a secret into the file store:**
 
@@ -105,12 +110,12 @@ If `secrets.json` exists but is not valid JSON, Abbenay treats reads as empty
 and **refuses writes** (it will not overwrite a corrupt file). Fix or remove
 the file on the config volume, then re-inject.
 
-> **Security note:** `GET /api/v1/ai/secrets` returns stored key **names**
-> (not values) to any client that can reach Gateway `:8080`. The Gateway REST
-> API relies on network-isolation auth (ADR-048) — operators must ensure an
-> outer auth layer (Ingress, Route, reverse proxy) before exposing `:8080`
-> outside the cluster. File-store `secrets.json` is mode `0600` on the
-> Abbenay config volume; treat that volume as secret material.
+> **Security note:** `GET /api/v1/ai/secrets` returns engine key **names**
+> and store metadata (not values) to any client that can reach Gateway
+> `:8080`. The Gateway REST API relies on network-isolation auth (ADR-048)
+> — operators must ensure an outer auth layer (Ingress, Route, reverse
+> proxy) before exposing `:8080` outside the cluster. Treat the Abbenay
+> config volume as secret material (`secrets.json`).
 
 ### Writable config volume (#498)
 
@@ -134,7 +139,7 @@ persistence:
     accessMode: ReadWriteOnce
 ```
 
-See [ADR-070](../../.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md) §6.
+See [ADR-070](../../.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md) §6 (config durability) and §7 (secrets remain Abbenay SoT).
 
 ---
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -53,7 +53,7 @@ This builds a shared base image, eleven service images, and pulls one official i
 | `apme-gateway:latest` | `containers/gateway/Dockerfile` | REST API + gRPC Reporting service (SQLite) |
 | `apme-ui:latest` | `containers/ui/Dockerfile` | React SPA served by nginx (proxies API to Gateway) |
 | `apme-cli:latest` | `containers/cli/Dockerfile` | CLI client |
-| `ghcr.io/redhat-developer/abbenay:v2026.8.5` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
+| `ghcr.io/redhat-developer/abbenay:v2026.8.6` | [Official image](https://github.com/redhat-developer/abbenay/pkgs/container/abbenay) (pulled) | Abbenay AI daemon (LLM gateway for Tier 2 remediation) |
 
 ### Configure Abbenay AI (optional)
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -114,7 +114,7 @@ The `remediate` command uses a bidirectional streaming RPC (`FixSession`, ADR-02
 
 ```bash
 tox -e down
-tox -e wipe    # also delete database + session cache
+tox -e wipe    # also delete database, session cache, and Abbenay secrets.json
 ```
 
 ### Health check
@@ -222,10 +222,13 @@ Abbenay uses `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` as a
 **writable** hostPath mount (`abbenay-config` → `/home/abbenay/.config/abbenay`).
 `up.sh` seeds that cache dir from `containers/abbenay/config/` (or legacy
 files) and never chowns the git checkout. The config defines LLM providers and
-models. API keys are injected from environment variables — never committed to
-the config file. To add providers or models, edit the cache `config.yaml` or
-POST via the Gateway admin proxy (`/api/v1/ai/provider/{id}/configure`);
-writes survive Abbenay restarts.
+models. Deploy-time API keys are injected from environment variables — never
+committed to the config file. Runtime file-store keys (Abbenay ≥ v2026.8.6,
+`secretStore: file`) are written to `secrets.json` on this same cache
+directory (treat as secret material). `tox -e down` leaves that file in
+place; `tox -e wipe` deletes it. To add providers or models, edit the cache
+`config.yaml` or POST via the Gateway admin proxy
+(`/api/v1/ai/provider/{id}/configure`); writes survive Abbenay restarts.
 
 The Abbenay daemon exposes a gRPC API on port 50057. Primary connects to it for AI model listing (`ListAIModels`) and batch remediation requests.
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -225,7 +225,10 @@ files) and never chowns the git checkout. The config defines LLM providers and
 models. Deploy-time API keys are injected from environment variables — never
 committed to the config file. Runtime file-store keys (Abbenay ≥ v2026.8.6,
 `secretStore: file`) are written to `secrets.json` on this same cache
-directory (treat as secret material). `tox -e down` leaves that file in
+directory (treat as secret material). On macOS, virtiofs cannot give
+container UID 1001 access to `secrets.json` without world-opening it; file
+store is unsupported there until [#562](https://github.com/ansible/apme/issues/562)
+(use env or memory). `tox -e down` leaves that file in
 place; `tox -e wipe` deletes it. To add providers or models, edit the cache
 `config.yaml` or POST via the Gateway admin proxy
 (`/api/v1/ai/provider/{id}/configure`); writes survive Abbenay restarts.

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -59,7 +59,7 @@ tox is the single entry point for all developer tasks. Every CI check has a corr
 | `tox -e build` | `containers/podman/build.sh` | Pod lifecycle |
 | `tox -e up` | `build.sh` + `up.sh` | Pod lifecycle |
 | `tox -e down` | `containers/podman/down.sh` | Pod lifecycle |
-| `tox -e wipe` | `down --wipe` (stop + delete DB/sessions) | Pod lifecycle |
+| `tox -e wipe` | `down --wipe` (stop + delete DB/sessions/Abbenay secrets.json) | Pod lifecycle |
 | `tox -e build-clean` | `wipe` + `build --no-cache` | Pod lifecycle |
 | `tox -e up-clean` | `wipe` + `build --no-cache` + `up` | Pod lifecycle |
 | `tox -e cli` | `containers/podman/run-cli.sh` | Pod lifecycle |
@@ -77,7 +77,7 @@ Use `--` to pass arguments through to the underlying command:
 tox -e unit -- -k test_sbom             # run a single test
 tox -e unit -- --no-cov                 # skip coverage
 tox -e build -- --no-cache          # rebuild from scratch
-tox -e wipe                          # stop + wipe DB/sessions
+tox -e wipe                          # stop + wipe DB/sessions/Abbenay secrets.json
 tox -e cli -- check .               # run CLI check in pod
 tox -e cli -- health-check          # run health check in pod
 ```
@@ -433,7 +433,7 @@ tox -e build                     # build images only (no start)
 tox -e build-clean               # wipe DB/sessions + rebuild --no-cache
 tox -e up-clean                  # wipe + rebuild + start (clean slate)
 tox -e down                      # stop the pod
-tox -e wipe                          # stop + wipe DB and session cache
+tox -e wipe                          # stop + wipe DB, session cache, and Abbenay secrets.json
 tox -e cli -- check .            # run check in pod
 tox -e cli -- health-check       # health check all services
 tox -e pm                            # build, start, wait, open browser

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -430,7 +430,7 @@ tox -e cli      # default: apme check .
 tox -e up                        # build images and start the pod
 tox -e up -- --no-cache          # rebuild from scratch and start
 tox -e build                     # build images only (no start)
-tox -e build-clean               # wipe DB/sessions + rebuild --no-cache
+tox -e build-clean               # wipe DB/sessions/Abbenay secrets.json + rebuild --no-cache
 tox -e up-clean                  # wipe + rebuild + start (clean slate)
 tox -e down                      # stop the pod
 tox -e wipe                          # stop + wipe DB, session cache, and Abbenay secrets.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 [project.optional-dependencies]
 ai = [
     # Pin to the same CalVer as the Abbenay daemon image (deploy pins).
-    "abbenay-client==2026.8.5",
+    "abbenay-client==2026.8.6",
 ]
 gateway = [
     "sqlalchemy>=2.0",

--- a/src/apme_gateway/api/abbenay_proxy.py
+++ b/src/apme_gateway/api/abbenay_proxy.py
@@ -7,7 +7,8 @@ Abbenay chat) is **not** proxied — chat stays Primary → Abbenay gRPC.
 ``GET /api/v1/ai/engines`` proxies Abbenay's engine registry (read-only
 discovery path, ADR-070 amendment 2026-08-03).
 ``GET/POST /api/v1/ai/secrets`` and ``DELETE /api/v1/ai/secrets/{key}`` proxy
-Abbenay's memory secret store (ADR-070 amendment 2026-08-13, Abbenay ≥ v2026.8.5).
+Abbenay's secret store (memory or file; ADR-070 amendments 2026-08-13 /
+2026-08-14, Abbenay ≥ v2026.8.6). Gateway does not persist keys.
 """
 
 from __future__ import annotations

--- a/src/apme_gateway/api/abbenay_proxy.py
+++ b/src/apme_gateway/api/abbenay_proxy.py
@@ -7,8 +7,9 @@ Abbenay chat) is **not** proxied — chat stays Primary → Abbenay gRPC.
 ``GET /api/v1/ai/engines`` proxies Abbenay's engine registry (read-only
 discovery path, ADR-070 amendment 2026-08-03).
 ``GET/POST /api/v1/ai/secrets`` and ``DELETE /api/v1/ai/secrets/{key}`` proxy
-Abbenay's secret store (memory or file; ADR-070 amendments 2026-08-13 /
-2026-08-14, Abbenay ≥ v2026.8.6). Gateway does not persist keys.
+Abbenay's secret store. Memory store: Abbenay ≥ v2026.8.5. File store:
+Abbenay ≥ v2026.8.6. Gateway does not persist keys and does not parse
+``secretStore`` (JSON body and query string are forwarded unchanged).
 """
 
 from __future__ import annotations

--- a/tests/test_gateway_abbenay_proxy.py
+++ b/tests/test_gateway_abbenay_proxy.py
@@ -251,20 +251,39 @@ async def test_post_secrets_proxied(app_client: AsyncClient, secret_store: str) 
     assert secret_store.encode() in content
 
 
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    ("query", "expected_suffix"),
+    [
+        ("", ""),
+        ("secretStore=memory", "?secretStore=memory"),
+        ("secretStore=file", "?secretStore=file"),
+    ],
+)
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
-async def test_delete_secret_by_key_proxied(app_client: AsyncClient) -> None:
-    """DELETE /api/v1/ai/secrets/{key} proxies to Abbenay /api/secrets/{key}.
+async def test_delete_secret_by_key_proxied(
+    app_client: AsyncClient,
+    query: str,
+    expected_suffix: str,
+) -> None:
+    """DELETE /api/v1/ai/secrets/{key} forwards secretStore query unchanged.
 
     Args:
         app_client: Async HTTP test client.
+        query: Raw query string (empty, or ``secretStore=…``).
+        expected_suffix: Expected ``?…`` suffix on the upstream URL.
     """
     client = _mock_upstream(content=b'{"deleted":true}')
+    path = "/api/v1/ai/secrets/OPENROUTER_API_KEY"
+    if query:
+        path = f"{path}?{query}"
     with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
-        resp = await app_client.delete("/api/v1/ai/secrets/OPENROUTER_API_KEY")
+        resp = await app_client.delete(path)
 
     assert resp.status_code == 200
     assert client.request.await_args is not None
-    assert client.request.await_args.args[1] == ("http://127.0.0.1:8787/api/secrets/OPENROUTER_API_KEY")
+    assert client.request.await_args.args[1] == (
+        f"http://127.0.0.1:8787/api/secrets/OPENROUTER_API_KEY{expected_suffix}"
+    )
     assert client.request.await_args.kwargs["headers"]["Authorization"] == "Bearer admin-http-token"
 
 

--- a/tests/test_gateway_abbenay_proxy.py
+++ b/tests/test_gateway_abbenay_proxy.py
@@ -200,7 +200,7 @@ async def test_chat_path_not_proxied(app_client: AsyncClient) -> None:
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_get_secrets_proxied(app_client: AsyncClient) -> None:
-    """GET /api/v1/ai/secrets proxies to Abbenay /api/secrets (memory store).
+    """GET /api/v1/ai/secrets proxies to Abbenay /api/secrets.
 
     Args:
         app_client: Async HTTP test client.
@@ -218,18 +218,20 @@ async def test_get_secrets_proxied(app_client: AsyncClient) -> None:
     assert "Cookie" not in client.request.await_args.kwargs["headers"]
 
 
+@pytest.mark.parametrize("secret_store", ["memory", "file"])  # type: ignore[untyped-decorator]
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
-async def test_post_secrets_proxied(app_client: AsyncClient) -> None:
-    """POST /api/v1/ai/secrets proxies to Abbenay /api/secrets (set secret).
+async def test_post_secrets_proxied(app_client: AsyncClient, secret_store: str) -> None:
+    """POST /api/v1/ai/secrets forwards JSON including secretStore unchanged.
 
     Args:
         app_client: Async HTTP test client.
+        secret_store: Abbenay store name forwarded as-is (``memory`` or ``file``).
     """
     client = _mock_upstream(content=b'{"ok":true}')
     body = {
         "key": "OPENROUTER_API_KEY",
         "value": "sk-or-test",
-        "secretStore": "memory",
+        "secretStore": secret_store,
     }
     with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
         resp = await app_client.post(
@@ -246,7 +248,7 @@ async def test_post_secrets_proxied(app_client: AsyncClient) -> None:
     content = client.request.await_args.kwargs.get("content") or b""
     assert b"sk-or-test" in content
     assert b"secretStore" in content
-    assert b"memory" in content
+    assert secret_store.encode() in content
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -20,15 +20,15 @@ constraints = [
 
 [[package]]
 name = "abbenay-client"
-version = "2026.8.5"
+version = "2026.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/1e/30227da7b62ef1981056f86a31a31aeffec44781b9f34022b9eeb864227d/abbenay_client-2026.8.5.tar.gz", hash = "sha256:87b305ed62fcab4f4204b3cf59f4bbe5e5949bfb38e19db04be6b82f1bb2ff97", size = 36609, upload-time = "2026-08-13T17:06:47.471Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b4/651d5f154c6ca3e921ede19e0c13e595a9c24d73000ee1c424942ab7b048/abbenay_client-2026.8.6.tar.gz", hash = "sha256:c6b1f147790764757b06610e1e99714ca73d80c5165e44be8be825ec6c5dc51d", size = 36628, upload-time = "2026-08-14T18:06:28.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/3c/e4e3218675c9943698ab9845e7285930f5f0a5f27c6c5403db6033d533c2/abbenay_client-2026.8.5-py3-none-any.whl", hash = "sha256:693bf3e86836f855a25e4df30aa027b3e70ff3a855fc2ab8ebcf9d43f2c0fa2b", size = 38443, upload-time = "2026-08-13T17:06:46.108Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9d/1fba7bed3e3f5dae6c3ad77ce2e00d976f64bd656d107312719560b35e8a/abbenay_client-2026.8.6-py3-none-any.whl", hash = "sha256:4ccfe2f199b53a34cad298425cdcf2fdedfd262878636637ff8ddcb022ff0bbf", size = 38460, upload-time = "2026-08-14T18:06:26.754Z" },
 ]
 
 [[package]]
@@ -303,7 +303,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "abbenay-client", marker = "extra == 'ai'", specifier = "==2026.8.5" },
+    { name = "abbenay-client", marker = "extra == 'ai'", specifier = "==2026.8.6" },
     { name = "aiosqlite", marker = "extra == 'gateway'", specifier = ">=0.20" },
     { name = "ansible-core", specifier = ">=2.20.7" },
     { name = "fastapi", specifier = ">=0.100" },


### PR DESCRIPTION
## Summary
- Pin Abbenay daemon image and `abbenay-client` to **v2026.8.6** (file secret store).
- Abbenay remains the source of truth for providers and API keys. Gateway stays an allowlisted HTTP proxy (ADR-070); it does **not** persist keys in SQLite.
- Durable container keys use `secretStore: "file"` (`secrets.json` on the same writable volume as `config.yaml`). Pair with Helm `persistence.abbenay.enabled=true` or the **Linux** Podman RW cache. Default Helm `emptyDir` is pod-lifetime only. macOS virtiofs hostPath cannot grant UID 1001 access without world-opening the file — file store unsupported there until #562.

This **rejects** the Gateway-DB-as-SoT approach in #560 rather than implementing it. File-store durability is Abbenay's job on the existing config volume.

## Changes
- Image/client pin: Helm `values.yaml`, Podman `pod.yaml`/`build.sh`, `pyproject.toml` + `uv.lock`, DEPLOYMENT / DESIGN / dependencies docs.
- ADR-070 §7: secrets remain Abbenay SoT; Alternative 4 documents why Gateway SQLite + push-to-memory was not chosen.
- `ABBENAY_AI.md`: memory vs file store, DELETE requires `?secretStore=` (Abbenay defaults to keychain), emptyDir vs PVC vs Podman cache, GET lists engine key slots (not values).
- Gateway proxy tests: POST body with `secretStore: memory|file`; DELETE forwards `?secretStore=`.
- Podman: Linux ACL grant; `tox -e wipe` removes `secrets.json`. Darwin does **not** chmod `secrets.json` to 0644; file store on virtiofs is #562.
- Helm NOTES when Abbenay is on and the PVC is off. Uninstall docs cover Retain PVs (identify, wipe backing store in the storage provider, then delete the PV).

## Quality of life
- ADR-070 amendment (secrets SoT / reject Gateway vault).
- `tox -e wipe` skill/docs mention Abbenay `secrets.json`.

## Test plan
- [x] `tox -e lint` passes
- [x] Gateway proxy unit tests pass (`test_gateway_abbenay_proxy.py`, including `secretStore=file` POST and DELETE query forwarding)
- [x] Docs/ADR updated
- [ ] Confirm `ghcr.io/redhat-developer/abbenay:v2026.8.6` pulls on amd64/arm64
- [ ] Helm: with `persistence.abbenay.enabled=true`, POST `secretStore: file` then pod recycle still has the key; with default emptyDir, pod recycle loses it
- [ ] DELETE without `?secretStore=` does not remove a file-store key (Abbenay keychain default)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable file-based secret storage alongside existing options.
  * Secret management now supports explicit store selection for provider keys and deletion.
  * Gateway proxying supports memory and file-based secret stores.

* **Deployment**
  * Updated Abbenay components to version 2026.8.6.
  * Helm and Podman deployments now document persistence, permissions, and storage requirements.

* **Bug Fixes**
  * Cleanup commands remove stored secrets and report their status.

* **Documentation**
  * Expanded guidance on secret security, persistence, storage behavior, cleanup, and macOS limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->