### PR TITLE
fix(L039): add ai_prompt for AI-assisted remediation

### DIFF
--- a/.sdlc/decisions/README.md
+++ b/.sdlc/decisions/README.md
@@ -101,9 +101,11 @@ Decision Requests (DRs) provide a formal mechanism for:
 
 | DR | Title | Category | Priority | Raised |
 |----|-------|----------|----------|--------|
-| [DR-013](open/DR-013-aa-integration-approach.md) | Automation Analytics Integration Approach | Architecture | Medium | 2026-03-25 |
 | [DR-014](open/DR-014-eda-integration-approach.md) | EDA Integration Approach | Architecture | High | 2026-03-25 |
 | [DR-015](open/DR-015-controller-policy-integration.md) | Controller Policy Integration | Architecture | High | 2026-03-25 |
+| [DR-020](open/DR-020-m005-false-positive-exemptions.md) | M005 False Positive Exemptions | Technical | High | 2026-08-20 |
+| [DR-021](open/DR-021-l039-ai-remediation-guidance.md) | L039 AI Remediation Guidance | Technical | High | 2026-08-21 |
+| [DR-013](open/DR-013-aa-integration-approach.md) | Automation Analytics Integration Approach | Architecture | Medium | 2026-03-25 |
 
 ### Closed: Decided
 

