### PR TITLE
fix(ui): restore ui-workflow pack shim deleted by R402

### DIFF
--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -28,12 +28,17 @@ locally-runnable tox environments; CI just calls them.
    CI runs `uvx --with tox-uv tox -e <env>`.
 
 3. **No scattered version pinning.** Python version is in `pyproject.toml`
-   (`requires-python`). Tool versions are managed in `.pre-commit-config.yaml`
+   (`requires-python`). Node is in `frontend/package.json` (`engines.node`).
+   Tool versions are managed in `.pre-commit-config.yaml`
    (ruff, mypy) and `pyproject.toml` (deps). Not in workflow YAML.
+   Jobs that need Node use `actions/setup-node` with
+   `node-version-file: frontend/package.json`.
 
 4. **Minimal setup actions.** `astral-sh/setup-uv` and `actions/checkout` only.
    No `actions/setup-python` (uv handles it). No other setup actions without
    explicit justification.
+   **Exception:** `test.yml` jobs `ui` and `ui-workflow-pack` use
+   `actions/setup-node` because `tox -e ui` / `ui-workflow-pack` need `npm`.
 
 5. **Pin actions to commit SHAs.** Mutable tags (`@v4`) allow upstream changes
    to affect CI without review. Always pin to a full commit SHA with a comment

--- a/.agents/skills/lean-ci/SKILL.md
+++ b/.agents/skills/lean-ci/SKILL.md
@@ -51,6 +51,7 @@ environment that developers run locally.
 | `tox -e integration` | Integration tests (requires OPA binary) | `test.yml` |
 | `tox -e ai` | AI extra tests (abbenay) | `test.yml` |
 | `tox -e ui` | Playwright UI tests | `test.yml` |
+| `tox -e ui-workflow-pack` | Pack `@apme/ui-workflow` release tarball | `test.yml` |
 | `tox -e grpc` | Regenerate gRPC stubs | manual |
 | `tox -e helm` | Lint + package Helm chart | `helm-charts.yml` |
 | `tox -e build` | Build container images | `container-images.yml` (GHCR) |
@@ -66,9 +67,10 @@ CI has six workflows in `.github/workflows/`:
 
 - **prek.yml**: Runs `prek` (ruff lint, ruff format, mypy strict, pydoclint,
   uv-lock). Quality gate for code style and type safety.
-- **test.yml**: Runs `tox -e unit`, `tox -e integration`, `tox -e ui`, and
-  `tox -e ai` as separate jobs. Quality gate for correctness. Coverage threshold
-  is enforced via `--cov-fail-under` in `tox.ini`.
+- **test.yml**: Runs `tox -e unit`, `tox -e integration`, `tox -e ui`,
+  `tox -e ai`, and `tox -e ui-workflow-pack` as separate jobs. Quality gate
+  for correctness. Coverage threshold is enforced via `--cov-fail-under` in
+  `tox.ini`.
 - **container-images.yml**: Builds and pushes multi-arch container images
   (`linux/amd64` + `linux/arm64`, ADR-063) to GHCR on `main`, version tags, and
   `workflow_dispatch`, then merges manifests via

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -363,6 +363,11 @@ Treat structured health/status bodies as contracts: reject
 substring/`"ok" in body` checks when the peer emits JSON with a
 ``status`` field — require exact equality (``status == "ok"``).
 ``{"status":"not ok"}`` must not pass a contains-ok test.
+When a snippet is embedded in a templated config (tox ``commands =``,
+GitHub ``run:``), construct interpolator collisions: unescaped
+``{...}`` that tox substitutes before Python runs. For
+``next(glob(...))``, construct the empty-match path and require an
+explicit error instead of ``StopIteration``.
 
 Do NOT discuss architecture philosophy. Rank findings
 critical/high/medium/low.
@@ -412,7 +417,11 @@ critical/high/medium/low.
 - **Dependencies pinned to intent** — version ranges, GitHub Action
   tags, base images, pip/uv specs (not tighter, not looser);
   checkout `persist-credentials: false` when write-scoped tokens
