### PR TITLE
fix(ui-workflow): rename Quick-fix labels to rule-based fix terminology

### DIFF
--- a/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
@@ -588,14 +588,14 @@ export function AssessFindingsPanel({
           },
           {
             key: 'ai',
-            label: 'AI eligible',
+            label: 'AI fix',
             primary: inventory.aiFindings,
             secondary: inventory.aiNodes,
             tone: 'ai',
           },
           {
             key: 'manual',
-            label: 'Manual',
+            label: 'Manual review',
             primary: inventory.manualFindings,
             secondary: inventory.manualNodes,
             tone: 'manual',

--- a/frontend/packages/ui-workflow/src/components/CheckOptionsForm.tsx
+++ b/frontend/packages/ui-workflow/src/components/CheckOptionsForm.tsx
@@ -19,8 +19,8 @@ export interface CheckOptionsFormProps {
   enableAi: boolean;
   onEnableAiChange: (checked: boolean) => void;
   /**
-   * When true, remediate uses interactive=false (legacy auto-apply quick-fixes).
-   * Default unchecked → interactive Quick-fix review (ADR-062 Option C).
+   * When true, remediate uses interactive=false (legacy auto-apply rule-based fixes).
+   * Default unchecked → interactive rule-based fix review (ADR-062 Option C).
    */
   autoApplyTier1?: boolean;
   onAutoApplyTier1Change?: (checked: boolean) => void;
@@ -97,7 +97,7 @@ export function CheckOptionsForm({
           <FlexItem>
             <Checkbox
               id={`${prefix}enable-ai`}
-              label="Enable AI-assisted remediation (Tier 2)"
+              label="Enable AI fix"
               isChecked={enableAi}
               onChange={(_e, checked) => onEnableAiChange(checked)}
             />
@@ -107,8 +107,8 @@ export function CheckOptionsForm({
           <FlexItem>
             <Checkbox
               id={`${prefix}auto-apply-tier1`}
-              label="Auto-apply quick-fixes (skip review)"
-              description="Applies after you leave Assessment (Remediate). Scan always pauses on findings first. When unchecked (default), Quick-fix proposals pause for per-location Accept / Decline."
+              label="Auto-apply rule-based fixes (skip review)"
+              description="Applies after you leave Assessment (Remediate). Scan always pauses on findings first. When unchecked (default), rule-based fix proposals pause for per-location Accept / Decline."
               isChecked={autoApplyTier1}
               onChange={(_e, checked) => onAutoApplyTier1Change(checked)}
             />

--- a/frontend/packages/ui-workflow/src/components/NodeReviewList.tsx
+++ b/frontend/packages/ui-workflow/src/components/NodeReviewList.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { Button, Flex, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 
-/** Per-node gate decision. ``ignored`` reserved for Quick-fix noqa. */
+/** Per-node gate decision. ``ignored`` reserved for rule-based fix noqa. */
 export type NodeDecision = 'accepted' | 'declined' | 'pending' | 'ignored';
 
 export interface NodeReviewItem {
@@ -34,7 +34,7 @@ export interface NodeReviewListProps {
    * Ignore can be enabled later via ``allowIgnore``.
    */
   decisionMode?: boolean;
-  /** Show Ignore option (Quick-fix noqa) — off until wired. */
+  /** Show Ignore option (rule-based fix noqa) — off until wired. */
   allowIgnore?: boolean;
   decisions?: Map<string, NodeDecision>;
   onDecisionChange?: (id: string, decision: NodeDecision) => void;

--- a/frontend/packages/ui-workflow/src/components/OperationResultCard.tsx
+++ b/frontend/packages/ui-workflow/src/components/OperationResultCard.tsx
@@ -75,7 +75,7 @@ export function OperationResultCard({
           {wasRemediate && (
             <Metric value={result.remediated_count ?? 0} label="Remediated" color="var(--pf-t--global--color--status--success--default)" />
           )}
-          <Metric value={result.manual_review} label="Manual" color="#9e8700" />
+          <Metric value={result.manual_review} label="Manual review" color="#9e8700" />
         </Split>
 
         {hasAi && (

--- a/frontend/packages/ui-workflow/src/components/ProposalReviewPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/ProposalReviewPanel.tsx
@@ -481,7 +481,7 @@ export function ProposalReviewPanel({
                 isCompact
                 color={fixTypeLabelColor(isAiGate ? 'ai' : 'auto')}
               >
-                {isAiGate ? 'AI' : 'Rule-based fix'}
+                {isAiGate ? 'AI fix' : 'Rule-based fix'}
               </Label>
               <Label
                 isCompact

--- a/frontend/packages/ui-workflow/src/hooks/useProjectOperationActions.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useProjectOperationActions.ts
@@ -101,7 +101,7 @@ export interface StartOperationOptions {
   collection_specs?: string[];
   enable_ai?: boolean;
   ai_model?: string;
-  /** ADR-062 Option C: when true, pause for Quick-fix review. */
+  /** ADR-062 Option C: when true, pause for rule-based fix review. */
   interactive?: boolean;
   /** ADR-064: pause after findings before Gate 1 (Scan → Remediate). */
   assess_pause?: boolean;

--- a/frontend/packages/ui-workflow/src/remediation/fixTypes.ts
+++ b/frontend/packages/ui-workflow/src/remediation/fixTypes.ts
@@ -58,9 +58,9 @@ export function fixMethodLabel(fixType: FixType | undefined): string {
     return 'Rule-based fix';
   }
   if (fixType === 'ai') {
-    return 'AI eligible';
+    return 'AI fix';
   }
-  return 'Manual';
+  return 'Manual review';
 }
 
 /** PatternFly Label ``color`` for a fix-type filter/row pill. */

--- a/frontend/packages/ui-workflow/src/remediation/proposalTier.ts
+++ b/frontend/packages/ui-workflow/src/remediation/proposalTier.ts
@@ -29,7 +29,7 @@ export function proposalNodeTitle(proposal: OperationProposal): string {
   return file;
 }
 
-/** True when the proposal is Gate 2 AI (not Quick-fix / deterministic). */
+/** True when the proposal is Gate 2 AI (not rule-based fix / deterministic). */
 export function isAiRemediationProposal(proposal: OperationProposal): boolean {
   if (proposal.source === 'ai' || proposal.source === 'ai-candidate') {
     return true;
@@ -75,7 +75,7 @@ export function gateLabel(proposals: OperationProposal[]): string {
   }
   return isAiRemediationProposal(proposals[0]!)
     ? 'AI proposals'
-    : 'Quick-fix proposals';
+    : 'Rule-based fix proposals';
 }
 
 /**

--- a/frontend/packages/ui-workflow/src/shared/severity.ts
+++ b/frontend/packages/ui-workflow/src/shared/severity.ts
@@ -155,7 +155,7 @@ export function scopeLabel(scope: number | undefined): string {
 export const FIX_AI_TRIED = 4;
 
 export const FIX_LABELS: Record<number, string> = {
-  1: 'Fixable', 2: 'AI', 3: 'Manual', [FIX_AI_TRIED]: 'AI Tried',
+  1: 'Rule-based fix', 2: 'AI fix', 3: 'Manual review', [FIX_AI_TRIED]: 'AI Tried',
 };
 
 export const FIX_ORDER = [1, 2, 3, FIX_AI_TRIED] as const;

--- a/frontend/src/components/ViolationDetailModal.tsx
+++ b/frontend/src/components/ViolationDetailModal.tsx
@@ -56,9 +56,9 @@ import { RESOLUTION_AI_ABSTAINED } from '../types/constants';
 
 function tierLabel(rc: number, isRemediate: boolean, resolution?: number): string {
   if (resolution === RESOLUTION_AI_ABSTAINED) return 'AI Tried';
-  if (rc === 1) return isRemediate ? 'Fixed' : 'Fixable';
-  if (rc === 2) return 'AI';
-  if (rc === 3) return 'Manual';
+  if (rc === 1) return isRemediate ? 'Fixed' : 'Rule-based fix';
+  if (rc === 2) return 'AI fix';
+  if (rc === 3) return 'Manual review';
   return 'Unknown';
 }
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -380,7 +380,7 @@ export function SettingsPage() {
         </FormGroup>
 
         <p style={{ marginTop: 24, opacity: 0.6, fontSize: 13, marginBottom: 32 }}>
-          The selected model is used for AI-assisted remediation (Tier 2) when
+          The selected model is used for AI fix (Tier 2) when
           starting a new scan with AI enabled. This preference is stored in your
           browser.
         </p>

--- a/frontend/src/test/proposalTier.test.ts
+++ b/frontend/src/test/proposalTier.test.ts
@@ -94,7 +94,7 @@ describe("proposalsGateKey / gateLabel", () => {
     const ai = [prop({ id: "ai-0001", source: "ai", tier: 2 })];
     expect(proposalsGateKey(t1)).toBe("t1:t1-0001");
     expect(proposalsGateKey(ai)).toBe("ai:ai-0001");
-    expect(gateLabel(t1)).toContain("Quick-fix");
+    expect(gateLabel(t1)).toContain("Rule-based fix");
     expect(gateLabel(ai)).toContain("AI");
   });
 });
@@ -116,6 +116,6 @@ describe("fixTypes", () => {
   it("maps effective fix type with AI toggle", () => {
     expect(effectiveFixType(2, true)).toBe("ai");
     expect(effectiveFixType(2, false)).toBe("manual");
-    expect(fixMethodLabel("auto")).toBe("Quick-fix");
+    expect(fixMethodLabel("auto")).toBe("Rule-based fix");
   });
 });

--- a/tests/test_ui_playwright.py
+++ b/tests/test_ui_playwright.py
@@ -360,7 +360,7 @@ def test_playground_auto_apply_tier1_toggle(dashboard: Page) -> None:
     advanced = dashboard.locator("button:has-text('Advanced Options')")
     expect(advanced).to_be_visible()
     advanced.click()
-    toggle = dashboard.locator("label:has-text('Auto-apply quick-fixes')")
+    toggle = dashboard.locator("label:has-text('Auto-apply rule-based fixes')")
     expect(toggle).to_be_visible()
     checkbox = dashboard.locator("#auto-apply-tier1")
     expect(checkbox).to_be_visible()

--- a/tests/test_ui_playwright.py
+++ b/tests/test_ui_playwright.py
@@ -350,7 +350,7 @@ def test_settings_info_text(settings_page: Page) -> None:
 
 
 def test_playground_auto_apply_tier1_toggle(dashboard: Page) -> None:
-    """Playground advanced options expose Auto-apply Tier 1 (interactive default).
+    """Playground advanced options expose auto-apply rule-based fixes (interactive default).
 
     Args:
         dashboard: Page positioned on the dashboard.


### PR DESCRIPTION
## Summary
- Rename user-facing remediation labels from "Quick-fix" / "AI eligible" / "Manual" to "Rule-based fix" / "AI fix" / "Manual review" across the Scan → Remediate workflow UI
- Align adjacent surfaces (ViolationDetailModal, OperationResultCard, SettingsPage, FIX_LABELS) so terminology stays consistent end-to-end

## Changes
- Update labels in AssessFindingsPanel, CheckOptionsForm, ProposalReviewPanel, Tier1ResultsPanel, workflow stepper, and fix-type helpers
- Update Vitest and Playwright tests for new copy
- Refresh ViolationDetailModal tier badges, OperationResultCard metric label, and Settings AI model description

## Follow-up (not in this PR)
- Activity/Project/Session table column headers still say "Fixable" (analytics vocabulary)
- Dashboard "Current Fixable" metric unchanged
- ADR-064/065 and engine comments still reference "Quick-fix" (historical/internal)

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes
- [ ] Manual: verify workflow stepper, assessment inventory, and proposal review panels show new labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated remediation terminology across findings, workflow, settings, and review screens.
  * Replaced “Quick-fix” with “Rule-based fix,” and clarified “AI fix” and “Manual review” labels.
  * Updated related descriptions, accessibility text, and workflow messaging for consistency.

* **Tests**
  * Updated test labels and descriptions to reflect the revised remediation terminology.

Fix: https://redhat.atlassian.net/browse/AAP-88781
<!-- end of auto-generated comment: release notes by coderabbit.ai -->