### PR TITLE
fix(ui-workflow): hide AI scan options when showAiOptions is false (AAP-88779)

### DIFF
--- a/frontend/packages/ui-workflow/src/components/CheckOptionsForm.tsx
+++ b/frontend/packages/ui-workflow/src/components/CheckOptionsForm.tsx
@@ -24,6 +24,8 @@ export interface CheckOptionsFormProps {
    */
   autoApplyTier1?: boolean;
   onAutoApplyTier1Change?: (checked: boolean) => void;
+ /** Platform-level AI availability flag; hides AI controls when false and defaults to true for standalone SPA backward compatibility. */
+  showAiOptions?: boolean;
   idPrefix?: string;
 }
 
@@ -36,6 +38,7 @@ export function CheckOptionsForm({
   onEnableAiChange,
   autoApplyTier1 = false,
   onAutoApplyTier1Change,
+  showAiOptions = true,
   idPrefix = '',
 }: CheckOptionsFormProps) {
   const prefix = idPrefix ? `${idPrefix}-` : '';
@@ -90,15 +93,17 @@ export function CheckOptionsForm({
             onChange={(_e, v) => onCollectionsChange(v)}
           />
         </FlexItem>
-        <FlexItem>
-          <Checkbox
-            id={`${prefix}enable-ai`}
-            label="Enable AI-assisted remediation (Tier 2)"
-            isChecked={enableAi}
-            onChange={(_e, checked) => onEnableAiChange(checked)}
-          />
-        </FlexItem>
-        {onAutoApplyTier1Change && (
+        {showAiOptions && (
+          <FlexItem>
+            <Checkbox
+              id={`${prefix}enable-ai`}
+              label="Enable AI-assisted remediation (Tier 2)"
+              isChecked={enableAi}
+              onChange={(_e, checked) => onEnableAiChange(checked)}
+            />
+          </FlexItem>
+        )}
+        {showAiOptions && onAutoApplyTier1Change && (
           <FlexItem>
             <Checkbox
               id={`${prefix}auto-apply-tier1`}
@@ -109,7 +114,7 @@ export function CheckOptionsForm({
             />
           </FlexItem>
         )}
-        {enableAi && (
+        {showAiOptions && enableAi && (
           <FlexItem>
             <label htmlFor={`${prefix}ai-model`} style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>
               AI Model


### PR DESCRIPTION
## Summary

Fixes [AAP-88779](https://redhat.atlassian.net/browse/AAP-88779): Advanced Options on the Quality scan form always showed AI-related controls even when portal app-config had `ansible.apme.enableAi: false`.

Adds a `showAiOptions` prop to `CheckOptionsForm` so hosts can hide AI UI based on platform config, separate from the per-scan `enableAi` toggle.

## Changes

- Add optional `showAiOptions` prop to `CheckOptionsForm` (default `true` for standalone SPA backward compatibility)
- When `showAiOptions={false}`, hide:
  - "Enable AI-assisted remediation (Tier 2)" checkbox
  - "Auto-apply quick-fixes (skip review)" checkbox
  - AI model selector
- Ansible Core Version and Collections remain visible in Advanced Options

## Portal integration

Portal host (`ApmeEntityTab` in ansible-backstage-plugins) passes `showAiOptions={portalAiEnabled}` from `useApmeAiEnabled()`. This PR only adds the UI contract; portal wiring is in the companion PR.

## Test plan

- [ ] With `showAiOptions={false}`: expand Advanced Options → only Ansible Core Version and Collections
- [ ] With `showAiOptions={true}` (default): AI checkbox, auto-apply, and model selector behave as before
- [ ] Toggle AI checkbox when `showAiOptions={true}` → model selector appears/disappears
- [ ] Standalone SPA (`ProjectDetailPage`) unchanged — omits prop, defaults to `true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to show or hide AI-related workflow settings.
  * AI controls are displayed by default and can be hidden when needed.
  * The AI model selector appears only when AI functionality is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->