-  must not remain in local Git config for later steps
+  must not remain in local Git config for later steps.
+  Tool versions in workflow YAML vs the repo-managed source
+  (``requires-python``, ``frontend/package.json`` ``engines.node``):
+  prefer ``node-version-file`` over a hard-coded number. Extra setup
+  actions need an explicit lean-ci exception next to the job.
 - **Dead weight** — unused imports/params; paid-for-but-wasteful work:
   double JSON parse, list.pop(0)/insert(0,…) vs deque, len(list(seq)),
   O(P×V) nested scans that should be O(P+V)

--- a/.agents/skills/tox/SKILL.md
+++ b/.agents/skills/tox/SKILL.md
@@ -116,6 +116,11 @@ tox -e unit              # run tests
 tox -e ui-workflow-pack   # npm pack (prepack tsc + CSS copy); do not run npm pack directly
 ```
 
+tox substitutes `{name}` in `commands =`. Only use braces for tox placeholders
+(`{env_tmp_dir}`, `{posargs}`). Python set literals and f-strings in
+`python -c` must use `set((...))` / `%s`, not `{...}`.
+
+
 ### "I changed a proto file"
 
 ```bash

--- a/.agents/skills/tox/SKILL.md
+++ b/.agents/skills/tox/SKILL.md
@@ -58,6 +58,7 @@ directly. Every task maps to a `tox -e <env>` command.
 | `tox -e integration` | `pytest tests/integration/` (needs OPA binary) | After engine or validator changes. |
 | `tox -e ai` | `pytest` with AI extras (abbenay) | After AI/remediation changes. |
 | `tox -e ui` | `pytest -m ui` (Playwright, needs running pod) | After Gateway or UI changes. |
+| `tox -e ui-workflow-pack` | `npm pack` for `@apme/ui-workflow` (release tarball) | After `frontend/packages/ui-workflow` or TypeScript changes. |
 
 ### Code generation
 
@@ -97,7 +98,8 @@ directly. Every task maps to a `tox -e <env>` command.
 ### Default set
 
 Running `tox` with no `-e` flag executes: `lint`, `unit`, `integration`, `ai`,
-`ui`. This is the full quality gate.
+`ui`. CI also runs `ui-workflow-pack` (needs Node/npm); run it locally after
+`frontend/packages/ui-workflow` changes.
 
 ## Common Agent Workflows
 
@@ -106,6 +108,12 @@ Running `tox` with no `-e` flag executes: `lint`, `unit`, `integration`, `ai`,
 ```bash
 tox -e lint              # check style + types
 tox -e unit              # run tests
+```
+
+### "I changed frontend/packages/ui-workflow or TypeScript in that package"
+
+```bash
+tox -e ui-workflow-pack   # npm pack (prepack tsc + CSS copy); do not run npm pack directly
 ```
 
 ### "I changed a proto file"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24
+          node-version-file: frontend/package.json
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Install OPA binary
@@ -104,9 +104,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      # npm pack: same setup-node exception as the ui job; version from engines.node
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24
+          node-version-file: frontend/package.json
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: uvx --with tox-uv tox -e ui-workflow-pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,3 +98,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - run: uvx --with tox-uv tox -e ai
+
+  ui-workflow-pack:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: uvx --with tox-uv tox -e ui-workflow-pack

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -52,6 +52,7 @@ tox is the single entry point for all developer tasks. Every CI check has a corr
 | `tox -e integration` | `pytest tests/integration/` (requires OPA binary) | Test |
 | `tox -e ai` | `pytest` with AI extras (abbenay) | Test |
 | `tox -e ui` | `pytest -m ui` (Playwright, requires running gateway + UI) | Test |
+| `tox -e ui-workflow-pack` | `npm pack` for `@apme/ui-workflow` (release tarball) | Test |
 | `tox -e openapi` | Export/check `docs/api/openapi.v1.json` | Code generation |
 | `tox -e grpc` | `scripts/gen_grpc.sh` | Code generation |
 | `tox -e helm` | `scripts/helm_chart.sh` (`helm lint` + `helm package`) | Helm chart |

--- a/frontend/packages/ui-workflow/src/css.d.ts
+++ b/frontend/packages/ui-workflow/src/css.d.ts
@@ -1,0 +1,5 @@
+/**
+ * Pack-time `tsc -p tsconfig.build.json` does not see frontend/src/globals.d.ts.
+ * TypeScript 7 reports TS2882 on the side-effect CSS import in index.ts without this.
+ */
+declare module '*.css';

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,16 @@ pass_env =
     APME_TEST_DATABASE_URL
     APME_GATEWAY_*
 
