### PR TITLE
fix(remediation): stop node-local AI from breaking data-flow consumers

### DIFF
--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -184,6 +184,9 @@ artifact type, translate it:
    a token in a *different* grammar in the same string — Jinja
    filters (`{{ x | quote }}`), URLs, or quoted YAML. Strip or
    parse the inner language before applying the outer check.
+   After stripping, also construct the whole-string-is-inner-language
+   case (`{{ command }}`): empty remainder is uninspectable, not
+   proven-safe.
    Also construct _temporal_ failures: what happens when an async
    dependency never responds, times out, or responds after the
    consumer has moved on? What happens when `asyncio.gather()`
@@ -433,7 +436,9 @@ Compare ADR/doc claims to what shipped. Label each finding
 - **Overloaded tokens** — a character that is a metacharacter in one
   grammar (shell `|`, glob `*`) is an operator in another (Jinja
   `|quote`) in the same string. Strip or parse the inner language
-  before applying the outer check.
+  before applying the outer check. After stripping, an empty remainder
+  is uninspectable, not proven-safe — treat it as the conservative
+  case (keep shell / skip substitution), not as "no features found".
 - **Information exposure** — logs, errors, user-facing strings,
   persisted diffs/explanations: credentials, secrets, user content,
   internal paths? Capability grants, CORS origins, container caps —

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -186,7 +186,10 @@ artifact type, translate it:
    parse the inner language before applying the outer check.
    After stripping, also construct the whole-string-is-inner-language
    case (`{{ command }}`): empty remainder is uninspectable, not
-   proven-safe.
+   proven-safe. When the same predicate exists in two languages
+   (Rego helper vs Python transform), construct whitespace that one
+   trim would drop and the other would keep (`\t` vs `" "` cutset)
+   — "empty" must mean the same thing on both sides.
    Also construct _temporal_ failures: what happens when an async
    dependency never responds, times out, or responds after the
    consumer has moved on? What happens when `asyncio.gather()`
@@ -351,6 +354,9 @@ critical/high/medium/low.
   vs filtered implementation)
 - Dual input shapes that normalize differently (ORM vs dict, dataclass
   vs mapping, servicer vs flush path)
