### PR TITLE
feat(gateway): persist SCM branch and commit SHA on scans

### DIFF
--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -353,6 +353,13 @@ sibling helpers (``resolve`` + ``is_relative_to`` / reject ``..``),
 and short-circuiting ``a() or b()`` / ``a() and b()`` when both calls
 have required side effects (e.g. promote ledger status after approving
 progression — evaluate both unconditionally).
+When adding a new error return after a status-machine transition
+(``SUBMITTING_PR``, ``APPLYING``, etc.), construct the failure *after*
+that transition and require the same restore-to-terminal path as
+sibling error handlers in the same function — a 404/409/422 that
+skips ``transition(COMPLETED)`` leaves live operations stuck in the
+in-flight status. Match existing SCM/token/provider error paths
+before introducing a new raise.
 When a parser treats ``:`` as host/port, construct the edge cases that
 break ``rpartition(":")``: empty host (``:port``), unbracketed IPv6
 (``::1``), ``[ipv6]:port``, and malformed ports (``[::1]:``,

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -75,7 +75,10 @@ module** surrounding each changed hunk — not just the hunk itself:
   before writing new code. If you add a `.pyi` field, read the other
   `.pyi` files for conventions. If you write a test, read the sibling
   tests for mock patterns. If you add an env var check, read how
-  existing env var checks handle the missing case.
+  existing env var checks handle the missing case. If you add a UI
+  control for an action the product already has (same label, href, or
+  table-cell pattern), reuse that component rather than a parallel
+  HTML primitive.
 
 **Artifact-type sweep.** Before answering the questions below, list
 every distinct artifact type in the diff (e.g., Python, proto, Rego,
@@ -434,6 +437,11 @@ critical/high/medium/low.
   double JSON parse, list.pop(0)/insert(0,…) vs deque, len(list(seq)),
   O(P×V) nested scans that should be O(P+V)
 - Pydantic/schema mutable defaults (`=[]`) vs sibling Field(default_factory=list)
+- UI controls that duplicate an existing product action with a
+  different primitive (raw ``<a>`` vs PatternFly ``Button
+  variant="link" component="a"`` already used for the same "View PR"
+  / table-cell link). Match the sibling component, including
+  ``isInline`` in table cells.
 
 Explain briefly why a Pass-1-style review would miss each finding.
 ```

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -355,11 +355,12 @@ have required side effects (e.g. promote ledger status after approving
 progression — evaluate both unconditionally).
 When adding a new error return after a status-machine transition
 (``SUBMITTING_PR``, ``APPLYING``, etc.), construct the failure *after*
-that transition and require the same restore-to-terminal path as
-sibling error handlers in the same function — a 404/409/422 that
-skips ``transition(COMPLETED)`` leaves live operations stuck in the
-in-flight status. Match existing SCM/token/provider error paths
-before introducing a new raise.
+that transition — both explicit raises *and* exceptions from helpers
+called in that window (DB commit, flush, RPC). Require the same
+restore-to-terminal path as sibling error handlers in the same
+function; a 404/409/422/500 that skips ``transition(COMPLETED)`` leaves
+live operations stuck in the in-flight status. Match existing
+SCM/token/provider error paths before introducing a new raise.
 When a parser treats ``:`` as host/port, construct the edge cases that
 break ``rpartition(":")``: empty host (``:port``), unbracketed IPv6
 (``::1``), ``[ipv6]:port``, and malformed ports (``[::1]:``,

--- a/.agents/skills/pr-new/SKILL.md
+++ b/.agents/skills/pr-new/SKILL.md
@@ -363,7 +363,9 @@ called in that window (DB commit, flush, RPC). Require the same
 restore-to-terminal path as sibling error handlers in the same
 function; a 404/409/422/500 that skips ``transition(COMPLETED)`` leaves
 live operations stuck in the in-flight status. Match existing
-SCM/token/provider error paths before introducing a new raise.
+SCM/token/provider error paths before introducing a new raise —
+including the same transition extras (``error=``) sibling failure
+handlers pass, so SSE subscribers see why the in-flight status ended.
 When a parser treats ``:`` as host/port, construct the edge cases that
 break ``rpartition(":")``: empty host (``:port``), unbracketed IPv6
 (``::1``), ``[ipv6]:port``, and malformed ports (``[::1]:``,

--- a/.sdlc/adrs/ADR-050-post-remediation-pr-creation.md
+++ b/.sdlc/adrs/ADR-050-post-remediation-pr-creation.md
@@ -361,11 +361,15 @@ globally via `APME_GITHUB_API_URL`.
 - **Project table**: Add optional `scm_token` column (plaintext text today; encryption
   at rest is a planned follow-up) and optional `scm_provider` column (enum: `github`,
   `gitlab`, `bitbucket`, or auto-detected from URL).
-- **Scan/Activity table**: Add optional `pr_url` column (text). Patched file
-  content is stored in a related `patched_files` table with columns
-  `(activity_id, path TEXT, content BLOB)`. Files are Ansible YAML (UTF-8
-  text) but stored as BLOBs to avoid encoding assumptions. A size cap per
-  activity (default 50 MiB total) prevents unbounded growth. Rows are
+- **Scan/Activity table**: Add optional `pr_url`, `branch_name`, and
+  `commit_sha` columns (text). `pr_url` is set when a pull request is
+  created. `branch_name` and `commit_sha` are stamped after every
+  successful push, including branch-only submit (`create_pr: false`).
+  All three are returned on activity list and detail REST responses.
+  Patched file content is stored in a related `patched_files` table with
+  columns `(activity_id, path TEXT, content BLOB)`. Files are Ansible YAML
+  (UTF-8 text) but stored as BLOBs to avoid encoding assumptions. A size cap
+  per activity (default 50 MiB total) prevents unbounded growth. Rows are
   cascade-deleted with the parent activity record.
 
 ### Configuration
@@ -416,3 +420,4 @@ globally via `APME_GITHUB_API_URL`.
 | 2026-07-06 | AI Agent | Consolidated to unified `/operation/submit` endpoint with `create_pr` flag; removed `POST /activity/{id}/pull-request` and `POST /operation/create-pr`; status → Accepted |
 | 2026-08-12 | AI Agent | Phase 2 implemented: GitLab + Bitbucket Cloud/Server providers (REQ-016); `APME_GITLAB_API_URL` / `APME_BITBUCKET_API_URL` |
 | 2026-08-12 | AI Agent | Clarify scm_token is plaintext at rest today; `APME_SECRET_KEY` encryption deferred to follow-up |
+| 2026-08-31 | AI Agent | Persist `branch_name` and `commit_sha` on the scan row; return them with `pr_url` on activity list/detail |

--- a/.sdlc/adrs/ADR-050-post-remediation-pr-creation.md
+++ b/.sdlc/adrs/ADR-050-post-remediation-pr-creation.md
@@ -205,8 +205,10 @@ Gateway:
   3. Create branch from project's default branch
   4. Push patched files to the new branch
   5. If create_pr=true: create PR against default branch
-  6. Store PR URL (if created) in scan record
-  7. Transition operation to PR_SUBMITTED
+  6. Stamp ``branch_name`` and ``commit_sha`` on the scan row (always);
+     store ``pr_url`` if a PR was created
+  7. If a PR was created, transition the live operation to PR_SUBMITTED;
+     otherwise leave it COMPLETED
   8. Return branch_name, commit_sha, pr_url to UI
         │
         ▼

--- a/.sdlc/adrs/ADR-062-ephemeral-proposal-working-set.md
+++ b/.sdlc/adrs/ADR-062-ephemeral-proposal-working-set.md
@@ -107,9 +107,10 @@ the fix without a human gate.
    and auto-stamps created for that check scan at FixCompleted (engine
    always emits fixed_yaml “would fix” rows).
 2. **PR / commit / push completed** → flush + delete for the **published
-   scan only** (scan-scoped). Phase 1 wires this into `set_scan_pr_url`;
-   push-only publish without a PR URL is Phase 2. Project-wide flush
-   remains for remediate→remediate replacement only.
+   scan only** (scan-scoped). Phase 1 wires this into
+   `record_scan_scm_publish` when a PR URL is set (and `set_scan_pr_url`).
+   Push-only publish without a PR URL does not flush (Phase 2).
+   Project-wide flush remains for remediate→remediate replacement only.
 3. **Historical activity GET** → if no working-set rows, **rebuild** proposals
    from violations in memory; do not `INSERT`. Use `original_yaml` /
    `fixed_yaml` for diffs when present.
@@ -266,3 +267,4 @@ match.
 | 2026-07-09 | Brad Thornton | Phase 2: draft PATCH, gate-commit stamps, id bridge, abandon |
 | 2026-07-20 | Brad Thornton | Cross-link ADR-065 for SPA vs registry ownership |
 | 2026-07-21 | Brad Thornton | AI escalation triage before Gate 2 (lift deferred) |
+| 2026-08-31 | AI Agent | PR flush is invoked from `record_scan_scm_publish` as well as `set_scan_pr_url` |

--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -31,7 +31,7 @@
         "type": "object"
       },
       "ActivityDetail": {
-        "description": "Full activity record with violations, proposals, logs, and patches.\n\nAttributes:\n    scan_id: UUID of the run (``scans.scan_id`` column).\n    session_id: Owning session hash.\n    project_id: Owning project UUID (None for CLI/playground runs).\n    project_path: Project root path.\n    source: Origin of the run.\n    created_at: ISO 8601 timestamp.\n    scan_type: Either ``check`` or ``remediate`` (stored in ``scans.scan_type``).\n    total_violations: Total violation count (initial, before Tier 1 fixes).\n    fixable: Tier-1 auto-fixable violation count (applied or dry-run).\n    ai_candidate: Count of tier-2 AI-candidate violations.\n    ai_proposed: AI proposals offered to the user.\n    ai_declined: Violations the AI could not fix.\n    ai_accepted: AI proposals the user approved and applied.\n    manual_review: Count of tier-3 manual violations.\n    remediated_count: Total applied (Tier 1 + AI accepted).\n    pr_url: URL of the PR created from this activity (ADR-050), if any.\n    diagnostics_json: Raw diagnostics JSON string.\n    violations: List of violation rows.\n    proposals: List of proposal rows.\n    logs: List of log entries.\n    patches: Per-file diffs.",
+        "description": "Full activity record with violations, proposals, logs, and patches.\n\nAttributes:\n    scan_id: UUID of the run (``scans.scan_id`` column).\n    session_id: Owning session hash.\n    project_id: Owning project UUID (None for CLI/playground runs).\n    project_path: Project root path.\n    source: Origin of the run.\n    created_at: ISO 8601 timestamp.\n    scan_type: Either ``check`` or ``remediate`` (stored in ``scans.scan_type``).\n    total_violations: Total violation count (initial, before Tier 1 fixes).\n    fixable: Tier-1 auto-fixable violation count (applied or dry-run).\n    ai_candidate: Count of tier-2 AI-candidate violations.\n    ai_proposed: AI proposals offered to the user.\n    ai_declined: Violations the AI could not fix.\n    ai_accepted: AI proposals the user approved and applied.\n    manual_review: Count of tier-3 manual violations.\n    remediated_count: Total applied (Tier 1 + AI accepted).\n    pr_url: URL of the PR created from this activity (ADR-050), if any.\n    branch_name: Head branch pushed during SCM submit (ADR-050), if any.\n    commit_sha: SHA of the commit pushed during SCM submit (ADR-050), if any.\n    diagnostics_json: Raw diagnostics JSON string.\n    violations: List of violation rows.\n    proposals: List of proposal rows.\n    logs: List of log entries.\n    patches: Per-file diffs.",
         "properties": {
           "ai_accepted": {
             "default": 0,
@@ -51,6 +51,28 @@
             "default": 0,
             "title": "Ai Proposed",
             "type": "integer"
+          },
+          "branch_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch Name"
+          },
+          "commit_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Commit Sha"
           },
           "created_at": {
             "title": "Created At",
@@ -175,7 +197,7 @@
         "type": "object"
       },
       "ActivitySummary": {
-        "description": "Activity list item (a persisted check or remediate run).\n\nAttributes:\n    scan_id: UUID of the run (``scans.scan_id`` column).\n    session_id: Owning session hash.\n    project_path: Project root path.\n    project_id: Owning project UUID when linked (None for CLI/playground).\n    source: Origin of the run (cli, ci, gateway).\n    created_at: ISO 8601 timestamp.\n    scan_type: Either ``check`` or ``remediate`` (stored in ``scans.scan_type``).\n    total_violations: Total violation count (initial, before Tier 1 fixes).\n    fixable: Tier-1 auto-fixable violation count (applied or dry-run).\n    ai_candidate: Count of tier-2 AI-candidate violations.\n    ai_proposed: AI proposals offered to the user.\n    ai_declined: Violations the AI could not fix.\n    ai_accepted: AI proposals the user approved and applied.\n    manual_review: Count of tier-3 manual violations.\n    remediated_count: Total applied (Tier 1 + AI accepted).\n    pr_url: URL of the PR created from this activity (ADR-050), if any.",
+        "description": "Activity list item (a persisted check or remediate run).\n\nAttributes:\n    scan_id: UUID of the run (``scans.scan_id`` column).\n    session_id: Owning session hash.\n    project_path: Project root path.\n    project_id: Owning project UUID when linked (None for CLI/playground).\n    source: Origin of the run (cli, ci, gateway).\n    created_at: ISO 8601 timestamp.\n    scan_type: Either ``check`` or ``remediate`` (stored in ``scans.scan_type``).\n    total_violations: Total violation count (initial, before Tier 1 fixes).\n    fixable: Tier-1 auto-fixable violation count (applied or dry-run).\n    ai_candidate: Count of tier-2 AI-candidate violations.\n    ai_proposed: AI proposals offered to the user.\n    ai_declined: Violations the AI could not fix.\n    ai_accepted: AI proposals the user approved and applied.\n    manual_review: Count of tier-3 manual violations.\n    remediated_count: Total applied (Tier 1 + AI accepted).\n    pr_url: URL of the PR created from this activity (ADR-050), if any.\n    branch_name: Head branch pushed during SCM submit (ADR-050), if any.\n    commit_sha: SHA of the commit pushed during SCM submit (ADR-050), if any.",
         "properties": {
           "ai_accepted": {
             "default": 0,
@@ -195,6 +217,28 @@
             "default": 0,
             "title": "Ai Proposed",
             "type": "integer"
+          },
+          "branch_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch Name"
+          },
+          "commit_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Commit Sha"
           },
           "created_at": {
             "title": "Created At",

--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -2286,7 +2286,7 @@
         "type": "object"
       },
       "SubmitResponse": {
-        "description": "Response after a successful SCM submit (ADR-050).\n\nAttributes:\n    branch_name: Name of the head branch that was created.\n    commit_sha: SHA of the commit pushed to the branch.\n    pr_url: Web URL of the PR, or ``None`` if ``create_pr`` was false.\n    provider: SCM provider that was used (e.g. ``github``).",
+        "description": "Response after a successful SCM submit (ADR-050).\n\nAttributes:\n    branch_name: Name of the head branch that was created.\n    commit_sha: SHA of the commit pushed to the branch.\n    pr_url: PR URL stored on the activity after persist (existing\n        or newly recorded), or ``None`` if none is stored.\n    provider: SCM provider that was used (e.g. ``github``).",
         "properties": {
           "branch_name": {
             "title": "Branch Name",

--- a/frontend/src/components/PublishedCell.tsx
+++ b/frontend/src/components/PublishedCell.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 interface PublishedCellProps {
@@ -14,16 +15,20 @@ function shortSha(sha: string): string {
 export function PublishedCell({ pr_url, branch_name, commit_sha }: PublishedCellProps) {
   if (pr_url) {
     return (
-      <a
+      <Button
+        variant="link"
+        isInline
+        component="a"
         href={pr_url}
         target="_blank"
         rel="noopener noreferrer"
+        icon={<ExternalLinkAltIcon />}
+        iconPosition="end"
+        size="sm"
         onClick={(e) => e.stopPropagation()}
-        style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
       >
         View PR
-        <ExternalLinkAltIcon style={{ width: 12, height: 12 }} />
-      </a>
+      </Button>
     );
   }
   if (branch_name) {

--- a/frontend/src/components/PublishedCell.tsx
+++ b/frontend/src/components/PublishedCell.tsx
@@ -1,0 +1,38 @@
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+interface PublishedCellProps {
+  pr_url?: string | null;
+  branch_name?: string | null;
+  commit_sha?: string | null;
+}
+
+function shortSha(sha: string): string {
+  return sha.length > 8 ? sha.slice(0, 8) : sha;
+}
+
+/** Compact SCM publish summary for activity lists (PR link, or branch + SHA). */
+export function PublishedCell({ pr_url, branch_name, commit_sha }: PublishedCellProps) {
+  if (pr_url) {
+    return (
+      <a
+        href={pr_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+      >
+        View PR
+        <ExternalLinkAltIcon style={{ width: 12, height: 12 }} />
+      </a>
+    );
+  }
+  if (branch_name) {
+    return (
+      <span style={{ fontFamily: 'var(--pf-t--global--font--family--mono)', fontSize: '0.875em' }}>
+        {branch_name}
+        {commit_sha ? ` @ ${shortSha(commit_sha)}` : ''}
+      </span>
+    );
+  }
+  return <span style={{ opacity: 0.3 }}>&mdash;</span>;
+}

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -107,9 +107,16 @@ export function ActivityDetailPage() {
     setPrError(null);
     try {
       const result = await submitActivity(detail.project_id, activityId);
-      if (result.pr_url) {
-        setDetail((prev) => (prev ? { ...prev, pr_url: result.pr_url } : prev));
-      }
+      setDetail((prev) =>
+        prev
+          ? {
+              ...prev,
+              pr_url: result.pr_url ?? prev.pr_url,
+              branch_name: result.branch_name ?? prev.branch_name,
+              commit_sha: result.commit_sha ?? prev.commit_sha,
+            }
+          : prev,
+      );
     } catch (err) {
       setPrError(err instanceof Error ? err.message : 'Failed to create pull request');
     } finally {
@@ -173,6 +180,14 @@ export function ActivityDetailPage() {
                 >
                   View PR
                 </Button>
+              </FlexItem>
+            )}
+            {detail.branch_name && (
+              <FlexItem>
+                <span style={{ fontFamily: 'var(--pf-t--global--font--family--mono)', fontSize: '0.875em' }}>
+                  {detail.branch_name}
+                  {detail.commit_sha ? ` @ ${detail.commit_sha.slice(0, 8)}` : ''}
+                </span>
               </FlexItem>
             )}
             {canCreatePR && (

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -6,6 +6,7 @@ import { apmeApiUrl, getApmeApiAdapter } from '../api/apmeApiAdapter';
 import { listActivity } from '../services/api';
 import type { ActivitySummary } from '../types/api';
 import { timeAgo } from '../services/format';
+import { PublishedCell } from '../components/PublishedCell';
 import {
   fetchProjectOperationState,
   LIVE_OPERATION_STATUSES,
@@ -158,6 +159,7 @@ export function ActivityPage() {
                 <th role="columnheader" title="AI could not fix">AI Declined</th>
                 <th role="columnheader" title="AI proposals accepted">AI Accepted</th>
                 <th role="columnheader">Manual</th>
+                <th role="columnheader">Published</th>
                 <th role="columnheader">Time</th>
                 <th role="columnheader">
                   <span className="pf-v6-screen-reader">Actions</span>
@@ -212,6 +214,13 @@ export function ActivityPage() {
                   <td role="cell">{item.ai_declined ?? 0}</td>
                   <td role="cell"><span className="apme-count-success">{item.ai_accepted ?? 0}</span></td>
                   <td role="cell"><span className="apme-count-warning">{item.manual_review ?? ''}</span></td>
+                  <td role="cell">
+                    <PublishedCell
+                      pr_url={item.pr_url}
+                      branch_name={item.branch_name}
+                      commit_sha={item.commit_sha}
+                    />
+                  </td>
                   <td role="cell" style={{ opacity: 0.7 }}>{timeAgo(item.created_at)}</td>
                   <td role="cell" onClick={(e) => e.stopPropagation()}>
                     {isResumable && item.project_id ? (

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -33,6 +33,7 @@ import type { ActivitySummary, DepHealthSummary, ProjectDependencies, ProjectDet
 import { GraphVisualization } from '../components/GraphVisualization';
 import { TrendChart } from '../components/TrendChart';
 import { timeAgo } from '../services/format';
+import { PublishedCell } from '../components/PublishedCell';
 import { useFeedbackEnabled } from '../hooks/useFeedbackEnabled';
 import {
   CheckOptionsForm,
@@ -488,6 +489,7 @@ export function ProjectDetailPage() {
                       <th role="columnheader">AI Declined</th>
                       <th role="columnheader">AI Accepted</th>
                       <th role="columnheader">Manual</th>
+                      <th role="columnheader">Published</th>
                       <th role="columnheader">Time</th>
                       <th role="columnheader">
                         <span className="pf-v6-screen-reader">Actions</span>
@@ -536,6 +538,13 @@ export function ProjectDetailPage() {
                         <td role="cell">{scan.ai_declined ?? 0}</td>
                         <td role="cell"><span className="apme-count-success">{scan.ai_accepted ?? 0}</span></td>
                         <td role="cell"><span className="apme-count-warning">{scan.manual_review}</span></td>
+                        <td role="cell">
+                          <PublishedCell
+                            pr_url={scan.pr_url}
+                            branch_name={scan.branch_name}
+                            commit_sha={scan.commit_sha}
+                          />
+                        </td>
                         <td role="cell" style={{ opacity: 0.7 }}>{timeAgo(scan.created_at)}</td>
                         <td role="cell" onClick={(e) => e.stopPropagation()}>
                           {isResumable ? (

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -74,6 +74,8 @@ export interface ActivitySummary {
   manual_review: number;
   remediated_count: number;
   pr_url: string | null;
+  branch_name?: string | null;
+  commit_sha?: string | null;
 }
 
 export interface PatchDetail {

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -708,9 +708,15 @@ async def submit_operation(
             )
         raise HTTPException(status_code=502, detail="SCM provider error") from exc
 
+    async with get_session() as db:
+        await q.record_scan_scm_publish(
+            db,
+            scan_id,
+            branch_name=branch_name,
+            commit_sha=commit_sha,
+            pr_url=pr_url,
+        )
     if pr_url:
-        async with get_session() as db:
-            await q.set_scan_pr_url(db, scan_id, pr_url)
         if state:
             get_operation_registry().set_pr_url(state.operation_id, pr_url)
     elif state:

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -709,13 +709,15 @@ async def submit_operation(
         raise HTTPException(status_code=502, detail="SCM provider error") from exc
 
     async with get_session() as db:
-        await q.record_scan_scm_publish(
+        persisted = await q.record_scan_scm_publish(
             db,
             scan_id,
             branch_name=branch_name,
             commit_sha=commit_sha,
             pr_url=pr_url,
         )
+    if not persisted:
+        raise HTTPException(status_code=404, detail="Activity not found")
     if pr_url:
         if state:
             get_operation_registry().set_pr_url(state.operation_id, pr_url)

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -710,7 +710,7 @@ async def submit_operation(
 
     try:
         async with get_session() as db:
-            persisted = await q.record_scan_scm_publish(
+            record = await q.record_scan_scm_publish(
                 db,
                 scan_id,
                 branch_name=branch_name,
@@ -725,13 +725,14 @@ async def submit_operation(
                 OperationStatus.COMPLETED,
             )
         raise HTTPException(status_code=500, detail="Failed to persist SCM publish metadata") from None
-    if not persisted:
+    if not record.found:
         if state:
             get_operation_registry().transition(
                 state.operation_id,
                 OperationStatus.COMPLETED,
             )
         raise HTTPException(status_code=404, detail="Activity not found")
+    pr_url = record.pr_url
     if pr_url:
         if state:
             get_operation_registry().set_pr_url(state.operation_id, pr_url)

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -708,14 +708,23 @@ async def submit_operation(
             )
         raise HTTPException(status_code=502, detail="SCM provider error") from exc
 
-    async with get_session() as db:
-        persisted = await q.record_scan_scm_publish(
-            db,
-            scan_id,
-            branch_name=branch_name,
-            commit_sha=commit_sha,
-            pr_url=pr_url,
-        )
+    try:
+        async with get_session() as db:
+            persisted = await q.record_scan_scm_publish(
+                db,
+                scan_id,
+                branch_name=branch_name,
+                commit_sha=commit_sha,
+                pr_url=pr_url,
+            )
+    except Exception:
+        logger.exception("Failed to persist SCM publish metadata for scan %s", scan_id)
+        if state:
+            get_operation_registry().transition(
+                state.operation_id,
+                OperationStatus.COMPLETED,
+            )
+        raise HTTPException(status_code=500, detail="Failed to persist SCM publish metadata") from None
     if not persisted:
         if state:
             get_operation_registry().transition(

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -717,6 +717,11 @@ async def submit_operation(
             pr_url=pr_url,
         )
     if not persisted:
+        if state:
+            get_operation_registry().transition(
+                state.operation_id,
+                OperationStatus.COMPLETED,
+            )
         raise HTTPException(status_code=404, detail="Activity not found")
     if pr_url:
         if state:

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -723,6 +723,7 @@ async def submit_operation(
             get_operation_registry().transition(
                 state.operation_id,
                 OperationStatus.COMPLETED,
+                error="Failed to persist SCM publish metadata",
             )
         raise HTTPException(status_code=500, detail="Failed to persist SCM publish metadata") from None
     if not record.found:
@@ -730,6 +731,7 @@ async def submit_operation(
             get_operation_registry().transition(
                 state.operation_id,
                 OperationStatus.COMPLETED,
+                error="Activity not found",
             )
         raise HTTPException(status_code=404, detail="Activity not found")
     pr_url = record.pr_url

--- a/src/apme_gateway/api/router.py
+++ b/src/apme_gateway/api/router.py
@@ -1584,6 +1584,8 @@ async def get_activity_detail(activity_id: str) -> ActivityDetail:
         manual_review=scan.manual_review,
         remediated_count=scan.fixed_count if scan.scan_type == "remediate" else 0,
         pr_url=scan.pr_url,
+        branch_name=scan.branch_name,
+        commit_sha=scan.commit_sha,
         diagnostics_json=scan.diagnostics_json,
         violations=[_to_violation_detail(v, suppressed_hashes, rule_only_hashes) for v in scan.violations],
         proposals=_proposals_for_activity(scan),
@@ -1731,6 +1733,8 @@ def _to_activity_summary(scan: Scan) -> ActivitySummary:
         manual_review=scan.manual_review,
         remediated_count=scan.fixed_count if scan.scan_type == "remediate" else 0,
         pr_url=scan.pr_url,
+        branch_name=scan.branch_name,
+        commit_sha=scan.commit_sha,
     )
 
 

--- a/src/apme_gateway/api/schemas.py
+++ b/src/apme_gateway/api/schemas.py
@@ -41,6 +41,8 @@ class ActivitySummary(BaseModel):  # type: ignore[misc]
         manual_review: Count of tier-3 manual violations.
         remediated_count: Total applied (Tier 1 + AI accepted).
         pr_url: URL of the PR created from this activity (ADR-050), if any.
+        branch_name: Head branch pushed during SCM submit (ADR-050), if any.
+        commit_sha: SHA of the commit pushed during SCM submit (ADR-050), if any.
     """
 
     scan_id: str
@@ -59,6 +61,8 @@ class ActivitySummary(BaseModel):  # type: ignore[misc]
     manual_review: int
     remediated_count: int = 0
     pr_url: str | None = None
+    branch_name: str | None = None
+    commit_sha: str | None = None
 
 
 class ViolationDetail(BaseModel):  # type: ignore[misc]
@@ -209,6 +213,8 @@ class ActivityDetail(BaseModel):  # type: ignore[misc]
         manual_review: Count of tier-3 manual violations.
         remediated_count: Total applied (Tier 1 + AI accepted).
         pr_url: URL of the PR created from this activity (ADR-050), if any.
+        branch_name: Head branch pushed during SCM submit (ADR-050), if any.
+        commit_sha: SHA of the commit pushed during SCM submit (ADR-050), if any.
         diagnostics_json: Raw diagnostics JSON string.
         violations: List of violation rows.
         proposals: List of proposal rows.
@@ -232,6 +238,8 @@ class ActivityDetail(BaseModel):  # type: ignore[misc]
     manual_review: int
     remediated_count: int = 0
     pr_url: str | None = None
+    branch_name: str | None = None
+    commit_sha: str | None = None
     diagnostics_json: str | None
     violations: list[ViolationDetail]
     proposals: list[ProposalDetail]

--- a/src/apme_gateway/api/schemas.py
+++ b/src/apme_gateway/api/schemas.py
@@ -685,7 +685,8 @@ class SubmitResponse(BaseModel):  # type: ignore[misc]
     Attributes:
         branch_name: Name of the head branch that was created.
         commit_sha: SHA of the commit pushed to the branch.
-        pr_url: Web URL of the PR, or ``None`` if ``create_pr`` was false.
+        pr_url: PR URL stored on the activity after persist (existing
+            or newly recorded), or ``None`` if none is stored.
         provider: SCM provider that was used (e.g. ``github``).
     """
 

--- a/src/apme_gateway/db/__init__.py
+++ b/src/apme_gateway/db/__init__.py
@@ -62,6 +62,7 @@ async def init_db(database_url_or_path: str) -> None:
         await conn.run_sync(Base.metadata.create_all)
         await conn.run_sync(_migrate_violations_table)
         await conn.run_sync(_migrate_proposals_table)
+        await conn.run_sync(_migrate_scans_table)
 
 
 async def init_db_from_config(*, database_url: str | None = None, db_path: str | None = None) -> str:
@@ -94,6 +95,7 @@ async def reset_db() -> None:
         await conn.run_sync(Base.metadata.create_all)
         await conn.run_sync(_migrate_violations_table)
         await conn.run_sync(_migrate_proposals_table)
+        await conn.run_sync(_migrate_scans_table)
 
 
 def get_engine() -> AsyncEngine:
@@ -214,6 +216,37 @@ def _migrate_proposals_table(conn: object) -> None:
         migrations.append("ALTER TABLE proposals ADD COLUMN draft INTEGER NOT NULL DEFAULT 0")
     if "stamp_rule_ids_json" not in existing:
         migrations.append("ALTER TABLE proposals ADD COLUMN stamp_rule_ids_json TEXT NOT NULL DEFAULT '[]'")
+
+    for stmt in migrations:
+        conn.execute(text(stmt))
+
+
+def _migrate_scans_table(conn: object) -> None:
+    """Add SCM publish columns to ``scans`` (ADR-050).
+
+    ``create_all`` only creates missing *tables* — it does not add columns
+    to existing tables.  This function inspects the ``scans`` table and
+    issues ``ALTER TABLE ADD COLUMN`` for any that are missing.
+
+    Args:
+        conn: Synchronous SQLAlchemy connection (from ``run_sync``).
+    """
+    from sqlalchemy.engine import Connection  # noqa: PLC0415
+
+    if not isinstance(conn, Connection):
+        return
+    insp = inspect(conn)
+    if not insp.has_table("scans"):
+        return
+    existing = {c["name"] for c in insp.get_columns("scans")}
+
+    migrations: list[str] = []
+    if "pr_url" not in existing:
+        migrations.append("ALTER TABLE scans ADD COLUMN pr_url TEXT DEFAULT NULL")
+    if "branch_name" not in existing:
+        migrations.append("ALTER TABLE scans ADD COLUMN branch_name TEXT DEFAULT NULL")
+    if "commit_sha" not in existing:
+        migrations.append("ALTER TABLE scans ADD COLUMN commit_sha TEXT DEFAULT NULL")
 
     for stmt in migrations:
         conn.execute(text(stmt))

--- a/src/apme_gateway/db/models.py
+++ b/src/apme_gateway/db/models.py
@@ -91,6 +91,8 @@ class Scan(Base):
         ai_accepted: Count of AI proposals accepted by the user.
         diagnostics_json: JSON-serialised ScanDiagnostics.
         pr_url: URL of the pull request created from this activity (ADR-050).
+        branch_name: Head branch pushed during SCM submit (ADR-050), if any.
+        commit_sha: SHA of the commit pushed during SCM submit (ADR-050), if any.
         session: Back-reference to owning Session.
         project: Back-reference to owning Project (ADR-037).
         violations: Related violation rows.
@@ -124,6 +126,8 @@ class Scan(Base):
     ai_accepted: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     diagnostics_json: Mapped[str | None] = mapped_column(Text, nullable=True)
     pr_url: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    branch_name: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    commit_sha: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
 
     session: Mapped[Session] = relationship(back_populates="scans")
     project: Mapped[Project | None] = relationship(back_populates="scans")

--- a/src/apme_gateway/db/queries.py
+++ b/src/apme_gateway/db/queries.py
@@ -7,7 +7,7 @@ import math
 from datetime import UTC, datetime
 from typing import Any, cast
 
-from sqlalchemy import case, func, or_, select
+from sqlalchemy import case, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -2049,6 +2049,61 @@ async def get_patched_files(
     return list(result.scalars().all())
 
 
+async def record_scan_scm_publish(
+    db: AsyncSession,
+    scan_id: str,
+    *,
+    branch_name: str,
+    commit_sha: str,
+    pr_url: str | None = None,
+) -> bool:
+    """Record SCM publish metadata on an activity (ADR-050).
+
+    Always stamps ``branch_name`` and ``commit_sha`` after a successful
+    push (including branch-only submit). When *pr_url* is provided,
+    uses a compare-and-set update (``WHERE pr_url IS NULL``) so that
+    concurrent PR creates cannot both succeed, then flushes this
+    scan's ephemeral proposal working set (ADR-062).
+
+    Args:
+        db: Active async database session.
+        scan_id: UUID of the scan (activity).
+        branch_name: Head branch that received the push.
+        commit_sha: SHA of the commit pushed to the branch.
+        pr_url: Web URL of the created pull request, or ``None`` for
+            a branch-only submit.
+
+    Returns:
+        True if the scan row was found and updated, False if the scan
+        does not exist.
+    """
+    from apme_gateway.proposals.flush import flush_proposals_for_scan  # noqa: PLC0415
+
+    stmt = (
+        update(Scan)
+        .where(Scan.scan_id == scan_id)
+        .values(branch_name=branch_name, commit_sha=commit_sha)
+        .returning(Scan.project_id, Scan.pr_url)
+    )
+    result = await db.execute(stmt)
+    row = result.first()
+    if row is None:
+        await db.commit()
+        return False
+
+    project_id = row[0] or ""
+    existing_pr_url = row[1]
+    if pr_url and existing_pr_url is None:
+        pr_stmt = update(Scan).where(Scan.scan_id == scan_id, Scan.pr_url.is_(None)).values(pr_url=pr_url)
+        await db.execute(pr_stmt)
+        # Publish flush is scan-scoped so PR on activity A cannot wipe an open
+        # remediate working set on activity B for the same project.
+        await flush_proposals_for_scan(db, scan_id, project_id=project_id)
+
+    await db.commit()
+    return True
+
+
 async def set_scan_pr_url(
     db: AsyncSession,
     scan_id: str,
@@ -2073,8 +2128,6 @@ async def set_scan_pr_url(
         True if the scan row was found and updated, False if it was
         already set or the scan does not exist.
     """
-    from sqlalchemy import update
-
     from apme_gateway.proposals.flush import flush_proposals_for_scan  # noqa: PLC0415
 
     # Single compare-and-set UPDATE with RETURNING — avoids a stale ORM

--- a/src/apme_gateway/db/queries.py
+++ b/src/apme_gateway/db/queries.py
@@ -2111,6 +2111,10 @@ async def set_scan_pr_url(
 ) -> bool:
     """Atomically record the PR URL on an activity (ADR-050).
 
+    Production submit uses ``record_scan_scm_publish`` so branch and
+    commit SHA are stamped with the PR. This helper remains for
+    PR-only compare-and-set callers (tests and ADR-062 flush).
+
     Uses a compare-and-set update (``WHERE pr_url IS NULL``) so that
     concurrent requests cannot both succeed — the second caller gets
     ``False`` and should return 409.

--- a/src/apme_gateway/db/queries.py
+++ b/src/apme_gateway/db/queries.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import math
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 from sqlalchemy import case, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -2049,6 +2049,19 @@ async def get_patched_files(
     return list(result.scalars().all())
 
 
+class ScmPublishRecord(NamedTuple):
+    """Outcome of recording SCM publish metadata on a scan row.
+
+    Attributes:
+        found: True if the scan row existed and was updated.
+        pr_url: PR URL stored on the row after persist (existing or
+            newly recorded), or ``None`` if none is stored.
+    """
+
+    found: bool
+    pr_url: str | None = None
+
+
 async def record_scan_scm_publish(
     db: AsyncSession,
     scan_id: str,
@@ -2056,7 +2069,7 @@ async def record_scan_scm_publish(
     branch_name: str,
     commit_sha: str,
     pr_url: str | None = None,
-) -> bool:
+) -> ScmPublishRecord:
     """Record SCM publish metadata on an activity (ADR-050).
 
     Always stamps ``branch_name`` and ``commit_sha`` after a successful
@@ -2074,8 +2087,10 @@ async def record_scan_scm_publish(
             a branch-only submit.
 
     Returns:
-        True if the scan row was found and updated, False if the scan
-        does not exist.
+        ``ScmPublishRecord`` with ``found`` False if the scan does not
+        exist; otherwise ``found`` True and ``pr_url`` set to the
+        value stored on the row (the existing URL if compare-and-set
+        declined, or the newly recorded URL).
     """
     from apme_gateway.proposals.flush import flush_proposals_for_scan  # noqa: PLC0415
 
@@ -2089,19 +2104,30 @@ async def record_scan_scm_publish(
     row = result.first()
     if row is None:
         await db.commit()
-        return False
+        return ScmPublishRecord(found=False)
 
     project_id = row[0] or ""
-    existing_pr_url = row[1]
-    if pr_url and existing_pr_url is None:
-        pr_stmt = update(Scan).where(Scan.scan_id == scan_id, Scan.pr_url.is_(None)).values(pr_url=pr_url)
-        await db.execute(pr_stmt)
-        # Publish flush is scan-scoped so PR on activity A cannot wipe an open
-        # remediate working set on activity B for the same project.
-        await flush_proposals_for_scan(db, scan_id, project_id=project_id)
+    stored_pr_url = row[1]
+    if pr_url and stored_pr_url is None:
+        pr_stmt = (
+            update(Scan)
+            .where(Scan.scan_id == scan_id, Scan.pr_url.is_(None))
+            .values(pr_url=pr_url)
+            .returning(Scan.pr_url)
+        )
+        pr_result = await db.execute(pr_stmt)
+        cas_row = pr_result.first()
+        if cas_row is not None:
+            stored_pr_url = cas_row[0]
+            # Publish flush is scan-scoped so PR on activity A cannot wipe an open
+            # remediate working set on activity B for the same project.
+            await flush_proposals_for_scan(db, scan_id, project_id=project_id)
+        else:
+            stored = await db.execute(select(Scan.pr_url).where(Scan.scan_id == scan_id))
+            stored_pr_url = stored.scalar_one_or_none()
 
     await db.commit()
-    return True
+    return ScmPublishRecord(found=True, pr_url=stored_pr_url)
 
 
 async def set_scan_pr_url(

--- a/tests/test_gateway_api.py
+++ b/tests/test_gateway_api.py
@@ -165,6 +165,10 @@ async def test_list_scans(client: AsyncClient) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["total"] == 1
+    item = body["items"][0]
+    assert item["pr_url"] is None
+    assert item["branch_name"] is None
+    assert item["commit_sha"] is None
 
 
 async def test_list_scans_filter_session(client: AsyncClient) -> None:

--- a/tests/test_gateway_pull_request.py
+++ b/tests/test_gateway_pull_request.py
@@ -936,6 +936,7 @@ class TestSubmitEndpoint:
         op = get_operation_registry().get_by_project("proj-1")
         assert op is not None
         assert op.status == OperationStatus.COMPLETED
+        assert op.error == "Activity not found"
 
     async def test_persist_exception_restores_completed(self, client: AsyncClient) -> None:
         """Live submit restores COMPLETED if persist raises after push.
@@ -969,6 +970,7 @@ class TestSubmitEndpoint:
         op = get_operation_registry().get_by_project("proj-1")
         assert op is not None
         assert op.status == OperationStatus.COMPLETED
+        assert op.error == "Failed to persist SCM publish metadata"
 
     async def test_submit_uses_persisted_pr_url(self, client: AsyncClient) -> None:
         """Submit response and registry use the PR URL stored on the scan.

--- a/tests/test_gateway_pull_request.py
+++ b/tests/test_gateway_pull_request.py
@@ -15,6 +15,7 @@ from httpx import ASGITransport, AsyncClient
 from apme_gateway.app import create_app
 from apme_gateway.db import get_session
 from apme_gateway.db.models import PatchedFile, Project, Scan, Session
+from apme_gateway.db.queries import ScmPublishRecord
 from apme_gateway.operation_registry import get_operation_registry
 from apme_gateway.operation_types import OperationResult, OperationStatus
 from apme_gateway.scm.base import PullRequestResult, detect_provider
@@ -642,14 +643,15 @@ class TestScanPrUrl:
             await db.commit()
 
         async with get_session() as db:
-            ok = await record_scan_scm_publish(
+            record = await record_scan_scm_publish(
                 db,
                 "sc1",
                 branch_name="apme/remediate-sc1",
                 commit_sha="abc123def",
                 pr_url="https://github.com/org/repo/pull/42",
             )
-        assert ok is True
+        assert record.found is True
+        assert record.pr_url == "https://github.com/org/repo/pull/42"
 
         async with get_session() as db:
             scan = await get_scan(db, "sc1")
@@ -675,13 +677,14 @@ class TestScanPrUrl:
             await db.commit()
 
         async with get_session() as db:
-            ok = await record_scan_scm_publish(
+            record = await record_scan_scm_publish(
                 db,
                 "sc1",
                 branch_name="apme/remediate-sc1",
                 commit_sha="deadbeef",
             )
-        assert ok is True
+        assert record.found is True
+        assert record.pr_url is None
 
         async with get_session() as db:
             scan = await get_scan(db, "sc1")
@@ -708,14 +711,15 @@ class TestScanPrUrl:
             await db.commit()
 
         async with get_session() as db:
-            ok = await record_scan_scm_publish(
+            record = await record_scan_scm_publish(
                 db,
                 "sc1",
                 branch_name="apme/remediate-sc1",
                 commit_sha="newsha",
                 pr_url="https://github.com/org/repo/pull/2",
             )
-        assert ok is True
+        assert record.found is True
+        assert record.pr_url == "https://github.com/org/repo/pull/1"
 
         async with get_session() as db:
             scan = await get_scan(db, "sc1")
@@ -725,17 +729,18 @@ class TestScanPrUrl:
         assert scan.pr_url == "https://github.com/org/repo/pull/1"
 
     async def test_record_scm_publish_not_found(self) -> None:
-        """record_scan_scm_publish returns False for a missing scan."""
+        """record_scan_scm_publish reports not found for a missing scan."""
         from apme_gateway.db.queries import record_scan_scm_publish
 
         async with get_session() as db:
-            ok = await record_scan_scm_publish(
+            record = await record_scan_scm_publish(
                 db,
                 "nonexistent",
                 branch_name="apme/remediate-x",
                 commit_sha="abc",
             )
-        assert ok is False
+        assert record.found is False
+        assert record.pr_url is None
 
 
 class TestProjectScmFields:
@@ -914,7 +919,7 @@ class TestSubmitEndpoint:
             patch(
                 "apme_gateway.api.operation_router.q.record_scan_scm_publish",
                 new_callable=AsyncMock,
-                return_value=False,
+                return_value=ScmPublishRecord(found=False),
             ),
         ):
             mock_provider = AsyncMock()
@@ -964,6 +969,41 @@ class TestSubmitEndpoint:
         op = get_operation_registry().get_by_project("proj-1")
         assert op is not None
         assert op.status == OperationStatus.COMPLETED
+
+    async def test_submit_uses_persisted_pr_url(self, client: AsyncClient) -> None:
+        """Submit response and registry use the PR URL stored on the scan.
+
+        Args:
+            client: Async test client.
+        """
+        await _seed_project_with_remediation(scm_token="ghp_test123")
+        _setup_completed_operation()
+        stored = "https://github.com/org/repo/pull/1"
+
+        with (
+            patch("apme_gateway.scm.get_provider") as mock_get,
+            patch("apme_gateway.config.load_config") as mock_cfg,
+            patch(
+                "apme_gateway.api.operation_router.q.record_scan_scm_publish",
+                new_callable=AsyncMock,
+                return_value=ScmPublishRecord(found=True, pr_url=stored),
+            ),
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.create_branch = AsyncMock(return_value="parent_sha")
+            mock_provider.push_files = AsyncMock(return_value="abc123def")
+            mock_provider.create_pull_request = AsyncMock(return_value=_MOCK_PR_RESULT)
+            mock_get.return_value = mock_provider
+            mock_cfg.return_value.scm_token = ""
+            mock_cfg.return_value.github_api_url = "https://api.github.com"
+
+            resp = await client.post("/api/v1/projects/proj-1/operation/submit")
+
+        assert resp.status_code == 200
+        assert resp.json()["pr_url"] == stored
+        op = get_operation_registry().get_by_project("proj-1")
+        assert op is not None
+        assert op.pr_url == stored
 
     async def test_no_operation(self, client: AsyncClient) -> None:
         """Return 404 when no operation exists for the project.

--- a/tests/test_gateway_pull_request.py
+++ b/tests/test_gateway_pull_request.py
@@ -625,6 +625,118 @@ class TestScanPrUrl:
             ok = await set_scan_pr_url(db, "nonexistent", "https://example.com")
         assert ok is False
 
+    async def test_record_scm_publish(self) -> None:
+        """Branch, commit SHA, and PR URL are recorded on a scan row."""
+        from apme_gateway.db.queries import get_scan, record_scan_scm_publish
+
+        async with get_session() as db:
+            db.add(Session(session_id="s1", project_path="/p", first_seen="t0", last_seen="t1"))
+            db.add(
+                Scan(
+                    scan_id="sc1",
+                    session_id="s1",
+                    project_path="/p",
+                    created_at="2026-01-01T00:00:00Z",
+                )
+            )
+            await db.commit()
+
+        async with get_session() as db:
+            ok = await record_scan_scm_publish(
+                db,
+                "sc1",
+                branch_name="apme/remediate-sc1",
+                commit_sha="abc123def",
+                pr_url="https://github.com/org/repo/pull/42",
+            )
+        assert ok is True
+
+        async with get_session() as db:
+            scan = await get_scan(db, "sc1")
+        assert scan is not None
+        assert scan.branch_name == "apme/remediate-sc1"
+        assert scan.commit_sha == "abc123def"
+        assert scan.pr_url == "https://github.com/org/repo/pull/42"
+
+    async def test_record_scm_publish_branch_only(self) -> None:
+        """Branch-only publish stamps branch and SHA without a PR URL."""
+        from apme_gateway.db.queries import get_scan, record_scan_scm_publish
+
+        async with get_session() as db:
+            db.add(Session(session_id="s1", project_path="/p", first_seen="t0", last_seen="t1"))
+            db.add(
+                Scan(
+                    scan_id="sc1",
+                    session_id="s1",
+                    project_path="/p",
+                    created_at="2026-01-01T00:00:00Z",
+                )
+            )
+            await db.commit()
+
+        async with get_session() as db:
+            ok = await record_scan_scm_publish(
+                db,
+                "sc1",
+                branch_name="apme/remediate-sc1",
+                commit_sha="deadbeef",
+            )
+        assert ok is True
+
+        async with get_session() as db:
+            scan = await get_scan(db, "sc1")
+        assert scan is not None
+        assert scan.branch_name == "apme/remediate-sc1"
+        assert scan.commit_sha == "deadbeef"
+        assert scan.pr_url is None
+
+    async def test_record_scm_publish_does_not_overwrite_pr_url(self) -> None:
+        """A later publish updates branch/SHA but does not replace an existing PR URL."""
+        from apme_gateway.db.queries import get_scan, record_scan_scm_publish
+
+        async with get_session() as db:
+            db.add(Session(session_id="s1", project_path="/p", first_seen="t0", last_seen="t1"))
+            db.add(
+                Scan(
+                    scan_id="sc1",
+                    session_id="s1",
+                    project_path="/p",
+                    created_at="2026-01-01T00:00:00Z",
+                    pr_url="https://github.com/org/repo/pull/1",
+                )
+            )
+            await db.commit()
+
+        async with get_session() as db:
+            ok = await record_scan_scm_publish(
+                db,
+                "sc1",
+                branch_name="apme/remediate-sc1",
+                commit_sha="newsha",
+                pr_url="https://github.com/org/repo/pull/2",
+            )
+        assert ok is True
+
+        async with get_session() as db:
+            scan = await get_scan(db, "sc1")
+        assert scan is not None
+        assert scan.branch_name == "apme/remediate-sc1"
+        assert scan.commit_sha == "newsha"
+        assert scan.pr_url == "https://github.com/org/repo/pull/1"
+
+    async def test_record_scm_publish_not_found(self) -> None:
+        """record_scan_scm_publish returns False for a missing scan."""
+        from apme_gateway.db.queries import record_scan_scm_publish
+
+        async with get_session() as db:
+            ok = await record_scan_scm_publish(
+                db,
+                "nonexistent",
+                branch_name="apme/remediate-x",
+                commit_sha="abc",
+            )
+        assert ok is False
+
 
 class TestProjectScmFields:
     """Tests for SCM-related project fields (ADR-050)."""
@@ -726,6 +838,20 @@ class TestSubmitEndpoint:
         assert data["provider"] == "github"
         assert data["branch_name"].startswith("apme/remediate-")
 
+        listed = await client.get("/api/v1/activity")
+        assert listed.status_code == 200
+        item = listed.json()["items"][0]
+        assert item["pr_url"] == "https://github.com/org/repo/pull/99"
+        assert item["branch_name"] == data["branch_name"]
+        assert item["commit_sha"] == "abc123def"
+
+        detail = await client.get("/api/v1/activity/scan-1")
+        assert detail.status_code == 200
+        body = detail.json()
+        assert body["pr_url"] == "https://github.com/org/repo/pull/99"
+        assert body["branch_name"] == data["branch_name"]
+        assert body["commit_sha"] == "abc123def"
+
     async def test_push_only_without_pr(self, client: AsyncClient) -> None:
         """Submit with create_pr=false pushes but does not open a PR.
 
@@ -758,6 +884,20 @@ class TestSubmitEndpoint:
         mock_provider.push_files.assert_called_once()
         assert mock_provider.push_files.call_args.kwargs.get("parent_commit_sha") == "parent_sha"
         mock_provider.create_pull_request.assert_not_called()
+
+        listed = await client.get("/api/v1/activity")
+        assert listed.status_code == 200
+        item = listed.json()["items"][0]
+        assert item["pr_url"] is None
+        assert item["branch_name"] == data["branch_name"]
+        assert item["commit_sha"] == "deadbeef"
+
+        detail = await client.get("/api/v1/activity/scan-1")
+        assert detail.status_code == 200
+        body = detail.json()
+        assert body["pr_url"] is None
+        assert body["branch_name"] == data["branch_name"]
+        assert body["commit_sha"] == "deadbeef"
 
     async def test_no_operation(self, client: AsyncClient) -> None:
         """Return 404 when no operation exists for the project.

--- a/tests/test_gateway_pull_request.py
+++ b/tests/test_gateway_pull_request.py
@@ -932,6 +932,39 @@ class TestSubmitEndpoint:
         assert op is not None
         assert op.status == OperationStatus.COMPLETED
 
+    async def test_persist_exception_restores_completed(self, client: AsyncClient) -> None:
+        """Live submit restores COMPLETED if persist raises after push.
+
+        Args:
+            client: Async test client.
+        """
+        await _seed_project_with_remediation(scm_token="ghp_test123")
+        _setup_completed_operation()
+
+        with (
+            patch("apme_gateway.scm.get_provider") as mock_get,
+            patch("apme_gateway.config.load_config") as mock_cfg,
+            patch(
+                "apme_gateway.api.operation_router.q.record_scan_scm_publish",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("db down"),
+            ),
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.create_branch = AsyncMock(return_value="parent_sha")
+            mock_provider.push_files = AsyncMock(return_value="abc123def")
+            mock_provider.create_pull_request = AsyncMock(return_value=_MOCK_PR_RESULT)
+            mock_get.return_value = mock_provider
+            mock_cfg.return_value.scm_token = ""
+            mock_cfg.return_value.github_api_url = "https://api.github.com"
+
+            resp = await client.post("/api/v1/projects/proj-1/operation/submit")
+
+        assert resp.status_code == 500
+        op = get_operation_registry().get_by_project("proj-1")
+        assert op is not None
+        assert op.status == OperationStatus.COMPLETED
+
     async def test_no_operation(self, client: AsyncClient) -> None:
         """Return 404 when no operation exists for the project.
 

--- a/tests/test_gateway_pull_request.py
+++ b/tests/test_gateway_pull_request.py
@@ -899,6 +899,39 @@ class TestSubmitEndpoint:
         assert body["branch_name"] == data["branch_name"]
         assert body["commit_sha"] == "deadbeef"
 
+    async def test_persist_miss_restores_completed(self, client: AsyncClient) -> None:
+        """Live submit restores COMPLETED if the scan row is gone after push.
+
+        Args:
+            client: Async test client.
+        """
+        await _seed_project_with_remediation(scm_token="ghp_test123")
+        _setup_completed_operation()
+
+        with (
+            patch("apme_gateway.scm.get_provider") as mock_get,
+            patch("apme_gateway.config.load_config") as mock_cfg,
+            patch(
+                "apme_gateway.api.operation_router.q.record_scan_scm_publish",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            mock_provider = AsyncMock()
+            mock_provider.create_branch = AsyncMock(return_value="parent_sha")
+            mock_provider.push_files = AsyncMock(return_value="abc123def")
+            mock_provider.create_pull_request = AsyncMock(return_value=_MOCK_PR_RESULT)
+            mock_get.return_value = mock_provider
+            mock_cfg.return_value.scm_token = ""
+            mock_cfg.return_value.github_api_url = "https://api.github.com"
+
+            resp = await client.post("/api/v1/projects/proj-1/operation/submit")
+
+        assert resp.status_code == 404
+        op = get_operation_registry().get_by_project("proj-1")
+        assert op is not None
+        assert op.status == OperationStatus.COMPLETED
+
     async def test_no_operation(self, client: AsyncClient) -> None:
         """Return 404 when no operation exists for the project.
 


### PR DESCRIPTION
## Summary
- Persist the remediation **branch name** and **commit SHA** on the scan row after a successful SCM push (including branch-only submit), and return them with the existing `pr_url` on every activity list and detail response.
- Activity and project history UIs show a Published column (View PR via PatternFly link Button, or branch + short SHA).
- After a successful push, persist failures restore the live operation to `COMPLETED` with an SSE `error` (404 if the scan row is gone, 500 if persist raises) so it cannot stick in `SUBMITTING_PR`.
- Submit response and SSE use the **persisted** PR URL (existing or newly recorded), not a compare-and-set reject from a concurrent create.

## Schema change — recreate local DBs

**This is a Gateway SQLite schema change.** Developers with an existing local database should drop it and recreate before pulling this branch:

```bash
tox -e wipe
tox -e up
```

`scans` gains nullable `branch_name` and `commit_sha` columns. Gateway also runs an idempotent `ALTER TABLE` on startup, but **wipe + recreate is the reliable path** if you hit schema errors after pulling.

## Changes
- `record_scan_scm_publish` stamps `branch_name` / `commit_sha` after every successful push; `pr_url` stays compare-and-set with the ADR-062 proposal flush, and the stored URL is what submit returns.
- Additive `/api/v1` fields on `ActivitySummary` and `ActivityDetail` (ADR-060; no version bump).
- OpenAPI regenerated (`docs/api/openapi.v1.json`).
- Concurrent submit still 409s only after a `pr_url` is stored; claiming the scan *before* SCM side effects is tracked in https://github.com/ansible/apme/issues/617.
- Idempotent retry after persist-failure (avoid a second `push_files` commit) is tracked in https://github.com/ansible/apme/issues/618.

## Quality of life
- ADR-050 updated for persist + list/detail fields.
- ADR-062 notes flush is invoked from `record_scan_scm_publish` when a PR URL is set.
- Rule of Five Pass 1 now constructs status-machine error returns after in-flight transitions, including helper exceptions and the same `error=` extras sibling paths pass for SSE.
- Rule of Five Q7 / Pass 2 now require matching sibling UI controls for the same action.

## Test plan
- [x] `tox -e lint` (skillmark skipped in this environment: missing `cc`)
- [x] `tox -e unit` (persist miss/exception restore and persisted-PR-URL response covered)
- [x] Docs/ADR updated
- [ ] After pull: `tox -e wipe` then `tox -e up`, then submit a remediate and confirm branch/SHA/PR appear on Activity and project History