### PR TITLE
feat(ui-workflow): open View PR links on files-changed diff tab

### DIFF
--- a/frontend/packages/ui-workflow/src/components/CommitChangesPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/CommitChangesPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { WorkflowNextBar } from './WorkflowNextBar';
+import { toPrFilesDiffUrl } from '../utils/prDiffUrl';
 
 export interface CommitSubmitOptions {
   create_pr?: boolean;
@@ -168,7 +169,7 @@ export function CommitChangesPanel({
                 <Button
                   variant="secondary"
                   component="a"
-                  href={prUrl}
+                  href={toPrFilesDiffUrl(prUrl)}
                   target="_blank"
                   rel="noopener noreferrer"
                   icon={<ExternalLinkAltIcon />}

--- a/frontend/packages/ui-workflow/src/components/OperationResultCard.tsx
+++ b/frontend/packages/ui-workflow/src/components/OperationResultCard.tsx
@@ -10,6 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import type { OperationResult } from '../types/operation';
+import { toPrFilesDiffUrl } from '../utils/prDiffUrl';
 
 export interface OperationResultCardProps {
   result: OperationResult;
@@ -111,7 +112,7 @@ export function OperationResultCard({
               <Button
                 variant="secondary"
                 component="a"
-                href={prUrl}
+                href={toPrFilesDiffUrl(prUrl)}
                 target="_blank"
                 rel="noopener noreferrer"
                 icon={<ExternalLinkAltIcon />}

--- a/frontend/packages/ui-workflow/src/index.ts
+++ b/frontend/packages/ui-workflow/src/index.ts
@@ -99,3 +99,5 @@ export {
 } from './shared/severity';
 
 export { DiffView, textsFromUnifiedDiff, CurrentYamlView } from './components/DiffView';
+
+export { toPrFilesDiffUrl } from './utils/prDiffUrl';

--- a/frontend/packages/ui-workflow/src/utils/prDiffUrl.ts
+++ b/frontend/packages/ui-workflow/src/utils/prDiffUrl.ts
@@ -1,0 +1,44 @@
+/**
+ * Map a canonical SCM pull/merge request URL to the "files changed" diff view.
+ * Display-time only — stored `pr_url` values remain the SCM web URL.
+ */
+
+function pathnameAlreadyDiffView(pathname: string): boolean {
+  return /\/(files|diffs|diff)$/.test(pathname.replace(/\/$/, ''));
+}
+
+/**
+ * Return a URL that opens the PR/MR files-changed tab for supported forges.
+ * Unrecognized URLs are returned unchanged.
+ */
+export function toPrFilesDiffUrl(prUrl: string): string {
+  if (!prUrl?.trim()) {
+    return prUrl;
+  }
+
+  try {
+    const url = new URL(prUrl);
+    const pathname = url.pathname.replace(/\/$/, '');
+
+    if (pathnameAlreadyDiffView(pathname)) {
+      return prUrl;
+    }
+
+    if (/\/pull\/\d+$/.test(pathname)) {
+      url.pathname = `${pathname}/files`;
+      return url.toString();
+    }
+    if (/\/merge_requests\/\d+$/.test(pathname)) {
+      url.pathname = `${pathname}/diffs`;
+      return url.toString();
+    }
+    if (/\/pull-requests\/\d+$/.test(pathname)) {
+      url.pathname = `${pathname}/diff`;
+      return url.toString();
+    }
+  } catch {
+    // Not a valid absolute URL — return as-is.
+  }
+
+  return prUrl;
+}

--- a/frontend/src/components/PublishedCell.tsx
+++ b/frontend/src/components/PublishedCell.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { toPrFilesDiffUrl } from '@apme/ui-workflow';
 
 interface PublishedCellProps {
   pr_url?: string | null;
@@ -19,7 +20,7 @@ export function PublishedCell({ pr_url, branch_name, commit_sha }: PublishedCell
         variant="link"
         isInline
         component="a"
-        href={pr_url}
+        href={toPrFilesDiffUrl(pr_url)}
         target="_blank"
         rel="noopener noreferrer"
         icon={<ExternalLinkAltIcon />}

--- a/frontend/src/pages/ActivityDetailPage.tsx
+++ b/frontend/src/pages/ActivityDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { PageLayout, PageHeader } from '@ansible/ansible-ui-framework';
-import { AssessFindingsPanel } from '@apme/ui-workflow';
+import { AssessFindingsPanel, toPrFilesDiffUrl } from '@apme/ui-workflow';
 import { PipelineLogOutput } from '../components/PipelineLogOutput';
 import {
   DependencyHealthOutput,
@@ -171,7 +171,7 @@ export function ActivityDetailPage() {
                 <Button
                   variant="link"
                   component="a"
-                  href={detail.pr_url}
+                  href={toPrFilesDiffUrl(detail.pr_url)}
                   target="_blank"
                   rel="noopener noreferrer"
                   icon={<ExternalLinkAltIcon />}

--- a/frontend/src/test/prDiffUrl.test.ts
+++ b/frontend/src/test/prDiffUrl.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { toPrFilesDiffUrl } from '../../packages/ui-workflow/src/utils/prDiffUrl';
+
+describe('toPrFilesDiffUrl', () => {
+  it('maps GitHub PR URLs to the files tab', () => {
+    expect(
+      toPrFilesDiffUrl('https://github.com/org/repo/pull/123'),
+    ).toBe('https://github.com/org/repo/pull/123/files');
+  });
+
+  it('maps GitHub Enterprise PR URLs to the files tab', () => {
+    expect(
+      toPrFilesDiffUrl('https://github.example.com/org/repo/pull/99'),
+    ).toBe('https://github.example.com/org/repo/pull/99/files');
+  });
+
+  it('maps GitLab MR URLs to the diffs tab', () => {
+    expect(
+      toPrFilesDiffUrl('https://gitlab.com/group/project/-/merge_requests/42'),
+    ).toBe('https://gitlab.com/group/project/-/merge_requests/42/diffs');
+  });
+
+  it('maps Bitbucket Cloud PR URLs to the diff tab', () => {
+    expect(
+      toPrFilesDiffUrl('https://bitbucket.org/workspace/repo/pull-requests/7'),
+    ).toBe('https://bitbucket.org/workspace/repo/pull-requests/7/diff');
+  });
+
+  it('maps Bitbucket Server PR URLs to the diff tab', () => {
+    expect(
+      toPrFilesDiffUrl(
+        'https://bitbucket.example.com/projects/PROJ/repos/my-repo/pull-requests/5',
+      ),
+    ).toBe(
+      'https://bitbucket.example.com/projects/PROJ/repos/my-repo/pull-requests/5/diff',
+    );
+  });
+
+  it('is idempotent when already on a diff view', () => {
+    const github =
+      'https://github.com/org/repo/pull/123/files';
+    const gitlab =
+      'https://gitlab.com/group/project/-/merge_requests/42/diffs';
+    const bitbucket =
+      'https://bitbucket.org/workspace/repo/pull-requests/7/diff';
+
+    expect(toPrFilesDiffUrl(github)).toBe(github);
+    expect(toPrFilesDiffUrl(gitlab)).toBe(gitlab);
+    expect(toPrFilesDiffUrl(bitbucket)).toBe(bitbucket);
+  });
+
+  it('preserves query parameters on GitHub URLs', () => {
+    expect(
+      toPrFilesDiffUrl('https://github.com/org/repo/pull/1?foo=bar'),
+    ).toBe('https://github.com/org/repo/pull/1/files?foo=bar');
+  });
+
+  it('returns unrecognized URLs unchanged', () => {
+    const unknown = 'https://example.com/pr/1';
+    expect(toPrFilesDiffUrl(unknown)).toBe(unknown);
+  });
+
+  it('returns empty input unchanged', () => {
+    expect(toPrFilesDiffUrl('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `toPrFilesDiffUrl` helper to map canonical SCM PR URLs to their files-changed diff tab (GitHub `/files`, GitLab `/diffs`, Bitbucket `/diff`)
- Wire into all "View PR" links in `@apme/ui-workflow` (`CommitChangesPanel`, `OperationResultCard`) and the native SPA (`PublishedCell`, `ActivityDetailPage`)
- Export helper from `@apme/ui-workflow` for host consumers
- Related [AAP-90184](https://redhat.atlassian.net/browse/AAP-90184).

## Test plan
- [x] `npm test -- src/test/prDiffUrl.test.ts` (9 tests)
- [x] `npm run build` in `frontend/packages/ui-workflow`
- [x] `npm run typecheck` in `frontend`
- [ ] After ui-workflow release: bump tarball pin in ansible-backstage-plugins and verify Quality tab "View pull request" opens diff view


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “View Pull Request” links now open the files-changed view for supported GitHub, GitLab, and Bitbucket pull or merge requests.
  * Existing diff links, unsupported URLs, and invalid or blank inputs continue to work unchanged.

* **Bug Fixes**
  * Updated pull request links throughout workflow results and activity views to direct users to the relevant file differences.

* **Tests**
  * Added coverage for supported providers, existing diff URLs, query parameters, and unsupported inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->