### PR TITLE
fix(engine): honor # noqa for OPA findings via ContentGraph filter

### DIFF
--- a/docs/guides/RULE_CONFIGURATION.md
+++ b/docs/guides/RULE_CONFIGURATION.md
@@ -38,9 +38,20 @@ Suppress rules on specific tasks using `# noqa`:
   ansible.builtin.shell: rm -rf /tmp/*
 ```
 
+This works for **native graph rules** (applied during rule evaluation) and for
+**OPA task-scoped findings** (applied by the engine after validator fan-out,
+using the node's `yaml_lines` from the ContentGraph when the finding's `path`
+is that node's id — e.g. `# noqa: L068` on a `lineinfile` task). Put the
+comment on the same task/node that owns the finding (typically the `name:`
+line or the module key line).
+
+Findings without a graph node `path`, or on nodes without `yaml_lines`
+(for example some file-level or playbook-scoped hits), are not suppressed
+by `# noqa`.
+
 **Note:** `enforced: true` affects `.apme/suppressions.yml` fingerprint
-suppressions during CLI suppression processing. Native graph-rule `# noqa`
-comments are parsed earlier during scan-time evaluation, so this setting does
+suppressions during CLI suppression processing. Inline `# noqa` comments are
+honored at scan time for native and OPA task findings, so this setting does
 not currently override those inline suppressions.
 
 Fingerprint suppressions live in `.apme/suppressions.yml`. The CLI can manage

--- a/src/apme_engine/daemon/engine_server.py
+++ b/src/apme_engine/daemon/engine_server.py
@@ -20,10 +20,7 @@ import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar
-
-if TYPE_CHECKING:
-    from apme_engine.graph.content_graph import ContentGraph
+from typing import TypeVar
 
 import grpc
 import grpc.aio
@@ -89,7 +86,8 @@ from apme_engine.daemon.fs_utils import write_chunked_fs as _write_chunked_fs
 from apme_engine.daemon.session import ResourceExhaustedError, SessionState, SessionStore
 from apme_engine.daemon.violation_convert import violation_dict_to_proto, violation_proto_to_dict
 from apme_engine.engine.models import RemediationClass, ViolationDict
-from apme_engine.graph.scanner import graph_rule_opt_in_from_rule_configs
+from apme_engine.graph.content_graph import ContentGraph
+from apme_engine.graph.scanner import filter_noqa_violations, graph_rule_opt_in_from_rule_configs
 from apme_engine.log_bridge import attach_collector
 from apme_engine.remediation.graph_engine import FilePatch as SplicedFilePatch
 from apme_engine.runner import run_scan
@@ -1189,6 +1187,17 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
 
             parts = " ".join(f"{n.title()}={counts.get(n, 0)}" for n in VALIDATOR_ENV_VARS)
             logger.info("Fan-out: done (%.0fms) %s Total=%d (req=%s)", fan_out_ms, parts, len(violations), scan_id)
+
+        before_noqa = len(violations)
+        violations = filter_noqa_violations(
+            violations, content_graph if isinstance(content_graph, ContentGraph) else None
+        )
+        if len(violations) < before_noqa:
+            logger.info(
+                "Fan-out: dropped %d violation(s) via # noqa (req=%s)",
+                before_noqa - len(violations),
+                scan_id,
+            )
 
         violations = _deduplicate_violations(_sort_violations(violations))
         if rule_configs:
@@ -2325,7 +2334,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
                         raise RequiredValidatorDependencyError(msg)
                     all_violations.extend(result.violations)
 
-            return all_violations
+            return filter_noqa_violations(all_violations, g)
 
         ai_provider = self._resolve_ai_provider(session.fix_options)
         assess_pause = bool(session.fix_options and session.fix_options.assess_pause)

--- a/src/apme_engine/graph/scanner.py
+++ b/src/apme_engine/graph/scanner.py
@@ -8,7 +8,9 @@ Also provides ``graph_report_to_violations`` for converting results to
 the ``ViolationDict`` format expected by the gRPC response path.
 
 Supports inline ``# noqa: <rule_id>`` comments in YAML to suppress
-specific rules on a per-task basis.
+specific rules on a per-task basis.  Native rules skip noqa'd IDs during
+``scan()``; ``filter_noqa_violations()`` applies the same comments to
+merged validator findings (e.g. OPA) in the engine after fan-out.
 """
 
 from __future__ import annotations
@@ -247,6 +249,59 @@ def parse_noqa(yaml_lines: str) -> frozenset[str]:
                 if rid:
                     suppressed.add(rid)
     return frozenset(suppressed)
+
+
+def filter_noqa_violations(
+    violations: Sequence[ViolationDict],
+    graph: ContentGraph | None,
+) -> list[ViolationDict]:
+    """Drop violations suppressed by ``# noqa:`` on their graph node.
+
+    Used by the engine after validator fan-out so inline noqa comments
+    work for findings that carry a ContentGraph ``path`` (node id) with
+    non-empty ``yaml_lines`` — notably OPA task-scoped rules such as
+    L068.  Native rules already skip noqa'd IDs at match time; filtering
+    again here is a no-op for those findings.
+
+    Lookup is by violation ``path`` (ContentGraph ``node_id``).  When
+    *graph* is ``None``, or a violation has no matching node / empty
+    ``yaml_lines`` / empty ``path``, the violation is kept (fail-open).
+
+    Args:
+        violations: Merged violation dicts from one or more validators.
+        graph: ContentGraph with ``yaml_lines`` on nodes, or ``None``.
+
+    Returns:
+        Violations whose rule ID is not listed in a matching noqa.
+    """
+    if graph is None or not violations:
+        return list(violations)
+
+    kept: list[ViolationDict] = []
+    dropped = 0
+    noqa_by_path: dict[str, frozenset[str]] = {}
+    for violation in violations:
+        path = str(violation.get("path") or "").strip()
+        rule_id = str(violation.get("rule_id") or "").strip().upper()
+        if not path or not rule_id:
+            kept.append(violation)
+            continue
+        node = graph.get_node(path)
+        if node is None or not node.yaml_lines:
+            kept.append(violation)
+            continue
+        suppressed = noqa_by_path.get(path)
+        if suppressed is None:
+            suppressed = parse_noqa(node.yaml_lines)
+            noqa_by_path[path] = suppressed
+        if rule_id in suppressed:
+            dropped += 1
+            continue
+        kept.append(violation)
+
+    if dropped:
+        logger.debug("Filtered %d violation(s) via # noqa on ContentGraph nodes", dropped)
+    return kept
 
 
 def _reset_rule_scan_state(rules: list[GraphRule]) -> None:

--- a/src/apme_engine/graph/scanner.py
+++ b/src/apme_engine/graph/scanner.py
@@ -227,7 +227,10 @@ def parse_noqa(yaml_lines: str) -> frozenset[str]:
 
     Supports both single-rule (``# noqa: R108``) and multi-rule
     (``# noqa: R108, L030``) forms.  Rule IDs are normalized to
-    uppercase with whitespace stripped.
+    uppercase.  Only the first whitespace-delimited token of each
+    comma-separated entry is treated as a rule ID, so trailing
+    justification text (``# noqa: L068 intentional``, ``# noqa: L068 lola``,
+    or ``# noqa: R114 - why trusted``) does not poison the ID.
 
     Strips simple single- and double-quoted strings before matching
     so that ``# noqa:`` inside typical quoted scalars is ignored.
@@ -244,8 +247,9 @@ def parse_noqa(yaml_lines: str) -> frozenset[str]:
     for line in yaml_lines.splitlines():
         stripped = _QUOTED_RE.sub("", line)
         for match in _NOQA_RE.finditer(stripped):
-            for rule_id in match.group(1).split(","):
-                rid = rule_id.strip().upper()
+            for part in match.group(1).split(","):
+                token = part.strip().split(None, 1)[0] if part.strip() else ""
+                rid = token.upper()
                 if rid:
                     suppressed.add(rid)
     return frozenset(suppressed)

--- a/tests/test_task_local_graph_rules_batch1.py
+++ b/tests/test_task_local_graph_rules_batch1.py
@@ -903,3 +903,84 @@ class TestNoqaSuppression:
 
         result = parse_noqa("  become: true  # noqa: R108, R103\n")
         assert result == frozenset({"R108", "R103"})
+
+    def test_filter_noqa_violations_drops_opa_l068(self) -> None:
+        """Engine-side filter drops OPA L068 when the task has ``# noqa: L068``."""
+        from apme_engine.graph.scanner import filter_noqa_violations
+        from apme_engine.graph.types import ViolationDict
+
+        g, tid = _make_task(module="ansible.builtin.lineinfile")
+        node = g.get_node(tid)
+        assert node is not None
+        node.yaml_lines = (
+            "- name: Disable SSH root login  # noqa: L068\n"
+            "  ansible.builtin.lineinfile:\n"
+            "    path: /etc/ssh/sshd_config\n"
+            "    regexp: ^#?PermitRootLogin\n"
+            "    line: PermitRootLogin no\n"
+        )
+
+        violations: list[ViolationDict] = [
+            {
+                "rule_id": "L068",
+                "severity": "info",
+                "message": "Avoid lineinfile; prefer template, ini_file, or blockinfile",
+                "file": "site.yml",
+                "line": 10,
+                "path": tid,
+            },
+            {
+                "rule_id": "L026",
+                "severity": "medium",
+                "message": "Use FQCN",
+                "file": "site.yml",
+                "line": 10,
+                "path": tid,
+            },
+        ]
+
+        kept = filter_noqa_violations(violations, g)
+        assert [v["rule_id"] for v in kept] == ["L026"]
+
+    def test_filter_noqa_violations_noop_without_graph(self) -> None:
+        """Without a ContentGraph, all violations are retained."""
+        from apme_engine.graph.scanner import filter_noqa_violations
+        from apme_engine.graph.types import ViolationDict
+
+        violations: list[ViolationDict] = [
+            {
+                "rule_id": "L068",
+                "severity": "info",
+                "message": "Avoid lineinfile",
+                "file": "site.yml",
+                "line": 1,
+                "path": "missing",
+            },
+        ]
+        assert filter_noqa_violations(violations, None) == violations
+
+    def test_filter_noqa_violations_keeps_when_no_comment(self) -> None:
+        """Violations are kept when the node YAML has no matching noqa."""
+        from apme_engine.graph.scanner import filter_noqa_violations
+        from apme_engine.graph.types import ViolationDict
+
+        g, tid = _make_task(module="ansible.builtin.lineinfile")
+        node = g.get_node(tid)
+        assert node is not None
+        node.yaml_lines = (
+            "- name: Disable SSH root login\n"
+            "  ansible.builtin.lineinfile:\n"
+            "    path: /etc/ssh/sshd_config\n"
+            "    line: PermitRootLogin no\n"
+        )
+        violations: list[ViolationDict] = [
+            {
+                "rule_id": "L068",
+                "severity": "info",
+                "message": "Avoid lineinfile",
+                "file": "site.yml",
+                "line": 10,
+                "path": tid,
+            },
+        ]
+        assert filter_noqa_violations(violations, g) == violations

--- a/tests/test_task_local_graph_rules_batch1.py
+++ b/tests/test_task_local_graph_rules_batch1.py
@@ -904,6 +904,19 @@ class TestNoqaSuppression:
         result = parse_noqa("  become: true  # noqa: R108, R103\n")
         assert result == frozenset({"R108", "R103"})
 
+    def test_parse_noqa_ignores_trailing_justification(self) -> None:
+        """Trailing words after a rule ID are not part of the ID.
+
+        Regression for reporter content like ``# noqa: L068 lola`` and the
+        documented ``# noqa: R114 - why trusted`` justification form.
+        """
+        from apme_engine.graph.scanner import parse_noqa
+
+        assert parse_noqa("- name: X  # noqa: L068 lola\n") == frozenset({"L068"})
+        assert parse_noqa("- name: X  #noqa: L068 lola\n") == frozenset({"L068"})
+        assert parse_noqa("- name: X  # noqa: R114 - why trusted\n") == frozenset({"R114"})
+        assert parse_noqa("- name: X  # noqa: L068, R108 intentional\n") == frozenset({"L068", "R108"})
+
     def test_filter_noqa_violations_drops_opa_l068(self) -> None:
         """Engine-side filter drops OPA L068 when the task has ``# noqa: L068``."""
         from apme_engine.graph.scanner import filter_noqa_violations


### PR DESCRIPTION
## Summary
- `# noqa` only worked for native graph rules; OPA findings such as L068 kept showing even with an inline noqa on the task
- After validator fan-out, the engine now drops findings whose ContentGraph node `yaml_lines` list that rule id (same `parse_noqa` used by the native scanner)
- `parse_noqa` now takes only the first token of each entry so trailing junk/justification (`# noqa: L068 lola`, `# noqa: R114 - why`) does not poison the rule id
- Applied on initial scan and remediation rescan; docs updated for task-scoped OPA noqa

## Changes
- Add `filter_noqa_violations()` in `graph/scanner.py` (path strip, per-path noqa cache, fail-open)
- Wire filter into engine scan merge and rescan bridge
- Fix `parse_noqa` to ignore trailing justification words after the rule id
- Unit tests for L068-style OPA noqa drop / keep / no-graph / trailing text
- Clarify `RULE_CONFIGURATION.md` that noqa applies to native + OPA task-scoped findings with a graph path

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e unit -- -k "filter_noqa or TestNoqaSuppression or parse_noqa"` passes
- [ ] Rebuild/restart the **engine daemon/pod** from this branch (CLI-only update is not enough — filtering runs in the engine)
- [ ] Confirm `# noqa: L068` on a `lineinfile` task no longer reports L068 (including forms like `# noqa: L068 intentional`)
- [ ] Confirm a task without noqa still reports L068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline YAML `# noqa` suppressions now apply consistently to native graph rules and OPA task findings.
  * Suppressions are honored during full scans and dirty-node rescans when matching graph-node information is available.

* **Bug Fixes**
  * Trailing justification text is no longer interpreted as a rule ID.
  * Suppressed findings are filtered while unrelated findings and results lacking sufficient graph data are preserved.

* **Documentation**
  * Clarified suppression requirements, including node paths and YAML line references.
  * Documented that `enforced` applies only to fingerprint suppressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->