### PR TITLE
build(podman): expose Abbenay admin UI on localhost for dev

### DIFF
--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -96,8 +96,11 @@ trusted co-tenant of the product runtime. Evidence:
   has no Service or hostPort; only in-pod processes reach `127.0.0.1:8787`
   or Gateway `:8080` without an outer Ingress/NetworkPolicy edge.
 - **Podman** (`containers/podman/pod.yaml`): same shared-netns all-in-one
-  pod; Abbenay binds loopback only; Gateway `:8080` is the sole published
-  product REST edge.
+  pod. For local dev, Abbenay HTTP may publish `hostPort: 8787` with
+  `hostIP: 127.0.0.1` only (`http://127.0.0.1:8787`) with
+  `ABBENAY_HTTP_AUTH=0` for passwordless dashboard access on localhost.
+  Gateway `:8080` remains the sole published product REST edge for non-local
+  access. Helm Simple has no hostPort for 8787.
 
 A compromised sidecar that can already talk to Gateway can hit
 `/api/v1/ai/*` and trigger the Gateway→Abbenay token rewrite — the same
@@ -109,7 +112,9 @@ only with a new ADR that changes ADR-048.
 `http://127.0.0.1:8787`. Loopback is not transport confidentiality against a
 compromised co-located process; it is a binding constraint so the token never
 crosses a pod boundary. Deployment evidence: no cluster Service/hostPort for
-8787 (Helm chart + Podman), Abbenay `--host 127.0.0.1`, Gateway default
+8787 in Helm; Podman may use `hostIP: 127.0.0.1` hostPort for localhost dev UI
+only. Abbenay `--host 127.0.0.1` in Helm; Podman dev uses `--host 0.0.0.0` with
+localhost-only host binding. Gateway default
 `APME_ABBENAY_HTTP_URL=http://127.0.0.1:8787`. Hardened hops (HTTPS+mTLS or a
 permission-protected Unix socket) require a separate ADR; they are not part of
 the accepted Simple design.

--- a/containers/podman/pod.yaml
+++ b/containers/podman/pod.yaml
@@ -223,12 +223,12 @@ spec:
           hostPort: 8081
     - name: abbenay
       image: ghcr.io/redhat-developer/abbenay:v2026.8.7
-      # ADR-070: HTTP + gRPC on loopback (pod-shared netns). No hostPort for
-      # Abbenay — matches Helm Simple and avoids plaintext host exposure.
+      # Local Podman: publish HTTP admin UI on host :8787. gRPC stays loopback
+      # (Unix socket for Engine). Helm Simple remains loopback-only (ADR-070).
       args:
         - "web"
         - "--host"
-        - "127.0.0.1"
+        - "0.0.0.0"
         - "--port"
         - "8787"
         - "--grpc-host"
@@ -236,6 +236,9 @@ spec:
         - "--grpc-port"
         - "50057"
       env:
+        # Local dev only: skip Abbenay web UI login (HTTP :8787). Do not use on exposed hosts.
+        - name: ABBENAY_HTTP_AUTH
+          value: "0"
         - name: OPENROUTER_API_KEY
           value: "${OPENROUTER_API_KEY}"
         - name: VERTEX_ANTHROPIC_API_KEY
@@ -249,8 +252,11 @@ spec:
         - name: XDG_CONFIG_HOME
           value: "/home/abbenay/.config"
       ports:
+        - containerPort: 8787
+          hostPort: 8787
+          hostIP: 127.0.0.1
         - containerPort: 50057
-          # no hostPort
+          # no hostPort — Engine uses unix socket, not TCP
       volumeMounts:
         - name: abbenay-config
           mountPath: /home/abbenay/.config/abbenay

--- a/containers/podman/up.sh
+++ b/containers/podman/up.sh
@@ -748,6 +748,7 @@ _relabel_podman_volumes
 echo "$POD_YAML" | podman play kube -
 
 echo "Pod apme-pod started (volumes: apme-sessions, apme-gateway-data, apme-proxy-cache). Run a scan: containers/podman/run-cli.sh"