+[testenv:ui-workflow-pack]
+description = Pack @apme/ui-workflow (release tarball; catches tsc CSS import errors)
+skip_install = true
+allowlist_externals = npm
+changedir = frontend
+commands =
+    npm ci
+    npm pack ./packages/ui-workflow --pack-destination {env_tmp_dir}
+    python -c "import tarfile, pathlib, sys; d=pathlib.Path(sys.argv[1]); tgz=next(d.glob('apme-ui-workflow-*.tgz')); names=set(tarfile.open(tgz).getnames()); need={'package/dist/index.js','package/dist/styles/workflow.css'}; missing=sorted(need - names); sys.exit(('missing in tarball: %s' % missing) if missing else 0)" {env_tmp_dir}
+
 # ── Code generation ──────────────────────────────────────────────────
 
 [testenv:openapi]

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ changedir = frontend
 commands =
     npm ci
     npm pack ./packages/ui-workflow --pack-destination {env_tmp_dir}
-    python -c "import tarfile, pathlib, sys; d=pathlib.Path(sys.argv[1]); tgz=next(d.glob('apme-ui-workflow-*.tgz')); names=set(tarfile.open(tgz).getnames()); need={'package/dist/index.js','package/dist/styles/workflow.css'}; missing=sorted(need - names); sys.exit(('missing in tarball: %s' % missing) if missing else 0)" {env_tmp_dir}
+    python -c "import tarfile, pathlib, sys; d=pathlib.Path(sys.argv[1]); tgz=next(d.glob('apme-ui-workflow-*.tgz')); names=set(tarfile.open(tgz).getnames()); need=set(('package/dist/index.js','package/dist/styles/workflow.css')); missing=sorted(need - names); sys.exit(('missing in tarball: %s' % missing) if missing else 0)" {env_tmp_dir}
 
 # ── Code generation ──────────────────────────────────────────────────
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ changedir = frontend
 commands =
     npm ci
     npm pack ./packages/ui-workflow --pack-destination {env_tmp_dir}
-    python -c "import tarfile, pathlib, sys; d=pathlib.Path(sys.argv[1]); tgz=next(d.glob('apme-ui-workflow-*.tgz')); names=set(tarfile.open(tgz).getnames()); need=set(('package/dist/index.js','package/dist/styles/workflow.css')); missing=sorted(need - names); sys.exit(('missing in tarball: %s' % missing) if missing else 0)" {env_tmp_dir}
+    python -c "import tarfile, pathlib, sys; d=pathlib.Path(sys.argv[1]); matches=sorted(d.glob('apme-ui-workflow-*.tgz')); sys.exit('no apme-ui-workflow-*.tgz in %s' % d) if not matches else None; tgz=matches[0]; tf=tarfile.open(tgz); names=set(tf.getnames()); tf.close(); need=set(('package/dist/index.js','package/dist/styles/workflow.css')); missing=sorted(need - names); sys.exit(('missing in tarball: %s' % missing) if missing else 0)" {env_tmp_dir}
 
 # ── Code generation ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- [v2026.8.8 attach-tarball](https://github.com/ansible/apme/actions/runs/32786430374) failed with TS2882 on `import './styles/workflow.css'`.
- #590 added `src/css.d.ts` and `tox -e ui-workflow-pack`; #355 (R402) deleted both as unrelated files, so the CalVer release pack gate was gone.
- Restore the shim and the CI job so this cannot ship unnoticed again.
- Pack check uses `set((...))` so tox does not treat a Python set literal as `{...}` substitution, and fails with an explicit error if no tarball is produced.
- `ui` / `ui-workflow-pack` read Node from `frontend/package.json` (`engines.node`) via `node-version-file` (lean-ci exception for `setup-node` because those tox envs need npm).

## Test plan
- [x] `tox -e ui-workflow-pack`
- [x] `tox -e lint` (skip skillmark locally)
- [x] Uploaded [apme-ui-workflow-2026.8.8.tgz](https://github.com/ansible/apme/releases/download/v2026.8.8/apme-ui-workflow-2026.8.8.tgz) to the existing release (re-running the failed job still checks out the old tag)