### PR TITLE
feat(ui-workflow): add showCollections prop to CheckOptionsForm (AAP-89526)

### DIFF
--- a/frontend/packages/ui-workflow/src/components/CheckOptionsForm.tsx
+++ b/frontend/packages/ui-workflow/src/components/CheckOptionsForm.tsx
@@ -26,6 +26,8 @@ export interface CheckOptionsFormProps {
   onAutoApplyTier1Change?: (checked: boolean) => void;
  /** Platform-level AI availability flag; hides AI controls when false and defaults to true for standalone SPA backward compatibility. */
   showAiOptions?: boolean;
+  /** Hide the Collections text input from the form. Defaults to true for standalone SPA backward compatibility. */
+  showCollections?: boolean;
   idPrefix?: string;
 }
 
@@ -39,6 +41,7 @@ export function CheckOptionsForm({
   autoApplyTier1 = false,
   onAutoApplyTier1Change,
   showAiOptions = true,
+  showCollections = true,
   idPrefix = '',
 }: CheckOptionsFormProps) {
   const prefix = idPrefix ? `${idPrefix}-` : '';
@@ -82,17 +85,19 @@ export function CheckOptionsForm({
             onChange={(_e, v) => onAnsibleVersionChange(v)}
           />
         </FlexItem>
-        <FlexItem>
-          <label htmlFor={`${prefix}collections`} style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>
-            Collections (comma-separated)
-          </label>
-          <TextInput
-            id={`${prefix}collections`}
-            placeholder="e.g. ansible.posix, community.general"
-            value={collections}
-            onChange={(_e, v) => onCollectionsChange(v)}
-          />
-        </FlexItem>
+        {showCollections && (
+          <FlexItem>
+            <label htmlFor={`${prefix}collections`} style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>
+              Collections (comma-separated)
+            </label>
+            <TextInput
+              id={`${prefix}collections`}
+              placeholder="e.g. ansible.posix, community.general"
+              value={collections}
+              onChange={(_e, v) => onCollectionsChange(v)}
+            />
+          </FlexItem>
+        )}
         {showAiOptions && (
           <FlexItem>
             <Checkbox


### PR DESCRIPTION
## Summary

- Adds an optional `showCollections` prop (default `true`) to `CheckOptionsForm`, allowing portal hosts to hide the "Collections (comma-separated)" text input
- Follows the same pattern as the existing `showAiOptions` prop — gating the `FlexItem` with a conditional render
- No behavioral change when `showCollections` is omitted (defaults to `true` for standalone SPA backward compatibility)

Ref: [AAP-89526](https://redhat.atlassian.net/browse/AAP-89526)

## Test plan

- [ ] Standalone APME SPA: verify collections field still renders by default
- [ ] Pass `showCollections={false}`: verify the collections field is hidden while all other Advanced Options remain visible
- [ ] Verify `collections` prop value is still forwarded to `useProjectWorkflow` even when hidden


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to show or hide the Collections field in check configuration forms.
  * The Collections field remains visible by default for existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->