### PR TITLE
chore: Add .github/SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,230 +1,42 @@
 # Security Policy
 
-## Supported Versions
+## Reporting a security vulnerability
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+All security vulnerability reports MUST be submitted by email to: [security@ansible.com](mailto:security@ansible.com)
 
-## Reporting a Vulnerability
+Security vulnerabilities MUST NOT be reported through public channels such as GitHub issues, pull requests, the Ansible Forum, or social media.
 
-We take security seriously. If you discover a security vulnerability in APME, please report it responsibly.
+## What to include
 
-### How to Report
+When submitting a vulnerability report, include the following:
 
-**DO NOT** open a public GitHub issue for security vulnerabilities.
+* **Title** (required): Clear, concise, descriptive summary.
+* **Impacted project** (required): Ideally a link to the GitHub project.
+* **Reporter details** (optional): Your name or handle and affiliation.
+* **Vulnerability description** (required): Technical details of the issue.
+* **Affected versions** (required): Known affected version(s), and ideally all affected versions.
+* **Reproduction steps** (required): Minimal example to reproduce the issue.
+* **Impact assessment** (required): Potential exploit scenarios and severity.
+* **Suggested fix** (optional): Proposed remediation, if any.
+* **Disclosure status** (required): Whether this has been shared with other parties or published and your plan for future sharing (e.g., at a conference).
 
-Instead, please report security issues via:
+## Timeline
 
-1. **GitHub Security Advisories**: Use the "Report a vulnerability" button in the Security tab
+* The Ansible Security Team aims to confirm receipt of vulnerability reports within one (1) business day.
+* Our goal is to assess the report, coordinate fix and disclosure as quickly as possible.
+* All confirmed vulnerabilities are addressed according to severity and impact.
 
-### What to Include
+## Backports
 
-- Description of the vulnerability
-- Steps to reproduce
-- Potential impact
-- Suggested fix (if any)
+Generally, only the latest release of this project receives security updates.
+Earlier versions may receive critical fixes on a best-effort basis.
 
-### Response Timeline
+## Ansible Security Policy
 
