### PR TITLE
feat(opa): add P001 banned collection rule

### DIFF
--- a/docs/guides/RULE_CONFIGURATION.md
+++ b/docs/guides/RULE_CONFIGURATION.md
@@ -336,11 +336,13 @@ startswith(node.module, "community.")
 
 ### Can I create custom rules without modifying APME source?
 
-**Current:** Not yet. Custom rules must be added to `src/apme_engine/validators/opa/bundle/` and containers rebuilt.
+**Programmatic Use:** Yes. `OpaValidator` supports external custom bundles via `bundle_path` and `entrypoint` parameters (see "OPA Custom Bundles" section above).
 
-**Future:** ADR-042 defines plugin architecture allowing external rule services. Status: design complete, implementation pending.
+**CLI/Container Use:** Custom rules must be added to `src/apme_engine/validators/opa/bundle/` and containers rebuilt to be available in the packaged CLI or pod deployments.
 
-**Workaround:** Fork APME, add rules to `opa/bundle/`, maintain custom image.
+**Future:** ADR-042 defines plugin architecture allowing external rule services discoverable at runtime. Status: design complete, implementation pending.
+
+**Workaround for CLI:** Fork APME, add rules to `opa/bundle/`, maintain custom image.
 
 ### How do I ban multiple collections with one rule?
 

--- a/docs/guides/RULE_CONFIGURATION.md
+++ b/docs/guides/RULE_CONFIGURATION.md
@@ -241,6 +241,131 @@ APME uses prefixed numeric IDs (per ADR-008):
 
 Custom rules should use the `CUSTOM-` or `EXT-` prefix to avoid conflicts.
 
+## Frequently Asked Questions
+
+### How do I ban a specific collection (e.g., community.general)?
+
+Create a custom OPA policy rule. Example: banning `community.general.*` modules.
+
+**1. Create the rule file:**
+
+`src/apme_engine/validators/opa/bundle/P001.rego`
+
+```rego
+# P001: Banned collection - community.general
+
+package apme.rules
+
+import future.keywords.if
+import future.keywords.in
+
+violations contains v if {
+	some tree in input.hierarchy
+	some node in tree.nodes
+	v := banned_collection(tree, node)
+}
+
+banned_collection(tree, node) := v if {
+	node.type == "taskcall"
+	node.module != ""
+	startswith(node.module, "community.general.")
+	count(node.line) > 0
+	v := {
+		"rule_id": "P001",
+		"severity": "high",
+		"message": sprintf("Banned collection: %s", [node.module]),
+		"file": node.file,
+		"line": node.line[0],
+		"path": node.key,
+		"scope": "task",
+	}
+}
+```
+
+**2. Create tests:**
+
+`src/apme_engine/validators/opa/bundle/P001_test.rego`
+
+```rego
+package apme.rules_test
+
+import data.apme.rules
+
+test_P001_fires_for_community_general if {
+	tree := {"nodes": [{"type": "taskcall", "module": "community.general.sysctl", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.banned_collection(tree, node)
+	v.rule_id == "P001"
+	v.severity == "high"
+}
+
+test_P001_does_not_fire_for_builtin if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.copy", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.banned_collection(tree, node)
+}
+```
+
+**3. Test:**
+
+```bash
+opa test src/apme_engine/validators/opa/bundle/P001_test.rego \
+         src/apme_engine/validators/opa/bundle/P001.rego -v
+```
+
+**4. Rebuild containers:**
+
+```bash
+tox -e down && tox -e build && tox -e up
+```
+
+**Pattern for other banned collections:**
+
+```rego
+# P002: Ban community.docker
+startswith(node.module, "community.docker.")
+
+# P003: Ban community.aws
+startswith(node.module, "community.aws.")
+
+# P004: Ban any community.* collection
+startswith(node.module, "community.")
+```
+
+**Location:** Rule lives in OPA bundle (`src/apme_engine/validators/opa/bundle/`), automatically loaded on container rebuild.
+
+### Can I create custom rules without modifying APME source?
+
+**Current:** Not yet. Custom rules must be added to `src/apme_engine/validators/opa/bundle/` and containers rebuilt.
+
+**Future:** ADR-042 defines plugin architecture allowing external rule services. Status: design complete, implementation pending.
+
+**Workaround:** Fork APME, add rules to `opa/bundle/`, maintain custom image.
+
+### How do I ban multiple collections with one rule?
+
+Use Rego list matching:
+
+```rego
+banned_collection(tree, node) := v if {
+	node.type == "taskcall"
+	node.module != ""
+	banned_namespaces := ["community.general.", "community.docker.", "community.aws."]
+	some ns in banned_namespaces
+	startswith(node.module, ns)
+	count(node.line) > 0
+	v := {
+		"rule_id": "P001",
+		"severity": "high",
+		"message": sprintf("Banned collection: %s", [node.module]),
+		"file": node.file,
+		"line": node.line[0],
+		"path": node.key,
+		"scope": "task",
+	}
+}
+```
+
 ## Related Documentation
 
 - [Rule Catalog](../rules/RULE_CATALOG.md) — Complete list of built-in rules

