### PR TITLE
feat(rule-catalog): add public API to get rule guidance and doc

### DIFF
--- a/src/apme_engine/remediation/abbenay_provider.py
+++ b/src/apme_engine/remediation/abbenay_provider.py
@@ -13,12 +13,12 @@ import functools
 import json
 import logging
 import os
-import re
 from importlib.resources import files as pkg_files
 from pathlib import Path
 
 import yaml
 
+from apme_engine.fingerprint import canonicalize_rule_id
 from apme_engine.remediation.ai_context import AINodeContext
 from apme_engine.remediation.ai_provider import (
     AINodeFix,
@@ -26,6 +26,7 @@ from apme_engine.remediation.ai_provider import (
     AIValidationResult,
     AIValidationVerdict,
 )
+from apme_engine.rule_catalog import _parse_ai_prompt_map
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +179,7 @@ def _build_validation_prompt(context: AINodeContext) -> str:
     message = str(v.get("message", ""))
 
     ai_prompts = _load_ai_prompts()
-    bare_id = rule_id.split(":")[-1] if ":" in rule_id else rule_id
+    bare_id = canonicalize_rule_id(rule_id)
     hint = ai_prompts.get(bare_id)
     rule_guidance = ""
     if hint:
@@ -276,7 +277,7 @@ def _build_node_prompt(context: AINodeContext) -> str:
     seen_rules: set[str] = set()
     for v in context.violations:
         rid = str(v.get("rule_id", ""))
-        bare = rid.split(":")[-1] if ":" in rid else rid
+        bare = canonicalize_rule_id(rid)
         if bare and bare not in seen_rules:
             hint = ai_prompts.get(bare)
             if hint:
@@ -507,8 +508,6 @@ def _load_best_practices() -> dict[str, list[str]]:
     return _BEST_PRACTICES
 
 
-_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
-
 _APME_ENGINE_ROOT = Path(__file__).resolve().parent.parent
 _RULE_DOC_DIRS = [
     _APME_ENGINE_ROOT / "graph" / "rules",
@@ -521,35 +520,17 @@ _RULE_DOC_DIRS = [
 def _load_ai_prompts() -> dict[str, str]:
     """Load ``ai_prompt`` hints from rule doc frontmatter across all validators.
 
-    Walks native/rules, opa/bundle, and ansible/rules directories, parsing
-    YAML frontmatter with ``yaml.safe_load`` to support multiline values.
-    The result is cached for the process lifetime (consistent with
-    ``_load_best_practices``).
+    Delegates to :func:`apme_engine.rule_catalog._parse_ai_prompt_map`, the
+    single shared frontmatter parser, so AI-assisted remediation and the
+    public ``apme_engine.rule_catalog.get_rule_guidance`` API can never
+    drift apart. This wrapper only exists to (a) target ``_RULE_DOC_DIRS``
+    (patched directly by tests) and (b) keep its own cache, independent of
+    ``rule_catalog``'s cache, consistent with ``_load_best_practices``.
 
     Returns:
         Mapping of rule_id to ai_prompt text.
     """
-    prompts: dict[str, str] = {}
-    for rule_dir in _RULE_DOC_DIRS:
-        if not rule_dir.is_dir():
-            continue
-        for md_path in rule_dir.glob("*.md"):
-            text = md_path.read_text(encoding="utf-8")
-            m = _FRONTMATTER_RE.match(text)
-            if not m:
-                continue
-            try:
-                fm = yaml.safe_load(m.group(1))
-            except yaml.YAMLError:
-                logger.warning("Failed to parse YAML frontmatter in %s", md_path)
-                continue
-            if not isinstance(fm, dict):
-                continue
-            rule_id = fm.get("rule_id", "")
-            ai_prompt = fm.get("ai_prompt", "")
-            if rule_id and ai_prompt:
-                prompts[str(rule_id)] = str(ai_prompt).strip()
-
+    prompts = _parse_ai_prompt_map(_RULE_DOC_DIRS)
     logger.debug("Loaded ai_prompt hints for %d rules", len(prompts))
     return prompts
 
@@ -568,7 +549,7 @@ def _get_best_practices_for_rules(rule_ids: list[str]) -> str:
 
     categories: set[str] = set()
     for rid in rule_ids:
-        bare = rid.split(":")[-1] if ":" in rid else rid
+        bare = canonicalize_rule_id(rid)
         cat = RULE_CATEGORY_MAP.get(bare, "")
         if cat:
             categories.add(cat)

--- a/src/apme_engine/rule_catalog.py
+++ b/src/apme_engine/rule_catalog.py
@@ -73,6 +73,30 @@ def _category_from_rule_id(rule_id: str) -> str:
     return "unknown"
 
 
+def _strip_quotes(value: str) -> str:
+    """Strip a single matching pair of surrounding quotes from a value.
+
+    ``_parse_frontmatter`` is a lightweight regex-based parser (not a full
+    YAML parser), so unlike ``yaml.safe_load`` it does not unquote scalar
+    values on its own. Without this, a frontmatter value like
+    ``rule_id: "R114"`` would be captured verbatim as ``'"R114"'``,
+    diverging from the YAML-parsed (quote-stripped) value used elsewhere
+    (e.g. ``_parse_ai_prompt_map``) and causing lookups for the same
+    rule to silently miss.
+
+    Args:
+        value: Raw captured frontmatter value, already stripped of
+            surrounding whitespace by ``_KV_RE``.
+
+    Returns:
+        The value with one matching pair of leading/trailing single or
+        double quotes removed, or the original value if unquoted.
+    """
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
 def _parse_frontmatter(path: Path) -> dict[str, str]:
     """Parse YAML frontmatter from a markdown file.
 
@@ -81,12 +105,16 @@ def _parse_frontmatter(path: Path) -> dict[str, str]:
 
     Returns:
         Dict of frontmatter key-value pairs, or empty dict if none found.
+        Values are unquoted (see ``_strip_quotes``) so a quoted
+        ``rule_id: "R114"`` normalizes the same as the unquoted
+        ``rule_id: R114`` form and matches ``yaml.safe_load``-based
+        parsers elsewhere in this module.
     """
     text = path.read_text(encoding="utf-8")
     m = _FRONTMATTER_RE.match(text)
     if not m:
         return {}
-    return dict(_KV_RE.findall(m.group(1)))
+    return {key: _strip_quotes(value) for key, value in _KV_RE.findall(m.group(1))}
 
 
 def _collect_native_rules() -> list[reporting_pb2.RuleDefinition]:

--- a/src/apme_engine/rule_catalog.py
+++ b/src/apme_engine/rule_catalog.py
@@ -14,9 +14,12 @@ rule-ID prefix per ADR-008.
 
 from __future__ import annotations
 
+import functools
 import logging
 import re
 from pathlib import Path
+
+import yaml
 
 from apme.v1 import common_pb2, reporting_pb2
 from apme_engine.engine.models import RuleScope
@@ -188,6 +191,136 @@ def _collect_from_frontmatter(
         )
     logger.info("Collected %d %s rules from frontmatter", len(defs), source)
     return defs
+
+
+@functools.lru_cache(maxsize=1)
+def _load_rule_guidance_map() -> dict[str, str]:
+    """Load ``ai_prompt`` remediation guidance from rule doc frontmatter.
+
+    Walks the native, OPA, and Ansible rule-doc directories, parsing YAML
+    frontmatter with ``yaml.safe_load`` (multiline-safe, unlike the
+    lightweight regex used by ``_parse_frontmatter``). The result is
+    cached for the process lifetime.
+
+    Returns:
+        Mapping of rule_id to stripped ``ai_prompt`` text, for rules that
+        define one.
+    """
+    guidance: dict[str, str] = {}
+    for rule_dir in (_GRAPH_RULES_DIR, _OPA_BUNDLE_DIR, _ANSIBLE_RULES_DIR):
+        if not rule_dir.is_dir():
+            continue
+        for md_path in sorted(rule_dir.glob("*.md")):
+            text = md_path.read_text(encoding="utf-8")
+            m = _FRONTMATTER_RE.match(text)
+            if not m:
+                continue
+            try:
+                fm = yaml.safe_load(m.group(1))
+            except yaml.YAMLError:
+                logger.warning("Failed to parse YAML frontmatter in %s", md_path)
+                continue
+            if not isinstance(fm, dict):
+                continue
+            rule_id = fm.get("rule_id", "")
+            ai_prompt = fm.get("ai_prompt", "")
+            if rule_id and ai_prompt:
+                guidance[str(rule_id)] = str(ai_prompt).strip()
+    return guidance
+
+
+def get_rule_guidance(rule_id: str) -> str | None:
+    """Get AI-remediation guidance text for a rule (public API).
+
+    This is the stable, public way for downstream consumers (e.g. projects
+    depending on ``apme-engine``) to retrieve the same ``ai_prompt``
+    guidance APME's own AI-assisted remediation uses, without reaching
+    into private modules or parsing rule markdown files directly.
+
+    Args:
+        rule_id: Rule identifier, e.g. ``"R114"`` or ``"L026"``. A
+            validator-prefixed form such as ``"opa:P001"`` is also
+            accepted; the prefix before the last ``:`` is stripped.
+
+    Returns:
+        The rule's ``ai_prompt`` guidance text if the rule defines one,
+        else ``None`` (either the rule is unknown or has no AI guidance).
+
+    Example:
+        >>> from apme_engine.rule_catalog import get_rule_guidance
+        >>> guidance = get_rule_guidance("R114")
+        >>> print(guidance)
+    """
+    bare_id = rule_id.split(":")[-1] if ":" in rule_id else rule_id
+    return _load_rule_guidance_map().get(bare_id)
+
+
+def list_rules_with_guidance() -> list[str]:
+    """List rule IDs that have AI-remediation guidance defined (public API).
+
+    Returns:
+        Sorted list of rule IDs whose markdown frontmatter defines an
+        ``ai_prompt``.
+    """
+    return sorted(_load_rule_guidance_map())
+
+
+@functools.lru_cache(maxsize=1)
+def _index_rule_doc_files() -> dict[str, Path]:
+    """Build a rule_id -> markdown file path index across all rule-doc dirs.
+
+    Reads each file's frontmatter (not just its filename) so the index is
+    correct even when a filename doesn't embed the rule_id verbatim.
+
+    Returns:
+        Mapping of rule_id to its ``.md`` doc path. When multiple files
+        declare the same rule_id, the first one found wins (directories
+        are walked in native -> opa -> ansible order).
+    """
+    index: dict[str, Path] = {}
+    for rule_dir in (_GRAPH_RULES_DIR, _OPA_BUNDLE_DIR, _ANSIBLE_RULES_DIR):
+        if not rule_dir.is_dir():
+            continue
+        for md_path in sorted(rule_dir.glob("*.md")):
+            fm = _parse_frontmatter(md_path)
+            rule_id = fm.get("rule_id", "")
+            if rule_id and rule_id not in index:
+                index[rule_id] = md_path
+    return index
+
+
+def get_rule_documentation(rule_id: str) -> str | None:
+    """Get the full markdown documentation body for a rule (public API).
+
+    Unlike :func:`get_rule_guidance` (which returns only the short
+    ``ai_prompt`` frontmatter field used for AI-assisted remediation),
+    this returns the full human-readable docs below the frontmatter:
+    description, pass/fail examples, and detailed remediation steps —
+    i.e. everything you'd see reading the rule's ``.md`` file directly,
+    minus the YAML frontmatter block itself.
+
+    Args:
+        rule_id: Rule identifier, e.g. ``"R114"`` or ``"L026"``. A
+            validator-prefixed form such as ``"opa:P001"`` is also
+            accepted; the prefix before the last ``:`` is stripped.
+
+    Returns:
+        The markdown body text (frontmatter stripped) if the rule has a
+        doc file, else ``None``.
+
+    Example:
+        >>> from apme_engine.rule_catalog import get_rule_documentation
+        >>> print(get_rule_documentation("R114"))
+    """
+    bare_id = rule_id.split(":")[-1] if ":" in rule_id else rule_id
+    md_path = _index_rule_doc_files().get(bare_id)
+    if md_path is None:
+        return None
+    text = md_path.read_text(encoding="utf-8")
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return text.strip()
+    return text[m.end() :].strip()
 
 
 def _collect_gitleaks_rules() -> list[reporting_pb2.RuleDefinition]:

--- a/src/apme_engine/rule_catalog.py
+++ b/src/apme_engine/rule_catalog.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 import functools
 import logging
 import re
+from collections.abc import Iterable
 from pathlib import Path
 
 import yaml
 
 from apme.v1 import common_pb2, reporting_pb2
 from apme_engine.engine.models import RuleScope
+from apme_engine.fingerprint import canonicalize_rule_id
 from apme_engine.graph.severity import get_severity, severity_to_proto
 from apme_engine.version_defaults import get_version_spec_str
 
@@ -193,21 +195,29 @@ def _collect_from_frontmatter(
     return defs
 
 
-@functools.lru_cache(maxsize=1)
-def _load_rule_guidance_map() -> dict[str, str]:
-    """Load ``ai_prompt`` remediation guidance from rule doc frontmatter.
+def _parse_ai_prompt_map(rule_dirs: Iterable[Path]) -> dict[str, str]:
+    """Parse ``ai_prompt`` frontmatter across a set of rule-doc directories.
 
-    Walks the native, OPA, and Ansible rule-doc directories, parsing YAML
-    frontmatter with ``yaml.safe_load`` (multiline-safe, unlike the
-    lightweight regex used by ``_parse_frontmatter``). The result is
-    cached for the process lifetime.
+    This is the single shared implementation for collecting AI-remediation
+    guidance from rule markdown frontmatter. Both :func:`_load_rule_guidance_map`
+    (this module's public API) and ``AbbenayProvider`` (AI-assisted
+    remediation) call this function so the two never drift apart.
+
+    Precedence is **first-write-wins**: if the same ``rule_id`` is declared
+    in more than one directory, the entry from the directory earliest in
+    ``rule_dirs`` is kept. Callers should pass directories in
+    native -> OPA -> Ansible order to match :func:`_index_rule_doc_files`.
+
+    Args:
+        rule_dirs: Directories to search, in precedence order (first wins).
 
     Returns:
         Mapping of rule_id to stripped ``ai_prompt`` text, for rules that
         define one.
     """
     guidance: dict[str, str] = {}
-    for rule_dir in (_GRAPH_RULES_DIR, _OPA_BUNDLE_DIR, _ANSIBLE_RULES_DIR):
+    for rule_dir in rule_dirs:
+        rule_dir = Path(rule_dir)
         if not rule_dir.is_dir():
             continue
         for md_path in sorted(rule_dir.glob("*.md")):
@@ -224,9 +234,26 @@ def _load_rule_guidance_map() -> dict[str, str]:
                 continue
             rule_id = fm.get("rule_id", "")
             ai_prompt = fm.get("ai_prompt", "")
-            if rule_id and ai_prompt:
+            if rule_id and ai_prompt and str(rule_id) not in guidance:
                 guidance[str(rule_id)] = str(ai_prompt).strip()
     return guidance
+
+
+@functools.lru_cache(maxsize=1)
+def _load_rule_guidance_map() -> dict[str, str]:
+    """Load ``ai_prompt`` remediation guidance from rule doc frontmatter.
+
+    Walks the native, OPA, and Ansible rule-doc directories (in that
+    precedence order, first-write-wins — see :func:`_parse_ai_prompt_map`)
+    parsing YAML frontmatter with ``yaml.safe_load`` (multiline-safe,
+    unlike the lightweight regex used by ``_parse_frontmatter``). The
+    result is cached for the process lifetime.
+
+    Returns:
+        Mapping of rule_id to stripped ``ai_prompt`` text, for rules that
+        define one.
+    """
+    return _parse_ai_prompt_map((_GRAPH_RULES_DIR, _OPA_BUNDLE_DIR, _ANSIBLE_RULES_DIR))
 
 
 def get_rule_guidance(rule_id: str) -> str | None:
@@ -238,9 +265,13 @@ def get_rule_guidance(rule_id: str) -> str | None:
     into private modules or parsing rule markdown files directly.
 
     Args:
-        rule_id: Rule identifier, e.g. ``"R114"`` or ``"L026"``. A
-            validator-prefixed form such as ``"opa:P001"`` is also
-            accepted; the prefix before the last ``:`` is stripped.
+        rule_id: Rule identifier, e.g. ``"R114"``, ``"L026"``, or
+            ``"SEC:generic-api-key"``. A legacy validator-prefixed form
+            such as ``"native:R114"`` is also accepted; only the known
+            ``native:``/``opa:``/``ansible:``/``gitleaks:`` prefixes are
+            stripped (see :func:`apme_engine.fingerprint.canonicalize_rule_id`)
+            so IDs whose colon is part of the ID itself (e.g. ``SEC:*``)
+            are preserved as-is.
 
     Returns:
         The rule's ``ai_prompt`` guidance text if the rule defines one,
@@ -251,7 +282,7 @@ def get_rule_guidance(rule_id: str) -> str | None:
         >>> guidance = get_rule_guidance("R114")
         >>> print(guidance)
     """
-    bare_id = rule_id.split(":")[-1] if ":" in rule_id else rule_id
+    bare_id = canonicalize_rule_id(rule_id)
     return _load_rule_guidance_map().get(bare_id)
 
 
@@ -300,9 +331,13 @@ def get_rule_documentation(rule_id: str) -> str | None:
     minus the YAML frontmatter block itself.
 
     Args:
-        rule_id: Rule identifier, e.g. ``"R114"`` or ``"L026"``. A
-            validator-prefixed form such as ``"opa:P001"`` is also
-            accepted; the prefix before the last ``:`` is stripped.
+        rule_id: Rule identifier, e.g. ``"R114"``, ``"L026"``, or
+            ``"SEC:generic-api-key"``. A legacy validator-prefixed form
+            such as ``"native:R114"`` is also accepted; only the known
+            ``native:``/``opa:``/``ansible:``/``gitleaks:`` prefixes are
+            stripped (see :func:`apme_engine.fingerprint.canonicalize_rule_id`)
+            so IDs whose colon is part of the ID itself (e.g. ``SEC:*``)
+            are preserved as-is.
 
     Returns:
         The markdown body text (frontmatter stripped) if the rule has a
@@ -312,7 +347,7 @@ def get_rule_documentation(rule_id: str) -> str | None:
         >>> from apme_engine.rule_catalog import get_rule_documentation
         >>> print(get_rule_documentation("R114"))
     """
-    bare_id = rule_id.split(":")[-1] if ":" in rule_id else rule_id
+    bare_id = canonicalize_rule_id(rule_id)
     md_path = _index_rule_doc_files().get(bare_id)
     if md_path is None:
         return None

--- a/tests/test_rule_catalog.py
+++ b/tests/test_rule_catalog.py
@@ -398,19 +398,29 @@ class TestGetRuleGuidance:
         """
         assert get_rule_guidance("SEC:*") is None
 
-    def test_get_rule_guidance_preserves_concrete_sec_id(self) -> None:
+    def test_get_rule_guidance_preserves_concrete_sec_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A concrete ``SEC:<id>`` rule ID keeps its colon intact for lookup.
 
         Naively splitting on the last ``:`` would turn
         ``SEC:generic-api-key`` into ``generic-api-key`` before lookup,
         which can never match a real rule_id. Guard against that
-        regression: the bare id passed to the guidance map must retain
-        the ``SEC:`` prefix.
+        regression with a patched guidance map so the assertion can only
+        pass if the full, colon-bearing ID is preserved through
+        canonicalization and used as the lookup key—comparing against the
+        real (empty) map would be vacuous, since both sides could be
+        ``None``.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
 
         Returns:
             None: Assert-only test.
         """
-        assert get_rule_guidance("SEC:generic-api-key") == _load_rule_guidance_map().get("SEC:generic-api-key")
+        monkeypatch.setattr(
+            "apme_engine.rule_catalog._load_rule_guidance_map",
+            lambda: {"SEC:generic-api-key": "guidance"},
+        )
+        assert get_rule_guidance("SEC:generic-api-key") == "guidance"
 
 
 class TestGetRuleDocumentation:

--- a/tests/test_rule_catalog.py
+++ b/tests/test_rule_catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -18,6 +19,8 @@ from apme_engine.rule_catalog import (
     _collect_gitleaks_rules,
     _index_rule_doc_files,
     _load_rule_guidance_map,
+    _parse_frontmatter,
+    _strip_quotes,
     collect_all_rules,
     get_rule_documentation,
     get_rule_guidance,
@@ -465,6 +468,80 @@ class TestGetRuleDocumentation:
             None: Assert-only test.
         """
         assert get_rule_documentation("SEC:*") is None
+
+    def test_get_rule_documentation_resolves_quoted_rule_id(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A quoted ``rule_id: "T777"`` frontmatter value is indexed under the bare ID.
+
+        Regression test: ``_index_rule_doc_files`` used the raw regex-based
+        ``_parse_frontmatter`` output as the index key, while
+        ``_parse_ai_prompt_map`` (used by ``get_rule_guidance``) unquotes
+        via ``yaml.safe_load``. A quoted rule_id would therefore be indexed
+        under ``'"T777"'`` instead of ``"T777"``, making
+        ``get_rule_documentation("T777")`` incorrectly return ``None``.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+            monkeypatch: Pytest monkeypatch fixture.
+
+        Returns:
+            None: Assert-only test.
+        """
+        rule_md = tmp_path / "T777_test.md"
+        rule_md.write_text(
+            '---\nrule_id: "T777"\ndescription: quoted rule id\n---\n# T777 body\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("apme_engine.rule_catalog._GRAPH_RULES_DIR", tmp_path)
+        monkeypatch.setattr("apme_engine.rule_catalog._OPA_BUNDLE_DIR", tmp_path / "does-not-exist-opa")
+        monkeypatch.setattr("apme_engine.rule_catalog._ANSIBLE_RULES_DIR", tmp_path / "does-not-exist-ansible")
+        doc = get_rule_documentation("T777")
+        assert doc is not None, "quoted rule_id must still resolve under its bare form"
+        assert "T777 body" in doc
+
+
+class TestParseFrontmatterQuoting:
+    """Tests for ``_strip_quotes`` and ``_parse_frontmatter`` quote normalization."""
+
+    @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+        ("raw", "expected"),
+        [
+            ('"R114"', "R114"),
+            ("'R114'", "R114"),
+            ("R114", "R114"),
+            ('"unterminated', '"unterminated'),
+            ("'mismatched\"", "'mismatched\""),
+            ('""', ""),
+        ],
+    )
+    def test_strip_quotes(self, raw: str, expected: str) -> None:
+        """``_strip_quotes`` removes one matching pair of quotes, else passes through.
+
+        Args:
+            raw: Raw captured frontmatter value.
+            expected: Expected normalized value.
+
+        Returns:
+            None: Assert-only test.
+        """
+        assert _strip_quotes(raw) == expected
+
+    def test_parse_frontmatter_unquotes_rule_id(self, tmp_path: Path) -> None:
+        """``_parse_frontmatter`` normalizes a quoted ``rule_id`` to its bare form.
+
+        Args:
+            tmp_path: Pytest temporary directory fixture.
+
+        Returns:
+            None: Assert-only test.
+        """
+        rule_md = tmp_path / "T778.md"
+        rule_md.write_text('---\nrule_id: "T778"\n---\n', encoding="utf-8")
+        fm = _parse_frontmatter(rule_md)
+        assert fm["rule_id"] == "T778", "quoted rule_id must be unquoted, matching yaml.safe_load parsers"
 
 
 def _grpc_context() -> AsyncMock:

--- a/tests/test_rule_catalog.py
+++ b/tests/test_rule_catalog.py
@@ -27,8 +27,6 @@ from apme_gateway.db import get_session
 from apme_gateway.db import queries as q
 from apme_gateway.grpc_reporting.servicer import ReportingServicer
 
-pytestmark = pytest.mark.usefixtures("gateway_db")
-
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("rule_id", "expected_category"),
@@ -385,6 +383,32 @@ class TestGetRuleGuidance:
         assert rule_ids == sorted(rule_ids), "rule IDs must be sorted"
         assert "R114" in rule_ids, "R114 defines ai_prompt and must be listed"
 
+    def test_get_rule_guidance_preserves_sec_wildcard_id(self) -> None:
+        """A colon-bearing ``SEC:*`` rule ID must not be mangled by prefix stripping.
+
+        ``SEC:*`` has no doc frontmatter (Gitleaks is a dynamic external
+        binary, see ``_collect_gitleaks_rules``), so this must resolve to
+        ``None`` rather than being corrupted into looking up ``"*"``.
+
+        Returns:
+            None: Assert-only test.
+        """
+        assert get_rule_guidance("SEC:*") is None
+
+    def test_get_rule_guidance_preserves_concrete_sec_id(self) -> None:
+        """A concrete ``SEC:<id>`` rule ID keeps its colon intact for lookup.
+
+        Naively splitting on the last ``:`` would turn
+        ``SEC:generic-api-key`` into ``generic-api-key`` before lookup,
+        which can never match a real rule_id. Guard against that
+        regression: the bare id passed to the guidance map must retain
+        the ``SEC:`` prefix.
+
+        Returns:
+            None: Assert-only test.
+        """
+        assert get_rule_guidance("SEC:generic-api-key") == _load_rule_guidance_map().get("SEC:generic-api-key")
+
 
 class TestGetRuleDocumentation:
     """Tests for the public ``get_rule_documentation`` full-docs API."""
@@ -434,6 +458,14 @@ class TestGetRuleDocumentation:
         """
         assert get_rule_documentation("native:R114") == get_rule_documentation("R114")
 
+    def test_get_rule_documentation_preserves_sec_wildcard_id(self) -> None:
+        """``SEC:*`` must not be mangled into ``"*"`` before doc lookup.
+
+        Returns:
+            None: Assert-only test.
+        """
+        assert get_rule_documentation("SEC:*") is None
+
 
 def _grpc_context() -> AsyncMock:
     """Build an async mock gRPC servicer context.
@@ -465,6 +497,7 @@ def _sample_rule(rule_id: str) -> reporting_pb2.RuleDefinition:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+@pytest.mark.usefixtures("gateway_db")  # type: ignore[untyped-decorator]
 async def test_register_rules_rejects_non_authority() -> None:
     """``RegisterRules`` with ``is_authority=False`` is rejected without persistence.
 
@@ -487,6 +520,7 @@ async def test_register_rules_rejects_non_authority() -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+@pytest.mark.usefixtures("gateway_db")  # type: ignore[untyped-decorator]
 async def test_register_rules_adds_new_rules() -> None:
     """Authority ``RegisterRules`` inserts new catalog rows.
 
@@ -512,6 +546,7 @@ async def test_register_rules_adds_new_rules() -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+@pytest.mark.usefixtures("gateway_db")  # type: ignore[untyped-decorator]
 async def test_register_rules_reconcile_removes_absent_rules() -> None:
     """A second full registration drops rules missing from the incoming set.
 

--- a/tests/test_rule_catalog.py
+++ b/tests/test_rule_catalog.py
@@ -16,7 +16,12 @@ from apme_engine.engine.models import ViolationDict
 from apme_engine.rule_catalog import (
     _category_from_rule_id,
     _collect_gitleaks_rules,
+    _index_rule_doc_files,
+    _load_rule_guidance_map,
     collect_all_rules,
+    get_rule_documentation,
+    get_rule_guidance,
+    list_rules_with_guidance,
 )
 from apme_gateway.db import get_session
 from apme_gateway.db import queries as q
@@ -323,6 +328,111 @@ def test_validate_rule_configs_complete_both_directions(
     unknown, missing = _validate_rule_configs(configs, complete=True)
     assert unknown == ["X999"], "X999 is not known to the Engine"
     assert missing == ["L002"], "L002 is known but absent from config"
+
+
+class TestGetRuleGuidance:
+    """Tests for the public ``get_rule_guidance`` / ``list_rules_with_guidance`` API."""
+
+    def setup_method(self) -> None:
+        """Clear the guidance cache before each test.
+
+        Returns:
+            None.
+        """
+        _load_rule_guidance_map.cache_clear()
+
+    def teardown_method(self) -> None:
+        """Clear the guidance cache after each test to avoid cross-test leakage.
+
+        Returns:
+            None.
+        """
+        _load_rule_guidance_map.cache_clear()
+
+    def test_get_rule_guidance_known_rule(self) -> None:
+        """``get_rule_guidance`` returns non-empty text for a rule with ``ai_prompt``.
+
+        Returns:
+            None: Assert-only test.
+        """
+        guidance = get_rule_guidance("R114")
+        assert guidance is not None, "R114 defines an ai_prompt and must return guidance"
+        assert "noqa" in guidance.lower(), "R114 guidance should mention the noqa exemption workflow"
+
+    def test_get_rule_guidance_unknown_rule_returns_none(self) -> None:
+        """``get_rule_guidance`` returns ``None`` for a rule with no guidance defined.
+
+        Returns:
+            None: Assert-only test.
+        """
+        assert get_rule_guidance("R9999-does-not-exist") is None
+
+    def test_get_rule_guidance_strips_validator_prefix(self) -> None:
+        """A ``validator:RULE_ID`` prefixed form resolves to the same guidance.
+
+        Returns:
+            None: Assert-only test.
+        """
+        assert get_rule_guidance("native:R114") == get_rule_guidance("R114")
+
+    def test_list_rules_with_guidance_sorted_and_contains_r114(self) -> None:
+        """``list_rules_with_guidance`` returns a sorted list including R114.
+
+        Returns:
+            None: Assert-only test.
+        """
+        rule_ids = list_rules_with_guidance()
+        assert rule_ids == sorted(rule_ids), "rule IDs must be sorted"
+        assert "R114" in rule_ids, "R114 defines ai_prompt and must be listed"
+
+
+class TestGetRuleDocumentation:
+    """Tests for the public ``get_rule_documentation`` full-docs API."""
+
+    def setup_method(self) -> None:
+        """Clear the doc-file index cache before each test.
+
+        Returns:
+            None.
+        """
+        _index_rule_doc_files.cache_clear()
+
+    def teardown_method(self) -> None:
+        """Clear the doc-file index cache after each test.
+
+        Returns:
+            None.
+        """
+        _index_rule_doc_files.cache_clear()
+
+    def test_get_rule_documentation_strips_frontmatter(self) -> None:
+        """``get_rule_documentation`` returns the markdown body without the frontmatter block.
+
+        Returns:
+            None: Assert-only test.
+        """
+        doc = get_rule_documentation("R114")
+        assert doc is not None, "R114 has a doc file and must return content"
+        assert not doc.startswith("---"), "frontmatter delimiter must be stripped"
+        assert "ai_prompt" not in doc, "frontmatter fields must not leak into the doc body"
+        assert "## File change (R114)" in doc, "doc body should retain the markdown heading"
+        assert "### Example: pass" in doc, "doc body should retain worked examples"
+
+    def test_get_rule_documentation_unknown_rule_returns_none(self) -> None:
+        """``get_rule_documentation`` returns ``None`` when no doc file exists for the rule.
+
+        Returns:
+            None: Assert-only test.
+        """
+        assert get_rule_documentation("R9999-does-not-exist") is None
+
+    def test_get_rule_documentation_strips_validator_prefix(self) -> None:
+        """A ``validator:RULE_ID`` prefixed form resolves to the same documentation.
+
+        Returns:
+            None: Assert-only test.
+        """
+        assert get_rule_documentation("native:R114") == get_rule_documentation("R114")
 
 
 def _grpc_context() -> AsyncMock:


### PR DESCRIPTION
## Summary

Add a stable public API on `apme_engine.rule_catalog` for downstream library consumers to retrieve AI remediation guidance and full rule documentation without parsing markdown privately.

## Changes

- `get_rule_guidance(rule_id)` — returns the short `ai_prompt` frontmatter used by AI-assisted remediation
- `get_rule_documentation(rule_id)` — returns the markdown docs body with frontmatter stripped
- `list_rules_with_guidance()` — sorted list of rule IDs that define an `ai_prompt`
- Share one frontmatter parser (`_parse_ai_prompt_map`) between `rule_catalog` and `AbbenayProvider` so guidance cannot drift
- Canonicalize rule IDs via `fingerprint.canonicalize_rule_id()` (strip only `native:`/`opa:`/`ansible:`/`gitleaks:`) so colon-bearing IDs like `SEC:generic-api-key` and `SEC:*` are preserved
- Consistent native → OPA → Ansible first-write-wins precedence for guidance and docs indexes
- Isolate new catalog unit tests from the `gateway_db` fixture (keep it only on Gateway registration tests)

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit -- tests/test_rule_catalog.py` passes (44 tests), including SEC colon-ID and quoted `rule_id` regressions
- [ ] Full `tox -e unit` in CI (local env has unrelated OPA/Podman infrastructure failures)
- [ ] Manual: `from apme_engine.rule_catalog import get_rule_guidance, get_rule_documentation, list_rules_with_guidance`

## Related Specs

None (library API surface for existing rule docs / AI guidance).

## Type of Change

- [x] New feature
- [x] Bug fix (colon-bearing rule ID mangling / loader drift)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to rule remediation guidance, including supported native, OPA, and Ansible rules.
  * Added rule documentation lookup with frontmatter removed for cleaner content.
  * Added a list of rules that include remediation guidance.
* **Bug Fixes**
  * Improved handling of quoted and colon-containing rule IDs for consistent lookups.
  * Malformed guidance metadata is safely skipped without interrupting processing.
* **Tests**
  * Expanded coverage for guidance, documentation, metadata parsing, and rule ID normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->