+- Dual implementations of the same predicate (Rego helper vs Python
+  transform) that disagree on empty/whitespace (`trim(..., " ")` vs
+  `str.strip()` / `trim_space`)
 - Overlay fields that drift (tier/source/gate/status→review must stay
   aligned for all pre-group sources). When a column documents
   "empty means fall back to X" (e.g. ``stamp_rule_ids_json`` →
@@ -439,6 +445,9 @@ Compare ADR/doc claims to what shipped. Label each finding
   before applying the outer check. After stripping, an empty remainder
   is uninspectable, not proven-safe — treat it as the conservative
   case (keep shell / skip substitution), not as "no features found".
+  "Empty" must use the same whitespace definition in every
+  implementation of the check (`trim_space` / `str.strip()`, not a
+  space-only cutset).
 - **Information exposure** — logs, errors, user-facing strings,
   persisted diffs/explanations: credentials, secrets, user content,
   internal paths? Capability grants, CORS origins, container caps —

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -189,7 +189,9 @@ artifact type, translate it:
    proven-safe. When the same predicate exists in two languages
    (Rego helper vs Python transform), construct whitespace that one
    trim would drop and the other would keep (`\t` vs `" "` cutset)
-   — "empty" must mean the same thing on both sides.
+   — "empty" must mean the same thing on both sides. After the
+   emptiness check uses ``trim_space``, tokenize/split on that
+   string with the same whitespace class, not ``split(trim(x, " "), " ")``.
    Also construct _temporal_ failures: what happens when an async
    dependency never responds, times out, or responds after the
    consumer has moved on? What happens when `asyncio.gather()`
@@ -356,7 +358,10 @@ critical/high/medium/low.
   vs mapping, servicer vs flush path)
 - Dual implementations of the same predicate (Rego helper vs Python
   transform) that disagree on empty/whitespace (`trim(..., " ")` vs
-  `str.strip()` / `trim_space`)
+  `str.strip()` / `trim_space`). After one path uses ``trim_space``,
+  later tokenize/split on the **same string** must use that whitespace
+  class — ``split(trim(cmd, " "), " ")`` will miss tabs/CRs the
+  emptiness check already treats as blank.
 - Overlay fields that drift (tier/source/gate/status→review must stay
   aligned for all pre-group sources). When a column documents
   "empty means fall back to X" (e.g. ``stamp_rule_ids_json`` →

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -179,6 +179,11 @@ artifact type, translate it:
    an empty-but-not-falsy value. Trace it through the code path.
    If it fails silently, sends a vacuous request, or produces a
    return value that violates the declared type, that's a finding.
+   When a check treats a character as a metacharacter (shell `|`,
+   glob `*`, YAML `&`), construct an input where that character is
+   a token in a *different* grammar in the same string — Jinja
+   filters (`{{ x | quote }}`), URLs, or quoted YAML. Strip or
+   parse the inner language before applying the outer check.
    Also construct _temporal_ failures: what happens when an async
    dependency never responds, times out, or responds after the
    consumer has moved on? What happens when `asyncio.gather()`
@@ -425,6 +430,10 @@ Compare ADR/doc claims to what shipped. Label each finding
 **Lens — break it / rethink it:** Be creatively adversarial:
 - Weird but realistic scenarios that corrupt durable state, double-count
   analytics, or bypass filters
+- **Overloaded tokens** — a character that is a metacharacter in one
+  grammar (shell `|`, glob `*`) is an operator in another (Jinja
+  `|quote`) in the same string. Strip or parse the inner language
+  before applying the outer check.
 - **Information exposure** — logs, errors, user-facing strings,
   persisted diffs/explanations: credentials, secrets, user content,
   internal paths? Capability grants, CORS origins, container caps —

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -184,6 +184,12 @@ artifact type, translate it:
    a token in a *different* grammar in the same string — Jinja
    filters (`{{ x | quote }}`), URLs, or quoted YAML. Strip or
    parse the inner language before applying the outer check.
+   The strip pattern must allow nested tokens of the inner language
+   (Jinja dicts ``{{ {'k': 'v'} }}`` — ``[^{}]*`` fails). Leftover
+   delimiters after the strip (``{{``) are still uninspectable.
+   Glob character classes (``[ab]``) are shell features like ``*``.
+   If a transform inspects ``cmd`` and ``argv``, the detector must
+   inspect those same sources — ``not mo["cmd"]`` is not "safe".
    After stripping, also construct the whole-string-is-inner-language
    case (`{{ command }}`): empty remainder is uninspectable, not
    proven-safe. When the same predicate exists in two languages
@@ -361,7 +367,9 @@ critical/high/medium/low.
   `str.strip()` / `trim_space`). After one path uses ``trim_space``,
   later tokenize/split on the **same string** must use that whitespace
   class — ``split(trim(cmd, " "), " ")`` will miss tabs/CRs the
-  emptiness check already treats as blank.
+  emptiness check already treats as blank. They must also inspect the
+  **same input shapes** (``cmd`` vs ``argv`` vs ``_raw_params`` vs
+  missing).
 - Overlay fields that drift (tier/source/gate/status→review must stay
   aligned for all pre-group sources). When a column documents
   "empty means fall back to X" (e.g. ``stamp_rule_ids_json`` →

--- a/docs/architecture/07-tier1-remediation.md
+++ b/docs/architecture/07-tier1-remediation.md
@@ -37,11 +37,12 @@ each violation to one of three tiers:
 |------|----------|---------|
 | **Tier 1** | Registry has a deterministic transform | L007, L013, M001 |
 | **Tier 2** | Scope is `task` or `block`, not cross-file, `ai_proposable=True` | L011 (complex naming) |
-| **Tier 3** | Play/role/collection scope, cross-file rules, or `info` severity | R111, R112, play-level |
+| **Tier 3** | Play/role/collection scope, cross-file / data-flow rules, or `info` severity | R111, R112, L006, L080, play-level |
 
 The routing uses scope metadata (ADR-026) rather than hardcoded rule lists.
-Cross-file rules (R111, R112) are always Tier 3 because their fix requires
-role/taskfile inventory context.
+Cross-file and data-flow rules (R111, R112, L006, L080) are always Tier 3
+because a node-local fix would change the producer without rewriting
+readers (role inventory, register consumers, or `set_fact` references).
 
 ## TransformRegistry
 

--- a/docs/architecture/07-tier1-remediation.md
+++ b/docs/architecture/07-tier1-remediation.md
@@ -39,8 +39,8 @@ each violation to one of three tiers:
 | **Tier 2** | Scope is `task` or `block`, not cross-file, `ai_proposable=True` | L011 (complex naming) |
 | **Tier 3** | Play/role/collection scope, cross-file / data-flow rules, or `info` severity | R111, R112, L006, L080, play-level |
 
-The routing uses scope metadata (ADR-026) rather than hardcoded rule lists.
-Cross-file and data-flow rules (R111, R112, L006, L080) are always Tier 3
+The routing uses scope metadata (ADR-026) for normal routing. The explicit
+`CROSS_FILE_RULES` exceptions (R111, R112, L006, L080) are always Tier 3
 because a node-local fix would change the producer without rewriting
 readers (role inventory, register consumers, or `set_fact` references).
 

--- a/docs/design/DESIGN_REMEDIATION.md
+++ b/docs/design/DESIGN_REMEDIATION.md
@@ -150,6 +150,13 @@ This is intentionally simple. A violation is resolvable if and only if the trans
 
 Violations that fail this check proceed to AI escalation (Tier 2) if an AIProvider is available (via `--ai`), otherwise they are reported as manual review (Tier 3).
 
+A small set of **task-scoped** rules still route to Tier 3
+(`CROSS_FILE_RULES` in `partition.py`): R111/R112 (need role/taskfile
+inventory) and L006/L080 (need every consumer of a register or `set_fact`
+rewritten). Node-local AI would rename the producer and leave readers on
+the old name or the old result shape. These wait for project-level
+remediation (ADR-027).
+
 ### Rule Metadata
 
 Each rule across all validators declares tier-awareness in its metadata:

--- a/docs/rules/REMEDIATION_TIER_REPORT.md
+++ b/docs/rules/REMEDIATION_TIER_REPORT.md
@@ -10,21 +10,21 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | Tier | Count | % of 157 |
 |------|-------|--------|
 | Tier 1 — auto (has transform) | 25 | 16% |
-| Tier 2 — AI (task/block, no fixer) | 69 | 44% |
-| Tier 3 — manual | 63 | 40% |
+| Tier 2 — AI (task/block, no fixer) | 67 | 43% |
+| Tier 3 — manual | 65 | 41% |
 
 ### Promotion potential
 
-- **27** Tier 2 rules could likely move to Tier 1 (mechanical transforms)
-- **8** Tier 3 rules have mechanical fixes blocked by scope
-- **69 - 27 = 42** Tier 2 rules should stay AI (judgment/security)
+- **26** Tier 2 rules could likely move to Tier 1 (mechanical transforms)
+- **9** Tier 3 rules have mechanical fixes blocked by scope
+- **67 - 26 = 41** Tier 2 rules should stay AI (judgment/security)
 
 ### Tier 3 breakdown
 
 | Reason | Count |
 |--------|-------|
 | info severity | 19 |
-| cross-file (R111/R112) | 2 |
+| cross-file / data-flow context | 4 |
 | playbook scope | 11 |
 | collection scope | 10 |
 | role scope | 10 |
@@ -61,7 +61,7 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | M008 | OPA | high | task | Bare include is removed in 2.19+; use include_tasks or import_tasks. |
 | M009 | OPA | high | task | with_* loops are deprecated; use loop instead. |
 
-## Tier 2 — AI (69 rules)
+## Tier 2 — AI (67 rules)
 
 ### Could move to Tier 1 auto
 
@@ -78,7 +78,6 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | L064 | low | task | Replace meta end_play with end_host |
 | L076 | low | task | Rewrite ansible_* to ansible_facts[] |
 | L078 | low | task | Convert dot to bracket notation in Jinja |
-| L080 | low | task | Prefix internal vars with underscore |
 | L091 | low | task | Add \| bool filter to bare when vars |
 | L092 | low | task | Remove loop var from task name |
 | L110 | high | task | Add no_log to debug task |
@@ -102,7 +101,6 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | A001 | medium | task | Task/block scope — AI can propose fix (Tier 2) |
 | A002 | high | task | Task/block scope — AI can propose fix (Tier 2) |
 | L004 | high | task | Task/block scope — AI can propose fix (Tier 2) |
-| L006 | low | task | Task/block scope — AI can propose fix (Tier 2) |
 | L014 | low | task | Task/block scope — AI can propose fix (Tier 2) |
 | L017 | low | task | Task/block scope — AI can propose fix (Tier 2) |
 | L030 | low | task | Task/block scope — AI can propose fix (Tier 2) |
@@ -142,11 +140,12 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | R115 | medium | task | Task/block scope — AI can propose fix (Tier 2) |
 | SEC:* | critical | task | Task/block scope — AI can propose fix (Tier 2) |
 
-## Tier 3 — Manual (63 rules)
+## Tier 3 — Manual (65 rules)
 
 | Rule ID | Validator | Severity | Scope | Auto candidate? | Reason |
 |---------|-----------|----------|-------|-----------------|--------|
 | L003 | OPA | low | play | Add play name | Scope 'play' — play/role/collection not AI-proposable |
+| L006 | OPA | low | task | — | Project-level context required (cross-file or data-flow consumers) |
 | L016 | OPA | info | task | — | Info severity — informational, no auto-fix |
 | L019 | OPA | low | playbook | — | Scope 'playbook' — play/role/collection not AI-proposable |
 | L023 | OPA | info | play | — | Info severity — informational, no auto-fix |
@@ -177,6 +176,7 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | L075 | Native | low | role | — | Scope 'role' — play/role/collection not AI-proposable |
 | L077 | Native | low | role | — | Scope 'role' — play/role/collection not AI-proposable |
 | L079 | Native | low | role | — | Scope 'role' — play/role/collection not AI-proposable |
+| L080 | Native | low | task | Prefix internal vars with underscore | Project-level context required (cross-file or data-flow consumers) |
 | L081 | Native | low | playbook | — | Scope 'playbook' — play/role/collection not AI-proposable |
 | L086 | Native | low | play | — | Scope 'play' — play/role/collection not AI-proposable |
 | L087 | Native | low | collection | — | Scope 'collection' — play/role/collection not AI-proposable |
@@ -201,8 +201,8 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | M029 | Native | medium | playbook | — | Scope 'playbook' — play/role/collection not AI-proposable |
 | P004 | Native | error | inventory | — | Scope 'inventory' — play/role/collection not AI-proposable |
 | R108 | Native | medium | play | — | Scope 'play' — play/role/collection not AI-proposable |
-| R111 | Native | medium | task | — | Cross-file context required (R111/R112) |
-| R112 | Native | medium | task | — | Cross-file context required (R111/R112) |
+| R111 | Native | medium | task | — | Project-level context required (cross-file or data-flow consumers) |
+| R112 | Native | medium | task | — | Project-level context required (cross-file or data-flow consumers) |
 | R117 | Native | info | role | — | Info severity — informational, no auto-fix |
 | R118 | OPA | info | task | — | Info severity — informational, no auto-fix |
 | R401 | Native | info | playbook | — | Info severity — informational, no auto-fix |

--- a/docs/rules/RULE_CATALOG.md
+++ b/docs/rules/RULE_CATALOG.md
@@ -51,8 +51,8 @@ Routing follows `src/apme_engine/remediation/partition.py` (ADR-026 scope metada
 | Tier | Label | Count | Routing |
 |------|-------|-------|---------|
 | 1 | auto | 25 | Deterministic transform in registry — applied by `apme remediate` |
-| 2 | ai | 69 | Task/block scope, no fixer — AI proposes patch (Abbenay) |
-| 3 | manual | 63 | Play/role/collection scope, cross-file, or info severity |
+| 2 | ai | 67 | Task/block scope, no fixer — AI proposes patch (Abbenay) |
+| 3 | manual | 65 | Play/role/collection scope, cross-file, or info severity |
 
 Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION_TIER_REPORT.md).
 
@@ -65,7 +65,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L003 | L | OPA | low | play | manual | Each play should have a name. | Yes | Yes | Yes | — |
 | L004 | L | OPA | high | task | ai | Do not use deprecated modules. | Yes | Yes | Yes | — |
 | L005 | L | OPA | low | task | auto | Community collection module detected; use certified or validated collections. | Yes | Yes | Yes | Yes |
-| L006 | L | OPA | low | task | ai | Use dedicated module instead of command. | Yes | Yes | Yes | — |
+| L006 | L | OPA | low | task | manual | Use dedicated module instead of command. | Yes | Yes | Yes | — |
 | L007 | L | OPA | low | task | auto | Prefer command when no shell features needed. | Yes | Yes | Yes | Yes |
 | L008 | L | OPA | low | task | auto | Use delegate_to: localhost instead of local_action. | Yes | Yes | Yes | Yes |
 | L009 | L | OPA | medium | task | auto | Avoid comparison to empty string in when. | Yes | Yes | Yes | Yes |
@@ -137,7 +137,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L077 | L | Native | low | role | manual | Roles should have meta/argument_specs.yml for fail-fast parameter validation. | Yes | Yes | Yes | — |
 | L078 | L | Native | low | task | ai | Use bracket notation for dict key access in Jinja. | Yes | Yes | Yes | — |
 | L079 | L | Native | low | role | manual | Role defaults/vars should be prefixed with the role name. | Yes | Yes | Yes | — |
-| L080 | L | Native | low | task | ai | Internal role variables should be prefixed with _ (underscore). | Yes | Yes | Yes | — |
+| L080 | L | Native | low | task | manual | Internal role variables should be prefixed with _ (underscore). | Yes | Yes | Yes | — |
 | L081 | L | Native | low | playbook | manual | Do not number roles or playbooks. | Yes | Yes | Yes | — |
 | L082 | L | Native | low | task | ai | Template source files should use .j2 extension. | Yes | — | Yes | — |
 | L083 | L | Native | low | task | ai | Do not hardcode host group names in roles. | Yes | Yes | Yes | — |
@@ -227,7 +227,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L003 | low | play | manual | Each play should have a name. | Yes | Yes | Yes | — |
 | L004 | high | task | ai | Do not use deprecated modules. | Yes | Yes | Yes | — |
 | L005 | low | task | auto | Community collection module detected; use certified or validated collections. | Yes | Yes | Yes | Yes |
-| L006 | low | task | ai | Use dedicated module instead of command. | Yes | Yes | Yes | — |
+| L006 | low | task | manual | Use dedicated module instead of command. | Yes | Yes | Yes | — |
 | L007 | low | task | auto | Prefer command when no shell features needed. | Yes | Yes | Yes | Yes |
 | L008 | low | task | auto | Use delegate_to: localhost instead of local_action. | Yes | Yes | Yes | Yes |
 | L009 | medium | task | auto | Avoid comparison to empty string in when. | Yes | Yes | Yes | Yes |
@@ -317,7 +317,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L077 | low | role | manual | Roles should have meta/argument_specs.yml for fail-fast parameter validation. | Yes | Yes | Yes | — |
 | L078 | low | task | ai | Use bracket notation for dict key access in Jinja. | Yes | Yes | Yes | — |
 | L079 | low | role | manual | Role defaults/vars should be prefixed with the role name. | Yes | Yes | Yes | — |
-| L080 | low | task | ai | Internal role variables should be prefixed with _ (underscore). | Yes | Yes | Yes | — |
+| L080 | low | task | manual | Internal role variables should be prefixed with _ (underscore). | Yes | Yes | Yes | — |
 | L081 | low | playbook | manual | Do not number roles or playbooks. | Yes | Yes | Yes | — |
 | L082 | low | task | ai | Template source files should use .j2 extension. | Yes | — | Yes | — |
 | L083 | low | task | ai | Do not hardcode host group names in roles. | Yes | Yes | Yes | — |

--- a/src/apme_engine/graph/rules/L080_internal_var_prefix.md
+++ b/src/apme_engine/graph/rules/L080_internal_var_prefix.md
@@ -26,3 +26,8 @@ Only fires inside `roles/` directories. Checks `set_fact` keys for a missing lea
   ansible.builtin.set_fact:
     _temp_value: "something"
 ```
+
+Renaming a `set_fact` key without updating every reader (`when`, later
+tasks, templates) leaves consumers on the old name — often a role default
+that stays `false`. L080 is not auto-remediated until a project-level
+rewrite can update all references.

--- a/src/apme_engine/remediation/partition.py
+++ b/src/apme_engine/remediation/partition.py
@@ -16,11 +16,17 @@ from apme_engine.remediation.registry import TransformRegistry
 
 AI_PROPOSABLE_SCOPES: frozenset[str] = frozenset({RuleScope.TASK, RuleScope.BLOCK})
 
-# Task-scoped rules whose remediation requires cross-file context.
+# Task-scoped rules whose remediation is unsafe at a single node.
+# Node-local AI would change the producer (module, set_fact key, register
+# shape) without rewriting readers — often silently, because the old name
+# remains defined as a role default. These need project-level context
+# (ADR-027) or a complete usage index before they can be auto-fixed.
 CROSS_FILE_RULES: frozenset[str] = frozenset(
     {
         "R111",  # parameterized role import — needs role inventory
         "R112",  # parameterized task import — needs taskfile inventory
+        "L006",  # command→module (e.g. cat→slurp) changes register result shape
+        "L080",  # __ prefix on set_fact keys — consumers keep the old name
     }
 )
 

--- a/src/apme_engine/remediation/partition.py
+++ b/src/apme_engine/remediation/partition.py
@@ -75,14 +75,20 @@ def normalize_rule_id(rule_id: str) -> str:
 def is_finding_resolvable(violation: ViolationDict, registry: TransformRegistry) -> bool:
     """Return True if the violation has a registered deterministic transform (Tier 1).
 
+    Cross-file / data-flow rules are never Tier 1, even if a caller registers
+    a node-local transform. Those rewrites are unsafe without project context.
+
     Args:
         violation: Violation dict with rule_id.
         registry: Transform registry to check for rule.
 
     Returns:
-        True if rule_id has a registered transform.
+        True if rule_id has a registered transform and is not cross-file.
     """
-    return normalize_rule_id(str(violation.get("rule_id", ""))) in registry
+    bare_id = normalize_rule_id(str(violation.get("rule_id", "")))
+    if bare_id in CROSS_FILE_RULES:
+        return False
+    return bare_id in registry
 
 
 def partition_violations(
@@ -92,6 +98,7 @@ def partition_violations(
     """Split violations into (tier1_fixable, tier2_ai, tier3_manual).
 
     Routing uses scope metadata (ADR-026) instead of hardcoded rule lists:
+    - Cross-file / data-flow rules (``CROSS_FILE_RULES``) are always Tier 3.
     - Tier 1: deterministic transform exists in registry.
     - Tier 2: scope is AI-proposable (task/block) and no cross-file constraint.
     - Tier 3: scope is not AI-proposable, or cross-file context required.
@@ -114,11 +121,11 @@ def partition_violations(
             v["remediation_resolution"] = RemediationResolution.INFORMATIONAL
             tier3.append(v)
             continue
-        if is_finding_resolvable(v, registry):
-            tier1.append(v)
-        elif bare_id in CROSS_FILE_RULES:
+        if bare_id in CROSS_FILE_RULES:
             v["remediation_resolution"] = RemediationResolution.NEEDS_CROSS_FILE
             tier3.append(v)
+        elif is_finding_resolvable(v, registry):
+            tier1.append(v)
         elif _get_scope(v) not in AI_PROPOSABLE_SCOPES:
             v["remediation_resolution"] = RemediationResolution.MANUAL
             tier3.append(v)

--- a/src/apme_engine/remediation/transforms/L007_shell_to_command.py
+++ b/src/apme_engine/remediation/transforms/L007_shell_to_command.py
@@ -2,12 +2,33 @@
 
 from __future__ import annotations
 
+import re
+
 from ruamel.yaml.comments import CommentedMap
 
 from apme_engine.engine.models import ViolationDict
 from apme_engine.remediation.transforms._helpers import get_module_key, rename_key
 
-_SHELL_CHARS = ("|", "&&", "||", ";", ">", ">>", "<", "$(", "`", "*", "?")
+# Inspected after Jinja ``{{ }}`` is stripped so ``|quote`` is not a pipe.
+_JINJA_RE = re.compile(r"\{\{[^{}]*\}\}")
+_SHELL_CHARS = (
+    "|",
+    "&&",
+    "||",
+    ";",
+    ">",
+    ">>",
+    "<",
+    "$(",
+    "`",
+    "*",
+    "?",
+    "&",
+    "(",
+    ")",
+    "$",
+    "\n",
+)
 
 _SHELL_TO_COMMAND = {
     "ansible.builtin.shell": "ansible.builtin.command",
@@ -19,13 +40,17 @@ _SHELL_TO_COMMAND = {
 def _uses_shell_features(cmd: str) -> bool:
     """Check if command string uses shell features (pipes, redirects, etc).
 
+    Jinja ``{{ }}`` expressions are stripped first so a filter such as
+    ``{{ path | quote }}`` is not treated as a shell pipe.
+
     Args:
         cmd: Command string to check.
 
     Returns:
-        True if cmd contains shell-specific characters.
+        True if the non-Jinja remainder contains shell-specific characters.
     """
-    return any(ch in cmd for ch in _SHELL_CHARS)
+    stripped = _JINJA_RE.sub(" ", cmd)
+    return any(ch in stripped for ch in _SHELL_CHARS)
 
 
 def _extract_command_string(module_args: object) -> str:

--- a/src/apme_engine/remediation/transforms/L007_shell_to_command.py
+++ b/src/apme_engine/remediation/transforms/L007_shell_to_command.py
@@ -41,15 +41,20 @@ def _uses_shell_features(cmd: str) -> bool:
     """Check if command string uses shell features (pipes, redirects, etc).
 
     Jinja ``{{ }}`` expressions are stripped first so a filter such as
-    ``{{ path | quote }}`` is not treated as a shell pipe.
+    ``{{ path | quote }}`` is not treated as a shell pipe.  A command that
+    is only Jinja (nothing inspectable after the strip) is treated as
+    using shell features — the rendered value is unknown.
 
     Args:
         cmd: Command string to check.
 
     Returns:
-        True if the non-Jinja remainder contains shell-specific characters.
+        True if the non-Jinja remainder is empty or contains shell-specific
+        characters.
     """
     stripped = _JINJA_RE.sub(" ", cmd)
+    if not stripped.strip():
+        return True
     return any(ch in stripped for ch in _SHELL_CHARS)
 
 

--- a/src/apme_engine/remediation/transforms/L007_shell_to_command.py
+++ b/src/apme_engine/remediation/transforms/L007_shell_to_command.py
@@ -28,8 +28,37 @@ def _uses_shell_features(cmd: str) -> bool:
     return any(ch in cmd for ch in _SHELL_CHARS)
 
 
+def _extract_command_string(module_args: object) -> str:
+    """Return the inspectable command string from shell module arguments.
+
+    Prefers free-form / ``cmd`` over ``argv``.  Returns empty when the
+    command cannot be inspected, in which case the transform must not
+    convert shell to command.
+
+    Args:
+        module_args: Scalar command string or argument mapping.
+
+    Returns:
+        Command string, or empty if none is available.
+    """
+    if isinstance(module_args, str):
+        return module_args
+    if not isinstance(module_args, dict):
+        return ""
+    cmd = module_args.get("cmd", "")
+    if isinstance(cmd, str) and cmd:
+        return cmd
+    argv = module_args.get("argv")
+    if isinstance(argv, list) and argv:
+        return " ".join(str(part) for part in argv)
+    return ""
+
+
 def fix_shell_to_command(task: CommentedMap, violation: ViolationDict) -> bool:
     """Replace shell with command when the command string uses no shell features.
+
+    Inspects free-form, ``cmd``, and ``argv``.  Refuses to convert when the
+    command cannot be inspected or contains shell metacharacters.
 
     Args:
         task: Task CommentedMap to modify in-place.
@@ -43,13 +72,8 @@ def fix_shell_to_command(task: CommentedMap, violation: ViolationDict) -> bool:
         return False
 
     module_args = task.get(module_key)
-    cmd = ""
-    if isinstance(module_args, str):
-        cmd = module_args
-    elif isinstance(module_args, dict):
-        cmd = module_args.get("cmd", "")
-
-    if cmd and _uses_shell_features(cmd):
+    cmd = _extract_command_string(module_args)
+    if not cmd or _uses_shell_features(cmd):
         return False
 
     new_key = _SHELL_TO_COMMAND[module_key]

--- a/src/apme_engine/remediation/transforms/L007_shell_to_command.py
+++ b/src/apme_engine/remediation/transforms/L007_shell_to_command.py
@@ -10,7 +10,8 @@ from apme_engine.engine.models import ViolationDict
 from apme_engine.remediation.transforms._helpers import get_module_key, rename_key
 
 # Inspected after Jinja ``{{ }}`` is stripped so ``|quote`` is not a pipe.
-_JINJA_RE = re.compile(r"\{\{[^{}]*\}\}")
+# Non-greedy so dict literals like ``{{ {'k': 'v'} }}`` are stripped too.
+_JINJA_RE = re.compile(r"\{\{.*?\}\}", re.DOTALL)
 _SHELL_CHARS = (
     "|",
     "&&",
@@ -26,6 +27,8 @@ _SHELL_CHARS = (
     "&",
     "(",
     ")",
+    "[",
+    "]",
     "$",
     "\n",
 )
@@ -43,16 +46,20 @@ def _uses_shell_features(cmd: str) -> bool:
     Jinja ``{{ }}`` expressions are stripped first so a filter such as
     ``{{ path | quote }}`` is not treated as a shell pipe.  A command that
     is only Jinja (nothing inspectable after the strip) is treated as
-    using shell features — the rendered value is unknown.
+    using shell features — the rendered value is unknown.  Leftover
+    ``{{`` after the strip (unclosed or nested beyond the pattern) is
+    also uninspectable.
 
     Args:
         cmd: Command string to check.
 
     Returns:
-        True if the non-Jinja remainder is empty or contains shell-specific
-        characters.
+        True if the non-Jinja remainder is empty, still contains Jinja
+        delimiters, or contains shell-specific characters.
     """
     stripped = _JINJA_RE.sub(" ", cmd)
+    if "{{" in stripped or "}}" in stripped:
+        return True
     if not stripped.strip():
         return True
     return any(ch in stripped for ch in _SHELL_CHARS)

--- a/src/apme_engine/validators/opa/bundle/L006.md
+++ b/src/apme_engine/validators/opa/bundle/L006.md
@@ -24,3 +24,18 @@ Use dedicated module instead of command.
     name: nginx
     state: present
 ```
+
+Piped or compound commands are not L006. `cat file | grep x` needs a shell;
+substituting `slurp` would drop the rest of the pipeline.
+
+### Example: pass
+
+```yaml
+- name: Collect MemTotal
+  ansible.builtin.shell:
+    cmd: cat /proc/meminfo | grep MemTotal
+```
+
+Remediation of a simple `cat` → `slurp` swap must also rewrite register
+consumers (`stdout` / `stdout_lines` → `content | b64decode`). That is
+not a node-local fix, so L006 is not auto-remediated.

--- a/src/apme_engine/validators/opa/bundle/L006.rego
+++ b/src/apme_engine/validators/opa/bundle/L006.rego
@@ -17,9 +17,9 @@ command_instead_of_module(tree, node) := v if {
 	mo := object.get(node, "module_options", {})
 	cmd := mo["cmd"]
 	cmd != null
-	trim(cmd, " ") != ""
+	normalized_cmd(cmd) != ""
 	not uses_shell_features(cmd)
-	first_token := split(trim(cmd, " "), " ")[0]
+	first_token := split(normalized_cmd(cmd), " ")[0]
 	suggested := data.apme.ansible.command_to_module[first_token]
 	suggested != ""
 	count(node.line) > 0

--- a/src/apme_engine/validators/opa/bundle/L006.rego
+++ b/src/apme_engine/validators/opa/bundle/L006.rego
@@ -18,6 +18,7 @@ command_instead_of_module(tree, node) := v if {
 	cmd := mo["cmd"]
 	cmd != null
 	trim(cmd, " ") != ""
+	not uses_shell_features(cmd)
 	first_token := split(trim(cmd, " "), " ")[0]
 	suggested := data.apme.ansible.command_to_module[first_token]
 	suggested != ""

--- a/src/apme_engine/validators/opa/bundle/L006_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L006_test.rego
@@ -62,3 +62,15 @@ test_L006_fires_when_cat_has_tab_separator if {
 	v := rules.command_instead_of_module(tree, node)
 	v.rule_id == "L006"
 }
+
+test_L006_does_not_fire_when_cat_has_bracket_glob if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.command", "module_options": {"cmd": "cat /tmp/[ab].txt"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_module(tree, node)
+}
+
+test_L006_does_not_fire_when_command_is_jinja_dict if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.command", "module_options": {"cmd": "{{ {'k': 'v'} }}"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_module(tree, node)
+}

--- a/src/apme_engine/validators/opa/bundle/L006_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L006_test.rego
@@ -29,3 +29,16 @@ test_L006_does_not_fire_when_cmd_has_and if {
 	node := tree.nodes[0]
 	not rules.command_instead_of_module(tree, node)
 }
+
+test_L006_fires_when_pipe_is_jinja_filter if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.command", "module_options": {"cmd": "cat {{ myfile|quote }}"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.command_instead_of_module(tree, node)
+	v.rule_id == "L006"
+}
+
+test_L006_does_not_fire_when_cmd_has_background if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.command", "module_options": {"cmd": "sleep 10 &"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_module(tree, node)
+}

--- a/src/apme_engine/validators/opa/bundle/L006_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L006_test.rego
@@ -48,3 +48,17 @@ test_L006_does_not_fire_when_command_is_only_jinja if {
 	node := tree.nodes[0]
 	not rules.command_instead_of_module(tree, node)
 }
+
+test_L006_fires_when_cat_has_leading_tab if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.command", "module_options": {"cmd": "\tcat /etc/hostname"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.command_instead_of_module(tree, node)
+	v.rule_id == "L006"
+}
+
+test_L006_fires_when_cat_has_tab_separator if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.command", "module_options": {"cmd": "cat\t/etc/hostname"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.command_instead_of_module(tree, node)
+	v.rule_id == "L006"
+}

--- a/src/apme_engine/validators/opa/bundle/L006_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L006_test.rego
@@ -10,3 +10,22 @@ test_L006_does_not_fire_for_plain_task if {
 	node := tree.nodes[0]
 	not rules.command_instead_of_module(tree, node)
 }
+
+test_L006_fires_for_simple_cat if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.command", "module_options": {"cmd": "cat /etc/hostname"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.command_instead_of_module(tree, node)
+	v.rule_id == "L006"
+}
+
+test_L006_does_not_fire_when_cmd_has_pipe if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.command", "module_options": {"cmd": "cat /proc/meminfo | grep MemTotal"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_module(tree, node)
+}
+
+test_L006_does_not_fire_when_cmd_has_and if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"cmd": "cat /tmp/a && cat /tmp/b"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_module(tree, node)
+}

--- a/src/apme_engine/validators/opa/bundle/L006_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L006_test.rego
@@ -42,3 +42,9 @@ test_L006_does_not_fire_when_cmd_has_background if {
 	node := tree.nodes[0]
 	not rules.command_instead_of_module(tree, node)
 }
+
+test_L006_does_not_fire_when_command_is_only_jinja if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.command", "module_options": {"cmd": "{{ command }}"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_module(tree, node)
+}

--- a/src/apme_engine/validators/opa/bundle/L007.rego
+++ b/src/apme_engine/validators/opa/bundle/L007.rego
@@ -11,13 +11,6 @@ violations contains v if {
 	v := command_instead_of_shell(tree, node)
 }
 
-_shell_chars := ["|", "&&", "||", ";", ">", ">>", "<", "$(", "`", "*", "?"]
-
-_uses_shell_features(cmd) if {
-	some ch in _shell_chars
-	contains(cmd, ch)
-}
-
 _shell_modules := {"shell", "ansible.builtin.shell", "ansible.legacy.shell"}
 
 command_instead_of_shell(tree, node) := v if {
@@ -41,7 +34,7 @@ command_instead_of_shell(tree, node) := v if {
 	node.type == "taskcall"
 	node.module in _shell_modules
 	cmd := object.get(node, "module_options", {})["cmd"]
-	not _uses_shell_features(cmd)
+	not uses_shell_features(cmd)
 	count(node.line) > 0
 	v := {
 		"rule_id": "L007",

--- a/src/apme_engine/validators/opa/bundle/L007.rego
+++ b/src/apme_engine/validators/opa/bundle/L007.rego
@@ -16,24 +16,8 @@ _shell_modules := {"shell", "ansible.builtin.shell", "ansible.legacy.shell"}
 command_instead_of_shell(tree, node) := v if {
 	node.type == "taskcall"
 	node.module in _shell_modules
-	mo := object.get(node, "module_options", {})
-	not mo["cmd"]
-	count(node.line) > 0
-	v := {
-		"rule_id": "L007",
-		"severity": "low",
-		"message": "Prefer ansible.builtin.command when no shell features are needed",
-		"file": node.file,
-		"line": node.line[0],
-		"path": node.key,
-		"scope": "task",
-	}
-}
-
-command_instead_of_shell(tree, node) := v if {
-	node.type == "taskcall"
-	node.module in _shell_modules
-	cmd := object.get(node, "module_options", {})["cmd"]
+	cmd := inspectable_command(object.get(node, "module_options", {}))
+	cmd != ""
 	not uses_shell_features(cmd)
 	count(node.line) > 0
 	v := {

--- a/src/apme_engine/validators/opa/bundle/L007_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L007_test.rego
@@ -83,3 +83,9 @@ test_L007_does_not_fire_when_shell_has_dollar_var if {
 	node := tree.nodes[0]
 	not rules.command_instead_of_shell(tree, node)
 }
+
+test_L007_does_not_fire_when_command_is_only_jinja if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"cmd": "{{ command }}"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_shell(tree, node)
+}

--- a/src/apme_engine/validators/opa/bundle/L007_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L007_test.rego
@@ -64,3 +64,22 @@ test_L007_does_not_fire_for_command_module if {
 	node := tree.nodes[0]
 	not rules.command_instead_of_shell(tree, node)
 }
+
+test_L007_fires_when_pipe_is_jinja_filter if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"cmd": "cat {{ myfile|quote }}"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.command_instead_of_shell(tree, node)
+	v.rule_id == "L007"
+}
+
+test_L007_does_not_fire_when_shell_has_background if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"cmd": "sleep 10 &"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_shell(tree, node)
+}
+
+test_L007_does_not_fire_when_shell_has_dollar_var if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"cmd": "echo $HOME"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_shell(tree, node)
+}

--- a/src/apme_engine/validators/opa/bundle/L007_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L007_test.rego
@@ -89,3 +89,9 @@ test_L007_does_not_fire_when_command_is_only_jinja if {
 	node := tree.nodes[0]
 	not rules.command_instead_of_shell(tree, node)
 }
+
+test_L007_does_not_fire_when_jinja_command_has_trailing_tab if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"cmd": "{{ command }}\t"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_shell(tree, node)
+}

--- a/src/apme_engine/validators/opa/bundle/L007_test.rego
+++ b/src/apme_engine/validators/opa/bundle/L007_test.rego
@@ -95,3 +95,41 @@ test_L007_does_not_fire_when_jinja_command_has_trailing_tab if {
 	node := tree.nodes[0]
 	not rules.command_instead_of_shell(tree, node)
 }
+
+test_L007_does_not_fire_when_jinja_has_dict_literal if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"cmd": "{{ {'k': 'v'} }}"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_shell(tree, node)
+}
+
+test_L007_fires_when_jinja_dict_is_an_argument if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"cmd": "cat {{ {'path': item} | quote }}"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.command_instead_of_shell(tree, node)
+	v.rule_id == "L007"
+}
+
+test_L007_does_not_fire_when_shell_has_bracket_glob if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"cmd": "cat /tmp/[ab].txt"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_shell(tree, node)
+}
+
+test_L007_does_not_fire_when_command_uninspectable if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"chdir": "/tmp"}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_shell(tree, node)
+}
+
+test_L007_fires_when_argv_has_no_shell_features if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"argv": ["whoami"]}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.command_instead_of_shell(tree, node)
+	v.rule_id == "L007"
+}
+
+test_L007_does_not_fire_when_argv_has_pipe if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.shell", "module_options": {"argv": ["cat", "/proc/meminfo", "|", "grep", "MemTotal"]}, "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.command_instead_of_shell(tree, node)
+}

