### PR TITLE
fix(ui): restore ui-workflow release tarball pack under TypeScript 7

### DIFF
--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -51,6 +51,7 @@ environment that developers run locally.
 | `tox -e integration` | Integration tests (requires OPA binary) | `test.yml` |
 | `tox -e ai` | AI extra tests (abbenay) | `test.yml` |
 | `tox -e ui` | Playwright UI tests | `test.yml` |
+| `tox -e ui-workflow-pack` | Pack `@apme/ui-workflow` release tarball | `test.yml` |
 | `tox -e grpc` | Regenerate gRPC stubs | manual |
 | `tox -e helm` | Lint + package Helm chart | `helm-charts.yml` |
 | `tox -e build` | Build container images | `container-images.yml` (GHCR) |
@@ -66,9 +67,10 @@ CI has six workflows in `.github/workflows/`:
 
 - **prek.yml**: Runs `prek` (ruff lint, ruff format, mypy strict, pydoclint,
   uv-lock). Quality gate for code style and type safety.
-- **test.yml**: Runs `tox -e unit`, `tox -e integration`, `tox -e ui`, and
-  `tox -e ai` as separate jobs. Quality gate for correctness. Coverage threshold
-  is enforced via `--cov-fail-under` in `tox.ini`.
+- **test.yml**: Runs `tox -e unit`, `tox -e integration`, `tox -e ui`,
+  `tox -e ai`, and `tox -e ui-workflow-pack` as separate jobs. Quality gate
+  for correctness. Coverage threshold is enforced via `--cov-fail-under` in
+  `tox.ini`.
 - **container-images.yml**: Builds and pushes multi-arch container images
   (`linux/amd64` + `linux/arm64`, ADR-063) to GHCR on `main`, version tags, and
   `workflow_dispatch`, then merges manifests via

--- a/.agents/skills/tox/SKILL.md
+++ b/.agents/skills/tox/SKILL.md
@@ -32,7 +32,7 @@ directly. Every task maps to a `tox -e <env>` command.
 ## Hard Rules
 
 1. **Never run `pytest` directly.** Use `tox -e unit`, `tox -e integration`,
-   `tox -e ai`, `tox -e ui`, or `tox -e ui-workflow-pack`.
+   `tox -e ai`, or `tox -e ui`.
 2. **Never run `ruff`, `mypy`, or `prek` directly.** Use `tox -e lint`.
 3. **Never run `./scripts/gen_grpc.sh` directly.** Use `tox -e grpc`.
 4. **Never run `./containers/podman/*.sh` directly.** Use `tox -e build`,
@@ -98,7 +98,8 @@ directly. Every task maps to a `tox -e <env>` command.
 ### Default set
 
 Running `tox` with no `-e` flag executes: `lint`, `unit`, `integration`, `ai`,
-`ui`. This is the full quality gate.
+`ui`. CI also runs `ui-workflow-pack` (needs Node/npm); run it locally after
+`frontend/packages/ui-workflow` changes.
 
 ## Common Agent Workflows
 
@@ -107,6 +108,12 @@ Running `tox` with no `-e` flag executes: `lint`, `unit`, `integration`, `ai`,
 ```bash
 tox -e lint              # check style + types
 tox -e unit              # run tests
+```
+
+### "I changed frontend/packages/ui-workflow or TypeScript in that package"
+
+```bash
+tox -e ui-workflow-pack   # npm pack (prepack tsc + CSS copy); do not run npm pack directly
 ```
 
 ### "I changed a proto file"

--- a/.agents/skills/tox/SKILL.md
+++ b/.agents/skills/tox/SKILL.md
@@ -32,7 +32,7 @@ directly. Every task maps to a `tox -e <env>` command.
 ## Hard Rules
 
 1. **Never run `pytest` directly.** Use `tox -e unit`, `tox -e integration`,
-   `tox -e ai`, or `tox -e ui`.
+   `tox -e ai`, `tox -e ui`, or `tox -e ui-workflow-pack`.
 2. **Never run `ruff`, `mypy`, or `prek` directly.** Use `tox -e lint`.
 3. **Never run `./scripts/gen_grpc.sh` directly.** Use `tox -e grpc`.
 4. **Never run `./containers/podman/*.sh` directly.** Use `tox -e build`,
@@ -58,6 +58,7 @@ directly. Every task maps to a `tox -e <env>` command.
 | `tox -e integration` | `pytest tests/integration/` (needs OPA binary) | After engine or validator changes. |
 | `tox -e ai` | `pytest` with AI extras (abbenay) | After AI/remediation changes. |
 | `tox -e ui` | `pytest -m ui` (Playwright, needs running pod) | After Gateway or UI changes. |
