### PR TITLE
fix(ui-workflow): keep rule chips toggling filters when resolveRuleHref returns undefined

### DIFF
--- a/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
@@ -393,7 +393,8 @@ export function AssessFindingsPanel({
     );
   }, []);
 
-  const ruleClickHandler = resolveRuleHref ? undefined : toggleRuleFilter;
+  // RuleId prefers definition links; unknown rules still toggle the filter chip.
+  const ruleClickHandler = toggleRuleFilter;
 
   const ruleFilterSet = useMemo(() => new Set(ruleFilters), [ruleFilters]);
 

--- a/frontend/src/test/AssessFindingsPanel.test.tsx
+++ b/frontend/src/test/AssessFindingsPanel.test.tsx
@@ -128,4 +128,25 @@ describe("AssessFindingsPanel rule filter", () => {
       screen.queryByRole("button", { name: "L050" }),
     ).not.toBeInTheDocument();
   });
+
+  it("resolveRuleHref keeps filter chips for rules without a catalog href", async () => {
+    const user = userEvent.setup();
+    render(
+      <AssessFindingsPanel
+        findings={findings}
+        resolveRuleHref={(bareId) =>
+          bareId === "L050"
+            ? "/self-service/repositories/quality-settings?rule=L050"
+            : undefined
+        }
+      />,
+    );
+
+    const m001Buttons = screen.getAllByRole("button", { name: "M001" });
+    expect(m001Buttons.length).toBeGreaterThan(0);
+    await user.click(m001Buttons[0]!);
+    expect(
+      screen.getByLabelText("Selected rule filters"),
+    ).toHaveTextContent("M001");
+  });
 });


### PR DESCRIPTION
**Description**
This PR addresses an issue in the AssessFindingsPanel component where rule chips were not properly toggling filters when resolveRuleHref returns undefined.

**Problem**
When resolveRuleHref function returns undefined, the rule chip click handler was not correctly toggling the filter state, causing inconsistent behavior in the UI filtering mechanism.

**Changes Made**

- Updated the ruleClickHandler function in `AssessFindingsPanel.tsx`
- Added corresponding test case in `AssessFindingsPanel.test.tsx`
- Issue: Fixes feedback from review for Jira ticket [AAP-88885](https://redhat.atlassian.net/browse/AAP-88885)

**Testing**

- Added unit test coverage for the updated ruleClickHandler functionality
- Verified existing functionality remains intact
- Tested edge case where resolveRuleHref returns undefined
- This is a targeted fix that ensures rule chips consistently toggle filters regardless of whether resolveRuleHref returns a valid href or undefined, improving the reliability of the filtering mechanism in the UI.

**Related PR**

- Addresses feedback from: [ansible-backstage-plugins/pull/610](https://github.com/ansible/ansible-backstage-plugins/pull/610)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clicking a rule now consistently updates the in-panel rule filter chip.
  - Rule links continue to support navigation while also applying the selected filter.
  - Rules without catalog links can now be selected through their filter chips.

- **Tests**
  - Added coverage for rule selection and filter-chip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->