+echo "Abbenay UI: http://127.0.0.1:8787 (localhost only; HTTP auth disabled for dev)"
 echo "OTel Prometheus metrics: http://localhost:8889/metrics (companion stack: containers/observability/up.sh)"
 
 if [[ -n "$APME_FEEDBACK_GITHUB_REPO" && -n "$APME_FEEDBACK_GITHUB_TOKEN" ]]; then

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -7,9 +7,14 @@ Vercel AI SDK.
 ## Gateway admin proxy (ADR-070)
 
 In the Simple in-pod topology (ADR-069 / ADR-070), Abbenay serves HTTP admin
-and gRPC on loopback (`--host 127.0.0.1 --port 8787` and
-`--grpc-host 127.0.0.1 --grpc-port 50057`; image ≥ v2026.8.0). No cluster
-Service or hostPort. Gateway HTTP admin uses `127.0.0.1:8787`. Engine
+on `:8787` and gRPC on loopback (`--grpc-host 127.0.0.1 --grpc-port 50057`;
+image ≥ v2026.8.0). Helm has no cluster Service or hostPort. Local Podman
+(`tox -e up`) publishes HTTP on host port 8787 with `hostIP: 127.0.0.1` so the
+Abbenay UI is reachable at `http://127.0.0.1:8787`; gRPC stays loopback.
+`pod.yaml` sets `ABBENAY_HTTP_AUTH=0` so the dashboard loads without a Bearer
+token (local dev only — do not disable HTTP auth when exposing Abbenay beyond
+your machine). Gateway HTTP admin still uses `127.0.0.1:8787` (shared netns).
+Engine
 gRPC uses a shared Unix socket (`APME_ABBENAY_ADDR=unix:///tmp/abbenay-run/abbenay/daemon.sock`)
 because `abbenay-client` ≥ 2026.8.7 rejects consumer tokens on plaintext TCP.
 The Gateway reverse-proxies an

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -241,6 +241,12 @@ place; `tox -e wipe` deletes it. To add providers or models, edit the cache
 `config.yaml` or POST via the Gateway admin proxy
 (`/api/v1/ai/provider/{id}/configure`); writes survive Abbenay restarts.
 
+**Local Podman dev UI:** `tox -e up` publishes Abbenay HTTP admin on
+`http://127.0.0.1:8787` (`hostPort` with `hostIP: 127.0.0.1` only — not LAN).
+`pod.yaml` sets `ABBENAY_HTTP_AUTH=0` so the dashboard loads without a Bearer
+token on that localhost bind. Helm Simple stays loopback-only with no hostPort
+(ADR-070). gRPC for Engine/Gateway remains the shared Unix socket.
+
 The Abbenay daemon still binds leftover gRPC TCP on `127.0.0.1:50057`. Engine AI RPCs, Gateway `/health`, and Helm probes use `APME_ABBENAY_ADDR=unix:///tmp/abbenay-run/abbenay/daemon.sock` (shared `emptyDir`) because `abbenay-client` ≥ 2026.8.7 rejects consumer tokens on plaintext TCP.
 
 #### UI
@@ -360,13 +366,14 @@ See [PODMAN_OPA_ISSUES.md](PODMAN_OPA_ISSUES.md) for common Podman rootless issu
 | 50054 | OPA | `APME_OPA_VALIDATOR_LISTEN` |
 | 50055 | Native | `APME_NATIVE_VALIDATOR_LISTEN` |
 | 50056 | Gitleaks | `APME_GITLEAKS_VALIDATOR_LISTEN` |