+| `tox -e ui-workflow-pack` | `npm pack` for `@apme/ui-workflow` (release tarball) | After `frontend/packages/ui-workflow` or TypeScript changes. |
 
 ### Code generation
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,3 +98,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - run: uvx --with tox-uv tox -e ai
+
+  ui-workflow-pack:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: uvx --with tox-uv tox -e ui-workflow-pack

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -52,6 +52,7 @@ tox is the single entry point for all developer tasks. Every CI check has a corr
 | `tox -e integration` | `pytest tests/integration/` (requires OPA binary) | Test |
 | `tox -e ai` | `pytest` with AI extras (abbenay) | Test |
 | `tox -e ui` | `pytest -m ui` (Playwright, requires running gateway + UI) | Test |
+| `tox -e ui-workflow-pack` | `npm pack` for `@apme/ui-workflow` (release tarball) | Test |
 | `tox -e openapi` | Export/check `docs/api/openapi.v1.json` | Code generation |
 | `tox -e grpc` | `scripts/gen_grpc.sh` | Code generation |
 | `tox -e helm` | `scripts/helm_chart.sh` (`helm lint` + `helm package`) | Helm chart |

--- a/frontend/packages/ui-workflow/src/css.d.ts
+++ b/frontend/packages/ui-workflow/src/css.d.ts
@@ -1,0 +1,5 @@
+/**
+ * Pack-time `tsc -p tsconfig.build.json` does not see frontend/src/globals.d.ts.
+ * TypeScript 7 reports TS2882 on the side-effect CSS import in index.ts without this.
+ */
+declare module '*.css';

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,15 @@ pass_env =
     APME_TEST_DATABASE_URL
     APME_GATEWAY_*
 
+[testenv:ui-workflow-pack]
+description = Pack @apme/ui-workflow (release tarball; catches tsc CSS import errors)
+skip_install = true
+allowlist_externals = npm
+changedir = frontend
+commands =
+    npm ci
+    npm pack ./packages/ui-workflow --pack-destination {env_tmp_dir}
+
 # ── Code generation ──────────────────────────────────────────────────
 
 [testenv:openapi]

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ changedir = frontend
 commands =
     npm ci
     npm pack ./packages/ui-workflow --pack-destination {env_tmp_dir}
-    python -c "import tarfile, pathlib, sys; d=pathlib.Path('{env_tmp_dir}'); tgz=next(d.glob('apme-ui-workflow-*.tgz')); names=tarfile.open(tgz).getnames(); need=('package/dist/index.js','package/dist/styles/workflow.css'); missing=[n for n in need if n not in names]; sys.exit(f'missing in tarball: {missing}') if missing else None"
+    python -c "import tarfile, pathlib, sys; d=pathlib.Path(sys.argv[1]); tgz=next(d.glob('apme-ui-workflow-*.tgz')); names=set(tarfile.open(tgz).getnames()); need={'package/dist/index.js','package/dist/styles/workflow.css'}; missing=sorted(need - names); sys.exit(('missing in tarball: %s' % missing) if missing else 0)" {env_tmp_dir}
 
 # ── Code generation ──────────────────────────────────────────────────
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ changedir = frontend
 commands =
     npm ci
     npm pack ./packages/ui-workflow --pack-destination {env_tmp_dir}
+    python -c "import tarfile, pathlib, sys; d=pathlib.Path('{env_tmp_dir}'); tgz=next(d.glob('apme-ui-workflow-*.tgz')); names=tarfile.open(tgz).getnames(); need=('package/dist/index.js','package/dist/styles/workflow.css'); missing=[n for n in need if n not in names]; sys.exit(f'missing in tarball: {missing}') if missing else None"
 
 # ── Code generation ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `v2026.8.7` published without `apme-ui-workflow-*.tgz` because `npm pack` failed with TS2882 on the side-effect CSS import
- TypeScript 7 no longer accepts that import unless the *package* `tsconfig.build.json` sees an ambient `*.css` module (the SPA `globals.d.ts` is out of that compilation)
- Add the shim and a `tox -e ui-workflow-pack` CI job so the next CalVer release attaches the artifact

## Changes
- `frontend/packages/ui-workflow/src/css.d.ts` — ambient `declare module '*.css'`
- `tox -e ui-workflow-pack` — `npm pack` plus a check that the tarball contains `dist/index.js` and `dist/styles/workflow.css` (pack dir passed as argv so tox does not expand Python braces)
- `test.yml` job calling that tox env
- tox / lean-ci skill and DEVELOPMENT.md env tables

## Quality of life
- Documented `tox -e ui-workflow-pack` so agents do not run `npm pack` directly (ADR-047)

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (3215 passed, 48 skipped)
- [x] `tox -e ui-workflow-pack` passes (tsc + tarball content assert)
- [ ] Next CalVer release attaches `apme-ui-workflow-X.Y.Z.tgz`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Added automated packaging checks for the UI workflow package.
  - Validation confirms release archives include the required JavaScript and CSS distribution files.
  - Improved support for CSS imports during TypeScript package builds.
  - Added a dedicated continuous integration check for package creation and archive contents.

- **Documentation**
  - Added development guidance for creating and validating the UI workflow package archive.
  - Documented the additional package check as part of the continuous integration test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->