### PR TITLE
fix(ui): restore Gate 2 AI workflow pause and stepper accuracy

### DIFF
--- a/frontend/packages/ui-workflow/src/components/AiAppliedPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AiAppliedPanel.tsx
@@ -1,0 +1,59 @@
+/**
+ * Gate 2 completion — user acknowledges AI fixes before Create branch.
+ */
+
+import { Button, Card, CardBody } from '@patternfly/react-core';
+import { WorkflowNextBar } from './WorkflowNextBar';
+
+export interface AiAppliedPanelProps {
+  aiAccepted: number;
+  remediatedCount: number;
+  onContinue: () => void;
+  onCancel?: () => void;
+}
+
+export function AiAppliedPanel({
+  aiAccepted,
+  remediatedCount,
+  onContinue,
+  onCancel,
+}: AiAppliedPanelProps) {
+  const appliedLabel =
+    aiAccepted > 0
+      ? `${aiAccepted} AI fix${aiAccepted !== 1 ? 'es' : ''} applied`
+      : 'No AI fixes applied';
+  const totalLabel =
+    remediatedCount > 0
+      ? `${remediatedCount} total change${remediatedCount !== 1 ? 's' : ''} ready to commit`
+      : 'Remediation complete';
+
+  return (
+    <Card style={{ marginBottom: 16 }}>
+      <CardBody>
+        <div className="apme-review-step-header" style={{ marginBottom: 8 }}>
+          <div className="apme-review-step-header__text">
+            <h3 style={{ marginTop: 0 }}>AI fixes applied</h3>
+            <span style={{ fontSize: 13, opacity: 0.7 }}>
+              {appliedLabel}. {totalLabel}. Next to create a branch and push.
+            </span>
+          </div>
+          <div className="apme-review-step-header__actions">
+            <WorkflowNextBar
+              placement="header"
+              label="Next"
+              summary="Continue to create branch and push your remediated changes."
+              onNext={onContinue}
+              secondary={
+                onCancel ? (
+                  <Button variant="link" onClick={onCancel}>
+                    Cancel
+                  </Button>
+                ) : undefined
+              }
+            />
+          </div>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/frontend/packages/ui-workflow/src/components/OperationPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/OperationPanel.tsx
@@ -19,7 +19,7 @@
  *   cancelled       → null (no panel)
  */
 
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import {
   Button,
   Card,
@@ -33,7 +33,14 @@ import type {
   ProjectOperationStatus,
 } from '../hooks/useProjectOperationState';
 import type { OperationProgress, OperationResult } from '../types/operation';
-import { needsCommitStep } from '../remediation';
+import { needsCommitStep, resolveProposalReviewGate } from '../remediation';
+import {
+  emptyWorkflowLatch,
+  shouldIncludeAiSteps,
+  updateWorkflowLatch,
+  type WorkflowLatch,
+} from '../remediation/workflowSteps';
+import { AiAppliedPanel } from './AiAppliedPanel';
 import { OperationProgressPanel } from './OperationProgressPanel';
 import {
   ProposalReviewPanel,
@@ -76,6 +83,11 @@ const RUNNING_STATUSES = new Set<ProjectOperationStatus>([
   'applying',
 ]);
 
+/** Show proposal review UI whenever engine is paused for user approval. */
+function shouldShowProposalReview(state: ProjectOperationState): boolean {
+  return state.status === 'awaiting_approval';
+}
+
 function mapStatus(s: ProjectOperationStatus): import('../types/operation').OperationStatus {
   const mapping: Partial<Record<ProjectOperationStatus, string>> = {
     queued: 'connecting',
@@ -90,14 +102,15 @@ function withStepper(
   state: ProjectOperationState,
   enableAi: boolean,
   body: ReactNode,
-  commitFinished = false,
+  options: { commitFinished?: boolean; aiApplyFinished?: boolean } = {},
 ): ReactNode {
   return (
     <div>
       <OperationWorkflowStepper
         state={state}
         enableAi={enableAi}
-        commitFinished={commitFinished}
+        commitFinished={options.commitFinished}
+        aiApplyFinished={options.aiApplyFinished}
       />
       {body}
     </div>
@@ -124,14 +137,19 @@ export function OperationPanel({
   const [escalating, setEscalating] = useState(false);
   const [escalateError, setEscalateError] = useState<string | null>(null);
   const [commitFinished, setCommitFinished] = useState(false);
+  const [aiApplyFinished, setAiApplyFinished] = useState(false);
   const [localPrUrl, setLocalPrUrl] = useState<string | null>(null);
+  const latchRef = useRef<WorkflowLatch>(emptyWorkflowLatch());
+  const opIdRef = useRef(state?.operation_id);
 
   useEffect(() => {
     setCommitFinished(false);
+    setAiApplyFinished(false);
     setPrError(null);
     setBeginError(null);
     setEscalateError(null);
     setLocalPrUrl(null);
+    latchRef.current = emptyWorkflowLatch();
   }, [state?.operation_id]);
 
   useEffect(() => {
@@ -214,6 +232,65 @@ export function OperationPanel({
   }
 
   const status = state.status;
+  const includeAi = shouldIncludeAiSteps(enableAi, state);
+  if (opIdRef.current !== state.operation_id) {
+    opIdRef.current = state.operation_id;
+    latchRef.current = emptyWorkflowLatch();
+  }
+  latchRef.current = updateWorkflowLatch(latchRef.current, state, includeAi);
+  const stepperOpts = { commitFinished, aiApplyFinished };
+
+  if (shouldShowProposalReview(state)) {
+    if (!state.proposals) {
+      return withStepper(
+        state,
+        enableAi,
+        <Card style={{ marginBottom: 16 }}>
+          <CardBody style={{ textAlign: 'center', padding: '32px 24px' }}>
+            <Spinner size="lg" />
+            <div style={{ marginTop: 12, fontSize: 16 }}>Loading proposals...</div>
+            <Button variant="link" onClick={handleCancel} style={{ marginTop: 8 }}>
+              Cancel
+            </Button>
+          </CardBody>
+        </Card>,
+      );
+    }
+    const proposals = state.proposals.map((p) => ({
+      id: p.id,
+      rule_id: p.rule_id,
+      file: p.file,
+      tier: p.tier,
+      confidence: p.confidence,
+      explanation: p.explanation,
+      diff_hunk: p.diff_hunk,
+      status: p.status,
+      suggestion: p.suggestion,
+      line_start: p.line_start,
+      path: p.path,
+      node_type: p.node_type,
+      source: p.source,
+      before_text: p.before_text,
+      after_text: p.after_text,
+    }));
+    return withStepper(
+      state,
+      enableAi,
+      <ProposalReviewPanel
+        proposals={proposals}
+        reviewGate={resolveProposalReviewGate(proposals, {
+          enableAi,
+          pastAiEscalation: (state.ai_triage_candidates?.length ?? 0) > 0,
+        })}
+        pastAiEscalation={(state.ai_triage_candidates?.length ?? 0) > 0}
+        onApprove={handleApprove}
+        onDraftUpdate={onDraftUpdate}
+        feedbackEnabled={feedbackEnabled ?? false}
+        scanId={state.scan_id}
+        onCancel={handleCancel}
+      />,
+    );
+  }
 
   if (RUNNING_STATUSES.has(status)) {
     if (status === 'queued') {
@@ -301,54 +378,6 @@ export function OperationPanel({
     );
   }
 
-  if (status === 'awaiting_approval') {
-    // status_changed can arrive before the proposals payload.
-    if (!state.proposals) {
-      return withStepper(
-        state,
-        enableAi,
-        <Card style={{ marginBottom: 16 }}>
-          <CardBody style={{ textAlign: 'center', padding: '32px 24px' }}>
-            <Spinner size="lg" />
-            <div style={{ marginTop: 12, fontSize: 16 }}>Loading proposals...</div>
-            <Button variant="link" onClick={handleCancel} style={{ marginTop: 8 }}>
-              Cancel
-            </Button>
-          </CardBody>
-        </Card>,
-      );
-    }
-    const proposals = state.proposals.map((p) => ({
-      id: p.id,
-      rule_id: p.rule_id,
-      file: p.file,
-      tier: p.tier,
-      confidence: p.confidence,
-      explanation: p.explanation,
-      diff_hunk: p.diff_hunk,
-      status: p.status,
-      suggestion: p.suggestion,
-      line_start: p.line_start,
-      path: p.path,
-      node_type: p.node_type,
-      source: p.source,
-      before_text: p.before_text,
-      after_text: p.after_text,
-    }));
-    return withStepper(
-      state,
-      enableAi,
-      <ProposalReviewPanel
-        proposals={proposals}
-        onApprove={handleApprove}
-        onDraftUpdate={onDraftUpdate}
-        feedbackEnabled={feedbackEnabled ?? false}
-        scanId={state.scan_id}
-        onCancel={handleCancel}
-      />,
-    );
-  }
-
   if (status === 'completed' || status === 'submitting_pr' || status === 'pr_submitted') {
     const resultData: OperationResult | null = state.result
       ? {
@@ -363,10 +392,32 @@ export function OperationPanel({
         }
       : null;
 
+    const showAiAppliedAck =
+      status === 'completed' &&
+      includeAi &&
+      !aiApplyFinished &&
+      needsCommitStep(state) &&
+      latchRef.current.seenGate2Review;
+
+    if (showAiAppliedAck) {
+      return withStepper(
+        state,
+        enableAi,
+        <AiAppliedPanel
+          aiAccepted={state.result?.ai_accepted ?? 0}
+          remediatedCount={state.result?.remediated_count ?? 0}
+          onContinue={() => setAiApplyFinished(true)}
+          onCancel={handleCancel}
+        />,
+        stepperOpts,
+      );
+    }
+
     const showCommit =
       (status === 'completed' || status === 'submitting_pr') &&
       !commitFinished &&
-      needsCommitStep(state);
+      needsCommitStep(state) &&
+      (!includeAi || !latchRef.current.seenGate2Review || aiApplyFinished);
 
     if (showCommit && resultData) {
       return withStepper(
@@ -382,7 +433,7 @@ export function OperationPanel({
           error={prError}
           prUrl={state.pr_url || localPrUrl}
         />,
-        false,
+        stepperOpts,
       );
     }
 
@@ -399,7 +450,7 @@ export function OperationPanel({
             </Button>
           </CardBody>
         </Card>,
-        true,
+        { ...stepperOpts, commitFinished: true },
       );
     }
 
@@ -426,7 +477,7 @@ export function OperationPanel({
         scanId={state.scan_id}
         onViewDetails={onViewDetails}
       />,
-      true,
+      { ...stepperOpts, commitFinished: true },
     );
   }
 

--- a/frontend/packages/ui-workflow/src/components/OperationWorkflowStepper.tsx
+++ b/frontend/packages/ui-workflow/src/components/OperationWorkflowStepper.tsx
@@ -23,6 +23,8 @@ export interface OperationWorkflowStepperProps {
   state: ProjectOperationState;
   /** User opted into AI for this run (Activity options). */
   enableAi?: boolean;
+  /** Gate 2 apply step acknowledged — advance to Create branch. */
+  aiApplyFinished?: boolean;
   /** Commit step finished / skipped (or PR already exists). */
   commitFinished?: boolean;
 }
@@ -147,10 +149,10 @@ function badgeContent(
 export function OperationWorkflowStepper({
   state,
   enableAi = false,
+  aiApplyFinished = false,
   commitFinished = false,
 }: OperationWorkflowStepperProps) {
   const includeAi = shouldIncludeAiSteps(enableAi, state);
-  const defs = workflowStepDefs(includeAi);
   const latchRef = useRef<WorkflowLatch>(emptyWorkflowLatch());
   const opIdRef = useRef(state.operation_id);
 
@@ -159,7 +161,11 @@ export function OperationWorkflowStepper({
     latchRef.current = emptyWorkflowLatch();
   }
   latchRef.current = updateWorkflowLatch(latchRef.current, state, includeAi);
+  const defs = workflowStepDefs(includeAi, {
+    skipTier1: latchRef.current.tier1GateSkipped,
+  });
   const currentId = resolveCurrentWorkflowStep(state, includeAi, latchRef.current, {
+    aiApplyFinished,
     commitFinished,
   });
   const activeIndex = defs.findIndex((d) => d.id === currentId);

--- a/frontend/packages/ui-workflow/src/components/ProposalReviewPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/ProposalReviewPanel.tsx
@@ -28,7 +28,6 @@ import {
   descendantProposalIds,
   filterByRuleKeepingNodeContext,
   fixTypeLabelColor,
-  isAiRemediationProposal,
   nodeTypeLabel,
   nodeTypeLabelColor,
   normalizeFindingNodeType,
@@ -37,7 +36,9 @@ import {
   proposalHasVisibleDiff,
   proposalNodeTitle,
   proposalsGateKey,
+  resolveProposalReviewGate,
   type FindingNodeType,
+  type ProposalReviewGate,
 } from '../remediation';
 import { RuleFilterInput } from './RuleFilterInput';
 
@@ -126,6 +127,10 @@ export interface ProposalDraftUpdate {
 
 export interface ProposalReviewPanelProps {
   proposals: OperationProposal[];
+  /** Gate 1 rule-based vs Gate 2 AI — prefer explicit signal from operation state. */
+  reviewGate?: ProposalReviewGate;
+  /** Operation had AI escalation triage before this review step. */
+  pastAiEscalation?: boolean;
   onApprove: (ids: string[]) => void;
   /** Optional optimistic draft decision sync (PATCH /operation/proposals). */
   onDraftUpdate?: (updates: ProposalDraftUpdate[]) => void;
@@ -163,6 +168,8 @@ function decisionToDraft(d: NodeDecision): ProposalDraftUpdate['status'] {
 
 export function ProposalReviewPanel({
   proposals,
+  reviewGate: reviewGateProp,
+  pastAiEscalation = false,
   onApprove,
   onDraftUpdate,
   feedbackEnabled,
@@ -184,7 +191,9 @@ export function ProposalReviewPanel({
   );
 
   const gateKey = proposalsGateKey(proposals);
-  const isAiGate = proposed.length > 0 && isAiRemediationProposal(proposed[0]!);
+  const isAiGate =
+    (reviewGateProp ??
+      resolveProposalReviewGate(proposals, { pastAiEscalation })) === 'ai';
 
   const [decisions, setDecisions] = useState<Map<string, NodeDecision>>(
     () => new Map(),
@@ -448,7 +457,8 @@ export function ProposalReviewPanel({
       label: 'Next',
       summary,
       onNext: () => onApprove(acceptedIds),
-      isDisabled: actionable.length === 0,
+      // No actionable diffs (e.g. only "Declined by AI") — still allow continue.
+      isDisabled: false,
     };
   }, [
     acceptedIds,
@@ -765,10 +775,29 @@ export function ProposalReviewPanel({
         ]}
       />
       <div style={{ marginTop: 8, fontSize: 13, opacity: 0.7 }}>
-        Every location starts undecided. Next stays disabled until you Accept or
-        Decline each one. Decided rows collapse. Accept remaining / Decline
-        remaining only apply to currently visible rows — widen filters to decide
-        the rest, or Clear to reset and expand again.
+        {actionable.length > 0 ? (
+          pendingCount > 0 ? (
+            <>
+              Every location starts undecided. Next stays disabled until you Accept
+              or Decline each one. Decided rows collapse. Accept remaining /
+              Decline remaining only apply to currently visible rows — widen
+              filters to decide the rest, or Clear to reset and expand again.
+            </>
+          ) : (
+            <>
+              All visible fixes are decided. Next to continue with your accepted
+              changes.
+            </>
+          )
+        ) : declined.length > 0 ? (
+          <>
+            AI could not propose fixes for the remaining violations. Review the
+            declined items below, then Next to continue without applying AI
+            changes.
+          </>
+        ) : (
+          <>No fixes to review. Next to continue.</>
+        )}
         {explanationOnly.length > 0
           ? ` ${explanationOnly.length} explanation-only proposal${
               explanationOnly.length !== 1 ? 's' : ''

--- a/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
@@ -389,12 +389,7 @@ export function applyOperationSseEvent(
         // cannot leave the UI on applying/progress and skip Gate 2 review.
         setState((prev) => {
           if (!prev) return prev;
-          if (
-            prev.status === "completed" ||
-            prev.status === "failed" ||
-            prev.status === "cancelled" ||
-            prev.status === "pr_submitted"
-          ) {
+          if (TERMINAL_STATUSES.has(prev.status)) {
             return prev;
           }
           return {

--- a/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
@@ -349,19 +349,28 @@ export function applyOperationSseEvent(
           error_code?: string;
           operation_budget_seconds?: number;
         };
-        setState((prev) =>
-          prev
-            ? {
-                ...prev,
-                status: data.status as ProjectOperationStatus,
-                ...(data.error ? { error: data.error } : {}),
-                ...(data.error_code ? { error_code: data.error_code } : {}),
-                ...(data.operation_budget_seconds
-                  ? { operation_budget_seconds: data.operation_budget_seconds }
-                  : {}),
-              }
-            : prev,
-        );
+        setState((prev) => {
+          if (!prev) return prev;
+          const newStatus = data.status as ProjectOperationStatus;
+          // Ignore stale APPLYING while Gate 1/2 proposals await review.
+          // approval_ack drives applying + clears proposals after user clicks Next.
+          if (
+            prev.status === "awaiting_approval" &&
+            newStatus === "applying" &&
+            (prev.proposals?.length ?? 0) > 0
+          ) {
+            return prev;
+          }
+          return {
+            ...prev,
+            status: newStatus,
+            ...(data.error ? { error: data.error } : {}),
+            ...(data.error_code ? { error_code: data.error_code } : {}),
+            ...(data.operation_budget_seconds
+              ? { operation_budget_seconds: data.operation_budget_seconds }
+              : {}),
+          };
+        });
         break;
       }
       case "progress": {
@@ -375,9 +384,25 @@ export function applyOperationSseEvent(
       }
       case "proposals": {
         const data = JSON.parse(ev.data) as { proposals: Proposal[] };
-        setState((prev) =>
-          prev ? { ...prev, proposals: data.proposals } : prev,
-        );
+        // Gateway always transitions to awaiting_approval before broadcasting
+        // proposals. Set status here too so a missed/out-of-order status_changed
+        // cannot leave the UI on applying/progress and skip Gate 2 review.
+        setState((prev) => {
+          if (!prev) return prev;
+          if (
+            prev.status === "completed" ||
+            prev.status === "failed" ||
+            prev.status === "cancelled" ||
+            prev.status === "pr_submitted"
+          ) {
+            return prev;
+          }
+          return {
+            ...prev,
+            status: "awaiting_approval",
+            proposals: data.proposals,
+          };
+        });
         break;
       }
       case "findings": {
@@ -439,13 +464,13 @@ export function applyOperationSseEvent(
         break;
       }
       case "approval_ack": {
-        // Do not force status to "applying" — two-gate interactive flow may
-        // return to awaiting_approval; status_changed owns transitions.
         const data = JSON.parse(ev.data) as { applied_count: number };
         setState((prev) =>
           prev
             ? {
                 ...prev,
+                status: "applying",
+                proposals: undefined,
                 result: prev.result
                   ? { ...prev.result, ai_accepted: data.applied_count }
                   : prev.result,
@@ -640,5 +665,18 @@ export function useProjectOperationState(
     setStateTracked(null);
   }, [cleanup, setStateTracked]);
 
-  return { state, connected, refresh, clear };
+  /** Optimistic transition after POST approve — operation SSE has no approval_ack event. */
+  const applyLocalApprovalAck = useCallback(() => {
+    setStateTracked((prev) =>
+      prev
+        ? {
+            ...prev,
+            status: "applying",
+            proposals: undefined,
+          }
+        : prev,
+    );
+  }, [setStateTracked]);
+
+  return { state, connected, refresh, clear, applyLocalApprovalAck };
 }

--- a/frontend/packages/ui-workflow/src/remediation/index.ts
+++ b/frontend/packages/ui-workflow/src/remediation/index.ts
@@ -21,7 +21,10 @@ export {
   proposalHasVisibleDiff,
   proposalNodeTitle,
   proposalsGateKey,
+  proposalsLookLikeAiGate,
+  resolveProposalReviewGate,
   splitRuleIds,
+  type ProposalReviewGate,
 } from './proposalTier';
 export {
   filterByRuleKeepingNodeContext,

--- a/frontend/packages/ui-workflow/src/remediation/proposalTier.ts
+++ b/frontend/packages/ui-workflow/src/remediation/proposalTier.ts
@@ -29,6 +29,41 @@ export function proposalNodeTitle(proposal: OperationProposal): string {
   return file;
 }
 
+/** True when any proposal belongs to Gate 2 (incl. ai-declined rows). */
+export function proposalsLookLikeAiGate(
+  proposals: OperationProposal[],
+): boolean {
+  return proposals.some(
+    (p) =>
+      isAiRemediationProposal(p) ||
+      (p.tier ?? 0) >= 2 ||
+      p.source === 'ai' ||
+      p.source === 'ai-candidate' ||
+      p.id.startsWith('ai-'),
+  );
+}
+
+export type ProposalReviewGate = 'tier1' | 'ai';
+
+/**
+ * Resolve Gate 1 vs Gate 2 review copy and behavior.
+ *
+ * Proposal shape alone is not enough: Gate 2 can be declined-only (no diffs)
+ * while ``ai_triage_candidates`` proves escalation already happened.
+ */
+export function resolveProposalReviewGate(
+  proposals: OperationProposal[],
+  options: { enableAi?: boolean; pastAiEscalation?: boolean } = {},
+): ProposalReviewGate {
+  if (proposalsLookLikeAiGate(proposals)) {
+    return 'ai';
+  }
+  if (options.enableAi && options.pastAiEscalation) {
+    return 'ai';
+  }
+  return 'tier1';
+}
+
 /** True when the proposal is Gate 2 AI (not rule-based fix / deterministic). */
 export function isAiRemediationProposal(proposal: OperationProposal): boolean {
   if (proposal.source === 'ai' || proposal.source === 'ai-candidate') {
@@ -64,18 +99,22 @@ export function proposalsGateKey(proposals: OperationProposal[]): string {
     return '';
   }
   const ids = proposals.map((p) => p.id).sort();
-  const gate = isAiRemediationProposal(proposals[0]!) ? 'ai' : 't1';
+  const gate = proposalsLookLikeAiGate(proposals) ? 'ai' : 't1';
   return `${gate}:${ids.join(',')}`;
 }
 
 /** Human label for the current approval gate. */
-export function gateLabel(proposals: OperationProposal[]): string {
-  if (proposals.length === 0) {
+export function gateLabel(
+  proposals: OperationProposal[],
+  reviewGate?: ProposalReviewGate,
+): string {
+  if (proposals.length === 0 && !reviewGate) {
     return 'Review';
   }
-  return isAiRemediationProposal(proposals[0]!)
-    ? 'AI proposals'
-    : 'Rule-based fix proposals';
+  const gate =
+    reviewGate ??
+    (proposalsLookLikeAiGate(proposals) ? 'ai' : 'tier1');
+  return gate === 'ai' ? 'AI proposals' : 'Rule-based fix proposals';
 }
 
 /**

--- a/frontend/packages/ui-workflow/src/remediation/workflowSteps.ts
+++ b/frontend/packages/ui-workflow/src/remediation/workflowSteps.ts
@@ -34,7 +34,11 @@ export interface WorkflowLatch {
   pastFindings: boolean;
   pastTier1Review: boolean;
   pastTier1Applied: boolean;
+  /** Gate 1 had no tier1 proposals — engine skips straight to AI triage. */
+  tier1GateSkipped: boolean;
   pastAiEscalation: boolean;
+  /** Gate 2 review screen was reached (awaiting_approval with AI proposals). */
+  seenGate2Review: boolean;
   pastAiReview: boolean;
   pastAiApplied: boolean;
 }
@@ -44,21 +48,35 @@ export function emptyWorkflowLatch(): WorkflowLatch {
     pastFindings: false,
     pastTier1Review: false,
     pastTier1Applied: false,
+    tier1GateSkipped: false,
     pastAiEscalation: false,
+    seenGate2Review: false,
     pastAiReview: false,
     pastAiApplied: false,
   };
 }
 
-export function workflowStepDefs(includeAi: boolean): WorkflowStepDef[] {
+export interface WorkflowStepDefOptions {
+  /** Omit tier1 steps when Gate 1 never ran (AI-only findings). */
+  skipTier1?: boolean;
+}
+
+export function workflowStepDefs(
+  includeAi: boolean,
+  options: WorkflowStepDefOptions = {},
+): WorkflowStepDef[] {
   const steps: WorkflowStepDef[] = [
     { id: 'scan', label: 'Scan' },
     { id: 'findings', label: 'Review findings' },
   ];
   if (includeAi) {
+    if (!options.skipTier1) {
+      steps.push(
+        { id: 'tier1_proposals', label: 'Rule-based fix proposals' },
+        { id: 'tier1_applied', label: 'Rule-based fix applied' },
+      );
+    }
     steps.push(
-      { id: 'tier1_proposals', label: 'Rule-based fix proposals' },
-      { id: 'tier1_applied', label: 'Rule-based fix applied' },
       { id: 'ai_escalation', label: 'AI escalation' },
       { id: 'ai_proposals', label: 'AI proposals' },
       { id: 'ai_applied', label: 'AI applied' },
@@ -101,7 +119,10 @@ function isTerminalSuccess(status: string): boolean {
 
 function isAiGate(state: ProjectOperationState): boolean {
   const proposals = state.proposals ?? [];
-  return proposals.length > 0 && isAiRemediationProposal(proposals[0]!);
+  if (proposals.length === 0) return false;
+  if (proposals.some((p) => isAiRemediationProposal(p))) return true;
+  // Gate 2 may bundle post-AI deterministic cleanup at tier=2.
+  return proposals.some((p) => (p.tier ?? 0) >= 2);
 }
 
 /** Advance latch from the latest operation state. */
@@ -120,37 +141,41 @@ export function updateWorkflowLatch(
 
   if (status === 'awaiting_ai_triage') {
     next.pastFindings = true;
-    next.pastTier1Review = true;
-    next.pastTier1Applied = true;
     next.pastAiEscalation = true;
+    if (next.pastTier1Review && !next.tier1GateSkipped) {
+      next.pastTier1Applied = true;
+    }
   }
 
   if (status === 'awaiting_approval') {
     next.pastFindings = true;
     if (aiGate) {
-      next.pastTier1Review = true;
-      next.pastTier1Applied = true;
+      if (next.pastTier1Review && !next.tier1GateSkipped) {
+        next.pastTier1Applied = true;
+      }
       next.pastAiEscalation = true;
-      next.pastAiReview = true;
+      // Latch review reached; pastAiReview/pastAiApplied set only after approve.
+      next.seenGate2Review = true;
     } else {
       next.pastTier1Review = true;
+      next.tier1GateSkipped = false;
     }
   }
 
   if (status === 'applying') {
     next.pastFindings = true;
-    if (next.pastAiReview) {
-      // Applying after Gate 2 approve.
+    if (next.seenGate2Review) {
+      // Applying after Gate 2 approve — show AI applied, not AI proposals.
+      next.pastAiReview = true;
       next.pastAiApplied = true;
     } else if (next.pastAiEscalation) {
       // AI running after escalate-ai — stay on AI escalation.
-    } else if (next.pastTier1Review || next.pastTier1Applied) {
+    } else if (next.pastTier1Review) {
       next.pastTier1Applied = true;
       // Do not mark pastAiEscalation — wait for awaiting_ai_triage.
-    } else {
-      // Auto-apply / empty Gate 1: skipped proposal review.
-      next.pastTier1Review = true;
-      next.pastTier1Applied = true;
+    } else if (!next.tier1GateSkipped) {
+      // Gate 1 produced no tier1 proposals — skip straight to AI triage.
+      next.tier1GateSkipped = true;
     }
   }
 
@@ -159,9 +184,28 @@ export function updateWorkflowLatch(
     next.pastTier1Review = true;
     next.pastTier1Applied = true;
     if (includeAi) {
-      next.pastAiEscalation = true;
-      next.pastAiReview = true;
-      next.pastAiApplied = true;
+      const aiProposed = state.result?.ai_proposed ?? 0;
+      const aiAccepted = state.result?.ai_accepted ?? 0;
+      const aiDeclined = state.result?.ai_declined ?? 0;
+      const remediated = state.result?.remediated_count ?? 0;
+      const hadTriage = (state.ai_triage_candidates?.length ?? 0) > 0;
+      if (next.pastAiEscalation || hadTriage || aiProposed > 0 || aiAccepted > 0) {
+        next.pastAiEscalation = true;
+      }
+      if (
+        next.seenGate2Review ||
+        aiProposed > 0 ||
+        aiAccepted > 0 ||
+        aiDeclined > 0
+      ) {
+        next.seenGate2Review = true;
+      }
+      if (next.seenGate2Review || next.pastAiReview || aiProposed > 0) {
+        next.pastAiReview = true;
+      }
+      if (next.pastAiApplied || aiAccepted > 0 || (next.seenGate2Review && remediated > 0)) {
+        next.pastAiApplied = true;
+      }
     }
   }
 
@@ -178,7 +222,7 @@ export function updateWorkflowLatch(
 /** Last meaningful step from latch (for failed / expired). */
 function stepFromLatch(latch: WorkflowLatch, includeAi: boolean): WorkflowStepId {
   if (includeAi && latch.pastAiApplied) return 'ai_applied';
-  if (includeAi && latch.pastAiReview) return 'ai_proposals';
+  if (includeAi && (latch.pastAiReview || latch.seenGate2Review)) return 'ai_proposals';
   if (includeAi && latch.pastAiEscalation) return 'ai_escalation';
   if (latch.pastTier1Applied) return includeAi ? 'tier1_applied' : 'apply_findings';
   if (latch.pastTier1Review) return includeAi ? 'tier1_proposals' : 'apply_findings';
@@ -187,6 +231,11 @@ function stepFromLatch(latch: WorkflowLatch, includeAi: boolean): WorkflowStepId
 }
 
 export interface WorkflowStepOptions {
+  /**
+   * User acknowledged the AI applied step (Gate 2 fixes landed).
+   * When false after Gate 2, ``completed`` lands on AI applied before Commit.
+   */
+  aiApplyFinished?: boolean;
   /**
    * User finished or skipped the Commit step (or PR already exists).
    * When false and patches remain, ``completed`` lands on Commit.
@@ -203,6 +252,7 @@ export function resolveCurrentWorkflowStep(
 ): WorkflowStepId {
   const status = state.status;
   const commitFinished = options.commitFinished === true || Boolean(state.pr_url);
+  const aiApplyFinished = options.aiApplyFinished === true;
 
   if (status === 'pr_submitted') {
     return 'complete';
@@ -213,6 +263,14 @@ export function resolveCurrentWorkflowStep(
   }
 
   if (status === 'completed') {
+    if (
+      includeAi &&
+      latch.seenGate2Review &&
+      !aiApplyFinished &&
+      needsCommitStep(state)
+    ) {
+      return 'ai_applied';
+    }
     if (!commitFinished && needsCommitStep(state)) {
       return 'commit';
     }
@@ -237,8 +295,15 @@ export function resolveCurrentWorkflowStep(
   }
 
   if (status === 'applying') {
-    if (latch.pastAiReview) {
+    if (latch.pastAiApplied) {
       return includeAi ? 'ai_applied' : 'apply_findings';
+    }
+    // Gate 2 proposals still in state after approve — stay on AI applied, not review.
+    if (includeAi && latch.seenGate2Review) {
+      return 'ai_applied';
+    }
+    if (includeAi && isAiGate(state)) {
+      return 'ai_proposals';
     }
     if (includeAi && latch.pastAiEscalation) {
       return 'ai_escalation';

--- a/frontend/packages/ui-workflow/src/useProjectWorkflow.ts
+++ b/frontend/packages/ui-workflow/src/useProjectWorkflow.ts
@@ -77,7 +77,7 @@ export function useProjectWorkflow(
 
   const [attachOp, setAttachOp] = useState(initiallyAttached);
 
-  const { state: opState, refresh: refreshOp, clear: clearOp } =
+  const { state: opState, refresh: refreshOp, clear: clearOp, applyLocalApprovalAck } =
     useProjectOperationState(projectId, {
       enabled: Boolean(projectId) && attachOp,
     });
@@ -128,6 +128,34 @@ export function useProjectWorkflow(
       refreshOp();
     }
   }, [attachOp, opState?.status, opState?.ai_triage_candidates, refreshOp]);
+
+  // Gate 2: proposals SSE can be missed while status stays applying — poll GET.
+  useEffect(() => {
+    if (!attachOp || !enableAi || opState?.status !== 'applying') {
+      return;
+    }
+    if (opState.ai_triage_candidates === undefined) {
+      return;
+    }
+    const timer = setInterval(() => {
+      refreshOp();
+    }, 3000);
+    return () => clearInterval(timer);
+  }, [
+    attachOp,
+    enableAi,
+    opState?.status,
+    opState?.ai_triage_candidates,
+    refreshOp,
+  ]);
+
+  const approveWithState = useCallback(
+    async (approvedIds: string[]) => {
+      await approve(approvedIds);
+      applyLocalApprovalAck();
+    },
+    [approve, applyLocalApprovalAck],
+  );
 
   const openSession = useCallback(() => {
     setAttachOp(true);
@@ -332,7 +360,7 @@ export function useProjectWorkflow(
     startScan,
     beginRemediate,
     escalateAi,
-    approve,
+    approve: approveWithState,
     cancel,
     createPR,
     patchProposals,

--- a/frontend/packages/ui-workflow/src/useProjectWorkflow.ts
+++ b/frontend/packages/ui-workflow/src/useProjectWorkflow.ts
@@ -151,8 +151,9 @@ export function useProjectWorkflow(
 
   const approveWithState = useCallback(
     async (approvedIds: string[]) => {
-      await approve(approvedIds);
+      const result = await approve(approvedIds);
       applyLocalApprovalAck();
+      return result;
     },
     [approve, applyLocalApprovalAck],
   );

--- a/frontend/src/test/ProposalReviewPanel.test.tsx
+++ b/frontend/src/test/ProposalReviewPanel.test.tsx
@@ -96,6 +96,39 @@ describe("ProposalReviewPanel", () => {
     expect(onApprove).toHaveBeenCalledWith(["t1-0001"]);
   });
 
+  it("enables Next when Gate 2 has only AI could-not-fix rows", async () => {
+    const user = userEvent.setup();
+    const onApprove = vi.fn();
+    const declinedOnly: OperationProposal[] = [
+      {
+        id: "ai-0000",
+        rule_id: "L005",
+        file: "playbook-1057-wrong-module.yml",
+        path: "playbook-1057-wrong-module.yml/plays[0]/tasks[0]",
+        source: "ai",
+        tier: 2,
+        confidence: 0,
+        status: "declined",
+        explanation: "AI could not generate a fix for this violation.",
+        suggestion: "Use a validated collection instead.",
+      },
+    ];
+    render(
+      <ProposalReviewPanel
+        proposals={declinedOnly}
+        onApprove={onApprove}
+        reviewGate="ai"
+        pastAiEscalation
+      />,
+    );
+    expect(
+      screen.getByText(/Continue with no AI fixes applied/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Next$/i })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: /^Next$/i }));
+    expect(onApprove).toHaveBeenCalledWith([]);
+  });
+
   it("Clear resets decisions and disables Next again", async () => {
     const user = userEvent.setup();
     const onDraftUpdate = vi.fn();

--- a/frontend/src/test/proposalTier.test.ts
+++ b/frontend/src/test/proposalTier.test.ts
@@ -6,6 +6,7 @@ import {
   proposalHasVisibleDiff,
   proposalNodeTitle,
   proposalsGateKey,
+  resolveProposalReviewGate,
   splitRuleIds,
 } from '../../packages/ui-workflow/src/remediation/proposalTier';
 import {
@@ -88,6 +89,29 @@ describe("proposalHasVisibleDiff", () => {
   });
 });
 
+describe("resolveProposalReviewGate", () => {
+  it("uses tier1 when only rule-based proposals and no escalation", () => {
+    const t1 = [prop({ id: "t1-0001", source: "deterministic", tier: 1 })];
+    expect(resolveProposalReviewGate(t1)).toBe("tier1");
+  });
+
+  it("uses ai after escalation even when proposals are declined-only", () => {
+    const declined = [
+      prop({
+        id: "ai-declined-0000",
+        source: "ai",
+        tier: 2,
+        status: "declined",
+        explanation: "AI could not generate a fix for this violation.",
+      }),
+    ];
+    expect(
+      resolveProposalReviewGate(declined, { enableAi: true, pastAiEscalation: true }),
+    ).toBe("ai");
+    expect(gateLabel(declined, "ai")).toContain("AI");
+  });
+});
+
 describe("proposalsGateKey / gateLabel", () => {
   it("resets key when gate proposals change", () => {
     const t1 = [prop({ id: "t1-0001", source: "deterministic", tier: 1 })];
@@ -96,6 +120,39 @@ describe("proposalsGateKey / gateLabel", () => {
     expect(proposalsGateKey(ai)).toBe("ai:ai-0001");
     expect(gateLabel(t1)).toContain("Rule-based fix");
     expect(gateLabel(ai)).toContain("AI");
+  });
+});
+
+describe("resolveProposalReviewGate edge cases", () => {
+  it("empty proposals without options returns tier1", () => {
+    expect(resolveProposalReviewGate([])).toBe("tier1");
+  });
+
+  it("tier2 deterministic proposals classified as ai gate", () => {
+    const t2det = [prop({ id: "t1-0001", source: "deterministic", tier: 2 })];
+    expect(resolveProposalReviewGate(t2det)).toBe("ai");
+  });
+
+  it("ai-candidate source classified as ai gate", () => {
+    const candidate = [prop({ id: "ai-cand-0", source: "ai-candidate", tier: 2 })];
+    expect(resolveProposalReviewGate(candidate)).toBe("ai");
+  });
+
+  it("pastAiEscalation + enableAi promotes tier1 proposals to ai gate", () => {
+    const t1 = [prop({ id: "t1-0001", source: "deterministic", tier: 1 })];
+    expect(resolveProposalReviewGate(t1, { enableAi: true, pastAiEscalation: true })).toBe("ai");
+  });
+
+  it("pastAiEscalation without enableAi stays tier1", () => {
+    const t1 = [prop({ id: "t1-0001", source: "deterministic", tier: 1 })];
+    expect(resolveProposalReviewGate(t1, { enableAi: false, pastAiEscalation: true })).toBe("tier1");
+  });
+
+  it("gateLabel with explicit reviewGate overrides intrinsic detection", () => {
+    const t1 = [prop({ id: "t1-0001", source: "deterministic", tier: 1 })];
+    expect(gateLabel(t1, "ai")).toContain("AI");
+    const ai = [prop({ id: "ai-0001", source: "ai", tier: 2 })];
+    expect(gateLabel(ai, "tier1")).toContain("Rule-based fix");
   });
 });
 

--- a/frontend/src/test/sseFetch.test.ts
+++ b/frontend/src/test/sseFetch.test.ts
@@ -222,6 +222,44 @@ describe('applyOperationSseEvent', () => {
     expect(state.proposals).toBeUndefined();
   });
 
+  it('ignores proposals SSE after operation expired', () => {
+    let state: ProjectOperationState = {
+      operation_id: 'op-1',
+      project_id: 'p-1',
+      scan_id: 's-1',
+      status: 'expired',
+      scan_type: 'remediate',
+      started_at: '2026-01-01T00:00:00Z',
+      progress: [],
+    };
+    const setState = vi.fn(
+      (updater: SetStateAction<ProjectOperationState | null>) => {
+        state =
+          typeof updater === 'function'
+            ? (updater(state) ?? state)
+            : (updater ?? state);
+      },
+    ) as Dispatch<SetStateAction<ProjectOperationState | null>>;
+    const setConnected = vi.fn();
+    applyOperationSseEvent(setState, setConnected, {
+      event: 'proposals',
+      data: JSON.stringify({
+        proposals: [
+          {
+            id: 'ai-0001',
+            rule_id: 'L001',
+            file: 'a.yml',
+            tier: 2,
+            confidence: 0.9,
+            source: 'ai',
+          },
+        ],
+      }),
+    });
+    expect(state.status).toBe('expired');
+    expect(state.proposals).toBeUndefined();
+  });
+
   it('merges error_code on status_changed', () => {
     let state: ProjectOperationState = {
       operation_id: 'op-1',

--- a/frontend/src/test/sseFetch.test.ts
+++ b/frontend/src/test/sseFetch.test.ts
@@ -146,6 +146,82 @@ describe('applyOperationSseEvent', () => {
     expect(state.status).toBe('scanning');
   });
 
+  it('sets awaiting_approval when proposals arrive', () => {
+    let state: ProjectOperationState = {
+      operation_id: 'op-1',
+      project_id: 'p-1',
+      scan_id: 's-1',
+      status: 'applying',
+      scan_type: 'remediate',
+      started_at: '2026-01-01T00:00:00Z',
+      progress: [],
+    };
+    const setState = vi.fn(
+      (updater: SetStateAction<ProjectOperationState | null>) => {
+        state =
+          typeof updater === 'function'
+            ? (updater(state) ?? state)
+            : (updater ?? state);
+      },
+    ) as Dispatch<SetStateAction<ProjectOperationState | null>>;
+    const setConnected = vi.fn();
+    applyOperationSseEvent(setState, setConnected, {
+      event: 'proposals',
+      data: JSON.stringify({
+        proposals: [
+          {
+            id: 'ai-0001',
+            rule_id: 'L001',
+            file: 'a.yml',
+            tier: 2,
+            confidence: 0.9,
+            source: 'ai',
+          },
+        ],
+      }),
+    });
+    expect(state.status).toBe('awaiting_approval');
+    expect(state.proposals).toHaveLength(1);
+  });
+
+  it('ignores proposals SSE after operation completed', () => {
+    let state: ProjectOperationState = {
+      operation_id: 'op-1',
+      project_id: 'p-1',
+      scan_id: 's-1',
+      status: 'completed',
+      scan_type: 'remediate',
+      started_at: '2026-01-01T00:00:00Z',
+      progress: [],
+    };
+    const setState = vi.fn(
+      (updater: SetStateAction<ProjectOperationState | null>) => {
+        state =
+          typeof updater === 'function'
+            ? (updater(state) ?? state)
+            : (updater ?? state);
+      },
+    ) as Dispatch<SetStateAction<ProjectOperationState | null>>;
+    const setConnected = vi.fn();
+    applyOperationSseEvent(setState, setConnected, {
+      event: 'proposals',
+      data: JSON.stringify({
+        proposals: [
+          {
+            id: 'ai-0001',
+            rule_id: 'L001',
+            file: 'a.yml',
+            tier: 2,
+            confidence: 0.9,
+            source: 'ai',
+          },
+        ],
+      }),
+    });
+    expect(state.status).toBe('completed');
+    expect(state.proposals).toBeUndefined();
+  });
+
   it('merges error_code on status_changed', () => {
     let state: ProjectOperationState = {
       operation_id: 'op-1',
@@ -177,5 +253,91 @@ describe('applyOperationSseEvent', () => {
     expect(state.status).toBe('failed');
     expect(state.error).toBe('Operation stalled without progress');
     expect(state.error_code).toBe('operation_stalled');
+  });
+
+  it('ignores stale applying status_changed while proposals await review', () => {
+    let state: ProjectOperationState = {
+      operation_id: 'op-1',
+      project_id: 'p-1',
+      scan_id: 's-1',
+      status: 'awaiting_approval',
+      scan_type: 'remediate',
+      started_at: '2026-01-01T00:00:00Z',
+      progress: [],
+      proposals: [
+        {
+          id: 'ai-0001',
+          rule_id: 'L001',
+          file: 'a.yml',
+          tier: 2,
+          confidence: 0.9,
+          source: 'ai',
+        },
+      ],
+    };
+    const setState = vi.fn(
+      (updater: SetStateAction<ProjectOperationState | null>) => {
+        state =
+          typeof updater === 'function'
+            ? (updater(state) ?? state)
+            : (updater ?? state);
+      },
+    ) as Dispatch<SetStateAction<ProjectOperationState | null>>;
+    const setConnected = vi.fn();
+    applyOperationSseEvent(setState, setConnected, {
+      event: 'status_changed',
+      data: JSON.stringify({ status: 'applying', previous: 'awaiting_approval' }),
+    });
+    expect(state.status).toBe('awaiting_approval');
+    expect(state.proposals).toHaveLength(1);
+  });
+
+  it('approval_ack moves to applying and clears proposals', () => {
+    let state: ProjectOperationState = {
+      operation_id: 'op-1',
+      project_id: 'p-1',
+      scan_id: 's-1',
+      status: 'awaiting_approval',
+      scan_type: 'remediate',
+      started_at: '2026-01-01T00:00:00Z',
+      progress: [],
+      proposals: [
+        {
+          id: 'ai-0001',
+          rule_id: 'L001',
+          file: 'a.yml',
+          tier: 2,
+          confidence: 0.9,
+          source: 'ai',
+        },
+      ],
+      result: {
+        total_violations: 1,
+        fixable: 1,
+        ai_proposed: 1,
+        ai_declined: 0,
+        ai_accepted: 0,
+        manual_review: 0,
+        remediated_count: 0,
+        fixed_violations: [],
+        patches: [],
+      },
+    };
+    const setState = vi.fn(
+      (updater: SetStateAction<ProjectOperationState | null>) => {
+        state =
+          typeof updater === 'function'
+            ? (updater(state) ?? state)
+            : (updater ?? state);
+      },
+    ) as Dispatch<SetStateAction<ProjectOperationState | null>>;
+    const setConnected = vi.fn();
+    applyOperationSseEvent(setState, setConnected, {
+      event: 'approval_ack',
+      data: JSON.stringify({ applied_count: 2 }),
+    });
+    expect(state.status).toBe('applying');
+    expect(state.proposals).toBeUndefined();
+    expect(state.result?.ai_accepted).toBe(2);
   });
 });

--- a/frontend/src/test/workflowSteps.test.ts
+++ b/frontend/src/test/workflowSteps.test.ts
@@ -126,6 +126,13 @@ describe('resolveCurrentWorkflowStep', () => {
   });
 
   it('uses AI escalation for awaiting_ai_triage', () => {
+    let latch = emptyWorkflowLatch();
+    latch = updateWorkflowLatch(
+      latch,
+      baseState({ status: 'applying', scan_type: 'remediate' }),
+      true,
+    );
+    expect(latch.tier1GateSkipped).toBe(true);
     const state = baseState({
       status: 'awaiting_ai_triage',
       ai_triage_candidates: [
@@ -137,10 +144,13 @@ describe('resolveCurrentWorkflowStep', () => {
         },
       ],
     });
-    const latch = updateWorkflowLatch(emptyWorkflowLatch(), state, true);
+    latch = updateWorkflowLatch(latch, state, true);
     expect(resolveCurrentWorkflowStep(state, true, latch)).toBe('ai_escalation');
-    expect(latch.pastTier1Applied).toBe(true);
+    expect(latch.pastTier1Applied).toBe(false);
     expect(latch.pastAiEscalation).toBe(true);
+    expect(workflowStepDefs(true, { skipTier1: true }).map((s) => s.id)).not.toContain(
+      'tier1_proposals',
+    );
   });
 
   it('keeps AI escalation while applying after escalate-ai', () => {
@@ -174,7 +184,33 @@ describe('resolveCurrentWorkflowStep', () => {
     });
     const latch = updateWorkflowLatch(emptyWorkflowLatch(), state, true);
     expect(resolveCurrentWorkflowStep(state, true, latch)).toBe('ai_proposals');
-    expect(latch.pastTier1Applied).toBe(true);
+    expect(latch.seenGate2Review).toBe(true);
+    expect(latch.pastAiReview).toBe(false);
+  });
+
+  it('uses AI proposals while applying when Gate 2 payloads beat status_changed', () => {
+    let latch = emptyWorkflowLatch();
+    latch = updateWorkflowLatch(
+      latch,
+      baseState({ status: 'awaiting_ai_triage', ai_triage_candidates: [] }),
+      true,
+    );
+    const state = baseState({
+      status: 'applying',
+      scan_type: 'remediate',
+      proposals: [
+        {
+          id: 'ai-1',
+          rule_id: 'L001',
+          file: 'a.yml',
+          tier: 2,
+          confidence: 0.8,
+          source: 'ai',
+        },
+      ],
+    });
+    latch = updateWorkflowLatch(latch, state, true);
+    expect(resolveCurrentWorkflowStep(state, true, latch)).toBe('ai_proposals');
   });
 
   it('uses AI applied while applying after Gate 2 approve', () => {
@@ -197,6 +233,78 @@ describe('resolveCurrentWorkflowStep', () => {
     latch = updateWorkflowLatch(latch, applying, true);
     expect(resolveCurrentWorkflowStep(applying, true, latch)).toBe('ai_applied');
     expect(latch.pastAiApplied).toBe(true);
+  });
+
+  it('uses AI applied while applying after Gate 2 approve even if proposals linger', () => {
+    let latch = emptyWorkflowLatch();
+    const review = baseState({
+      status: 'awaiting_approval',
+      proposals: [
+        {
+          id: 'ai-1',
+          rule_id: 'L001',
+          file: 'a.yml',
+          tier: 2,
+          confidence: 0.8,
+          source: 'ai',
+        },
+      ],
+    });
+    latch = updateWorkflowLatch(latch, review, true);
+    const applying = baseState({
+      status: 'applying',
+      scan_type: 'remediate',
+      proposals: review.proposals,
+    });
+    latch = updateWorkflowLatch(latch, applying, true);
+    expect(resolveCurrentWorkflowStep(applying, true, latch)).toBe('ai_applied');
+    expect(latch.pastAiApplied).toBe(true);
+  });
+
+  it('lands on AI applied when completed after Gate 2 until acknowledged', () => {
+    let latch = emptyWorkflowLatch();
+    latch = updateWorkflowLatch(
+      latch,
+      baseState({
+        status: 'awaiting_approval',
+        proposals: [
+          {
+            id: 'ai-1',
+            rule_id: 'L001',
+            file: 'a.yml',
+            tier: 2,
+            confidence: 0.8,
+            source: 'ai',
+          },
+        ],
+      }),
+      true,
+    );
+    latch = updateWorkflowLatch(
+      latch,
+      baseState({ status: 'applying', scan_type: 'remediate' }),
+      true,
+    );
+    const completed = baseState({
+      status: 'completed',
+      scan_type: 'remediate',
+      result: {
+        total_violations: 5,
+        fixable: 2,
+        ai_proposed: 1,
+        ai_declined: 0,
+        ai_accepted: 1,
+        manual_review: 0,
+        remediated_count: 2,
+        fixed_violations: [],
+        patches: [{ file: 'a.yml', diff: '@@' }],
+      },
+    });
+    latch = updateWorkflowLatch(latch, completed, true);
+    expect(resolveCurrentWorkflowStep(completed, true, latch)).toBe('ai_applied');
+    expect(
+      resolveCurrentWorkflowStep(completed, true, latch, { aiApplyFinished: true }),
+    ).toBe('commit');
   });
 
   it('lands on Commit when completed with remediations', () => {
@@ -262,6 +370,29 @@ describe('resolveCurrentWorkflowStep', () => {
     expect(
       resolveCurrentWorkflowStep(state, true, emptyWorkflowLatch()),
     ).toBe('complete');
+  });
+
+  it('does not mark AI review/applied on completed when Gate 2 was skipped', () => {
+    const state = baseState({
+      status: 'completed',
+      scan_type: 'remediate',
+      ai_triage_candidates: [{ rule_id: 'L001', message: 'x', file: 'a.yml' }],
+      result: {
+        total_violations: 5,
+        fixable: 4,
+        ai_proposed: 0,
+        ai_declined: 0,
+        ai_accepted: 0,
+        manual_review: 0,
+        remediated_count: 4,
+        fixed_violations: [],
+        patches: [{ file: 'a.yml', diff: '@@' }],
+      },
+    });
+    const latch = updateWorkflowLatch(emptyWorkflowLatch(), state, true);
+    expect(latch.pastAiEscalation).toBe(true);
+    expect(latch.pastAiReview).toBe(false);
+    expect(latch.pastAiApplied).toBe(false);
   });
 });
 
@@ -358,5 +489,158 @@ describe('stepVisualState', () => {
     expect(
       stepVisualState('tier1_proposals', 'findings', defs, 'assessed'),
     ).toEqual({ variant: 'pending', isCurrent: false });
+  });
+});
+
+describe('edge cases', () => {
+  it('skipTier1 omits tier1_proposals and tier1_applied from step defs', () => {
+    const defs = workflowStepDefs(true, { skipTier1: true });
+    const ids = defs.map((s) => s.id);
+    expect(ids).not.toContain('tier1_proposals');
+    expect(ids).not.toContain('tier1_applied');
+    expect(ids).toContain('ai_escalation');
+    expect(ids).toContain('ai_proposals');
+  });
+
+  it('tier1GateSkipped stays false when Gate 1 proposals arrive', () => {
+    let latch = emptyWorkflowLatch();
+    const state = baseState({
+      status: 'awaiting_approval',
+      proposals: [
+        { id: 't1-0', rule_id: 'M001', file: 'a.yml', tier: 1, confidence: 1, source: 'deterministic' },
+      ],
+    });
+    latch = updateWorkflowLatch(latch, state, true);
+    expect(latch.tier1GateSkipped).toBe(false);
+    expect(latch.pastTier1Review).toBe(true);
+  });
+
+  it('applying twice does not double-set tier1GateSkipped', () => {
+    let latch = emptyWorkflowLatch();
+    const applying = baseState({ status: 'applying', scan_type: 'remediate' });
+    latch = updateWorkflowLatch(latch, applying, true);
+    expect(latch.tier1GateSkipped).toBe(true);
+    // Second applying should not flip it back
+    latch = updateWorkflowLatch(latch, applying, true);
+    expect(latch.tier1GateSkipped).toBe(true);
+  });
+
+  it('full flow: Gate 1 → Gate 2 → completed latches correctly', () => {
+    let latch = emptyWorkflowLatch();
+    // Gate 1 proposals arrive
+    latch = updateWorkflowLatch(
+      latch,
+      baseState({
+        status: 'awaiting_approval',
+        proposals: [{ id: 't1-0', rule_id: 'M001', file: 'a.yml', tier: 1, confidence: 1, source: 'deterministic' }],
+      }),
+      true,
+    );
+    expect(latch.pastTier1Review).toBe(true);
+    expect(latch.tier1GateSkipped).toBe(false);
+
+    // Applying after Gate 1 approve
+    latch = updateWorkflowLatch(latch, baseState({ status: 'applying', scan_type: 'remediate' }), true);
+    expect(latch.pastTier1Applied).toBe(true);
+    expect(latch.pastAiEscalation).toBe(false);
+
+    // AI triage
+    latch = updateWorkflowLatch(
+      latch,
+      baseState({ status: 'awaiting_ai_triage', ai_triage_candidates: [{ rule_id: 'L001', message: 'x', file: 'a.yml', path: 'a.yml::0' }] }),
+      true,
+    );
+    expect(latch.pastAiEscalation).toBe(true);
+
+    // Gate 2 proposals
+    latch = updateWorkflowLatch(
+      latch,
+      baseState({
+        status: 'awaiting_approval',
+        proposals: [{ id: 'ai-0', rule_id: 'L001', file: 'a.yml', tier: 2, confidence: 0.8, source: 'ai' }],
+      }),
+      true,
+    );
+    expect(latch.seenGate2Review).toBe(true);
+    expect(latch.pastAiReview).toBe(false);
+
+    // Applying after Gate 2 approve
+    latch = updateWorkflowLatch(latch, baseState({ status: 'applying', scan_type: 'remediate' }), true);
+    expect(latch.pastAiApplied).toBe(true);
+
+    // Completed
+    latch = updateWorkflowLatch(
+      latch,
+      baseState({
+        status: 'completed',
+        scan_type: 'remediate',
+        result: { total_violations: 5, fixable: 3, ai_proposed: 1, ai_declined: 0, ai_accepted: 1, manual_review: 1, remediated_count: 3, fixed_violations: [], patches: [{ file: 'a.yml', diff: '@@' }] },
+      }),
+      true,
+    );
+    expect(latch.pastAiEscalation).toBe(true);
+    expect(latch.pastAiReview).toBe(true);
+    expect(latch.pastAiApplied).toBe(true);
+  });
+
+  it('mixed tier2 proposals (AI + post-AI deterministic) are recognized as aiGate', () => {
+    const state = baseState({
+      status: 'awaiting_approval',
+      proposals: [
+        { id: 'ai-0', rule_id: 'L001', file: 'a.yml', tier: 2, confidence: 0.8, source: 'ai' },
+        { id: 't1-0001', rule_id: 'M002', file: 'b.yml', tier: 2, confidence: 1, source: 'deterministic' },
+      ],
+    });
+    const latch = updateWorkflowLatch(emptyWorkflowLatch(), state, true);
+    expect(latch.seenGate2Review).toBe(true);
+    expect(latch.pastAiReview).toBe(false);
+    expect(resolveCurrentWorkflowStep(state, true, latch)).toBe('ai_proposals');
+  });
+
+  it('failed status preserves latch without inventing later milestones', () => {
+    let latch = emptyWorkflowLatch();
+    latch = updateWorkflowLatch(
+      latch,
+      baseState({ status: 'awaiting_approval', proposals: [{ id: 't1-0', rule_id: 'M001', file: 'a.yml', tier: 1, confidence: 1, source: 'deterministic' }] }),
+      true,
+    );
+    latch = updateWorkflowLatch(latch, baseState({ status: 'failed' }), true);
+    expect(latch.pastTier1Review).toBe(true);
+    expect(latch.pastAiEscalation).toBe(false);
+    expect(latch.pastAiReview).toBe(false);
+  });
+
+  it('infers seenGate2Review on completed after AI triage produced fixes', () => {
+    const completed = baseState({
+      status: 'completed',
+      scan_type: 'remediate',
+      ai_triage_candidates: [{ rule_id: 'L001', message: 'x', file: 'a.yml', path: 'a.yml::0' }],
+      result: {
+        total_violations: 5,
+        fixable: 2,
+        ai_proposed: 1,
+        ai_declined: 0,
+        ai_accepted: 1,
+        manual_review: 0,
+        remediated_count: 2,
+        fixed_violations: [],
+        patches: [{ file: 'a.yml', diff: '@@' }],
+      },
+    });
+    const latch = updateWorkflowLatch(emptyWorkflowLatch(), completed, true);
+    expect(latch.seenGate2Review).toBe(true);
+    expect(resolveCurrentWorkflowStep(completed, true, latch)).toBe('ai_applied');
+  });
+
+  it('completed with no AI activity does not mark ai steps (AI-enabled but no triage)', () => {
+    const state = baseState({
+      status: 'completed',
+      scan_type: 'remediate',
+      result: { total_violations: 2, fixable: 2, ai_proposed: 0, ai_declined: 0, ai_accepted: 0, manual_review: 0, remediated_count: 2, fixed_violations: [], patches: [{ file: 'a.yml', diff: '@@' }] },
+    });
+    const latch = updateWorkflowLatch(emptyWorkflowLatch(), state, true);
+    expect(latch.pastAiEscalation).toBe(false);
+    expect(latch.pastAiReview).toBe(false);
+    expect(latch.pastAiApplied).toBe(false);
   });
 });

--- a/src/apme_engine/daemon/engine_server.py
+++ b/src/apme_engine/daemon/engine_server.py
@@ -2573,6 +2573,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         if proposed_proposals:
             for p in proposed_proposals:
                 session.proposals[p.id] = p
+            session.review_declined_proposals = {p.id: p for p in declined_proposals}
             session.ai_proposals = list(graph_report.ai_proposals) if graph_report.ai_proposals else []
             session.current_tier = 2
             session.status = 1  # AWAITING_APPROVAL
@@ -2739,6 +2740,53 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
                 )
             )
         return proposals
+
+    @staticmethod
+    def _consolidate_gate2_proposals(
+        ai_proposals: list[Proposal],
+        tier1_proposals: list[Proposal],
+    ) -> list[Proposal]:
+        """Return one selectable Gate 2 proposal per graph node.
+
+        AI and post-AI Tier 1 cleanup can target the same node. Approval applies
+        to the whole node, so duplicate rows would let conflicting decisions
+        override each other in ``_apply_graph_approvals``.
+
+        Args:
+            ai_proposals: Gate 2 AI proposals from ``_build_graph_proposals``.
+            tier1_proposals: Gate 2 Tier 1 proposals (``g2-t1-*`` ids).
+
+        Returns:
+            Ordered proposals with at most one row per ``Proposal.path``.
+        """
+        by_node: dict[str, Proposal] = {}
+        order: list[str] = []
+        for proposal in ai_proposals:
+            key = (proposal.path or "").strip() or proposal.id
+            if key not in by_node:
+                order.append(key)
+            by_node[key] = proposal
+        for tier1 in tier1_proposals:
+            key = (tier1.path or "").strip() or tier1.id
+            if key in by_node:
+                existing = by_node[key]
+                merged_rules = {r.strip() for r in existing.rule_id.split(",") if r.strip()}
+                merged_rules.update(r.strip() for r in tier1.rule_id.split(",") if r.strip())
+                if merged_rules:
+                    existing.rule_id = ",".join(sorted(merged_rules))
+                existing.after_text = tier1.after_text
+                existing.diff_hunk = tier1.diff_hunk
+                if tier1.explanation:
+                    existing.explanation = (
+                        f"{existing.explanation}\n{tier1.explanation}".strip()
+                        if existing.explanation
+                        else tier1.explanation
+                    )
+            else:
+                if key not in by_node:
+                    order.append(key)
+                by_node[key] = tier1
+        return [by_node[key] for key in order]
 
     async def _session_begin_remediate(
         self,
@@ -3082,16 +3130,17 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         session.remaining_ai = list(remaining)
 
         proposed_proposals: list[Proposal] = []
+        ai_built: list[Proposal] = []
         if graph_report.ai_proposals:
-            proposed_proposals.extend(self._build_graph_proposals(graph_report.ai_proposals))
-        # Post-AI Tier 1 cleanup stays pending until Gate 2 ApprovalRequest.
+            ai_built = self._build_graph_proposals(graph_report.ai_proposals)
+        gate2_t1_built: list[Proposal] = []
         if getattr(graph_report, "tier1_proposals", None):
-            t1_start = len(proposed_proposals)
-            gate2_t1 = self._build_tier1_proposals(graph_report.tier1_proposals)
-            for offset, proposal in enumerate(gate2_t1):
-                proposal.id = f"t1-{t1_start + offset:04d}"
+            gate2_t1_raw = self._build_tier1_proposals(graph_report.tier1_proposals)
+            for offset, proposal in enumerate(gate2_t1_raw):
+                proposal.id = f"g2-t1-{offset:04d}"
                 proposal.tier = 2
-            proposed_proposals.extend(gate2_t1)
+            gate2_t1_built = gate2_t1_raw
+        proposed_proposals = self._consolidate_gate2_proposals(ai_built, gate2_t1_built)
         proposed_rule_files: set[tuple[str, str]] = set()
         for p in proposed_proposals:
             for raw_rid in p.rule_id.split(","):
@@ -3109,6 +3158,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
             # Do NOT splice into working_files until Gate 2 approve/decline.
             for p in proposed_proposals:
                 session.proposals[p.id] = p
+            session.review_declined_proposals = {p.id: p for p in declined_proposals}
             session.ai_proposals = list(graph_report.ai_proposals) if graph_report.ai_proposals else []
             session.tier1_proposals = list(getattr(graph_report, "tier1_proposals", None) or [])
             session.status = 1  # AWAITING_APPROVAL
@@ -3170,6 +3220,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
             Number of proposals successfully applied.
         """
         if not approved_ids and not session.proposals:
+            session.review_declined_proposals.clear()
             if finalize:
                 session.status = 3  # COMPLETE
             session.awaiting_tier1_gate = False
@@ -3178,7 +3229,9 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         graph = session.content_graph
         originals = session.graph_originals
 
-        has_graph_proposals = graph is not None and any(pid.startswith(("ai-", "t1-")) for pid in session.proposals)
+        has_graph_proposals = graph is not None and any(
+            pid.startswith(("ai-", "t1-", "g2-t1-")) for pid in session.proposals
+        )
 
         temp_patches: list[SplicedFilePatch] | None = None
         if has_graph_proposals and graph is not None and originals is not None:
@@ -3198,6 +3251,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
             applied = _apply_text_approvals(session, approved_ids)
 
         session.awaiting_tier1_gate = False
+        session.review_declined_proposals.clear()
         if finalize:
             session.status = 3  # COMPLETE — user has finished reviewing
         else:
@@ -3472,11 +3526,15 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
                 ),
             )
         elif (
-            session.proposals and session.status == 1 and not session.awaiting_assess and not session.awaiting_ai_triage
+            (session.proposals or session.review_declined_proposals)
+            and session.status == 1
+            and not session.awaiting_assess
+            and not session.awaiting_ai_triage
         ):
+            review_proposals = list(session.proposals.values()) + list(session.review_declined_proposals.values())
             yield SessionEvent(
                 proposals=ProposalsReady(
-                    proposals=list(session.proposals.values()),
+                    proposals=review_proposals,
                     tier=session.current_tier,
                     status=1,
                 ),
@@ -3838,6 +3896,7 @@ def _apply_graph_approvals(
         proposal_node_map[f"ai-{idx:04d}"] = anp.node_id
     for idx, tnp in enumerate(tier1_proposals):
         proposal_node_map[f"t1-{idx:04d}"] = tnp.node_id
+        proposal_node_map[f"g2-t1-{idx:04d}"] = tnp.node_id
 
     applied = 0
     rejected_node_ids: set[str] = set()

--- a/src/apme_engine/daemon/engine_server.py
+++ b/src/apme_engine/daemon/engine_server.py
@@ -3081,7 +3081,17 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         )
         session.remaining_ai = list(remaining)
 
-        proposed_proposals = self._build_graph_proposals(graph_report.ai_proposals) if graph_report.ai_proposals else []
+        proposed_proposals: list[Proposal] = []
+        if graph_report.ai_proposals:
+            proposed_proposals.extend(self._build_graph_proposals(graph_report.ai_proposals))
+        # Post-AI Tier 1 cleanup stays pending until Gate 2 ApprovalRequest.
+        if getattr(graph_report, "tier1_proposals", None):
+            t1_start = len(proposed_proposals)
+            gate2_t1 = self._build_tier1_proposals(graph_report.tier1_proposals)
+            for offset, proposal in enumerate(gate2_t1):
+                proposal.id = f"t1-{t1_start + offset:04d}"
+                proposal.tier = 2
+            proposed_proposals.extend(gate2_t1)
         proposed_rule_files: set[tuple[str, str]] = set()
         for p in proposed_proposals:
             for raw_rid in p.rule_id.split(","):
@@ -3095,11 +3105,12 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         )
         all_proposals = proposed_proposals + declined_proposals
 
-        if proposed_proposals:
+        if all_proposals:
             # Do NOT splice into working_files until Gate 2 approve/decline.
             for p in proposed_proposals:
                 session.proposals[p.id] = p
-            session.ai_proposals = list(graph_report.ai_proposals)
+            session.ai_proposals = list(graph_report.ai_proposals) if graph_report.ai_proposals else []
+            session.tier1_proposals = list(getattr(graph_report, "tier1_proposals", None) or [])
             session.status = 1  # AWAITING_APPROVAL
             yield SessionEvent(
                 proposals=ProposalsReady(

--- a/src/apme_engine/daemon/session.py
+++ b/src/apme_engine/daemon/session.py
@@ -49,6 +49,8 @@ class SessionState:
         tier1_patches: Applied Tier 1 patches.
         format_diffs: Format diffs from the formatting phase.
         proposals: Pending AI proposals keyed by proposal ID.
+        review_declined_proposals: Declined-only review rows (display/replay;
+            not applied via ApprovalRequest).
         current_tier: Current remediation tier (1, 2, or 3).
         report: Remediation report from the engine.
         temp_dir: Temporary directory for materialized files.
@@ -120,6 +122,7 @@ class SessionState:
     tier1_patches: list[FilePatch] = field(default_factory=list)
     format_diffs: list[FileDiff] = field(default_factory=list)
     proposals: dict[str, Proposal] = field(default_factory=dict)
+    review_declined_proposals: dict[str, Proposal] = field(default_factory=dict)
     current_tier: int = 1
     report: FixReport | None = None
     temp_dir: Path | None = None

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -452,6 +452,7 @@ class GraphRemediationEngine:
                             graph,
                             pass_num,
                             resolve_fixed_by="deterministic",
+                            resolve_status="pending_review" if interactive else "fixed",
                         )
                         violations = graph.collect_violations()
                         _, new_tier2, _ = partition_violations(violations, registry)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -708,6 +708,7 @@ class TestSessionApprovalGates:
                         fixed_violations=[],
                         oscillation_detected=False,
                         ai_proposals=[],
+                        tier1_proposals=[],
                     )
                 )
 
@@ -800,6 +801,7 @@ class TestSessionApprovalGates:
                         fixed_violations=[],
                         oscillation_detected=False,
                         ai_proposals=[ai_prop],
+                        tier1_proposals=[],
                     )
                 )
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -833,6 +833,208 @@ class TestSessionApprovalGates:
         assert (tmp_path / "play.yml").read_bytes() == baseline
         assert session.pre_gate2_files["play.yml"] == baseline
 
+    async def test_ai_gate_pauses_on_declined_only_proposals(self, tmp_path: Path) -> None:
+        """Gate 2 emits ProposalsReady when AI produces only declined rows.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from apme_engine.daemon.engine_server import EngineServicer
+        from apme_engine.graph.content_graph import ContentGraph
+
+        remaining = {
+            "rule_id": "L005",
+            "file": "play.yml",
+            "path": "play.yml/plays[0]/tasks[0]",
+            "message": "Use a module instead of command.",
+            "severity": "medium",
+            "line": 1,
+            "scope": "task",
+        }
+
+        class _DummyGraphEngine:
+            def __init__(self) -> None:
+                from apme_engine.remediation.transforms import build_default_registry
+
+                self._registry = build_default_registry()
+                self._ai_provider = None
+                self._max_ai_attempts = 2
+                self.remediate = AsyncMock(
+                    return_value=SimpleNamespace(
+                        passes=1,
+                        fixed=0,
+                        remaining_violations=[remaining],
+                        fixed_violations=[],
+                        oscillation_detected=False,
+                        ai_proposals=[],
+                        tier1_proposals=[],
+                    )
+                )
+
+        servicer = EngineServicer()
+        session = SessionState(session_id="gate-declined-only")
+        session.content_graph = ContentGraph()
+        session.graph_engine = _DummyGraphEngine()
+        baseline = b"- name: test\n  command: echo hi\n"
+        session.working_files = {"play.yml": baseline}
+        session.fix_options = FixOptions(enable_ai=True)
+        session.graph_originals = {"play.yml": baseline.decode()}
+        session.temp_dir = tmp_path
+        (tmp_path / "play.yml").write_bytes(baseline)
+
+        with patch("apme_engine.remediation.graph_engine.GraphRemediationEngine", _DummyGraphEngine):
+            events = [e async for e in servicer._session_run_ai_gate(session)]
+
+        assert [e.WhichOneof("event") for e in events] == ["progress", "proposals"]
+        assert session.status == 1  # AWAITING_APPROVAL
+        assert session.proposals == {}
+        assert list(session.review_declined_proposals) == ["ai-declined-0000"]
+        emitted = events[1].proposals.proposals
+        assert len(emitted) == 1
+        assert emitted[0].id == "ai-declined-0000"
+        assert emitted[0].status == "declined"
+        assert emitted[0].tier == 2
+        assert session.working_files["play.yml"] == baseline
+        assert (tmp_path / "play.yml").read_bytes() == baseline
+
+    async def test_ai_gate_pauses_on_post_ai_tier1_cleanup(self, tmp_path: Path) -> None:
+        """Post-AI deterministic cleanup is staged as g2-t1-* Gate 2 review.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+        """
+        from apme_engine.daemon.engine_server import EngineServicer
+        from apme_engine.graph.content_graph import ContentGraph
+        from apme_engine.remediation.graph_engine import Tier1NodeProposal
+
+        t1_prop = Tier1NodeProposal(
+            node_id="play.yml/plays[0]/tasks[0]",
+            file_path="play.yml",
+            before_yaml="- name: test\n  command: echo hi\n",
+            after_yaml="- name: test\n  ansible.builtin.command:\n    cmd: echo hi\n",
+            rule_ids=["L001"],
+            violation_summaries=["[L001]: FQCN"],
+            line_start=1,
+            line_end=2,
+            node_type="task",
+        )
+
+        class _DummyGraphEngine:
+            def __init__(self) -> None:
+                from apme_engine.remediation.transforms import build_default_registry
+
+                self._registry = build_default_registry()
+                self._ai_provider = None
+                self._max_ai_attempts = 2
+                self.remediate = AsyncMock(
+                    return_value=SimpleNamespace(
+                        passes=1,
+                        fixed=0,
+                        remaining_violations=[],
+                        fixed_violations=[],
+                        oscillation_detected=False,
+                        ai_proposals=[],
+                        tier1_proposals=[t1_prop],
+                    )
+                )
+
+        servicer = EngineServicer()
+        session = SessionState(session_id="gate-g2-t1")
+        session.content_graph = ContentGraph()
+        session.graph_engine = _DummyGraphEngine()
+        baseline = b"- name: test\n  command: echo hi\n"
+        session.working_files = {"play.yml": baseline}
+        session.fix_options = FixOptions(enable_ai=True)
+        session.graph_originals = {"play.yml": baseline.decode()}
+        session.temp_dir = tmp_path
+        (tmp_path / "play.yml").write_bytes(baseline)
+
+        with patch("apme_engine.remediation.graph_engine.GraphRemediationEngine", _DummyGraphEngine):
+            events = [e async for e in servicer._session_run_ai_gate(session)]
+
+        assert [e.WhichOneof("event") for e in events] == ["progress", "proposals"]
+        assert session.status == 1
+        assert list(session.proposals) == ["g2-t1-0000"]
+        emitted = events[1].proposals.proposals
+        assert emitted[0].id == "g2-t1-0000"
+        assert emitted[0].tier == 2
+        assert emitted[0].source == "deterministic"
+        assert session.working_files["play.yml"] == baseline
+        assert (tmp_path / "play.yml").read_bytes() == baseline
+
+    def test_consolidate_gate2_proposals_merges_same_node(self) -> None:
+        """AI and post-AI Tier 1 rows for one node become a single proposal."""
+        from apme_engine.daemon.engine_server import EngineServicer
+
+        ai_row = Proposal(
+            id="ai-0000",
+            file="play.yml",
+            path="play.yml/plays[0]/tasks[0]",
+            rule_id="L050",
+            after_text="ai after",
+            explanation="AI rewrite",
+            tier=2,
+            source="ai",
+        )
+        t1_same = Proposal(
+            id="g2-t1-0000",
+            file="play.yml",
+            path="play.yml/plays[0]/tasks[0]",
+            rule_id="L001",
+            after_text="t1 after",
+            diff_hunk="@@ t1 @@",
+            explanation="FQCN cleanup",
+            tier=2,
+            source="deterministic",
+        )
+        t1_other = Proposal(
+            id="g2-t1-0001",
+            file="other.yml",
+            path="other.yml/plays[0]/tasks[0]",
+            rule_id="M001",
+            after_text="other after",
+            tier=2,
+            source="deterministic",
+        )
+
+        merged = EngineServicer._consolidate_gate2_proposals([ai_row], [t1_same, t1_other])
+        assert [p.id for p in merged] == ["ai-0000", "g2-t1-0001"]
+        assert merged[0].after_text == "t1 after"
+        assert merged[0].diff_hunk == "@@ t1 @@"
+        assert set(merged[0].rule_id.split(",")) == {"L001", "L050"}
+        assert "FQCN cleanup" in merged[0].explanation
+        assert merged[1].id == "g2-t1-0001"
+
+    async def test_declined_only_gate2_approval_completes(self) -> None:
+        """Empty approve on declined-only Gate 2 marks the session complete."""
+        from apme_engine.daemon.engine_server import EngineServicer
+
+        servicer = EngineServicer()
+        session = SessionState(session_id="declined-approve")
+        session.status = 1
+        session.awaiting_tier1_gate = False
+        session.review_declined_proposals = {
+            "ai-declined-0000": Proposal(
+                id="ai-declined-0000",
+                file="play.yml",
+                rule_id="L005",
+                tier=2,
+                status="declined",
+                source="ai",
+            )
+        }
+
+        async def _fake_build_result(_self: EngineServicer, _session: SessionState) -> AsyncIterator[SessionEvent]:
+            yield SessionEvent(result=SessionResult())
+
+        with patch.object(EngineServicer, "_session_build_result", _fake_build_result):
+            events = [e async for e in servicer._session_handle_approval(session, set())]
+
+        assert [e.WhichOneof("event") for e in events] == ["approval_ack", "result"]
+        assert session.status == 3  # COMPLETE
+        assert session.review_declined_proposals == {}
+        assert events[0].approval_ack.applied_count == 0
+
     async def test_decline_all_restores_pre_gate2_working_files(self, tmp_path: Path) -> None:
         """Declining every Gate 2 proposal restores the pre-AI working tree.
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -981,6 +981,32 @@ class TestSessionReplayState:
         assert "tier1_complete" in types
         assert "proposals" in types
 
+    async def test_replays_declined_only_gate2_proposals(self) -> None:
+        """Declined-only Gate 2 review rows replay after reconnect."""
+        from apme_engine.daemon.engine_server import EngineServicer
+
+        servicer = EngineServicer()
+        session = SessionState(session_id="declined-replay")
+        session.report = FixReport()
+        session.review_declined_proposals = {
+            "ai-declined-0000": Proposal(
+                id="ai-declined-0000",
+                file="play.yml",
+                rule_id="M001",
+                tier=2,
+                status="declined",
+                source="ai",
+            ),
+        }
+        session.current_tier = 2
+        session.status = 1
+
+        events = [e async for e in servicer._session_replay_state(session)]
+        proposal_events = [e for e in events if e.WhichOneof("event") == "proposals"]
+        assert len(proposal_events) == 1
+        assert len(proposal_events[0].proposals.proposals) == 1
+        assert proposal_events[0].proposals.proposals[0].id == "ai-declined-0000"
+
     async def test_replays_result_when_complete(self) -> None:
         """Replay emits final result when session status is complete."""
         from apme_engine.daemon.engine_server import EngineServicer


### PR DESCRIPTION
## Summary
- Fixes Quality tab skipping **AI proposals** and **AI applied** after AI escalation — workflow now pauses at Gate 2 review and requires acknowledgement before Create branch (ADR-062 Option C).
- Engine emits `ProposalsReady` for declined-only Gate 2 rows and bundles post-AI tier1 cleanup at Gate 2 instead of auto-applying during interactive runs.
- UI stepper accurately reflects tier1 skip, Gate 2 review/applied latching, and declined-only Next enablement.

## Changes
- **Engine** (`engine_server.py`, `graph_engine.py`): Gate 2 pause on `all_proposals`; post-AI tier1 cleanup stays `pending_review` when interactive.
- **UI** (`OperationPanel`, `ProposalReviewPanel`, `workflowSteps`, `proposalTier`, `useProjectOperationState`, `useProjectWorkflow`): Gate 1/2 detection, `seenGate2Review` latch, `AiAppliedPanel` ack step, SSE guards, optimistic `applyLocalApprovalAck` after POST approve (operation SSE has no `approval_ack` event).
- **Tests**: `workflowSteps`, `proposalTier`, `sseFetch`, `ProposalReviewPanel`, `test_session` (declined-only Gate 2 pause, post-AI `g2-t1-*` staging, same-node merge, empty approve completes).

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit -- tests/test_session.py` passes (67 tests)
- [x] Full `tox -e unit`: 3300 passed, 48 skipped
- [ ] Manual: Backstage remediate with AI enabled — verify stepper stops at Rule-based fix proposals → AI escalation → AI proposals → AI applied → Create branch
- [ ] Manual: Gate 2 with only "Declined by AI" rows — Next enabled, correct copy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation step after AI fixes are applied, showing fix and remediation counts.
  * Added support for reviewing combined AI and deterministic fixes in a single Gate 2 approval.
  * Improved workflow progression when initial review gates are skipped or AI fixes require acknowledgment.
* **Bug Fixes**
  * Improved handling of delayed or stale status updates.
  * Reviews with no actionable fixes can now continue appropriately, including AI-declined cases.
* **Tests**
  * Expanded coverage for Gate 2 reviews, workflow transitions, approvals, and real-time updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->