### PR TITLE
feat(ui-workflow): add resolveRuleHref for rule definition links (AAP-88885)

### DIFF
--- a/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
@@ -65,6 +65,11 @@ export interface AssessFindingsPanelProps {
    * Prefixed IDs like ``native:L022`` are normalized to bare form.
    */
   initialRuleFilters?: string[];
+  /**
+   * Host-supplied rule definition URL. When provided, rule chips navigate to
+   * the definition instead of toggling the in-panel rule filter.
+   */
+  resolveRuleHref?: (bareId: string) => string | undefined;
 }
 
 function formatReviewStatus(status: string): string {
@@ -144,12 +149,14 @@ function FindingRow({
   enableAi,
   onHighlightLine,
   onRuleClick,
+  resolveRuleHref,
 }: {
   f: AssessFinding;
   snippetYaml: string;
   enableAi: boolean;
   onHighlightLine?: (line: number | null) => void;
   onRuleClick?: (bareId: string) => void;
+  resolveRuleHref?: (bareId: string) => string | undefined;
 }) {
   const fix = findingFixType(f, enableAi);
   const sev = f.severity || 'info';
@@ -160,6 +167,7 @@ function FindingRow({
       <RuleId
         ruleId={f.rule_id}
         onRuleClick={onRuleClick}
+        resolveRuleHref={resolveRuleHref}
         onHoverChange={
           canHighlight
             ? (hovering) =>
@@ -209,10 +217,12 @@ export function AssessNodeDetail({
   findings,
   enableAi,
   onRuleClick,
+  resolveRuleHref,
 }: {
   findings: AssessFinding[];
   enableAi: boolean;
   onRuleClick?: (bareId: string) => void;
+  resolveRuleHref?: (bareId: string) => string | undefined;
 }) {
   const [highlightLine, setHighlightLine] = useState<number | null>(null);
   // Assess/history findings are read-only: current YAML only. Proposed diffs
@@ -229,6 +239,7 @@ export function AssessNodeDetail({
             snippetYaml={beforeYaml}
             enableAi={enableAi}
             onRuleClick={onRuleClick}
+            resolveRuleHref={resolveRuleHref}
             onHighlightLine={
               beforeYaml.trim() ? setHighlightLine : undefined
             }
@@ -252,6 +263,7 @@ function findingsToNodeItem(
     isSingleton?: boolean;
     enableAi: boolean;
     onRuleClick?: (bareId: string) => void;
+    resolveRuleHref?: (bareId: string) => string | undefined;
   },
 ): NodeReviewItem {
   const nodeType = normalizeFindingNodeType(
@@ -277,6 +289,7 @@ function findingsToNodeItem(
         findings={findings}
         enableAi={opts.enableAi}
         onRuleClick={opts.onRuleClick}
+        resolveRuleHref={opts.resolveRuleHref}
       />
     ),
   };
@@ -312,6 +325,7 @@ export function AssessFindingsPanel({
   enableAi = true,
   error = null,
   initialRuleFilters,
+  resolveRuleHref,
 }: AssessFindingsPanelProps) {
   const [view, setView] = useState<ViewMode>('grouped');
   const [sevFilters, setSevFilters] = useState<Set<string>>(
@@ -378,6 +392,8 @@ export function AssessFindingsPanel({
         : [...prev, bareId],
     );
   }, []);
+
+  const ruleClickHandler = resolveRuleHref ? undefined : toggleRuleFilter;
 
   const ruleFilterSet = useMemo(() => new Set(ruleFilters), [ruleFilters]);
 
@@ -477,7 +493,8 @@ export function AssessFindingsPanel({
           {
             isSingleton: !(f.path || '').trim(),
             enableAi,
-            onRuleClick: toggleRuleFilter,
+            onRuleClick: ruleClickHandler,
+            resolveRuleHref,
           },
         ),
       );
@@ -486,10 +503,11 @@ export function AssessFindingsPanel({
       findingsToNodeItem(g.key, g.title, g.findings, {
         isSingleton: g.isSingleton,
         enableAi,
-        onRuleClick: toggleRuleFilter,
+        onRuleClick: ruleClickHandler,
+        resolveRuleHref,
       }),
     );
-  }, [view, filteredFindings, groups, enableAi, toggleRuleFilter]);
+  }, [view, filteredFindings, groups, enableAi, ruleClickHandler, resolveRuleHref]);
 
   const filterGroups: ReviewFilterGroup[] = useMemo(
     () => [

--- a/frontend/packages/ui-workflow/src/shared/RuleId.tsx
+++ b/frontend/packages/ui-workflow/src/shared/RuleId.tsx
@@ -10,6 +10,11 @@ export interface RuleIdProps {
    * Receives the bare rule ID that was clicked.
    */
   onRuleClick?: (bareId: string) => void;
+  /**
+   * Host-supplied rule definition URL. When it returns a string, the rule chip
+   * navigates in the same tab. When it returns undefined, render plain text.
+   */
+  resolveRuleHref?: (bareId: string) => string | undefined;
 }
 
 function SingleRuleId({
@@ -17,53 +22,73 @@ function SingleRuleId({
   className,
   onHoverChange,
   onRuleClick,
+  resolveRuleHref,
 }: {
   ruleId: string;
   className?: string;
   onHoverChange?: (hovering: boolean) => void;
   onRuleClick?: (bareId: string) => void;
+  resolveRuleHref?: (bareId: string) => string | undefined;
 }) {
   const bare = bareRuleId(ruleId);
-  const clickable = onRuleClick != null;
+  const href = resolveRuleHref?.(bare);
+  const filterClickable = href == null && onRuleClick != null;
   const hoverable = onHoverChange != null;
-  const interactive = clickable || hoverable;
+  const interactive = href != null || filterClickable || hoverable;
   const spanClassName = [
     className ?? 'apme-rule-id',
     interactive ? 'apme-rule-id-hoverable' : '',
-    clickable ? 'apme-rule-id-clickable' : '',
+    href != null ? 'apme-rule-id-link' : '',
+    filterClickable ? 'apme-rule-id-clickable' : '',
   ]
     .filter(Boolean)
     .join(' ');
 
+  const hoverHandlers = hoverable
+    ? {
+        onMouseEnter: () => onHoverChange!(true),
+        onMouseLeave: () => onHoverChange!(false),
+        onFocus: () => onHoverChange!(true),
+        onBlur: () => onHoverChange!(false),
+      }
+    : undefined;
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        className={spanClassName}
+        aria-label={`View rule definition: ${bare}`}
+        {...hoverHandlers}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {bare}
+      </a>
+    );
+  }
+
+  if (filterClickable) {
+    return (
+      <button
+        type="button"
+        className={spanClassName}
+        title={`Toggle filter: ${bare}`}
+        {...hoverHandlers}
+        onClick={(e) => {
+          e.stopPropagation();
+          onRuleClick(bare);
+        }}
+      >
+        {bare}
+      </button>
+    );
+  }
+
   return (
     <span
       className={spanClassName}
-      tabIndex={interactive ? 0 : undefined}
-      title={clickable ? `Toggle filter: ${bare}` : undefined}
-      role={clickable ? 'button' : undefined}
-      onMouseEnter={hoverable ? () => onHoverChange(true) : undefined}
-      onMouseLeave={hoverable ? () => onHoverChange(false) : undefined}
-      onFocus={hoverable ? () => onHoverChange(true) : undefined}
-      onBlur={hoverable ? () => onHoverChange(false) : undefined}
-      onClick={
-        clickable
-          ? (e) => {
-              e.stopPropagation();
-              onRuleClick(bare);
-            }
-          : undefined
-      }
-      onKeyDown={
-        clickable
-          ? (e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                e.stopPropagation();
-                onRuleClick(bare);
-              }
-            }
-          : undefined
-      }
+      tabIndex={hoverable ? 0 : undefined}
+      {...hoverHandlers}
     >
       {bare}
     </span>
@@ -75,6 +100,7 @@ export function RuleId({
   className,
   onHoverChange,
   onRuleClick,
+  resolveRuleHref,
 }: RuleIdProps) {
   const ids = ruleId.split(',').map((s) => s.trim()).filter(Boolean);
   if (ids.length <= 1) {
@@ -84,6 +110,7 @@ export function RuleId({
         className={className}
         onHoverChange={onHoverChange}
         onRuleClick={onRuleClick}
+        resolveRuleHref={resolveRuleHref}
       />
     );
   }
@@ -97,6 +124,7 @@ export function RuleId({
             className={className}
             onHoverChange={onHoverChange}
             onRuleClick={onRuleClick}
+            resolveRuleHref={resolveRuleHref}
           />
         </span>
       ))}

--- a/frontend/packages/ui-workflow/src/styles/workflow.css
+++ b/frontend/packages/ui-workflow/src/styles/workflow.css
@@ -562,6 +562,15 @@
   min-width: 0;
 }
 
+button.apme-rule-id-clickable {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+}
+
 .apme-rule-id-clickable {
   cursor: pointer;
   text-decoration: underline;
@@ -571,6 +580,20 @@
 
 .apme-rule-id-clickable:hover,
 .apme-rule-id-clickable:focus {
+  text-decoration-style: solid;
+}
+
+a.apme-rule-id-link {
+  color: var(--pf-t--global--link--Color, #0066cc);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
+a.apme-rule-id-link:hover,
+a.apme-rule-id-link:focus {
+  color: var(--pf-t--global--link--Color--hover, #004080);
   text-decoration-style: solid;
 }
 

--- a/frontend/src/test/AssessFindingsPanel.test.tsx
+++ b/frontend/src/test/AssessFindingsPanel.test.tsx
@@ -101,4 +101,28 @@ describe("AssessFindingsPanel rule filter", () => {
       screen.getByLabelText("Selected rule filters"),
     ).toHaveTextContent("L050");
   });
+
+  it("resolveRuleHref renders rule definition links instead of filter chips", () => {
+    render(
+      <AssessFindingsPanel
+        findings={findings}
+        resolveRuleHref={(bareId) =>
+          bareId === "L050"
+            ? "/self-service/repositories/quality-settings?rule=L050"
+            : undefined
+        }
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: "View rule definition: L050",
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "/self-service/repositories/quality-settings?rule=L050",
+    );
+    expect(
+      screen.queryByRole("button", { name: "L050" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/test/AssessFindingsPanel.test.tsx
+++ b/frontend/src/test/AssessFindingsPanel.test.tsx
@@ -114,13 +114,16 @@ describe("AssessFindingsPanel rule filter", () => {
       />,
     );
 
-    const link = screen.getByRole("link", {
+    const l050Links = screen.getAllByRole("link", {
       name: "View rule definition: L050",
     });
-    expect(link).toHaveAttribute(
-      "href",
-      "/self-service/repositories/quality-settings?rule=L050",
-    );
+    expect(l050Links).toHaveLength(2);
+    for (const link of l050Links) {
+      expect(link).toHaveAttribute(
+        "href",
+        "/self-service/repositories/quality-settings?rule=L050",
+      );
+    }
     expect(
       screen.queryByRole("button", { name: "L050" }),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

Adds optional `resolveRuleHref` support to `@apme/ui-workflow` so portal hosts
can render rule IDs as same-tab links to rule definition pages (AAP-88885).

- `RuleId`: when `resolveRuleHref(bareId)` returns a URL, render an `<a href>`
  with PatternFly link styling; when it returns `undefined`, render plain text
  (no broken link).
- `AssessFindingsPanel`: accepts `resolveRuleHref`; when set, rule chips navigate
  instead of toggling the in-panel rule filter (filter UI still available via
  Rule filter control).
- Adds regression test for link rendering vs filter-chip behavior.

Portal wiring and tarball bump: ansible/ansible-backstage-plugins (follow-up).

## Test plan

- [ ] `uvx --with tox-uv tox -e ui-workflow-pack`
- [ ] `cd frontend && npm test -- --run src/test/AssessFindingsPanel.test.tsx`
- [ ] Portal follow-up: Quality activity detail → rule link → Quality settings rule dialog

Jira: https://redhat.atlassian.net/browse/AAP-88885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rule identifiers can now link directly to their corresponding rule definitions.
  * Hosts can provide custom destinations for rule links.
  * Rule identifiers without a destination continue to support filtering or display as text.
  * Added distinct visual styling and interaction states for rule links and clickable rule identifiers.

* **Tests**
  * Added coverage confirming rule identifiers render with the expected destination and accessible label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->