--- a/src/apme_engine/graph/rules/R114_file_change.md
+++ b/src/apme_engine/graph/rules/R114_file_change.md
@@ -11,22 +11,38 @@ ai_prompt: |
 
   RESOLUTION OPTIONS:
 
-  1. If the variable comes from TRUSTED sources (role defaults, group_vars,
-     playbook vars defined by the author):
+  1. If the effective path value is CONSTRAINED to an approved set and CANNOT
+     be overridden by external input (e.g., hardcoded literal, or loop over
+     a compile-time constant list):
      - Add "# noqa: R114" inline comment with justification
-     - Example: "# noqa: R114 - path from role defaults, not user input"
+     - Example: "# noqa: R114 - path is hardcoded literal /opt/app/config.yml"
+     
+     WARNING: Do NOT exempt paths from role defaults, group_vars, or playbook
+     variables alone, as these can be overridden by extra_vars (-e) at runtime.
 
   2. If the variable COULD come from external/untrusted input (inventory,
-     extra_vars, API responses, registered output from commands):
+     extra_vars, API responses, registered output from commands, OR any
+     overridable variable):
      - Add an ansible.builtin.assert task BEFORE this task to validate
-       the path is under an allowed base directory
-     - Example validation:
+       the CANONICAL path (after resolving traversal) is under an allowed base
+     - Example validation (prevents ../ traversal):
        ```yaml
        - name: Validate path is under allowed base
          ansible.builtin.assert:
            that:
              - my_path is match('^/opt/server/')
+             - "'/..' not in my_path"
+             - my_path is not search('\\.\\.')
            fail_msg: "Invalid path: {{ my_path }}"
+       ```
+     
+     Or use realpath filter (Ansible 2.10+) to canonicalize first:
+       ```yaml
+       - name: Canonicalize and validate path
+         ansible.builtin.assert:
+           that:
+             - (my_path | realpath) is match('^/opt/server/')
+           fail_msg: "Path resolves outside allowed directory"
        ```
 
   3. If path components come from a loop variable over trusted data:

--- a/src/apme_engine/graph/rules/R114_file_change.md
+++ b/src/apme_engine/graph/rules/R114_file_change.md
@@ -3,6 +3,38 @@ rule_id: R114
 validator: native
 description: File change (annotation-based).
 scope: task
+ai_prompt: |
+  R114 flags file operations (copy, template, file, etc.) where path or src
+  contains Jinja variables. This is a security risk when variables come from
+  untrusted sources — attackers could manipulate paths to access/modify
+  unintended files.
+
+  RESOLUTION OPTIONS:
+
+  1. If the variable comes from TRUSTED sources (role defaults, group_vars,
+     playbook vars defined by the author):
+     - Add "# noqa: R114" inline comment with justification
+     - Example: "# noqa: R114 - path from role defaults, not user input"
+
+  2. If the variable COULD come from external/untrusted input (inventory,
+     extra_vars, API responses, registered output from commands):
+     - Add an ansible.builtin.assert task BEFORE this task to validate
+       the path is under an allowed base directory
+     - Example validation:
+       ```yaml
+       - name: Validate path is under allowed base
+         ansible.builtin.assert:
+           that:
+             - my_path is match('^/opt/server/')
+           fail_msg: "Invalid path: {{ my_path }}"
+       ```
+
+  3. If path components come from a loop variable over trusted data:
+     - The exemption applies if the loop source is trusted
+     - Add "# noqa: R114 - loop over role-defined sites dict"
+
+  When adding noqa, your explanation MUST state WHY the variable is trusted.
+  "Variable is defined in defaults" is acceptable. "Variable is needed" is not.
 ---
 
 ## File change (R114)