-| 50057 | Abbenay AI (pod-local) | `--grpc-host 127.0.0.1 --grpc-port` (no hostPort) |
+| 50057 | Abbenay AI gRPC (pod-local) | `--grpc-host 127.0.0.1 --grpc-port` (no hostPort) |
 | 50058 | Collection Health | `APME_COLLECTION_HEALTH_VALIDATOR_LISTEN` |
 | 50059 | Dep Audit | `APME_DEP_AUDIT_VALIDATOR_LISTEN` |
 | 50060 | Gateway (gRPC) | `APME_GATEWAY_GRPC_LISTEN` |
 | 8080 | Gateway (HTTP) | `APME_GATEWAY_HTTP_PORT` |
 | 8081 | UI (nginx) | — |
 | 8765 | Galaxy Proxy | `APME_GALAXY_PROXY_URL` |
+| 8787 | Abbenay HTTP admin UI (Podman `hostPort`, `hostIP: 127.0.0.1`) | `--host 0.0.0.0 --port` |
 
 ## Related Documents
 


### PR DESCRIPTION
## Summary

Local Podman dev (`tox -e up`) now publishes the Abbenay web dashboard on **http://127.0.0.1:8787** so developers can configure LLM providers without going through the Gateway proxy. HTTP auth is disabled for that localhost bind only (`ABBENAY_HTTP_AUTH=0`). Helm Simple and production topology remain unchanged: loopback-only Abbenay HTTP with no cluster Service or hostPort (ADR-070).

## Problem

Abbenay’s admin UI was only reachable inside the pod network namespace. Developers running the Podman pod had no direct URL for the dashboard and were prompted for a Bearer token when Abbenay HTTP auth was enabled. Gateway’s allowlisted `/api/v1/ai/*` proxy covers runtime admin APIs but not the full Abbenay web UI experience.

## Changes

### `containers/podman/pod.yaml`

- Bind Abbenay HTTP with `--host 0.0.0.0` (required for hostPort forwarding) on container port **8787**.
- Publish **hostPort 8787** with **`hostIP: 127.0.0.1`** so the UI is reachable only on the developer’s machine, not on LAN interfaces (matches `containers/observability/pod.yaml` pattern).
- Set **`ABBENAY_HTTP_AUTH=0`** to skip dashboard login on that localhost bind.
- gRPC unchanged: Engine uses Unix socket (`unix:///tmp/abbenay-run/abbenay/daemon.sock`); TCP **50057** has no hostPort.
- Consumer tokens (`APME_ABBENAY_TOKEN`, `ABBENAY_API_TOKEN`) remain for gRPC and Gateway→Abbenay HTTP proxy paths.

### `containers/podman/up.sh`

- Print `Abbenay UI: http://127.0.0.1:8787 (localhost only; HTTP auth disabled for dev)` after pod start.

### Documentation

- **`docs/guides/ABBENAY_AI.md`** — Podman vs Helm binding; `hostIP` and `ABBENAY_HTTP_AUTH=0` behavior.
- **`docs/guides/DEPLOYMENT.md`** — Abbenay dev UI section; port table row for **8787** with `hostIP` caveat.
- **`.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md`** — Podman localhost hostPort exception; Helm still no hostPort.

## Security notes

| Surface | Podman dev (this PR) | Helm Simple |
|--------|----------------------|-------------|
| Abbenay HTTP bind | `0.0.0.0:8787` in container | `127.0.0.1:8787` |
| Host exposure | `127.0.0.1:8787` only (`hostIP`) | None (no hostPort) |
| HTTP auth | Disabled (`ABBENAY_HTTP_AUTH=0`) | Enabled (Bearer token) |
| Gateway REST `:8080` | Sole non-local product edge | Same |

**Do not** remove `hostIP: 127.0.0.1` or disable HTTP auth when exposing Abbenay beyond localhost. Abbenay’s unauthenticated admin API includes secrets and provider configuration endpoints.

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` — 3295 passed; one intermittent `test_launcher.py` failure in parallel run (environment `/proc` identity check; unrelated to this change)
- [ ] Manual: `tox -e down && tox -e up` → open http://127.0.0.1:8787 → dashboard loads without Bearer token
- [ ] Manual: confirm Gateway AI proxy still works (`GET /api/v1/ai/providers` on `:8080`)
- [ ] Manual: confirm `http://<lan-ip>:8787` is **not** reachable (hostIP lockdown)