-- **Acknowledgment**: Within 48 hours
-- **Initial Assessment**: Within 7 days
-- **Resolution Timeline**: Communicated after assessment
+For the complete Ansible Security Policy, including what qualifies as a reportable vulnerability, severity classification, the response process, coordinated disclosure, and the vulnerability management process, see [ansible.com/security](https://ansible.com/security).
 
-### Safe Harbor
+## EU Cyber Resilience Act: Open-Source Steward Statement
 
-We consider security research conducted in accordance with this policy to be:
-- Authorized under anti-hacking laws
-- Exempt from DMCA restrictions
-- Conducted in good faith
+This project is stewarded by **Red Hat, Inc.**, an open-source software steward as defined in Article 3(14) of the [EU Cyber Resilience Act (Regulation 2024/2847)](https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng).
 
-We will not pursue legal action against researchers who follow this policy.
-
----
-
-## Security Best Practices for Contributors
-
-### Secrets Management
-
-**NEVER commit secrets to the repository.**
-
-```bash
-# Check for secrets before committing
-gitleaks detect --source . --verbose
-
-# prek hooks run automatically on commit (ruff, mypy, pydoclint)
-# Install with: uv tool install prek && prek install
-```
-
-#### What NOT to commit:
-- API keys, tokens, passwords
-- Private keys (*.pem, *.key, id_rsa)
-- Environment files (.env, .env.local)
-- Ansible Vault passwords
-- Cloud credentials (AWS, GCP, Azure)
-- Kubeconfig files
-- Database connection strings
-
-#### Safe alternatives:
-- Use environment variables
-- Use Ansible Vault for encrypted secrets
-- Use `.env.example` with placeholder values
-- Document required secrets in README
-
-### Code Security
-
-#### Input Validation
-```python
-# Always validate external input
-def scan_path(path: Path) -> ScanResult:
-    resolved = path.resolve()
-    if not resolved.is_relative_to(allowed_root):
-        raise SecurityError("Path traversal detected")
-```
-
-#### Subprocess Safety
-```python
-# NEVER use shell=True with user input
-# BAD:
-subprocess.run(f"scan {user_input}", shell=True)
-
-# GOOD:
-subprocess.run(["scan", user_input], shell=False)
-```
-
-#### YAML Safety
-```python
-# Use safe loaders
-from ruamel.yaml import YAML
-yaml = YAML(typ='safe')  # Prevents arbitrary code execution
-```
-
-### Container Security
-
-#### Dockerfile Best Practices
-```dockerfile
-# Use specific versions, not :latest (ADR-061: UBI10 application bases)
-FROM registry.access.redhat.com/ubi10/python-312-minimal:10.2
-
-# Run as non-root user (UBI Python images default to UID 1001)
-USER 1001
-
-# Don't store secrets in ENV
-# BAD: ENV API_KEY=secret123
-# GOOD: Use runtime secrets
-
-# Minimize attack surface
-USER root
-RUN microdnf install -y required-package && microdnf clean all
-USER 1001
-```
-
-#### Image Scanning
-
-Container image vulnerability scanning runs in the `container-images` GitHub
-Actions workflow on each release. For local Python supply-chain artifacts, use:
-
-```bash
-tox -e release-supply-chain
-```
-
-### Dependency Security
-
-#### Regular Updates
-```bash
-# Check for vulnerable dependencies
-pip-audit
-
-# Dependencies are managed via pyproject.toml and uv.lock
-# Review dependency changes in PRs
-```
-
-#### Lock Files
-- Always commit lock files (`uv.lock`)
-- Review dependency changes in PRs
-
-### gRPC Security
-
-#### Transport Security
-```python
-# Production: Use TLS
-credentials = grpc.ssl_channel_credentials()
-channel = grpc.secure_channel('server:50051', credentials)
-
-# Development only: Insecure channel
-# channel = grpc.insecure_channel('localhost:50051')
-```
-
-#### Input Validation
-- Validate all protobuf message fields
-- Set maximum message sizes
-- Implement rate limiting
-
-### Logging Security
-
-```python
-# NEVER log secrets
-logger.info("Connecting to database")  # GOOD
-logger.info(f"Password: {password}")   # BAD
-
-# Sanitize user input in logs
-logger.info("Scanning path", path=sanitize(user_path))
-```
-
----
-
-## Security Checklist for PRs
-
-Before submitting a PR, verify:
-
-- [ ] No secrets in code or comments
-- [ ] No hardcoded credentials
-- [ ] Input validation for all external data
-- [ ] Safe subprocess calls (no shell=True with user input)
-- [ ] Dependencies updated and scanned
-- [ ] Container runs as non-root user
-- [ ] Sensitive data not logged
-- [ ] gitleaks passes locally
-
----
-
-## Security Tools
-
-### Recommended
-
-```bash
-# Secret detection (manual scan)
-gitleaks detect --source . --verbose
-
-# Python security linting
-bandit -r src/
-
-# Dependency vulnerabilities
-pip-audit
-
-# Container image scanning — see container-images GitHub Actions workflow
-```
-
----
-
-## Incident Response
-
-If you believe the project has been compromised:
-
-1. **Rotate all credentials** immediately
-2. **Audit git history** for leaked secrets
-3. **Notify maintainers** via GitHub Security Advisory
-4. **Document the incident** for post-mortem
-
-### Git History Cleanup
-
-If secrets are committed:
-```bash
-# Use git-filter-repo (preferred) or BFG Repo-Cleaner
-git filter-repo --path secrets.txt --invert-paths
-
-# Force push (coordinate with team)
-git push --force-with-lease
-```
-
-**Note**: Once pushed to a public repo, assume the secret is compromised and rotate it.
+Contact: [cra-steward@redhat.com](mailto:cra-steward@redhat.com)


### PR DESCRIPTION
## Summary

Add a standardised `SECURITY.md` to `.github/` so security reporting instructions are discoverable across all Ansible repositories.

The canonical source is [`ansible-community/project-template/SECURITY.md`](https://github.com/ansible-community/project-template/blob/main/SECURITY.md).

The file has already been reviewed

See [Forum Post](https://forum.ansible.com/t/cra-updating-security-md/46223) for context
