### PR TITLE
feat(ui-workflow): support opening rule definition links in a new tab

### DIFF
--- a/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/AssessFindingsPanel.tsx
@@ -66,10 +66,11 @@ export interface AssessFindingsPanelProps {
    */
   initialRuleFilters?: string[];
   /**
-   * Host-supplied rule definition URL. When provided, rule chips navigate to
-   * the definition instead of toggling the in-panel rule filter.
+   * Host-supplied rule definition URL. Known rules link; others keep filter chips.
    */
   resolveRuleHref?: (bareId: string) => string | undefined;
+  /** Anchor target for resolveRuleHref links (default: same tab). */
+  ruleHrefTarget?: '_blank' | '_self';
 }
 
 function formatReviewStatus(status: string): string {
@@ -150,6 +151,7 @@ function FindingRow({
   onHighlightLine,
   onRuleClick,
   resolveRuleHref,
+  ruleHrefTarget,
 }: {
   f: AssessFinding;
   snippetYaml: string;
@@ -157,6 +159,7 @@ function FindingRow({
   onHighlightLine?: (line: number | null) => void;
   onRuleClick?: (bareId: string) => void;
   resolveRuleHref?: (bareId: string) => string | undefined;
+  ruleHrefTarget?: '_blank' | '_self';
 }) {
   const fix = findingFixType(f, enableAi);
   const sev = f.severity || 'info';
@@ -168,6 +171,7 @@ function FindingRow({
         ruleId={f.rule_id}
         onRuleClick={onRuleClick}
         resolveRuleHref={resolveRuleHref}
+        ruleHrefTarget={ruleHrefTarget}
         onHoverChange={
           canHighlight
             ? (hovering) =>
@@ -218,11 +222,13 @@ export function AssessNodeDetail({
   enableAi,
   onRuleClick,
   resolveRuleHref,
+  ruleHrefTarget,
 }: {
   findings: AssessFinding[];
   enableAi: boolean;
   onRuleClick?: (bareId: string) => void;
   resolveRuleHref?: (bareId: string) => string | undefined;
+  ruleHrefTarget?: '_blank' | '_self';
 }) {
   const [highlightLine, setHighlightLine] = useState<number | null>(null);
   // Assess/history findings are read-only: current YAML only. Proposed diffs
@@ -240,6 +246,7 @@ export function AssessNodeDetail({
             enableAi={enableAi}
             onRuleClick={onRuleClick}
             resolveRuleHref={resolveRuleHref}
+            ruleHrefTarget={ruleHrefTarget}
             onHighlightLine={
               beforeYaml.trim() ? setHighlightLine : undefined
             }
@@ -264,6 +271,7 @@ function findingsToNodeItem(
     enableAi: boolean;
     onRuleClick?: (bareId: string) => void;
     resolveRuleHref?: (bareId: string) => string | undefined;
+    ruleHrefTarget?: '_blank' | '_self';
   },
 ): NodeReviewItem {
   const nodeType = normalizeFindingNodeType(
@@ -290,6 +298,7 @@ function findingsToNodeItem(
         enableAi={opts.enableAi}
         onRuleClick={opts.onRuleClick}
         resolveRuleHref={opts.resolveRuleHref}
+        ruleHrefTarget={opts.ruleHrefTarget}
       />
     ),
   };
@@ -326,6 +335,7 @@ export function AssessFindingsPanel({
   error = null,
   initialRuleFilters,
   resolveRuleHref,
+  ruleHrefTarget,
 }: AssessFindingsPanelProps) {
   const [view, setView] = useState<ViewMode>('grouped');
   const [sevFilters, setSevFilters] = useState<Set<string>>(
@@ -496,6 +506,7 @@ export function AssessFindingsPanel({
             enableAi,
             onRuleClick: ruleClickHandler,
             resolveRuleHref,
+            ruleHrefTarget,
           },
         ),
       );
@@ -506,9 +517,10 @@ export function AssessFindingsPanel({
         enableAi,
         onRuleClick: ruleClickHandler,
         resolveRuleHref,
+        ruleHrefTarget,
       }),
     );
-  }, [view, filteredFindings, groups, enableAi, ruleClickHandler, resolveRuleHref]);
+  }, [view, filteredFindings, groups, enableAi, ruleClickHandler, resolveRuleHref, ruleHrefTarget]);
 
   const filterGroups: ReviewFilterGroup[] = useMemo(
     () => [

--- a/frontend/packages/ui-workflow/src/shared/RuleId.tsx
+++ b/frontend/packages/ui-workflow/src/shared/RuleId.tsx
@@ -12,9 +12,12 @@ export interface RuleIdProps {
   onRuleClick?: (bareId: string) => void;
   /**
    * Host-supplied rule definition URL. When it returns a string, the rule chip
-   * navigates in the same tab. When it returns undefined, render plain text.
+   * links to the definition. When it returns undefined, render plain text or
+   * a filter chip when onRuleClick is set.
    */
   resolveRuleHref?: (bareId: string) => string | undefined;
+  /** Anchor target for resolveRuleHref links (default: same tab). */
+  ruleHrefTarget?: '_blank' | '_self';
 }
 
 function SingleRuleId({
@@ -23,12 +26,14 @@ function SingleRuleId({
   onHoverChange,
   onRuleClick,
   resolveRuleHref,
+  ruleHrefTarget,
 }: {
   ruleId: string;
   className?: string;
   onHoverChange?: (hovering: boolean) => void;
   onRuleClick?: (bareId: string) => void;
   resolveRuleHref?: (bareId: string) => string | undefined;
+  ruleHrefTarget?: '_blank' | '_self';
 }) {
   const bare = bareRuleId(ruleId);
   const href = resolveRuleHref?.(bare);
@@ -54,13 +59,26 @@ function SingleRuleId({
     : undefined;
 
   if (href) {
+    const opensNewTab = ruleHrefTarget === '_blank';
     return (
       <a
         href={href}
         className={spanClassName}
-        aria-label={`View rule definition: ${bare}`}
+        target={ruleHrefTarget}
+        rel={opensNewTab ? 'noopener noreferrer' : undefined}
+        aria-label={
+          opensNewTab
+            ? `View rule definition in new tab: ${bare}`
+            : `View rule definition: ${bare}`
+        }
         {...hoverHandlers}
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (opensNewTab) {
+            e.preventDefault();
+            window.open(href, '_blank', 'noopener,noreferrer');
+          }
+        }}
       >
         {bare}
       </a>
@@ -101,6 +119,7 @@ export function RuleId({
   onHoverChange,
   onRuleClick,
   resolveRuleHref,
+  ruleHrefTarget,
 }: RuleIdProps) {
   const ids = ruleId.split(',').map((s) => s.trim()).filter(Boolean);
   if (ids.length <= 1) {
@@ -111,6 +130,7 @@ export function RuleId({
         onHoverChange={onHoverChange}
         onRuleClick={onRuleClick}
         resolveRuleHref={resolveRuleHref}
+        ruleHrefTarget={ruleHrefTarget}
       />
     );
   }
@@ -125,6 +145,7 @@ export function RuleId({
             onHoverChange={onHoverChange}
             onRuleClick={onRuleClick}
             resolveRuleHref={resolveRuleHref}
+            ruleHrefTarget={ruleHrefTarget}
           />
         </span>
       ))}

--- a/frontend/src/test/AssessFindingsPanel.test.tsx
+++ b/frontend/src/test/AssessFindingsPanel.test.tsx
@@ -129,6 +129,39 @@ describe("AssessFindingsPanel rule filter", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("ruleHrefTarget=_blank opens rule definition links in a new tab", async () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const user = userEvent.setup();
+    render(
+      <AssessFindingsPanel
+        findings={findings}
+        resolveRuleHref={(bareId) =>
+          bareId === "L050"
+            ? "/self-service/repositories/quality-settings?rule=L050"
+            : undefined
+        }
+        ruleHrefTarget="_blank"
+      />,
+    );
+
+    const l050Links = screen.getAllByRole("link", {
+      name: "View rule definition in new tab: L050",
+    });
+    expect(l050Links).toHaveLength(2);
+    for (const link of l050Links) {
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+
+    await user.click(l050Links[0]!);
+    expect(openSpy).toHaveBeenCalledWith(
+      "/self-service/repositories/quality-settings?rule=L050",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    openSpy.mockRestore();
+  });
+
   it("resolveRuleHref keeps filter chips for rules without a catalog href", async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
## Summary

Adds an optional `ruleHrefTarget` prop (`'_blank' | '_self'`) to `RuleId` and `AssessFindingsPanel`, letting host apps control where catalog rule definition links open.

- **Default unchanged** — when `ruleHrefTarget` is omitted, rule chips still navigate in the same tab.
- **`_blank` behavior** — sets `target="_blank"`, `rel="noopener noreferrer"`, updates the aria-label, and uses `window.open()` so links reliably open in a new tab without navigating away from the findings view.
- **Plumbed through** `AssessFindingsPanel` → `AssessNodeDetail` → `FindingRow` → `RuleId`.

This supports Backstage Quality findings, where users should be able to inspect a rule definition without losing their current findings context.

## Test plan

- [x] Unit test: `ruleHrefTarget="_blank"` renders links with correct `target`, `rel`, and aria-label
- [x] Unit test: clicking a rule link calls `window.open()` with `noopener,noreferrer`
- [x] Existing tests still pass for same-tab navigation and filter-chip fallback when `resolveRuleHref` returns `undefined`
- [ ] Manual: in a host that passes `ruleHrefTarget="_blank"`, click a catalog rule chip and confirm Quality settings opens in a new tab while findings stay open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Rule-definition links can now open in the current tab or a new tab.
  - New-tab links include appropriate security protections and accessibility labeling.

- **Tests**
  - Added coverage verifying new-tab behavior, link attributes, and navigation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->