--- a/src/apme_engine/validators/opa/bundle/_helpers.rego
+++ b/src/apme_engine/validators/opa/bundle/_helpers.rego
@@ -39,19 +39,71 @@ set_fact_modules[m] if {
 # A command that is only Jinja (nothing inspectable after the strip)
 # is treated as using shell features — the rendered value is unknown.
 # Use trim_space so tabs/CR match Python str.strip(), not a space-only cutset.
-shell_metacharacters := ["|", "&&", "||", ";", ">", ">>", "<", "$(", "`", "*", "?", "&", "(", ")", "$", "\n"]
+# [ and ] are glob character classes (cat /tmp/[ab].txt).
+shell_metacharacters := ["|", "&&", "||", ";", ">", ">>", "<", "$(", "`", "*", "?", "&", "(", ")", "[", "]", "$", "\n"]
+
+# Non-greedy {{ ... }} so dict literals like {{ {'k': 'v'} }} are stripped.
+jinja_stripped(cmd) := regex.replace(cmd, `\{\{.*?\}\}`, " ") if {
+	is_string(cmd)
+}
 
 uses_shell_features(cmd) if {
 	is_string(cmd)
-	stripped := trim_space(regex.replace(cmd, `\{\{[^{}]*\}\}`, " "))
+	stripped := jinja_stripped(cmd)
+	contains(stripped, "{{")
+}
+
+uses_shell_features(cmd) if {
+	is_string(cmd)
+	stripped := jinja_stripped(cmd)
+	contains(stripped, "}}")
+}
+
+uses_shell_features(cmd) if {
+	is_string(cmd)
+	stripped := trim_space(jinja_stripped(cmd))
 	stripped == ""
 }
 
 uses_shell_features(cmd) if {
 	is_string(cmd)
-	stripped := regex.replace(cmd, `\{\{[^{}]*\}\}`, " ")
+	stripped := jinja_stripped(cmd)
 	some ch in shell_metacharacters
 	contains(stripped, ch)
+}
+
+# Prefer cmd, then free-form _raw_params, then joined argv — same sources
+# as the L007 Python transform.
+has_cmd_text(mo) if {
+	cmd := object.get(mo, "cmd", "")
+	is_string(cmd)
+	trim_space(cmd) != ""
+}
+
+has_raw_text(mo) if {
+	raw := object.get(mo, "_raw_params", "")
+	is_string(raw)
+	trim_space(raw) != ""
+}
+
+inspectable_command(mo) := cmd if {
+	has_cmd_text(mo)
+	cmd := object.get(mo, "cmd", "")
+}
+
+inspectable_command(mo) := raw if {
+	not has_cmd_text(mo)
+	has_raw_text(mo)
+	raw := object.get(mo, "_raw_params", "")
+}
+
+inspectable_command(mo) := joined if {
+	not has_cmd_text(mo)
+	not has_raw_text(mo)
+	argv := object.get(mo, "argv", [])
+	is_array(argv)
+	count(argv) > 0
+	joined := concat(" ", [sprintf("%v", [x]) | x := argv[_]])
 }
 
 # Collapse all whitespace so first-token lookup matches trim_space emptiness

--- a/src/apme_engine/validators/opa/bundle/_helpers.rego
+++ b/src/apme_engine/validators/opa/bundle/_helpers.rego
@@ -38,11 +38,12 @@ set_fact_modules[m] if {
 # Inspected after Jinja {{ }} is stripped so |quote is not a pipe.
 # A command that is only Jinja (nothing inspectable after the strip)
 # is treated as using shell features — the rendered value is unknown.
+# Use trim_space so tabs/CR match Python str.strip(), not a space-only cutset.
 shell_metacharacters := ["|", "&&", "||", ";", ">", ">>", "<", "$(", "`", "*", "?", "&", "(", ")", "$", "\n"]
 
 uses_shell_features(cmd) if {
 	is_string(cmd)
-	stripped := trim(regex.replace(cmd, `\{\{[^{}]*\}\}`, " "), " ")
+	stripped := trim_space(regex.replace(cmd, `\{\{[^{}]*\}\}`, " "))
 	stripped == ""
 }
 

--- a/src/apme_engine/validators/opa/bundle/_helpers.rego
+++ b/src/apme_engine/validators/opa/bundle/_helpers.rego
@@ -33,6 +33,16 @@ set_fact_modules[m] if {
 	m := data.apme.ansible.set_fact_modules[_]
 }
 
+# Shell metacharacters that require ansible.builtin.shell (or make a
+# command-instead-of-module substitution invalid, e.g. cat | grep).
+shell_metacharacters := ["|", "&&", "||", ";", ">", ">>", "<", "$(", "`", "*", "?"]
+
+uses_shell_features(cmd) if {
+	is_string(cmd)
+	some ch in shell_metacharacters
+	contains(cmd, ch)
+}
+
 has_with_loop(opts) := key if {
 	some key in object.keys(opts)
 	startswith(key, "with_")

--- a/src/apme_engine/validators/opa/bundle/_helpers.rego
+++ b/src/apme_engine/validators/opa/bundle/_helpers.rego
@@ -36,7 +36,15 @@ set_fact_modules[m] if {
 # Shell metacharacters that require ansible.builtin.shell (or make a
 # command-instead-of-module substitution invalid, e.g. cat | grep).
 # Inspected after Jinja {{ }} is stripped so |quote is not a pipe.
+# A command that is only Jinja (nothing inspectable after the strip)
+# is treated as using shell features — the rendered value is unknown.
 shell_metacharacters := ["|", "&&", "||", ";", ">", ">>", "<", "$(", "`", "*", "?", "&", "(", ")", "$", "\n"]
+
+uses_shell_features(cmd) if {
+	is_string(cmd)
+	stripped := trim(regex.replace(cmd, `\{\{[^{}]*\}\}`, " "), " ")
+	stripped == ""
+}
 
 uses_shell_features(cmd) if {
 	is_string(cmd)

--- a/src/apme_engine/validators/opa/bundle/_helpers.rego
+++ b/src/apme_engine/validators/opa/bundle/_helpers.rego
@@ -35,12 +35,14 @@ set_fact_modules[m] if {
 
 # Shell metacharacters that require ansible.builtin.shell (or make a
 # command-instead-of-module substitution invalid, e.g. cat | grep).
-shell_metacharacters := ["|", "&&", "||", ";", ">", ">>", "<", "$(", "`", "*", "?"]
+# Inspected after Jinja {{ }} is stripped so |quote is not a pipe.
+shell_metacharacters := ["|", "&&", "||", ";", ">", ">>", "<", "$(", "`", "*", "?", "&", "(", ")", "$", "\n"]
 
 uses_shell_features(cmd) if {
 	is_string(cmd)
+	stripped := regex.replace(cmd, `\{\{[^{}]*\}\}`, " ")
 	some ch in shell_metacharacters
-	contains(cmd, ch)
+	contains(stripped, ch)
 }
 
 has_with_loop(opts) := key if {

--- a/src/apme_engine/validators/opa/bundle/_helpers.rego
+++ b/src/apme_engine/validators/opa/bundle/_helpers.rego
@@ -54,6 +54,12 @@ uses_shell_features(cmd) if {
 	contains(stripped, ch)
 }
 
+# Collapse all whitespace so first-token lookup matches trim_space emptiness
+# (tabs/CR, not a space-only cutset).
+normalized_cmd(cmd) := trim_space(regex.replace(cmd, `\s+`, " ")) if {
+	is_string(cmd)
+}
+
 has_with_loop(opts) := key if {
 	some key in object.keys(opts)
 	startswith(key, "with_")

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -325,16 +325,25 @@ class TestPartition:
         assert len(t2) == 1
 
     def test_partition_cross_file_rules_still_tier3(self) -> None:
-        """Verifies R111/R112 still route to tier3 with NEEDS_CROSS_FILE."""
+        """Verifies cross-file and data-flow rules route to tier3."""
         reg = TransformRegistry()
         violations: list[ViolationDict] = [
             {"rule_id": "R111", "scope": RuleScope.TASK},
             {"rule_id": "R112", "scope": "task"},
+            {"rule_id": "L006", "scope": RuleScope.TASK},
+            {"rule_id": "L080", "scope": "task"},
         ]
         t1, t2, t3 = partition_violations(violations, reg)
-        assert len(t3) == 2
+        assert len(t1) == 0
+        assert len(t2) == 0
+        assert len(t3) == 4
         for v in t3:
             assert v["remediation_resolution"] == RemediationResolution.NEEDS_CROSS_FILE
+
+    def test_classify_data_flow_rules_manual_review(self) -> None:
+        """Verifies L006/L080 classify as manual-review despite task scope."""
+        assert classify_violation({"rule_id": "L006", "scope": RuleScope.TASK}) == RemediationClass.MANUAL_REVIEW
+        assert classify_violation({"rule_id": "L080", "scope": "task"}) == RemediationClass.MANUAL_REVIEW
 
     def test_partition_missing_scope_defaults_to_task(self) -> None:
         """Verifies violations without scope default to task (AI proposable)."""
@@ -537,6 +546,43 @@ class TestL007ShellToCommand:
         result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is True
         assert "ansible.builtin.command" in result.content
+
+    def test_converts_argv_without_shell_features(self) -> None:
+        """Verifies argv-only shell without pipes is converted to command."""
+        content = textwrap.dedent("""\
+        - name: Simple argv
+          ansible.builtin.shell:
+            argv:
+              - whoami
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is True
+        assert "ansible.builtin.command" in result.content
+
+    def test_no_change_when_argv_has_pipe(self) -> None:
+        """Verifies argv containing a pipe is not converted to command."""
+        content = textwrap.dedent("""\
+        - name: Piped argv
+          ansible.builtin.shell:
+            argv:
+              - cat
+              - /proc/meminfo
+              - "|"
+              - grep
+              - MemTotal
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is False
+
+    def test_no_change_when_command_uninspectable(self) -> None:
+        """Verifies shell without cmd or argv is left unchanged."""
+        content = textwrap.dedent("""\
+        - name: Only chdir
+          ansible.builtin.shell:
+            chdir: /tmp
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -340,6 +340,24 @@ class TestPartition:
         for v in t3:
             assert v["remediation_resolution"] == RemediationResolution.NEEDS_CROSS_FILE
 
+    def test_cross_file_rules_beat_registry(self) -> None:
+        """Verifies L006/L080 stay Tier 3 even if a transform is registered."""
+        reg = TransformRegistry()
+        reg.register("L006", node=lambda t, v: False)
+        reg.register("L080", node=lambda t, v: False)
+        violations: list[ViolationDict] = [
+            {"rule_id": "L006", "scope": RuleScope.TASK},
+            {"rule_id": "L080", "scope": "task"},
+        ]
+        assert is_finding_resolvable(violations[0], reg) is False
+        assert is_finding_resolvable(violations[1], reg) is False
+        t1, t2, t3 = partition_violations(violations, reg)
+        assert t1 == []
+        assert t2 == []
+        assert len(t3) == 2
+        for v in t3:
+            assert v["remediation_resolution"] == RemediationResolution.NEEDS_CROSS_FILE
+
     def test_classify_data_flow_rules_manual_review(self) -> None:
         """Verifies L006/L080 classify as manual-review despite task scope."""
         assert classify_violation({"rule_id": "L006", "scope": RuleScope.TASK}) == RemediationClass.MANUAL_REVIEW
@@ -580,6 +598,48 @@ class TestL007ShellToCommand:
         - name: Only chdir
           ansible.builtin.shell:
             chdir: /tmp
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is False
+
+    def test_converts_when_pipe_is_jinja_filter(self) -> None:
+        """Verifies Jinja |quote is not treated as a shell pipe."""
+        content = textwrap.dedent("""\
+        - name: Cat quoted path
+          ansible.builtin.shell: "cat {{ myfile | quote }}"
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is True
+        assert "ansible.builtin.command" in result.content
+
+    def test_no_change_when_background_ampersand(self) -> None:
+        """Verifies standalone & is treated as a shell feature."""
+        content = textwrap.dedent("""\
+        - name: Background sleep
+          ansible.builtin.shell:
+            cmd: sleep 10 &
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is False
+
+    def test_no_change_when_argv_has_ampersand(self) -> None:
+        """Verifies argv containing & is not converted to command."""
+        content = textwrap.dedent("""\
+        - name: Background argv
+          ansible.builtin.shell:
+            argv:
+              - sleep
+              - "10"
+              - "&"
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is False
+
+    def test_no_change_when_shell_variable(self) -> None:
+        """Verifies $VAR expansion is treated as a shell feature."""
+        content = textwrap.dedent("""\
+        - name: Echo home
+          ansible.builtin.shell: "echo $HOME"
         """)
         result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is False

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -659,6 +659,34 @@ class TestL007ShellToCommand:
         result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
+    def test_no_change_when_jinja_has_dict_literal(self) -> None:
+        """Verifies a Jinja dict literal is stripped, not treated as inspectable."""
+        content = textwrap.dedent("""\
+        - name: Dynamic mapping
+          ansible.builtin.shell: "{{ {'k': 'v'} }}"
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is False
+
+    def test_converts_when_jinja_dict_is_an_argument(self) -> None:
+        """Verifies Jinja dict-plus-filter is stripped so cat remains convertible."""
+        content = textwrap.dedent("""\
+        - name: Cat quoted mapping
+          ansible.builtin.shell: "cat {{ {'path': item} | quote }}"
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is True
+        assert "ansible.builtin.command" in result.content
+
+    def test_no_change_when_bracket_glob(self) -> None:
+        """Verifies [ab] glob classes are treated as shell features."""
+        content = textwrap.dedent("""\
+        - name: Cat glob
+          ansible.builtin.shell: cat /tmp/[ab].txt
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is False
+
 
 # ---------------------------------------------------------------------------
 # M001/M003 transform: FQCN

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -644,6 +644,15 @@ class TestL007ShellToCommand:
         result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
+    def test_no_change_when_command_is_only_jinja(self) -> None:
+        """Verifies a whole-command Jinja expression is not converted."""
+        content = textwrap.dedent("""\
+        - name: Dynamic command
+          ansible.builtin.shell: "{{ command }}"
+        """)
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is False
+
 
 # ---------------------------------------------------------------------------
 # M001/M003 transform: FQCN

--- a/tests/test_remediation.py
+++ b/tests/test_remediation.py
@@ -653,6 +653,12 @@ class TestL007ShellToCommand:
         result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
         assert result.applied is False
 
+    def test_no_change_when_jinja_command_has_trailing_tab(self) -> None:
+        """Verifies Jinja plus trailing whitespace is still uninspectable."""
+        content = '- name: Dynamic command\n  ansible.builtin.shell: "{{ command }}\t"\n'
+        result = _apply_node(fix_shell_to_command, content, {"rule_id": "L007", "line": 1})
+        assert result.applied is False
+
 
 # ---------------------------------------------------------------------------
 # M001/M003 transform: FQCN

--- a/tools/generate_rule_catalog.py
+++ b/tools/generate_rule_catalog.py
@@ -731,7 +731,7 @@ def generate_remediation_report() -> str:
     ]
     tier3_reasons = (
         "info severity",
-        "cross-file (R111/R112)",
+        "cross-file / data-flow context",
         "playbook scope",
         "collection scope",
         "role scope",

--- a/tools/rule_analysis.py
+++ b/tools/rule_analysis.py
@@ -35,7 +35,8 @@ _RULE_SCOPE_NAMES: dict[str, str] = {
     "COLLECTION": "collection",
 }
 AI_PROPOSABLE_SCOPES = frozenset({"task", "block"})
-CROSS_FILE_RULES = frozenset({"R111", "R112"})
+# Keep in sync with apme_engine.remediation.partition.CROSS_FILE_RULES.
+CROSS_FILE_RULES = frozenset({"R111", "R112", "L006", "L080"})
 
 GRAPH_RULES_DIR = REPO_ROOT / "src" / "apme_engine" / "graph" / "rules"
 NATIVE_DIR = REPO_ROOT / "src" / "apme_engine" / "validators" / "native" / "rules"
@@ -215,7 +216,7 @@ def tier3_breakdown_reason(meta: RuleMetadata) -> str:
     if meta.severity == "info":
         return "info severity"
     if meta.rule_id in CROSS_FILE_RULES:
-        return "cross-file (R111/R112)"
+        return "cross-file / data-flow context"
     scope_labels = {
         "playbook": "playbook scope",
         "collection": "collection scope",
@@ -238,7 +239,7 @@ def classify_remediation_tier(
     if severity == Severity.INFO:
         return "manual", "Info severity — informational, no auto-fix"
     if rule_id in CROSS_FILE_RULES:
-        return "manual", "Cross-file context required (R111/R112)"
+        return "manual", "Project-level context required (cross-file or data-flow consumers)"
     if scope not in AI_PROPOSABLE_SCOPES:
         return "manual", f"Scope '{scope}' — play/role/collection not AI-proposable"
     return "ai", "Task/block scope — AI can propose fix (Tier 2)"


### PR DESCRIPTION
## Summary
- Stop auto-remediating **L080** (`set_fact` `__` prefix) and **L006** (`cat` → `slurp`): node-local AI rewrites the producer and leaves readers on the old name or `stdout_lines`.
- L006 no longer fires on piped/compound commands (`cat file | grep …`).
- L007 shell→command refuses to convert when `cmd`/`argv` cannot be inspected or contains shell metacharacters.

Long-term fix: project-level remediation (#565). The graph does not know every variable use (bare `when:`, templates, nested options).

## Changes
- `CROSS_FILE_RULES` now includes L006 and L080 → Tier 3 (`needs-cross-file`), evaluated **before** the transform registry
- Shared OPA `uses_shell_features()`; strips Jinja `{{ }}` first so `|quote` is not a pipe; also rejects `&`, `$`, `()`, `[]`, newlines
- Jinja strip is non-greedy (`{{ ... }}`) so dict literals like `{{ {'k': 'v'} }}` are uninspectable, not treated as shell-free
- A command that is **only Jinja** is uninspectable after that strip — keep `shell`, do not emit L007
- Empty remainder uses `trim_space` (tabs/CR match Python `str.strip()`, not a space-only cutset)
- L006 first-token lookup uses `normalized_cmd()` (`trim_space` + collapse `\s+`) so leading/internal tabs still match `cat`
- L007 detector uses `inspectable_command()` (`cmd`, `_raw_params`, joined `argv`) — no finding when the command cannot be inspected, no finding when argv contains metacharacters
- L007 transform inspects `cmd` and `argv`; empty/uninspectable command is a no-op
- Catalog/tier report regenerated; architecture + rule docs updated

## Quality of life
- Strengthened pr-new Q8 / Rule of Five Pass 5 for overloaded tokens (a metacharacter in one grammar is an operator in another in the same string)
- After stripping an inner grammar, empty remainder is uninspectable, not proven-safe; leftover delimiters and nested inner-language tokens must still strip
- Dual implementations of the same predicate (Rego vs Python) must agree on what "empty" whitespace means and inspect the same input shapes (`cmd` / `argv` / `_raw_params`)
- After `trim_space` for emptiness, tokenize/split the same string with that whitespace class, not `trim(..., " ")`

## Test plan
- [x] `tox -e lint` passes (skillmark skipped locally — no C compiler for the rust hook)
- [x] Focused `tox -e unit` for partition/L007 plus OPA bundle tests
- [x] Docs updated (partition, L006/L080, architecture, generated catalog)