### PR TITLE
fix(ui-workflow): Simplify non-AI remediation stepper to Apply findings

### DIFF
--- a/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
@@ -581,7 +581,7 @@ export function AssessFindingsPanel({
           },
           {
             key: 'auto',
-            label: 'Quick-fix',
+            label: 'Rule-based fix',
             primary: inventory.autoFindings,
             secondary: inventory.autoNodes,
             tone: 'auto',
@@ -612,7 +612,7 @@ export function AssessFindingsPanel({
 
   const nextSummary =
     inventory.autoFindings > 0
-      ? `Move on to remediation — review quick-fix proposals for ${findingsPhrase(inventory.autoFindings)} (same session, no rescan).`
+      ? `Move on to remediation — review rule-based fix proposals for ${findingsPhrase(inventory.autoFindings)} (same session, no rescan).`
       : 'Move on to remediation — continue this session to review any available fixes (no rescan).';
 
   return (

--- a/frontend/packages/ui-workflow/src/components/OperationWorkflowStepper.tsx
+++ b/frontend/packages/ui-workflow/src/components/OperationWorkflowStepper.tsx
@@ -29,6 +29,7 @@ export interface OperationWorkflowStepperProps {
 
 const SPINNING_STEPS = new Set<WorkflowStepId>([
   'scan',
+  'apply_findings',
   'tier1_applied',
   'ai_escalation',
   'ai_applied',

--- a/frontend/packages/ui-workflow/src/components/ProposalReviewPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/ProposalReviewPanel.tsx
@@ -441,8 +441,8 @@ export function ProposalReviewPanel({
     } else {
       summary =
         acceptedIds.length > 0
-          ? `Apply ${acceptedIds.length} accepted quick-fix${acceptedIds.length !== 1 ? 'es' : ''}${declinedNote}, then continue to AI assessment if enabled.`
-          : 'Continue with no quick-fixes applied, then AI assessment if enabled (or finish if AI is off).';
+          ? `Apply ${acceptedIds.length} accepted rule-based fix${acceptedIds.length !== 1 ? 'es' : ''}${declinedNote}, then continue to AI assessment if enabled.`
+          : 'Continue with no rule-based fixes applied, then AI assessment if enabled (or finish if AI is off).';
     }
     return {
       label: 'Next',
@@ -481,7 +481,7 @@ export function ProposalReviewPanel({
                 isCompact
                 color={fixTypeLabelColor(isAiGate ? 'ai' : 'auto')}
               >
-                {isAiGate ? 'AI' : 'Quick-fix'}
+                {isAiGate ? 'AI' : 'Rule-based fix'}
               </Label>
               <Label
                 isCompact
@@ -519,7 +519,7 @@ export function ProposalReviewPanel({
                             {severityDisplayLabel(sev, ruleId)}
                           </Label>
                         )}
-                        {!isAiGate && <Label isCompact>Quick-fix</Label>}
+                        {!isAiGate && <Label isCompact>Rule-based fix</Label>}
                         <span className="apme-assess-finding-msg">{message}</span>
                       </div>
                     );
@@ -799,7 +799,7 @@ export function ProposalReviewPanel({
           ? undefined
           : {
               items: filteredActionableItems,
-              ariaLabel: isAiGate ? 'AI proposals' : 'Quick-fix proposals',
+              ariaLabel: isAiGate ? 'AI proposals' : 'Rule-based fix proposals',
               decisionMode: true,
               decisions,
               onDecisionChange: handleDecisionChange,

--- a/frontend/packages/ui-workflow/src/components/Tier1ResultsPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/Tier1ResultsPanel.tsx
@@ -26,11 +26,11 @@ export function Tier1ResultsPanel({ tier1 }: Tier1ResultsPanelProps) {
       <CardBody>
         <Split hasGutter>
           <SplitItem>
-            <Label color="green" isCompact>Auto-Fix</Label>
+            <Label color="green" isCompact>Rule-based fix</Label>
           </SplitItem>
           <SplitItem isFilled>
             <h3>
-              Quick-fix — {patchCount} fix{patchCount !== 1 ? 'es' : ''} applied
+              Rule-based fix — {patchCount} fix{patchCount !== 1 ? 'es' : ''} applied
               {formatCount > 0 && `, ${formatCount} formatted`}
             </h3>
           </SplitItem>

--- a/frontend/packages/ui-workflow/src/remediation/fixTypes.ts
+++ b/frontend/packages/ui-workflow/src/remediation/fixTypes.ts
@@ -55,7 +55,7 @@ export function effectiveFixType(
 
 export function fixMethodLabel(fixType: FixType | undefined): string {
   if (fixType === 'auto') {
-    return 'Quick-fix';
+    return 'Rule-based fix';
   }
   if (fixType === 'ai') {
     return 'AI eligible';

--- a/frontend/packages/ui-workflow/src/remediation/workflowSteps.ts
+++ b/frontend/packages/ui-workflow/src/remediation/workflowSteps.ts
@@ -1,9 +1,12 @@
 /**
  * Derive Scan → Remediate workflow stepper position (ADR-064 + ADR-062 Option C).
  *
- * Steps (AI pair omitted when AI is off):
- *   Scan → Review findings → Quick-fix proposals → Quick-fix applied
- *     → AI escalation → AI proposals → AI applied → Commit → Complete
+ * Non-AI (EAP) path — simplified per AAP-88780:
+ *   Scan → Review findings → Apply findings → Create branch → Commit
+ *
+ * AI path (unchanged):
+ *   Scan → Review findings → Rule-based fix proposals → Rule-based fix applied
+ *     → AI escalation → AI proposals → AI applied → Create branch → Commit
  */
 
 import type { ProjectOperationState } from '../hooks/useProjectOperationState';
@@ -12,6 +15,7 @@ import { isAiRemediationProposal } from './proposalTier';
 export type WorkflowStepId =
   | 'scan'
   | 'findings'
+  | 'apply_findings'
   | 'tier1_proposals'
   | 'tier1_applied'
   | 'ai_escalation'
@@ -50,17 +54,22 @@ export function workflowStepDefs(includeAi: boolean): WorkflowStepDef[] {
   const steps: WorkflowStepDef[] = [
     { id: 'scan', label: 'Scan' },
     { id: 'findings', label: 'Review findings' },
-    { id: 'tier1_proposals', label: 'Quick-fix proposals' },
-    { id: 'tier1_applied', label: 'Quick-fix applied' },
   ];
   if (includeAi) {
     steps.push(
+      { id: 'tier1_proposals', label: 'Rule-based fix proposals' },
+      { id: 'tier1_applied', label: 'Rule-based fix applied' },
       { id: 'ai_escalation', label: 'AI escalation' },
       { id: 'ai_proposals', label: 'AI proposals' },
       { id: 'ai_applied', label: 'AI applied' },
     );
+  } else {
+    steps.push({ id: 'apply_findings', label: 'Apply findings' });
   }
-  steps.push({ id: 'commit', label: 'Commit' }, { id: 'complete', label: 'Complete' });
+  steps.push(
+    { id: 'commit', label: 'Create branch' },
+    { id: 'complete', label: 'Commit' },
+  );
   return steps;
 }
 
@@ -171,8 +180,8 @@ function stepFromLatch(latch: WorkflowLatch, includeAi: boolean): WorkflowStepId
   if (includeAi && latch.pastAiApplied) return 'ai_applied';
   if (includeAi && latch.pastAiReview) return 'ai_proposals';
   if (includeAi && latch.pastAiEscalation) return 'ai_escalation';
-  if (latch.pastTier1Applied) return 'tier1_applied';
-  if (latch.pastTier1Review) return 'tier1_proposals';
+  if (latch.pastTier1Applied) return includeAi ? 'tier1_applied' : 'apply_findings';
+  if (latch.pastTier1Review) return includeAi ? 'tier1_proposals' : 'apply_findings';
   if (latch.pastFindings) return 'findings';
   return 'scan';
 }
@@ -223,17 +232,18 @@ export function resolveCurrentWorkflowStep(
   }
 
   if (status === 'awaiting_approval') {
-    return isAiGate(state) ? 'ai_proposals' : 'tier1_proposals';
+    if (isAiGate(state)) return 'ai_proposals';
+    return includeAi ? 'tier1_proposals' : 'apply_findings';
   }
 
   if (status === 'applying') {
     if (latch.pastAiReview) {
-      return includeAi ? 'ai_applied' : 'tier1_applied';
+      return includeAi ? 'ai_applied' : 'apply_findings';
     }
     if (includeAi && latch.pastAiEscalation) {
       return 'ai_escalation';
     }
-    return 'tier1_applied';
+    return includeAi ? 'tier1_applied' : 'apply_findings';
   }
 
   // queued | cloning | scanning
@@ -242,12 +252,12 @@ export function resolveCurrentWorkflowStep(
       return 'ai_escalation';
     }
     if (latch.pastTier1Applied) {
-      return 'tier1_applied';
+      return includeAi ? 'tier1_applied' : 'apply_findings';
     }
     if (latch.pastTier1Review) {
-      return 'tier1_applied';
+      return includeAi ? 'tier1_applied' : 'apply_findings';
     }
-    return 'tier1_proposals';
+    return includeAi ? 'tier1_proposals' : 'apply_findings';
   }
 
   return 'scan';

--- a/frontend/src/test/workflowSteps.test.ts
+++ b/frontend/src/test/workflowSteps.test.ts
@@ -26,19 +26,23 @@ function baseState(
 }
 
 describe('workflowStepDefs', () => {
-  it('omits AI steps when AI is off but always includes Commit', () => {
-    expect(workflowStepDefs(false).map((s) => s.id)).toEqual([
+  it('uses simplified Apply findings step when AI is off (AAP-88780)', () => {
+    const defs = workflowStepDefs(false);
+    expect(defs.map((s) => s.id)).toEqual([
       'scan',
       'findings',
-      'tier1_proposals',
-      'tier1_applied',
+      'apply_findings',
       'commit',
       'complete',
     ]);
+    expect(defs.find((s) => s.id === 'apply_findings')?.label).toBe('Apply findings');
+    expect(defs.find((s) => s.id === 'commit')?.label).toBe('Create branch');
+    expect(defs.find((s) => s.id === 'complete')?.label).toBe('Commit');
   });
 
-  it('includes AI steps when AI is on', () => {
-    expect(workflowStepDefs(true).map((s) => s.id)).toEqual([
+  it('includes AI steps with separate tier1 when AI is on', () => {
+    const defs = workflowStepDefs(true);
+    expect(defs.map((s) => s.id)).toEqual([
       'scan',
       'findings',
       'tier1_proposals',
@@ -49,9 +53,14 @@ describe('workflowStepDefs', () => {
       'commit',
       'complete',
     ]);
-    expect(workflowStepDefs(true).find((s) => s.id === 'ai_escalation')?.label).toBe(
+    expect(defs.find((s) => s.id === 'ai_escalation')?.label).toBe(
       'AI escalation',
     );
+    expect(defs.find((s) => s.id === 'tier1_proposals')?.label).toBe(
+      'Rule-based fix proposals',
+    );
+    expect(defs.find((s) => s.id === 'commit')?.label).toBe('Create branch');
+    expect(defs.find((s) => s.id === 'complete')?.label).toBe('Commit');
   });
 });
 
@@ -76,7 +85,7 @@ describe('resolveCurrentWorkflowStep', () => {
     ).toBe('findings');
   });
 
-  it('uses Quick-fix proposals for Gate 1 awaiting_approval', () => {
+  it('uses apply_findings for Gate 1 awaiting_approval when AI is off (AAP-88780)', () => {
     const state = baseState({
       status: 'awaiting_approval',
       proposals: [
@@ -92,6 +101,26 @@ describe('resolveCurrentWorkflowStep', () => {
     });
     const latch = updateWorkflowLatch(emptyWorkflowLatch(), state, false);
     expect(resolveCurrentWorkflowStep(state, false, latch)).toBe(
+      'apply_findings',
+    );
+  });
+
+  it('uses tier1_proposals for Gate 1 awaiting_approval when AI is on', () => {
+    const state = baseState({
+      status: 'awaiting_approval',
+      proposals: [
+        {
+          id: 't1-1',
+          rule_id: 'M001',
+          file: 'a.yml',
+          tier: 1,
+          confidence: 1,
+          source: 'deterministic',
+        },
+      ],
+    });
+    const latch = updateWorkflowLatch(emptyWorkflowLatch(), state, true);
+    expect(resolveCurrentWorkflowStep(state, true, latch)).toBe(
       'tier1_proposals',
     );
   });
@@ -305,7 +334,7 @@ describe('shouldIncludeAiSteps', () => {
 });
 
 describe('stepVisualState', () => {
-  it('marks prior steps success and current info', () => {
+  it('marks prior steps success and current info (non-AI)', () => {
     const defs = workflowStepDefs(false);
     expect(stepVisualState('scan', 'findings', defs, 'assessed')).toEqual({
       variant: 'success',
@@ -314,6 +343,17 @@ describe('stepVisualState', () => {
     expect(stepVisualState('findings', 'findings', defs, 'assessed')).toEqual({
       variant: 'info',
       isCurrent: true,
+    });
+    expect(
+      stepVisualState('apply_findings', 'findings', defs, 'assessed'),
+    ).toEqual({ variant: 'pending', isCurrent: false });
+  });
+
+  it('marks prior steps success and current info (AI)', () => {
+    const defs = workflowStepDefs(true);
+    expect(stepVisualState('scan', 'findings', defs, 'assessed')).toEqual({
+      variant: 'success',
+      isCurrent: false,
     });
     expect(
       stepVisualState('tier1_proposals', 'findings', defs, 'assessed'),


### PR DESCRIPTION
## Summary

- Simplify the non-AI (EAP) remediation stepper from `Scan → Review findings → Quick-fix proposals → Quick-fix applied → Commit → Complete` to `Scan → Review findings → Apply findings → Create branch → Commit`.
- Merge the redundant Tier 1 stepper steps into a single `apply_findings` step when AI is disabled, while keeping the existing AI workflow unchanged.
- Rename "Quick-fix" UI terminology to "Rule-based fix" across findings, proposal review, and results panels.

Fixes [AAP-88780](https://redhat.atlassian.net/browse/AAP-88780).

## What changed

- `workflowSteps.ts`: add `apply_findings` for the non-AI path; map `awaiting_approval` and `applying` to that step; rename terminal step labels to `Create branch` and `Commit`.
- `fixTypes.ts`, `AssessFindingsPanel.tsx`, `ProposalReviewPanel.tsx`, `Tier1ResultsPanel.tsx`: update labels and summary text from "Quick-fix" to "Rule-based fix".
- `OperationWorkflowStepper.tsx`: show spinner on `apply_findings` during `applying`.
- `workflowSteps.test.ts`: update non-AI stepper expectations and add AI-path coverage.

## Why

For the non-AI Early Access path, the separate Quick-fix proposals / Quick-fix applied steps duplicated work that should happen in one Apply findings step. This reduces extra navigation before branch creation and aligns step labels with EAP terminology.

## Scope

- Repo: `apme` only
- Package: `@apme/ui-workflow`
- No backend or `ansible-backstage-plugins` code changes required; the portal consumes the shared workflow package.

## Test plan

- [ ] Deploy with `ansible.apme.enableAi: false`
- [ ] Run a scan with findings and verify the stepper shows: `Scan → Review findings → Apply findings → Create branch → Commit`
- [ ] Advance through remediation and confirm `Apply findings` stays active during both proposal review (`awaiting_approval`) and apply progress (`applying`)
- [ ] Verify UI labels show `Rule-based fix` instead of `Quick-fix` in findings inventory, proposal review, and results
- [ ] Deploy with `ansible.apme.enableAi: true` and confirm the AI workflow still shows separate Tier 1 + AI steps
- [ ] Run `workflowSteps.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Apply findings” step to non-AI remediation workflows.
  * Updated workflow progress indicators to show the findings application step.

* **Improvements**
  * Renamed “Quick-fix” and “Auto-Fix” labels to “Rule-based fix” throughout remediation screens.
  * Clarified non-AI workflow labels for creating a branch and committing changes.

* **Tests**
  * Updated workflow coverage for AI and non-AI remediation paths and visual states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->