--- a/.sdlc/decisions/open/DR-021-l039-ai-remediation-guidance.md
+++ b/.sdlc/decisions/open/DR-021-l039-ai-remediation-guidance.md
@@ -1,0 +1,155 @@
+# DR-021: Should L039 (undefined variable) have AI remediation guidance?
+
+## Status
+
+Open
+
+## Raised By
+
+User — 2026-08-21
+
+## Category
+
+Technical
+
+## Priority
+
+High
+
+---
+
+## Question
+
+Should L039 (undefined variable) have an `ai_prompt` field to enable effective AI-assisted remediation, and what should the guidance say?
+
+## Context
+
+During AI remediation testing on [eloycoto/ansible-sample PR #2](https://github.com/eloycoto/ansible-sample/pull/2), L039 findings were marked "AI eligible" but the AI made no fixes ("Findings resolved: 0").
+
+Investigation found:
+1. Only 5 rules have `ai_prompt` guidance — all R-series (R101, R103, R104, R105, R108)
+2. L039 has no `ai_prompt`, so AI doesn't know how to handle undefined variables
+3. Without guidance, AI skips L039 findings entirely
+
+The flagged code:
+```yaml
+- name: Create PostgreSQL database
+  ansible.builtin.shell:
+    cmd: sudo -u postgres psql -c "CREATE DATABASE {{ db_name }} OWNER {{ db_username }};"
+  when: pg_db_check.stdout != '1'
+```
+
+L039 flags `db_name`, `db_username`, `pg_db_check` as potentially undefined — but they come from inventory/role params and are valid at runtime.
+
+## Impact of Not Deciding
+
+- L039 findings remain "AI eligible" but never fixed
+- Users see false promise of AI remediation
+- Reduces trust in AI remediation feature
+
+---
+
+## Options Considered
+
+### Option A: Add ai_prompt with noqa-first guidance
+
+**Description**: Add guidance that tells AI to add `# noqa: L039` when variables appear to come from trusted sources (inventory, role params, extra_vars).
+
+**Proposed ai_prompt**:
+```yaml
+ai_prompt: |
+  L039 flags variables that may be undefined at static analysis time. If the
+  variable appears to come from inventory, role parameters, extra_vars, or is
+  a registered variable from a prior task, add "# noqa: L039" to suppress —
+  but your explanation MUST justify why (e.g. "variable comes from role
+  defaults"). If the variable appears genuinely undefined with no clear source,
+  skip the finding and let the user handle it manually.
+```
+
+**Pros**:
+- Matches R-series pattern (noqa when intentional)
+- Reduces false positive noise
+- Conservative — doesn't add arbitrary defaults
+
+**Cons**:
+- May suppress some true positives
+- Doesn't actually define missing variables
+
+**Effort**: Low
+
+### Option B: Add ai_prompt with default() filter guidance
+
+**Description**: Tell AI to add `| default('')` or similar filters to make variables safe.
+
+**Pros**:
+- Actually fixes the code
+- Makes playbook more defensive
+
+**Cons**:
+- Wrong default value could break playbook
+- Not what user intended in most cases
+- Variables from inventory/params shouldn't need defaults
+
+**Effort**: Low
+
+### Option C: Keep L039 manual-only
+
+**Description**: Remove L039 from AI eligibility — undefined variable detection requires human judgment about where variables should come from.
+
+**Pros**:
+- Avoids AI making wrong assumptions
+- Human reviews variable sources
+
+**Cons**:
+- Defeats purpose of AI remediation
+- Other rules with similar ambiguity still work (R-series)
+
+**Effort**: Low
+
+---
+
+## Recommendation
+
+**Option A** — matches existing R-series pattern. AI adds noqa when source appears trusted, skips when genuinely unknown.
+
+---
+
+## Related Artifacts
+
+- DR-019: AI Remediation Rule Compliance
+- DR-020: M005 False Positive Exemptions
+- GitHub: eloycoto/ansible-sample PR #2 (test case)
+- **PR #582**: [fix(L039): add ai_prompt for AI-assisted remediation](https://github.com/ansible/apme/pull/582)
+
+---
+
+## Discussion Log
+
+| Date | Participant | Input |
+|------|-------------|-------|
+| 2026-08-21 | User | Reported AI remediation not fixing L039 findings |
+| 2026-08-21 | Claude | Found L039 has no ai_prompt; only R-series rules have guidance |
+
+---
+
+## Decision
+
+**Status**: Open
+**Date**: 
+**Decided By**: 
+
+**Decision**: 
+
+**Rationale**: 
+
+**Action Items**:
+- [ ] Add ai_prompt to L039 guidance file
+- [ ] Test with eloycoto/ansible-sample PR
+- [ ] Document in remediation docs
+
+---
+
+## Post-Decision Updates
+
+| Date | Update |
+|------|--------|

--- a/docs/rules/REMEDIATION_TIER_REPORT.md
+++ b/docs/rules/REMEDIATION_TIER_REPORT.md
@@ -10,14 +10,14 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | Tier | Count | % of 157 |
 |------|-------|--------|
 | Tier 1 — auto (has transform) | 25 | 16% |
-| Tier 2 — AI (task/block, no fixer) | 69 | 44% |
-| Tier 3 — manual | 63 | 40% |
+| Tier 2 — AI (task/block, no fixer) | 70 | 45% |
+| Tier 3 — manual | 62 | 39% |
 
 ### Promotion potential
 
 - **27** Tier 2 rules could likely move to Tier 1 (mechanical transforms)
 - **8** Tier 3 rules have mechanical fixes blocked by scope
-- **69 - 27 = 42** Tier 2 rules should stay AI (judgment/security)
+- **70 - 27 = 43** Tier 2 rules should stay AI (judgment/security)
 
 ### Tier 3 breakdown
 
@@ -29,7 +29,7 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | collection scope | 10 |
 | role scope | 10 |
 | play scope | 7 |
-| inventory scope | 4 |
+| inventory scope | 3 |
 
 ## Tier 1 — Auto (25 rules)
 
@@ -61,7 +61,7 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | M008 | OPA | high | task | Bare include is removed in 2.19+; use include_tasks or import_tasks. |
 | M009 | OPA | high | task | with_* loops are deprecated; use loop instead. |
 
-## Tier 2 — AI (69 rules)
+## Tier 2 — AI (70 rules)
 
 ### Could move to Tier 1 auto
 
@@ -111,6 +111,7 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | L033 | low | task | Task/block scope — AI can propose fix (Tier 2) |
 | L035 | low | task | Task/block scope — AI can propose fix (Tier 2) |
 | L036 | low | task | Task/block scope — AI can propose fix (Tier 2) |
+| L039 | medium | task | Task/block scope — AI can propose fix (Tier 2) |
 | L041 | low | task | Task/block scope — AI can propose fix (Tier 2) |
 | L044 | low | task | Task/block scope — AI can propose fix (Tier 2) |
 | L045 | low | task | Task/block scope — AI can propose fix (Tier 2) |
@@ -142,7 +143,7 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | R115 | medium | task | Task/block scope — AI can propose fix (Tier 2) |
 | SEC:* | critical | task | Task/block scope — AI can propose fix (Tier 2) |
 
-## Tier 3 — Manual (63 rules)
+## Tier 3 — Manual (62 rules)
 
 | Rule ID | Validator | Severity | Scope | Auto candidate? | Reason |
 |---------|-----------|----------|-------|-----------------|--------|
@@ -154,7 +155,6 @@ Analysis of default remediation routing for all rules. Regenerate with:
 | L034 | Native | low | inventory | — | Scope 'inventory' — play/role/collection not AI-proposable |
 | L037 | Native | medium | collection | — | Scope 'collection' — play/role/collection not AI-proposable |
 | L038 | Native | medium | role | — | Scope 'role' — play/role/collection not AI-proposable |
-| L039 | Native | medium | inventory | — | Scope 'inventory' — play/role/collection not AI-proposable |
 | L040 | Native | info | playbook | Replace tabs with spaces | Info severity — informational, no auto-fix |
 | L042 | Native | info | play | — | Info severity — informational, no auto-fix |
 | L052 | Native | low | role | — | Scope 'role' — play/role/collection not AI-proposable |

--- a/docs/rules/RULE_CATALOG.md
+++ b/docs/rules/RULE_CATALOG.md
@@ -51,8 +51,8 @@ Routing follows `src/apme_engine/remediation/partition.py` (ADR-026 scope metada
 | Tier | Label | Count | Routing |
 |------|-------|-------|---------|
 | 1 | auto | 25 | Deterministic transform in registry — applied by `apme remediate` |
-| 2 | ai | 69 | Task/block scope, no fixer — AI proposes patch (Abbenay) |
-| 3 | manual | 63 | Play/role/collection scope, cross-file, or info severity |
+| 2 | ai | 70 | Task/block scope, no fixer — AI proposes patch (Abbenay) |
+| 3 | manual | 62 | Play/role/collection scope, cross-file, or info severity |
 
 Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION_TIER_REPORT.md).
 
@@ -96,7 +96,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L036 | L | Native | low | task | ai | include_vars without when/tags. | Yes | Yes | Yes | — |
 | L037 | L | Native | medium | collection | manual | Module name could not be resolved. | Yes | Yes | Yes | — |
 | L038 | L | Native | medium | role | manual | Role could not be resolved. | Yes | — | Yes | — |
-| L039 | L | Native | medium | inventory | manual | Variable use may be undefined. | Yes | — | Yes | — |
+| L039 | L | Native | medium | task | ai | Variable use may be undefined. | Yes | — | Yes | — |
 | L040 | L | Native | info | playbook | manual | YAML should not contain tabs; use spaces. | Yes | Yes | Yes | — |
 | L041 | L | Native | low | task | ai | Task keys should follow canonical order (e.g. name before module). | Yes | Yes | Yes | — |
 | L042 | L | Native | info | play | manual | Play/block has high task count. | Yes | Yes | Yes | — |
@@ -291,7 +291,7 @@ Full analysis and promotion candidates: [REMEDIATION_TIER_REPORT.md](REMEDIATION
 | L036 | low | task | ai | include_vars without when/tags. | Yes | Yes | Yes | — |
 | L037 | medium | collection | manual | Module name could not be resolved. | Yes | Yes | Yes | — |
 | L038 | medium | role | manual | Role could not be resolved. | Yes | — | Yes | — |
-| L039 | medium | inventory | manual | Variable use may be undefined. | Yes | — | Yes | — |
+| L039 | medium | task | ai | Variable use may be undefined. | Yes | — | Yes | — |
 | L040 | info | playbook | manual | YAML should not contain tabs; use spaces. | Yes | Yes | Yes | — |
 | L041 | low | task | ai | Task keys should follow canonical order (e.g. name before module). | Yes | Yes | Yes | — |
 | L042 | info | play | manual | Play/block has high task count. | Yes | Yes | Yes | — |

--- a/src/apme_engine/graph/rules/L039_undefined_variable.md
+++ b/src/apme_engine/graph/rules/L039_undefined_variable.md
@@ -2,7 +2,16 @@
 rule_id: L039
 validator: native
 description: Variable use may be undefined.
-scope: inventory
+scope: task
+ai_prompt: |
+  L039 flags variables that may be undefined at static analysis time. If the
+  variable appears to come from inventory, role parameters, extra_vars, or is
+  a registered variable from a prior task, add "# noqa: L039" to the task
+  line — but your explanation MUST justify why (e.g. "variable comes from
+  role defaults" or "registered by prior task"). If the variable appears
+  genuinely undefined with no clear source, skip the finding and let the
+  user handle it manually. Do NOT add default() filters unless the user's
+  intent is clear.
 ---
 
 ## Undefined variable (L039)


### PR DESCRIPTION
## Summary

L039 (undefined variable) was marked "AI eligible" but had no `ai_prompt` guidance, causing AI remediation to skip findings entirely with "Findings resolved: 0".

**Changes:**
- Add `ai_prompt` field to L039 guidance with instructions for when to add noqa
- Fix `scope` from "inventory" to "task" to match actual rule behavior
- Add DR-021 documenting the decision

**Root cause:** Only 5 R-series rules had `ai_prompt` guidance. L039 had none, so AI didn't know whether to add defaults, noqa, or skip.

## Test case

Reported in [eloycoto/ansible-sample PR #2](https://github.com/eloycoto/ansible-sample/pull/2) — AI ran remediation but made only cosmetic changes, skipping L039 findings.

## Related

- Closes DR-021: L039 AI Remediation Guidance
- Related to DR-020: M005 False Positive Exemptions
- Related to GitHub #581: M005 false positive on assert

---
*Generated with [Claude Code](https://claude.ai/code)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling L039 undefined-variable findings, including trusted variable sources and genuinely unknown variables.
  * Updated L039 classification from inventory-scoped manual review to task-scoped AI-assisted remediation.
  * Updated remediation tier counts and rule catalog details.
  * Added decision records covering AI remediation guidance and false-positive exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->