### PR TITLE
fix(ui): show actual database engine type on System Health page

### DIFF
--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -1024,7 +1024,7 @@
         "type": "object"
       },
       "HealthStatus": {
-        "description": "Gateway health response.\n\nAttributes:\n    status: Overall health (ok or degraded).\n    database: Database connectivity status.\n    components: Health status of each upstream service.",
+        "description": "Gateway health response.\n\nAttributes:\n    status: Overall health (ok or degraded).\n    database: Database connectivity status.\n    database_type: Human-readable database engine name (e.g. PostgreSQL, SQLite).\n    components: Health status of each upstream service.",
         "properties": {
           "components": {
             "items": {
@@ -1035,6 +1035,11 @@
           },
           "database": {
             "title": "Database",
+            "type": "string"
+          },
+          "database_type": {
+            "default": "unknown",
+            "title": "Database Type",
             "type": "string"
           },
           "status": {

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -58,7 +58,7 @@ export function HealthPage() {
               </tr>
               <tr role="row">
                 <td role="cell">Database</td>
-                <td role="cell" style={{ opacity: 0.7 }}>SQLite</td>
+                <td role="cell" style={{ opacity: 0.7 }}>{health.database_type || 'unknown'}</td>
                 <td role="cell">
                   <Label color={isOk(health.database) ? 'green' : 'red'} isCompact>
                     {health.database}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -147,6 +147,7 @@ export interface ComponentHealth {
 export interface HealthStatus {
   status: string;
   database: string;
+  database_type: string;
   components: ComponentHealth[];
 }
 

--- a/src/apme_gateway/api/router.py
+++ b/src/apme_gateway/api/router.py
@@ -68,7 +68,7 @@ from apme_gateway.api.schemas import (
     UpdateProjectRequest,
     ViolationDetail,
 )
-from apme_gateway.db import get_session
+from apme_gateway.db import get_database_type, get_session
 from apme_gateway.db import queries as q
 from apme_gateway.db.models import GalaxyServer, Project, Rule, RuleOverride, Scan, ScanManifest
 
@@ -256,6 +256,7 @@ async def health() -> HealthStatus:
     return HealthStatus(
         status="ok" if all_ok else "degraded",
         database="ok" if db_ok else "unavailable",
+        database_type=get_database_type(),
         components=component_list,
     )
 

--- a/src/apme_gateway/api/schemas.py
+++ b/src/apme_gateway/api/schemas.py
@@ -381,11 +381,13 @@ class HealthStatus(BaseModel):  # type: ignore[misc]
     Attributes:
         status: Overall health (ok or degraded).
         database: Database connectivity status.
+        database_type: Human-readable database engine name (e.g. PostgreSQL, SQLite).
         components: Health status of each upstream service.
     """
 
     status: str
     database: str
+    database_type: str = "unknown"
     components: list[ComponentHealth] = Field(default_factory=list)
 
 

--- a/src/apme_gateway/db/__init__.py
+++ b/src/apme_gateway/db/__init__.py
@@ -113,6 +113,22 @@ def get_engine() -> AsyncEngine:
     return _engine
 
 
+def get_database_type() -> str:
+    """Return a human-readable label for the active database engine.
+
+    Returns:
+        ``PostgreSQL``, ``SQLite``, or ``unknown`` when the engine is not ready.
+    """
+    if _engine is None:
+        return "unknown"
+    dialect = str(_engine.dialect.name)
+    if dialect == "postgresql":
+        return "PostgreSQL"
+    if dialect == "sqlite":
+        return "SQLite"
+    return dialect.capitalize()
+
+
 def get_in_clause_chunk_size() -> int:
     """Return the safe ``IN`` clause chunk size for the active database.
 

--- a/tests/test_gateway_api.py
+++ b/tests/test_gateway_api.py
@@ -101,6 +101,7 @@ async def test_health(client: AsyncClient) -> None:
     body = resp.json()
     assert body["status"] == "ok"
     assert body["database"] == "ok"
+    assert body["database_type"] in {"SQLite", "PostgreSQL"}
 
 
 async def test_list_sessions_empty(client: AsyncClient) -> None:

--- a/tests/test_gateway_api.py
+++ b/tests/test_gateway_api.py
@@ -101,7 +101,7 @@ async def test_health(client: AsyncClient) -> None:
     body = resp.json()
     assert body["status"] == "ok"
     assert body["database"] == "ok"
-    assert body["database_type"] in {"SQLite", "PostgreSQL"}
+    assert body["database_type"] == "SQLite"
 
 
 async def test_list_sessions_empty(client: AsyncClient) -> None:

--- a/tests/test_gateway_db_postgresql.py
+++ b/tests/test_gateway_db_postgresql.py
@@ -11,9 +11,13 @@ from __future__ import annotations
 
 import os
 from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from httpx import ASGITransport, AsyncClient
 
+from apme_gateway.api.schemas import ComponentHealth
+from apme_gateway.app import create_app
 from apme_gateway.db import close_db, get_session, init_db, reset_db
 from apme_gateway.db import queries as q
 from apme_gateway.db.models import Session
@@ -48,3 +52,21 @@ async def test_postgresql_list_sessions_round_trip() -> None:
         sessions = await q.list_sessions(db)
     assert len(sessions) == 1
     assert sessions[0].session_id == "pg-sess"
+
+
+async def test_postgresql_health_reports_database_type() -> None:
+    """Health endpoint reports PostgreSQL when backed by PostgreSQL."""
+    app = create_app()
+    transport = ASGITransport(app=app)
+    mock_component = ComponentHealth(name="mock", status="ok", address="127.0.0.1:0")
+    with patch(
+        "apme_gateway.api.router._check_component",
+        new_callable=AsyncMock,
+        return_value=mock_component,
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/v1/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["database"] == "ok"
+    assert body["database_type"] == "PostgreSQL"


### PR DESCRIPTION
## Summary
- `/api/v1/health` now returns `database_type` (`PostgreSQL` / `SQLite`) from the active SQLAlchemy dialect
- System Health page uses that field instead of a hardcoded `SQLite` label

## Test plan
- [ ] `uv run pytest tests/test_gateway_api.py -k health`
- [ ] With a Postgres-backed gateway, open System Health and confirm Address shows `PostgreSQL`
- [ ] With default/SQLite gateway, confirm Address shows `SQLite`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Health information now reports the configured database engine, such as PostgreSQL or SQLite.
  - The health page displays the detected database type and shows “unknown” when it is unavailable.
  - Health API documentation now includes the database type field and its default value.

- **Bug Fixes**
  - Corrected the health page to display the actual database engine instead of always showing SQLite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->