@@ -16,4 +48,37 @@ File change with mutable path/src (annotation-based). Depends on FILE_CHANGE + i
   ansible.builtin.copy:
     src: files/config.yml
     dest: /etc/app/config.yml
+```
+
+### Example: fail
+
+```yaml
+- name: Copy file to user-specified path
+  ansible.builtin.copy:
+    src: files/config.yml
+    dest: "{{ user_provided_path }}"  # R114 - path from variable
+```
+
+### Remediation
+
+If the variable is trusted (from role defaults/vars):
+```yaml
+- name: Copy file to configured path
+  ansible.builtin.copy:
+    src: files/config.yml
+    dest: "{{ app_config_path }}"  # noqa: R114 - path from role defaults
+```
+
+If the variable could be untrusted, add validation:
+```yaml
+- name: Validate destination path
+  ansible.builtin.assert:
+    that:
+      - dest_path is match('^/opt/myapp/')
+    fail_msg: "Invalid destination: {{ dest_path }}"
+
+- name: Copy file to validated path
+  ansible.builtin.copy:
+    src: files/config.yml
+    dest: "{{ dest_path }}"
 ```

--- a/src/apme_engine/graph/rules/R114_file_change_graph.py
+++ b/src/apme_engine/graph/rules/R114_file_change_graph.py
@@ -101,6 +101,11 @@ class FileChangeGraphRule(GraphRule):
                 file=(node.file_path, node.line_start),
             )
 
+        detail["message"] = (
+            "A file change with parameterized path found; "
+            "exempt trusted vars with '# noqa: R114' or add path validation"
+        )
+
         return GraphRuleResult(
             verdict=True,
             detail=detail,

--- a/src/apme_engine/validators/opa/bundle/P001.md
+++ b/src/apme_engine/validators/opa/bundle/P001.md
@@ -54,7 +54,22 @@ startswith(node.module, "community.docker.")  # P002
 startswith(node.module, "community.aws.")     # P003
 ```
 
-Or use a configurable list in `data.apme.policy.banned_collections`.
+**Advanced Pattern (Requires Implementation):**
+
+To use a configurable banned list instead of hardcoded checks, modify the rule to read from `data.apme.policy.banned_collections`:
+
+```rego
+banned_collection(tree, node) := v if {
+    node.type == "taskcall"
+    node.module != ""
+    banned_namespaces := data.apme.policy.banned_collections
+    some ns in banned_namespaces
+    startswith(node.module, ns)
+    # ... rest of rule
+}
+```
+
+This requires injecting the banned list into OPA via `--data` or bundle data files. See OPA documentation on external data.
 
 ## Remediation
 

--- a/src/apme_engine/validators/opa/bundle/P001.md
+++ b/src/apme_engine/validators/opa/bundle/P001.md
@@ -1,0 +1,69 @@
+# P001: Banned collection - community.general
+
+**Category:** Policy  
+**Severity:** High
+
+## Description
+
+Flags tasks using modules from the `community.general` collection, which may be banned by organizational policy.
+
+## Rationale
+
+Organizations often restrict certain collections due to:
+- Support/maintenance concerns
+- Security compliance requirements
+- Standardization on certified/supported collections
+- Migration to AAP-supported alternatives
+
+## Examples
+
+**Fail:**
+```yaml
+- name: Configure sysctl
+  community.general.sysctl:
+    name: vm.swappiness
+    value: 10
+
+- name: Modify INI file
+  community.general.ini_file:
+    path: /etc/app.conf
+    section: main
+    option: debug
+    value: "false"
+```
+
+**Pass:**
+```yaml
+- name: Copy config
+  ansible.builtin.copy:
+    src: app.conf
+    dest: /etc/app.conf
+
+- name: Set authorized key
+  ansible.posix.authorized_key:
+    user: deploy
+    key: "{{ ssh_key }}"
+```
+
+## Configuration
+
+To ban different collections, create additional P00x rules with modified `startswith()` checks:
+
+```rego
+startswith(node.module, "community.docker.")  # P002
+startswith(node.module, "community.aws.")     # P003
+```
+
+Or use a configurable list in `data.apme.policy.banned_collections`.
+
+## Remediation
+
+Replace banned modules with:
+- `ansible.builtin.*` certified modules
+- AAP-certified collections (`ansible.posix`, `ansible.windows`, etc.)
+- Organization-approved alternatives
+
+## See Also
+
+- ADR-008: Rule ID conventions (P = Policy)
+- L004: Deprecated modules

