### PR TITLE
fix(ui-workflow): remove duplicate PR create action from final screen (AAP-89528)

### DIFF
--- a/frontend/packages/ui-workflow/src/components/OperationPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/OperationPanel.tsx
@@ -454,9 +454,6 @@ export function OperationPanel({
       );
     }
 
-    const canStillCommit =
-      needsCommitStep(state) && !(state.pr_url || localPrUrl);
-
     return withStepper(
       state,
       enableAi,
@@ -464,14 +461,6 @@ export function OperationPanel({
         result={resultData}
         isRemediate={state.scan_type === 'remediate' || (resultData.remediated_count ?? 0) > 0}
         onDismiss={onDismiss}
-        onCreatePR={
-          canStillCommit
-            ? () => {
-                handleSubmit({ create_pr: true }).catch(() => {});
-              }
-            : undefined
-        }
-        prCreating={prCreating || status === 'submitting_pr'}
         prUrl={state.pr_url || localPrUrl}
         prError={prError}
         scanId={state.scan_id}

--- a/frontend/packages/ui-workflow/src/components/OperationResultCard.tsx
+++ b/frontend/packages/ui-workflow/src/components/OperationResultCard.tsx
@@ -17,8 +17,6 @@ export interface OperationResultCardProps {
   isRemediate?: boolean;
   onDismiss?: () => void;
   actions?: ReactNode;
-  onCreatePR?: () => void;
-  prCreating?: boolean;
   prUrl?: string | null;
   prError?: string | null;
   scanId?: string;
@@ -50,8 +48,6 @@ export function OperationResultCard({
   isRemediate,
   onDismiss,
   actions,
-  onCreatePR,
-  prCreating,
   prUrl,
   prError,
   scanId,
@@ -59,8 +55,6 @@ export function OperationResultCard({
 }: OperationResultCardProps) {
   const wasRemediate = isRemediate ?? result.remediated_count != null;
   const hasAi = (result.ai_proposed ?? 0) > 0 || (result.ai_declined ?? 0) > 0 || (result.ai_accepted ?? 0) > 0;
-  // Caller decides eligibility (e.g. patches or remediated_count via needsCommitStep).
-  const showCreatePR = Boolean(onCreatePR) && !prUrl;
 
   return (
     <Card style={{ marginBottom: 16, borderLeft: '4px solid var(--pf-t--global--color--status--success--default)' }}>
@@ -119,18 +113,6 @@ export function OperationResultCard({
                 iconPosition="end"
               >
                 View Pull Request
-              </Button>
-            </FlexItem>
-          )}
-          {showCreatePR && (
-            <FlexItem>
-              <Button
-                variant="secondary"
-                onClick={onCreatePR}
-                isLoading={prCreating}
-                isDisabled={prCreating}
-              >
-                {prCreating ? 'Creating PR...' : 'Create PR'}
               </Button>
             </FlexItem>
           )}


### PR DESCRIPTION
## Summary

- Remove the redundant **Create PR** action from the workflow final screen (`OperationResultCard`); PR creation remains available only in the dedicated commit step (`CommitChangesPanel`).
- Final screen now offers a single **View Pull Request** link when a PR already exists.
- Prefer useful PR links where supported (GitHub → `/files`, GitLab → `/diffs`) via a shared `toPullRequestViewUrl` helper.

Fixes [AAP-89528](https://redhat.atlassian.net/browse/AAP-89528).

## Why

The workflow evolved to create PRs in the commit step, but the final screen still exposed a second **Create PR** action alongside **View Pull Request**. That duplicated the same capability and confused the end of the flow.

## Test plan

- [ ] Run a remediate workflow with patches and reach the commit step
- [ ] Confirm **Commit & open PR** / **Open pull request** still work on the commit step
- [ ] Continue to the final screen and confirm **Create PR** is not shown
- [ ] After a PR is created, confirm the final screen shows only **View Pull Request**
- [ ] Open the link for a GitHub PR and confirm it lands on the files/diff view
- [ ] When Dev Spaces is configured, confirm the post-push banner still appears above the workflow panel
- [ ] `npm run typecheck` and `npm run build` in `frontend/packages/ui-workflow`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **User Interface Changes**
  - Removed the “Create PR” action from operation result cards.
  - Pull-request links now open the relevant file-diff view.
  - Pull-request creation errors continue to be displayed in the results card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->