### PR TITLE
fix(L077): detect standalone meta/argument_specs.yml files

### DIFF
--- a/src/apme_engine/engine/model_loader.py
+++ b/src/apme_engine/engine/model_loader.py
@@ -20,6 +20,8 @@ except Exception:
 
 import contextlib
 
+from apme_engine.graph.argument_specs import extract_argument_specs_from_standalone_yaml
+
 from . import logger
 from .awx_utils import could_be_playbook, search_playbooks
 from .finder import (
@@ -1255,8 +1257,9 @@ def load_role(
                 try:
                     with open(arg_specs_path) as file:
                         arg_specs_data = yaml.load(file, Loader=Loader)
-                        if isinstance(arg_specs_data, dict) and "argument_specs" in arg_specs_data:
-                            roleObj.metadata["argument_specs"] = arg_specs_data["argument_specs"]
+                    specs = extract_argument_specs_from_standalone_yaml(arg_specs_data)
+                    if specs is not None:
+                        roleObj.metadata["argument_specs"] = specs
                 except Exception as e:
                     logger.debug(f"failed to load argument_specs file; {e.args[0]}")
                 break

--- a/src/apme_engine/engine/model_loader.py
+++ b/src/apme_engine/engine/model_loader.py
@@ -20,7 +20,10 @@ except Exception:
 
 import contextlib
 
-from apme_engine.graph.argument_specs import extract_argument_specs_from_standalone_yaml
+from apme_engine.graph.argument_specs import (
+    extract_argument_specs_from_standalone_yaml,
+    get_argument_specs_from_metadata,
+)
 
 from . import logger
 from .awx_utils import could_be_playbook, search_playbooks
@@ -1248,9 +1251,9 @@ def load_role(
                 roleObj.dependency["collections"] = roleObj.metadata.get("collections", [])
 
     # Load standalone argument_specs if not in meta/main.yml (Ansible 2.11+ pattern)
-    if roleObj.metadata is None:
+    if not isinstance(roleObj.metadata, dict):
         roleObj.metadata = {}
-    if isinstance(roleObj.metadata, dict) and not roleObj.metadata.get("argument_specs"):
+    if get_argument_specs_from_metadata(roleObj.metadata) is None:
         for ext in ("yml", "yaml"):
             arg_specs_path = os.path.join(fullpath, f"meta/argument_specs.{ext}")
             if os.path.exists(arg_specs_path):

--- a/src/apme_engine/engine/model_loader.py
+++ b/src/apme_engine/engine/model_loader.py
@@ -1252,13 +1252,13 @@ def load_role(
         for ext in ("yml", "yaml"):
             arg_specs_path = os.path.join(fullpath, f"meta/argument_specs.{ext}")
             if os.path.exists(arg_specs_path):
-                with open(arg_specs_path) as file:
-                    try:
+                try:
+                    with open(arg_specs_path) as file:
                         arg_specs_data = yaml.load(file, Loader=Loader)
                         if isinstance(arg_specs_data, dict) and "argument_specs" in arg_specs_data:
                             roleObj.metadata["argument_specs"] = arg_specs_data["argument_specs"]
-                    except Exception as e:
-                        logger.debug(f"failed to load argument_specs file; {e.args[0]}")
+                except Exception as e:
+                    logger.debug(f"failed to load argument_specs file; {e.args[0]}")
                 break
 
     requirements_yml_path = os.path.join(fullpath, "requirements.yml")

--- a/src/apme_engine/engine/model_loader.py
+++ b/src/apme_engine/engine/model_loader.py
@@ -1245,6 +1245,22 @@ def load_role(
                 roleObj.dependency["roles"] = roleObj.metadata.get("dependencies", [])
                 roleObj.dependency["collections"] = roleObj.metadata.get("collections", [])
 
+    # Load standalone argument_specs if not in meta/main.yml (Ansible 2.11+ pattern)
+    if roleObj.metadata is None:
+        roleObj.metadata = {}
+    if isinstance(roleObj.metadata, dict) and not roleObj.metadata.get("argument_specs"):
+        for ext in ("yml", "yaml"):
+            arg_specs_path = os.path.join(fullpath, f"meta/argument_specs.{ext}")
+            if os.path.exists(arg_specs_path):
+                with open(arg_specs_path) as file:
+                    try:
+                        arg_specs_data = yaml.load(file, Loader=Loader)
+                        if isinstance(arg_specs_data, dict) and "argument_specs" in arg_specs_data:
+                            roleObj.metadata["argument_specs"] = arg_specs_data["argument_specs"]
+                    except Exception as e:
+                        logger.debug(f"failed to load argument_specs file; {e.args[0]}")
+                break
+
     requirements_yml_path = os.path.join(fullpath, "requirements.yml")
     if os.path.exists(requirements_yml_path):
         with open(requirements_yml_path) as file:

--- a/src/apme_engine/graph/argument_specs.py
+++ b/src/apme_engine/graph/argument_specs.py
@@ -1,0 +1,70 @@
+"""Helpers for parsing role ``argument_specs`` metadata (ADR-059)."""
+
+from __future__ import annotations
+
+import os
+from typing import cast
+
+import yaml
+
+from apme_engine.graph.types import YAMLDict
+
+
+def get_argument_specs_from_metadata(metadata: object) -> YAMLDict | None:
+    """Return the inline ``argument_specs`` mapping from parsed role metadata.
+
+    Args:
+        metadata: Parsed ``meta/main.yml`` contents.
+
+    Returns:
+        The ``argument_specs`` dict when present and well-formed, else ``None``.
+    """
+    if not isinstance(metadata, dict):
+        return None
+    specs = metadata.get("argument_specs")
+    return cast(YAMLDict, specs) if isinstance(specs, dict) else None
+
+
+def extract_argument_specs_from_standalone_yaml(data: object) -> YAMLDict | None:
+    """Return argument specs parsed from standalone ``meta/argument_specs`` YAML.
+
+    Standalone files may wrap specs under ``argument_specs`` (as in some fixtures)
+    or declare entry points such as ``main`` at the top level (Ansible 2.11+).
+
+    Args:
+        data: Parsed standalone argument-spec file contents.
+
+    Returns:
+        The argument-spec mapping when well-formed, else ``None``.
+    """
+    if not isinstance(data, dict):
+        return None
+    if "argument_specs" in data:
+        specs = data["argument_specs"]
+        return cast(YAMLDict, specs) if isinstance(specs, dict) else None
+    if data:
+        return cast(YAMLDict, data)
+    return None
+
+
+def load_standalone_argument_specs(role_path: str) -> YAMLDict | None:
+    """Load argument specs from ``meta/argument_specs.yml`` or ``.yaml``.
+
+    Args:
+        role_path: Path to the role root directory.
+
+    Returns:
+        Parsed argument-spec mapping when a valid standalone file exists, else ``None``.
+    """
+    meta_dir = os.path.join(role_path, "meta")
+    for name in ("argument_specs.yml", "argument_specs.yaml"):
+        path = os.path.join(meta_dir, name)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path) as file:
+                data = yaml.safe_load(file)
+        except (OSError, yaml.YAMLError):
+            return None
+        return extract_argument_specs_from_standalone_yaml(data)
+    return None

--- a/src/apme_engine/graph/argument_specs.py
+++ b/src/apme_engine/graph/argument_specs.py
@@ -9,6 +9,31 @@ import yaml
 
 from apme_engine.graph.types import YAMLDict
 
+_META_MAIN_KEYS = frozenset(
+    {
+        "galaxy_info",
+        "dependencies",
+        "collections",
+        "allows_duplicates",
+    }
+)
+
+
+def _is_valid_argument_specs_mapping(specs: object) -> YAMLDict | None:
+    """Return specs when mapping entry points are non-empty dict values.
+
+    Args:
+        specs: Parsed argument-spec mapping candidate.
+
+    Returns:
+        The validated mapping, or ``None`` when shape is invalid.
+    """
+    if not isinstance(specs, dict) or not specs:
+        return None
+    if not all(isinstance(entry, dict) for entry in specs.values()):
+        return None
+    return cast(YAMLDict, specs)
+
 
 def get_argument_specs_from_metadata(metadata: object) -> YAMLDict | None:
     """Return the inline ``argument_specs`` mapping from parsed role metadata.
@@ -21,8 +46,7 @@ def get_argument_specs_from_metadata(metadata: object) -> YAMLDict | None:
     """
     if not isinstance(metadata, dict):
         return None
-    specs = metadata.get("argument_specs")
-    return cast(YAMLDict, specs) if isinstance(specs, dict) else None
+    return _is_valid_argument_specs_mapping(metadata.get("argument_specs"))
 
 
 def extract_argument_specs_from_standalone_yaml(data: object) -> YAMLDict | None:
@@ -41,10 +65,11 @@ def extract_argument_specs_from_standalone_yaml(data: object) -> YAMLDict | None
         return None
     if "argument_specs" in data:
         specs = data["argument_specs"]
-        return cast(YAMLDict, specs) if isinstance(specs, dict) else None
-    if data:
-        return cast(YAMLDict, data)
-    return None
+    elif data.keys() & _META_MAIN_KEYS:
+        return None
+    else:
+        specs = data
+    return _is_valid_argument_specs_mapping(specs)
 
 
 def load_standalone_argument_specs(role_path: str) -> YAMLDict | None:

--- a/src/apme_engine/graph/rules/L077_role_arg_specs_graph.py
+++ b/src/apme_engine/graph/rules/L077_role_arg_specs_graph.py
@@ -1,9 +1,9 @@
 """GraphRule L077: Roles should declare argument_specs for fail-fast validation."""
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import cast
 
+from apme_engine.graph.argument_specs import get_argument_specs_from_metadata, load_standalone_argument_specs
 from apme_engine.graph.content_graph import ContentGraph, NodeType
 from apme_engine.graph.rule_base import GraphRule, GraphRuleResult
 from apme_engine.graph.types import RuleScope, Severity, YAMLDict
@@ -52,11 +52,9 @@ class RoleArgSpecsGraphRule(GraphRule):
     def process(self, graph: ContentGraph, node_id: str) -> GraphRuleResult | None:
         """Flag roles missing ``argument_specs`` in metadata.
 
-        Falls back to a filesystem check for a standalone
-        ``meta/argument_specs.yml`` (or ``.yaml``).  ``node.file_path``
-        for ROLE nodes is relative to the scan basedir, so the on-disk
-        check assumes CWD is the project root (same assumption as the
-        CLI and daemon scan entry-points).
+        Falls back to parsing standalone ``meta/argument_specs.yml`` (or
+        ``.yaml``) when inline metadata is absent. Malformed standalone
+        content does not satisfy the rule.
 
         Args:
             graph: The full ContentGraph.
@@ -69,10 +67,11 @@ class RoleArgSpecsGraphRule(GraphRule):
         if node is None:
             return None
 
-        has_arg_specs = bool(node.role_metadata.get("argument_specs"))
+        specs = get_argument_specs_from_metadata(node.role_metadata)
+        has_arg_specs = bool(specs)
         if not has_arg_specs and node.file_path:
-            meta_dir = Path(node.file_path) / "meta"
-            has_arg_specs = (meta_dir / "argument_specs.yml").is_file() or (meta_dir / "argument_specs.yaml").is_file()
+            standalone_specs = load_standalone_argument_specs(node.file_path)
+            has_arg_specs = bool(standalone_specs)
         verdict = not has_arg_specs
         if verdict:
             return GraphRuleResult(

--- a/tests/test_engine_model_loader.py
+++ b/tests/test_engine_model_loader.py
@@ -14,6 +14,7 @@ from apme_engine.engine.model_loader import (
     load_playbook,
     load_playbooks,
     load_requirements,
+    load_role,
     load_roleinplay,
     load_roles,
     load_task,
@@ -25,6 +26,7 @@ from apme_engine.engine.models import (
     Play,
     Playbook,
     PlaybookFormatError,
+    Role,
     RoleInPlay,
     Task,
     TaskFile,
@@ -883,3 +885,74 @@ class TestLoadRoles:
         assert len(roles) == 1
         assert "helper" in str(roles[0])
         assert not any("requirements.yml" in str(r) for r in roles)
+
+
+class TestLoadRoleArgumentSpecs:
+    """Tests for standalone meta/argument_specs loading in load_role."""
+
+    def _make_role_dir(self, tmp_path: Path) -> Path:
+        role_dir = tmp_path / "myrole"
+        tasks_dir = role_dir / "tasks"
+        tasks_dir.mkdir(parents=True)
+        (tasks_dir / "main.yml").write_text("---\n- name: Hello\n  ansible.builtin.debug:\n    msg: hi\n")
+        return role_dir
+
+    def test_loads_standalone_argument_specs_yml(self, tmp_path: Path) -> None:
+        """Standalone ``meta/argument_specs.yml`` merges into role metadata.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role_dir = self._make_role_dir(tmp_path)
+        meta_dir = role_dir / "meta"
+        meta_dir.mkdir()
+        (meta_dir / "main.yml").write_text("---\ngalaxy_info:\n  author: me\ndependencies: []\n")
+        (meta_dir / "argument_specs.yml").write_text(
+            "---\nmain:\n  short_description: Role description.\n  options: {}\n"
+        )
+
+        role = load_role(str(role_dir), basedir=str(tmp_path), load_children=False)
+
+        assert isinstance(role, Role)
+        assert role.metadata is not None
+        assert role.metadata.get("argument_specs") == {
+            "main": {"short_description": "Role description.", "options": {}},
+        }
+
+    def test_loads_standalone_argument_specs_yaml(self, tmp_path: Path) -> None:
+        """Standalone ``meta/argument_specs.yaml`` merges into role metadata.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role_dir = self._make_role_dir(tmp_path)
+        meta_dir = role_dir / "meta"
+        meta_dir.mkdir()
+        (meta_dir / "main.yml").write_text("---\ngalaxy_info:\n  author: me\ndependencies: []\n")
+        (meta_dir / "argument_specs.yaml").write_text(
+            "---\nargument_specs:\n  main:\n    short_description: Role description.\n"
+        )
+
+        role = load_role(str(role_dir), basedir=str(tmp_path), load_children=False)
+
+        assert isinstance(role, Role)
+        assert role.metadata is not None
+        assert role.metadata.get("argument_specs") == {"main": {"short_description": "Role description."}}
+
+    def test_ignores_malformed_standalone_argument_specs(self, tmp_path: Path) -> None:
+        """Malformed standalone argument_specs files are not merged into metadata.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role_dir = self._make_role_dir(tmp_path)
+        meta_dir = role_dir / "meta"
+        meta_dir.mkdir()
+        (meta_dir / "main.yml").write_text("---\ngalaxy_info:\n  author: me\ndependencies: []\n")
+        (meta_dir / "argument_specs.yml").write_text("invalid\n")
+
+        role = load_role(str(role_dir), basedir=str(tmp_path), load_children=False)
+
+        assert isinstance(role, Role)
+        assert role.metadata is not None
+        assert "argument_specs" not in role.metadata

--- a/tests/test_engine_model_loader.py
+++ b/tests/test_engine_model_loader.py
@@ -992,3 +992,25 @@ class TestLoadRoleArgumentSpecs:
         assert isinstance(role, Role)
         assert role.metadata is not None
         assert "argument_specs" not in role.metadata
+
+    def test_loads_standalone_when_inline_argument_specs_invalid(self, tmp_path: Path) -> None:
+        """Invalid inline argument_specs in main.yml falls back to standalone file.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role_dir = self._make_role_dir(tmp_path)
+        meta_dir = role_dir / "meta"
+        meta_dir.mkdir()
+        (meta_dir / "main.yml").write_text("---\nargument_specs: invalid\ngalaxy_info:\n  author: me\n")
+        (meta_dir / "argument_specs.yml").write_text(
+            "---\nmain:\n  short_description: Role description.\n  options: {}\n"
+        )
+
+        role = load_role(str(role_dir), basedir=str(tmp_path), load_children=False)
+
+        assert isinstance(role, Role)
+        assert role.metadata is not None
+        assert role.metadata.get("argument_specs") == {
+            "main": {"short_description": "Role description.", "options": {}},
+        }

--- a/tests/test_engine_model_loader.py
+++ b/tests/test_engine_model_loader.py
@@ -956,3 +956,39 @@ class TestLoadRoleArgumentSpecs:
         assert isinstance(role, Role)
         assert role.metadata is not None
         assert "argument_specs" not in role.metadata
+
+    def test_ignores_standalone_galaxy_info_mapping(self, tmp_path: Path) -> None:
+        """Standalone files with only galaxy_info are not treated as argument_specs.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role_dir = self._make_role_dir(tmp_path)
+        meta_dir = role_dir / "meta"
+        meta_dir.mkdir()
+        (meta_dir / "main.yml").write_text("---\ngalaxy_info:\n  author: me\ndependencies: []\n")
+        (meta_dir / "argument_specs.yml").write_text("---\ngalaxy_info:\n  author: me\n")
+
+        role = load_role(str(role_dir), basedir=str(tmp_path), load_children=False)
+
+        assert isinstance(role, Role)
+        assert role.metadata is not None
+        assert "argument_specs" not in role.metadata
+
+    def test_ignores_standalone_invalid_entry_point(self, tmp_path: Path) -> None:
+        """Standalone files with scalar entry-point values are not merged.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        role_dir = self._make_role_dir(tmp_path)
+        meta_dir = role_dir / "meta"
+        meta_dir.mkdir()
+        (meta_dir / "main.yml").write_text("---\ngalaxy_info:\n  author: me\ndependencies: []\n")
+        (meta_dir / "argument_specs.yml").write_text("---\nargument_specs:\n  main: invalid\n")
+
+        role = load_role(str(role_dir), basedir=str(tmp_path), load_children=False)
+
+        assert isinstance(role, Role)
+        assert role.metadata is not None
+        assert "argument_specs" not in role.metadata

--- a/tests/test_golden_collection.py
+++ b/tests/test_golden_collection.py
@@ -275,9 +275,8 @@ class TestL077RoleArgSpecs:
     """L077: roles should have argument_specs in metadata.
 
     The golden collection embeds ``argument_specs`` inline in
-    ``roles/run/meta/main.yml`` so the loader populates ``role_metadata``
-    correctly (the separate ``meta/argument_specs.yml`` file is not read
-    by the loader today).
+    ``roles/run/meta/main.yml``. The loader also reads standalone
+    ``meta/argument_specs.yml`` when inline specs are absent.
     """
 
     def test_fires_without_argument_specs(self, collection_root: Path) -> None:

--- a/tests/test_golden_collection.py
+++ b/tests/test_golden_collection.py
@@ -281,13 +281,18 @@ class TestL077RoleArgSpecs:
     """
 
     def test_fires_without_argument_specs(self, collection_root: Path) -> None:
-        """Rewriting meta/main.yml without argument_specs causes L077 to fire.
+        """Removing argument_specs from both main.yml and standalone file causes L077 to fire.
 
         Args:
             collection_root: Isolated copy of the golden collection.
         """
-        meta_main = collection_root / "roles" / "run" / "meta" / "main.yml"
+        meta_dir = collection_root / "roles" / "run" / "meta"
+        meta_main = meta_dir / "main.yml"
         meta_main.write_text("---\ngalaxy_info:\n  author: foo\ndependencies: []\n")
+        # Also remove standalone argument_specs file (now loaded by model_loader)
+        arg_specs_file = meta_dir / "argument_specs.yml"
+        if arg_specs_file.exists():
+            arg_specs_file.unlink()
         graph = _build_graph(collection_root)
         assert "L077" in _violations_for(graph, [RoleArgSpecsGraphRule()])
 
@@ -297,6 +302,22 @@ class TestL077RoleArgSpecs:
         Args:
             collection_root: Isolated copy of the golden collection.
         """
+        graph = _build_graph(collection_root)
+        assert "L077" not in _violations_for(graph, [RoleArgSpecsGraphRule()])
+
+    def test_passes_with_standalone_argument_specs(self, collection_root: Path) -> None:
+        """Standalone meta/argument_specs.yml is detected by model loader.
+
+        Args:
+            collection_root: Isolated copy of the golden collection.
+        """
+        meta_dir = collection_root / "roles" / "run" / "meta"
+        # Remove argument_specs from main.yml but keep standalone file
+        meta_main = meta_dir / "main.yml"
+        meta_main.write_text("---\ngalaxy_info:\n  author: foo\ndependencies: []\n")
+        # Ensure standalone file exists
+        arg_specs_file = meta_dir / "argument_specs.yml"
+        assert arg_specs_file.exists(), "Test requires standalone argument_specs.yml"
         graph = _build_graph(collection_root)
         assert "L077" not in _violations_for(graph, [RoleArgSpecsGraphRule()])
 

--- a/tests/test_role_metadata_graph_rules.py
+++ b/tests/test_role_metadata_graph_rules.py
@@ -513,6 +513,44 @@ class TestL077RoleArgSpecsGraphRule:
         assert result is not None
         assert result.verdict is True
 
+    def test_violation_standalone_invalid_entry_point(self, rule: RoleArgSpecsGraphRule, tmp_path: Path) -> None:
+        """Scalar entry-point values in standalone files still violate.
+
+        Args:
+            rule: Rule instance under test.
+            tmp_path: Pytest-provided temporary directory.
+        """
+        role_dir = tmp_path / "myrole"
+        (role_dir / "meta").mkdir(parents=True)
+        (role_dir / "meta" / "argument_specs.yml").write_text("---\nargument_specs:\n  main: invalid\n")
+        g, rid = _make_role(
+            role_metadata={},
+            file_path=str(role_dir),
+            path=str(role_dir),
+        )
+        result = rule.process(g, rid)
+        assert result is not None
+        assert result.verdict is True
+
+    def test_violation_standalone_galaxy_info_only(self, rule: RoleArgSpecsGraphRule, tmp_path: Path) -> None:
+        """Standalone files with only galaxy_info do not satisfy L077.
+
+        Args:
+            rule: Rule instance under test.
+            tmp_path: Pytest-provided temporary directory.
+        """
+        role_dir = tmp_path / "myrole"
+        (role_dir / "meta").mkdir(parents=True)
+        (role_dir / "meta" / "argument_specs.yml").write_text("---\ngalaxy_info:\n  author: me\n")
+        g, rid = _make_role(
+            role_metadata={},
+            file_path=str(role_dir),
+            path=str(role_dir),
+        )
+        result = rule.process(g, rid)
+        assert result is not None
+        assert result.verdict is True
+
     def test_violation_no_standalone_file(self, rule: RoleArgSpecsGraphRule, tmp_path: Path) -> None:
         """Role with empty meta dir and no argument_specs still violates.
 

--- a/tests/test_role_metadata_graph_rules.py
+++ b/tests/test_role_metadata_graph_rules.py
@@ -475,6 +475,44 @@ class TestL077RoleArgSpecsGraphRule:
         assert result is not None
         assert result.verdict is False
 
+    def test_violation_malformed_standalone_yml(self, rule: RoleArgSpecsGraphRule, tmp_path: Path) -> None:
+        """Malformed standalone ``meta/argument_specs.yml`` still violates.
+
+        Args:
+            rule: Rule instance under test.
+            tmp_path: Pytest-provided temporary directory.
+        """
+        role_dir = tmp_path / "myrole"
+        (role_dir / "meta").mkdir(parents=True)
+        (role_dir / "meta" / "argument_specs.yml").write_text("invalid\n")
+        g, rid = _make_role(
+            role_metadata={},
+            file_path=str(role_dir),
+            path=str(role_dir),
+        )
+        result = rule.process(g, rid)
+        assert result is not None
+        assert result.verdict is True
+
+    def test_violation_malformed_standalone_yaml(self, rule: RoleArgSpecsGraphRule, tmp_path: Path) -> None:
+        """Malformed standalone ``meta/argument_specs.yaml`` still violates.
+
+        Args:
+            rule: Rule instance under test.
+            tmp_path: Pytest-provided temporary directory.
+        """
+        role_dir = tmp_path / "myrole"
+        (role_dir / "meta").mkdir(parents=True)
+        (role_dir / "meta" / "argument_specs.yaml").write_text("- invalid\n")
+        g, rid = _make_role(
+            role_metadata={},
+            file_path=str(role_dir),
+            path=str(role_dir),
+        )
+        result = rule.process(g, rid)
+        assert result is not None
+        assert result.verdict is True
+
     def test_violation_no_standalone_file(self, rule: RoleArgSpecsGraphRule, tmp_path: Path) -> None:
         """Role with empty meta dir and no argument_specs still violates.
 


### PR DESCRIPTION
## Summary

Fixes L077 false positive when `argument_specs` is defined in a standalone `meta/argument_specs.yml` file rather than inline in `meta/main.yml`.

**Bug:** When scanning roles with standalone `meta/argument_specs.yml` (Ansible 2.11+ pattern), L077 incorrectly reported:
```
role should have argument_specs in meta/main.yml or a standalone meta/argument_specs.yml
```

**Root cause:** `load_role()` in `model_loader.py` only parsed `meta/main.yml` for role metadata. It never checked for the standalone `argument_specs.yml` file that Ansible has supported since version 2.11.

**Fix:**
- After loading `meta/main.yml`, check for standalone `meta/argument_specs.yml` or `.yaml`
- Shared parsing/validation in `graph/argument_specs.py` (used by loader and L077 rule)
- Accept wrapped (`argument_specs:`) and Ansible-native top-level entry-point formats
- Reject malformed, empty, or non-dict entry-point mappings
- Fall back to standalone file when inline `argument_specs` is missing or invalid
- Merge valid standalone specs into `role.metadata` so L077 and metadata stay consistent

## Test plan

- [x] `test_fires_without_argument_specs` — updated to remove both `main.yml` content AND standalone file
- [x] `test_passes_with_argument_specs` — unchanged, validates inline case still works
- [x] `test_passes_with_standalone_argument_specs` — new test for explicit standalone file coverage
- [x] Loader tests for `.yml`/`.yaml`, malformed content, galaxy_info-only files, invalid entry points
- [x] Regression test for invalid inline `argument_specs` with valid standalone file
- [x] L077 rule tests for standalone and malformed standalone files
- [x] `tox -e lint` and `tox -e unit` pass

## Related

Reported via user testing: scanning role with valid standalone `argument_specs.yml` triggered false positive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role metadata now recognizes standalone `argument_specs.yml` and `argument_specs.yaml` files when inline specifications are unavailable.
  * Valid standalone specifications are incorporated into role metadata automatically.

* **Bug Fixes**
  * Invalid, malformed, empty, or incorrectly structured standalone files no longer satisfy argument-specification validation.
  * Parsing errors are handled without preventing role loading.

* **Tests**
  * Added coverage for valid and invalid standalone argument-specification files and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->