--- a/src/apme_engine/validators/opa/bundle/P001.rego
+++ b/src/apme_engine/validators/opa/bundle/P001.rego
@@ -1,0 +1,28 @@
+# P001: Banned collection - community.general
+
+package apme.rules
+
+import future.keywords.if
+import future.keywords.in
+
+violations contains v if {
+	some tree in input.hierarchy
+	some node in tree.nodes
+	v := banned_collection(tree, node)
+}
+
+banned_collection(tree, node) := v if {
+	node.type == "taskcall"
+	node.module != ""
+	startswith(node.module, "community.general.")
+	count(node.line) > 0
+	v := {
+		"rule_id": "P001",
+		"severity": "high",
+		"message": sprintf("Banned collection: %s", [node.module]),
+		"file": node.file,
+		"line": node.line[0],
+		"path": node.key,
+		"scope": "task",
+	}
+}

--- a/src/apme_engine/validators/opa/bundle/P001_test.rego
+++ b/src/apme_engine/validators/opa/bundle/P001_test.rego
@@ -1,0 +1,40 @@
+# Tests for P001: Banned collection - community.general
+
+package apme.rules_test
+
+import data.apme.rules
+
+test_P001_fires_for_community_general if {
+	tree := {"nodes": [{"type": "taskcall", "module": "community.general.sysctl", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	v := rules.banned_collection(tree, node)
+	v.rule_id == "P001"
+	v.severity == "high"
+	contains(v.message, "community.general.sysctl")
+}
+
+test_P001_fires_for_community_general_fqcn if {
+	tree := {"nodes": [{"type": "taskcall", "module": "community.general.ini_file", "line": [42], "key": "k", "file": "playbook.yml"}]}
+	node := tree.nodes[0]
+	v := rules.banned_collection(tree, node)
+	v.rule_id == "P001"
+	v.line == 42
+}
+
+test_P001_does_not_fire_for_builtin if {
+	tree := {"nodes": [{"type": "taskcall", "module": "ansible.builtin.copy", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.banned_collection(tree, node)
+}
+
+test_P001_does_not_fire_for_other_collection if {
+	tree := {"nodes": [{"type": "taskcall", "module": "community.docker.docker_container", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.banned_collection(tree, node)
+}
+
+test_P001_does_not_fire_for_non_task if {
+	tree := {"nodes": [{"type": "block", "module": "", "line": [1], "key": "k", "file": "f.yml"}]}
+	node := tree.nodes[0]
+	not rules.banned_collection(tree, node)
+}


### PR DESCRIPTION
## Summary

Add P001 policy rule to flag banned collections (e.g., `community.general.*`). Provides template pattern for organizations to restrict specific Ansible collections based on support, compliance, or standardization requirements.

## Changes

- **P001.rego**: Flags tasks using `community.general.*` modules
- **P001_test.rego**: 5 OPA test cases (all passing)
- **P001.md**: Rule documentation with examples and remediation guidance
- **RULE_CONFIGURATION.md**: New FAQ section on banning collections

## Pattern

Rule follows ADR-008 conventions (P = Policy). Extends to other collections by modifying `startswith()` check:

```rego
startswith(node.module, "community.docker.")  # P002
startswith(node.module, "community.aws.")     # P003
startswith(node.module, "community.")         # Ban all community.*
```

## Testing

- ✅ OPA tests: `PASS: 5/5`
- ✅ Follows L004 pattern for consistency
- ✅ FAQ documents usage and extension patterns

## Usage

Requires container rebuild:
```bash
tox -e down && tox -e build && tox -e up
tox -e cli -- check playbook.yml  # Flags community.general usage
```

## Test plan

- [x] OPA unit tests pass
- [x] Rule structure matches existing L/R/M rules
- [x] Documentation complete with examples
- [ ] Integration test in live pod (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a high-severity policy that flags tasks using the `community.general` collection, with file, line, path, and task details.
  * Added guidance for configuring additional banned collections and combining multiple collections in one policy.

* **Documentation**
  * Added configuration FAQs covering custom policies, testing, container rebuilds, and remediation options.
  * Expanded R114 guidance with security explanations, validation recommendations, exemption requirements, and practical examples.
  * Added documentation describing the new policy’s severity, examples, configuration, and remediation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->