### PR TITLE
fix(ui): show stopping state while workflow cancel is in flight

### DIFF
--- a/frontend/packages/ui-workflow/src/ProjectWorkflowPanel.tsx
+++ b/frontend/packages/ui-workflow/src/ProjectWorkflowPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Session-tab body for the shared scan/remediate workflow.
- * Host supplies chrome (tabs, Overview); this renders OperationPanel or starting spinner.
+ * Host supplies chrome (tabs, Overview); this renders OperationPanel or session spinners.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -30,8 +30,8 @@ export function ProjectWorkflowPanel({
   onViewDetails,
 }: ProjectWorkflowPanelProps) {
   const {
-    operationActive,
     opState,
+    isCancelling,
     approve,
     beginRemediate,
     escalateAi,
@@ -51,7 +51,27 @@ export function ProjectWorkflowPanel({
     setDraftError(null);
   }, [operationId, opStatus]);
 
-  if (!operationActive || !opState) {
+  // Cancel clears the op snapshot before dismiss — show stopping, not starting.
+  if (isCancelling) {
+    return (
+      <Card>
+        <CardBody style={{ textAlign: 'center', padding: '48px 24px' }}>
+          <Spinner size="lg" />
+          <div style={{ marginTop: 12, fontSize: 16 }}>Stopping session…</div>
+          <Button
+            variant="link"
+            onClick={dismiss}
+            style={{ marginTop: 16 }}
+          >
+            Dismiss
+          </Button>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  // Only show the pre-op spinner while waiting for the first snapshot.
+  if (!opState) {
     return (
       <Card>
         <CardBody style={{ textAlign: 'center', padding: '48px 24px' }}>

--- a/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
@@ -503,6 +503,8 @@ export function useProjectOperationState(
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
   const connectGenRef = useRef(0);
+  /** Bumped on clear/cleanup so in-flight poll() results cannot update stale opState. */
+  const pollGenRef = useRef(0);
   /** Latest operation status for reconnect gating (SSE ends on terminal). */
   const statusRef = useRef<ProjectOperationStatus | null>(null);
   const errorBackoffRef = useRef(0);
@@ -520,6 +522,7 @@ export function useProjectOperationState(
   );
 
   const cleanup = useCallback(() => {
+    pollGenRef.current += 1;
     connectGenRef.current += 1;
     if (abortRef.current) {
       abortRef.current.abort();
@@ -612,10 +615,11 @@ export function useProjectOperationState(
         }
         return;
       }
+      const pollGen = pollGenRef.current;
       try {
         const s = await fetchProjectOperationState(projectId);
-        // Never update React state after unmount — force only bypasses enabled.
-        if (!mountedRef.current) return;
+        // Never update React state after unmount or after clear/cleanup invalidated this poll.
+        if (!mountedRef.current || pollGen !== pollGenRef.current) return;
         if (!s) {
           setStateTracked(null);
           return;
@@ -656,6 +660,7 @@ export function useProjectOperationState(
   }, [poll]);
 
   const clear = useCallback(() => {
+    pollGenRef.current += 1;
     cleanup();
     setStateTracked(null);
   }, [cleanup, setStateTracked]);

--- a/frontend/packages/ui-workflow/src/useProjectWorkflow.ts
+++ b/frontend/packages/ui-workflow/src/useProjectWorkflow.ts
@@ -42,6 +42,8 @@ export interface ProjectWorkflowController {
   setAttachOp: (v: boolean) => void;
   opState: ProjectOperationState | null;
   isRunning: boolean;
+  /** True while POST cancel is in flight (op snapshot may clear before dismiss). */
+  isCancelling: boolean;
   operationActive: boolean;
   sessionTabVisible: boolean;
   refreshOp: () => void;
@@ -76,6 +78,7 @@ export function useProjectWorkflow(
   const { ansibleVersion, collections, enableAi, autoApplyTier1 } = checkOptions;
 
   const [attachOp, setAttachOp] = useState(initiallyAttached);
+  const [isCancelling, setIsCancelling] = useState(false);
 
   const { state: opState, refresh: refreshOp, clear: clearOp, applyLocalApprovalAck } =
     useProjectOperationState(projectId, {
@@ -114,7 +117,8 @@ export function useProjectWorkflow(
   } = useProjectOperationActions(projectId);
 
   const isRunning =
-    opState != null && LIVE_OPERATION_STATUSES.has(opState.status);
+    isCancelling ||
+    (opState != null && LIVE_OPERATION_STATUSES.has(opState.status));
   const operationActive =
     attachOp && opState != null && opState.status !== 'cancelled';
   const sessionTabVisible = attachOp;
@@ -173,6 +177,7 @@ export function useProjectWorkflow(
   );
 
   const startScan = useCallback(async () => {
+    setIsCancelling(false);
     const colls = buildColls();
     openSession();
 
@@ -279,10 +284,18 @@ export function useProjectWorkflow(
   );
 
   const dismiss = useCallback(() => {
-    clearOp();
     setAttachOp(false);
+    setIsCancelling(false);
+    clearOp();
     onDismissSession?.();
   }, [clearOp, onDismissSession]);
+
+  // Server-side cancel (or stale cancelled snapshot) — detach without blank panel.
+  useEffect(() => {
+    if (attachOp && opState?.status === 'cancelled' && !isCancelling) {
+      dismiss();
+    }
+  }, [attachOp, opState?.status, isCancelling, dismiss]);
 
   const resumeSession = useCallback(() => {
     openSession();
@@ -295,6 +308,7 @@ export function useProjectWorkflow(
     if (!ok) return;
 
     const colls = buildColls();
+    setIsCancelling(false);
     setAttachOp(true);
     onOpenSession?.();
     try {
@@ -346,14 +360,26 @@ export function useProjectWorkflow(
   );
 
   const cancel = useCallback(async () => {
-    await cancelOp();
-  }, [cancelOp]);
+    if (isCancelling) return;
+    setIsCancelling(true);
+    try {
+      await cancelOp();
+      dismiss();
+    } catch (err) {
+      console.error('Failed to cancel operation:', err);
+      setIsCancelling(false);
+      window.alert(
+        err instanceof Error ? err.message : 'Failed to cancel operation.',
+      );
+    }
+  }, [cancelOp, dismiss, isCancelling]);
 
   return {
     attachOp,
     setAttachOp,
     opState,
     isRunning,
+    isCancelling,
     operationActive,
     sessionTabVisible,
     refreshOp,

--- a/frontend/packages/ui-workflow/src/useProjectWorkflow.ts
+++ b/frontend/packages/ui-workflow/src/useProjectWorkflow.ts
@@ -3,7 +3,7 @@
  * Owns attach/session state and operation actions; presentation is ProjectWorkflowPanel.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   fetchProjectOperationState,
   LIVE_OPERATION_STATUSES,
@@ -79,6 +79,10 @@ export function useProjectWorkflow(
 
   const [attachOp, setAttachOp] = useState(initiallyAttached);
   const [isCancelling, setIsCancelling] = useState(false);
+  /** Bumped when session dismissed or replaced so stale cancelOp() completions are ignored. */
+  const cancelGenerationRef = useRef(0);
+  /** operation_id for the attached session — gates server-side auto-dismiss on cancelled. */
+  const trackedOpIdRef = useRef<string | null>(null);
 
   const { state: opState, refresh: refreshOp, clear: clearOp, applyLocalApprovalAck } =
     useProjectOperationState(projectId, {
@@ -162,6 +166,11 @@ export function useProjectWorkflow(
     [approve, applyLocalApprovalAck],
   );
 
+  const invalidatePendingCancel = useCallback(() => {
+    cancelGenerationRef.current += 1;
+    setIsCancelling(false);
+  }, []);
+
   const openSession = useCallback(() => {
     setAttachOp(true);
     onOpenSession?.();
@@ -177,7 +186,8 @@ export function useProjectWorkflow(
   );
 
   const startScan = useCallback(async () => {
-    setIsCancelling(false);
+    invalidatePendingCancel();
+    clearOp();
     const colls = buildColls();
     openSession();
 
@@ -230,6 +240,8 @@ export function useProjectWorkflow(
     buildColls,
     enableAi,
     getAiModel,
+    clearOp,
+    invalidatePendingCancel,
     openSession,
     refreshOp,
     startOp,
@@ -284,18 +296,36 @@ export function useProjectWorkflow(
   );
 
   const dismiss = useCallback(() => {
+    invalidatePendingCancel();
+    trackedOpIdRef.current = null;
     setAttachOp(false);
-    setIsCancelling(false);
     clearOp();
     onDismissSession?.();
-  }, [clearOp, onDismissSession]);
+  }, [clearOp, invalidatePendingCancel, onDismissSession]);
 
-  // Server-side cancel (or stale cancelled snapshot) — detach without blank panel.
   useEffect(() => {
-    if (attachOp && opState?.status === 'cancelled' && !isCancelling) {
+    if (attachOp && opState?.operation_id) {
+      trackedOpIdRef.current = opState.operation_id;
+    }
+  }, [attachOp, opState?.operation_id]);
+
+  // Server-side cancel — detach without blank panel; ignore stale cancelled snapshots.
+  useEffect(() => {
+    if (
+      attachOp &&
+      opState?.status === 'cancelled' &&
+      !isCancelling &&
+      opState.operation_id === trackedOpIdRef.current
+    ) {
       dismiss();
     }
-  }, [attachOp, opState?.status, isCancelling, dismiss]);
+  }, [
+    attachOp,
+    opState?.status,
+    opState?.operation_id,
+    isCancelling,
+    dismiss,
+  ]);
 
   const resumeSession = useCallback(() => {
     openSession();
@@ -308,7 +338,8 @@ export function useProjectWorkflow(
     if (!ok) return;
 
     const colls = buildColls();
-    setIsCancelling(false);
+    invalidatePendingCancel();
+    clearOp();
     setAttachOp(true);
     onOpenSession?.();
     try {
@@ -329,8 +360,10 @@ export function useProjectWorkflow(
   }, [
     ansibleVersion,
     buildColls,
+    clearOp,
     enableAi,
     getAiModel,
+    invalidatePendingCancel,
     onOpenSession,
     refreshOp,
     startOp,
@@ -361,11 +394,14 @@ export function useProjectWorkflow(
 
   const cancel = useCallback(async () => {
     if (isCancelling) return;
+    const generation = cancelGenerationRef.current;
     setIsCancelling(true);
     try {
       await cancelOp();
+      if (generation !== cancelGenerationRef.current) return;
       dismiss();
     } catch (err) {
+      if (generation !== cancelGenerationRef.current) return;
       console.error('Failed to cancel operation:', err);
       setIsCancelling(false);
       window.alert(

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -118,6 +118,7 @@ export function ProjectDetailPage() {
     attachOp,
     opState,
     isRunning,
+    isCancelling,
     operationActive,
     sessionTabVisible,
     startScan: handleScan,
@@ -315,7 +316,11 @@ export function ProjectDetailPage() {
                   <CardBody>
                     <Flex alignItems={{ default: 'alignItemsCenter' }} justifyContent={{ default: 'justifyContentSpaceBetween' }}>
                       <FlexItem>
-                        {operationActive ? 'Live session in progress' : 'Starting session…'}
+                        {isCancelling
+                          ? 'Stopping session…'
+                          : operationActive
+                            ? 'Live session in progress'
+                            : 'Starting session…'}
                         {opState?.status ? (
                           <span style={{ opacity: 0.7, marginLeft: 8 }}>({opState.status})</span>
                         ) : null}
@@ -423,9 +428,11 @@ export function ProjectDetailPage() {
               title={
                 <TabTitleText>
                   Session
-                  {opState?.status
-                    ? ` · ${opState.status.replace(/_/g, ' ')}`
-                    : ' · starting'}
+                  {isCancelling
+                    ? ' · stopping'
+                    : opState?.status
+                      ? ` · ${opState.status.replace(/_/g, ' ')}`
+                      : ' · starting'}
                 </TabTitleText>
               }
             >


### PR DESCRIPTION
## Summary
- Fixes a flash of "Starting scan…" when the user cancels an in-flight workflow operation
- Cancel clears the Gateway operation snapshot before the session tab dismisses; the UI now tracks `isCancelling` through that gap

## Changes
- Add `isCancelling` to `useProjectWorkflow` and show a "Stopping session…" spinner in `ProjectWorkflowPanel` (with Dismiss escape hatch)
- Keep `isRunning` true while cancel is in flight so Activity Scan/Cancel controls stay consistent
- Align Overview card and Session tab title with stopping state
- Dismiss session only after cancel succeeds; alert and keep session open on failure
- Auto-detach when a server-side `cancelled` snapshot arrives without user cancel

## Test plan
- [x] `tox -e lint` passes
- [ ] `tox -e unit` passes (1 unrelated failure on this host: `test_start_daemon_returns_existing_healthy_without_fork` — `/proc` identity check)
- [ ] Manual: start scan from Activity → Cancel from Session tab → verify "Stopping session…" (not "Starting scan…") until dismiss
- [ ] Manual: cancel failure (e.g. stop Gateway) → session stays open with alert
- [ ] Manual: Overview card and Session tab title show stopping during cancel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added clear “Stopping session…” progress indicators while a workflow session is being cancelled.
- Added a Dismiss option for the cancellation progress view.
- Session status and tab labels now reflect when cancellation is in progress.

## Bug Fixes
- Prevented duplicate cancellation requests and stale updates from affecting the active session.
- Improved cancellation handling across dismissal, restart, and scan flows.
- Users are notified when cancellation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fix: https://redhat.atlassian.net/browse/AAP-89748