### PR TITLE
fix(native): avoid false duplicate-key findings in YAML sequences

### DIFF
--- a/src/apme_engine/graph/rules/L098_yaml_key_duplicates_graph.py
+++ b/src/apme_engine/graph/rules/L098_yaml_key_duplicates_graph.py
@@ -12,6 +12,7 @@ from apme_engine.graph.types import Severity, YAMLDict
 _TASK_TYPES = frozenset({NodeType.TASK, NodeType.HANDLER})
 
 _KEY_LINE = re.compile(r"^(\s*)([^\s#:][^:]*?)\s*:")
+_SEQUENCE_ITEM = re.compile(r"^(\s*)-(?:\s+|$)")
 
 
 @dataclass
@@ -72,15 +73,24 @@ class YamlKeyDuplicatesGraphRule(GraphRule):
                 file=(node.file_path, node.line_start),
             )
 
-        seen: dict[tuple[int, str], int] = {}
+        seen: dict[tuple[int, str, tuple[tuple[int, int], ...]], int] = {}
+        sequence_items: dict[int, int] = {}
         duplicates: list[str] = []
         for line in raw.splitlines():
+            sequence_match = _SEQUENCE_ITEM.match(line)
+            if sequence_match:
+                sequence_indent = len(sequence_match.group(1))
+                sequence_items[sequence_indent] = sequence_items.get(sequence_indent, 0) + 1
+                sequence_items = {indent: item for indent, item in sequence_items.items() if indent <= sequence_indent}
             m = _KEY_LINE.match(line)
             if not m:
                 continue
             indent_len = len(m.group(1))
             key = m.group(2).strip()
-            loc = (indent_len, key)
+            if sequence_match and key.startswith("-"):
+                key = key[1:].strip()
+            scope = tuple(sorted((indent, item) for indent, item in sequence_items.items() if indent <= indent_len))
+            loc = (indent_len, key, scope)
             if loc in seen:
                 duplicates.append(f"duplicate key '{key}' at indent {indent_len}")
             seen[loc] = seen.get(loc, 0) + 1

--- a/src/apme_engine/graph/rules/L098_yaml_key_duplicates_graph.py
+++ b/src/apme_engine/graph/rules/L098_yaml_key_duplicates_graph.py
@@ -86,6 +86,8 @@ class YamlKeyDuplicatesGraphRule(GraphRule):
             if not m:
                 continue
             indent_len = len(m.group(1))
+            if not sequence_match:
+                sequence_items = {indent: item for indent, item in sequence_items.items() if indent_len > indent}
             key = m.group(2).strip()
             if sequence_match and key.startswith("-"):
                 key = key[1:].strip()

--- a/src/apme_engine/graph/rules/L098_yaml_key_duplicates_graph.py
+++ b/src/apme_engine/graph/rules/L098_yaml_key_duplicates_graph.py
@@ -75,12 +75,14 @@ class YamlKeyDuplicatesGraphRule(GraphRule):
 
         seen: dict[tuple[int, str, tuple[tuple[int, int], ...]], int] = {}
         sequence_items: dict[int, int] = {}
+        next_sequence_id = 0
         duplicates: list[str] = []
         for line in raw.splitlines():
             sequence_match = _SEQUENCE_ITEM.match(line)
             if sequence_match:
                 sequence_indent = len(sequence_match.group(1))
-                sequence_items[sequence_indent] = sequence_items.get(sequence_indent, 0) + 1
+                next_sequence_id += 1
+                sequence_items[sequence_indent] = next_sequence_id
                 sequence_items = {indent: item for indent, item in sequence_items.items() if indent <= sequence_indent}
             m = _KEY_LINE.match(line)
             if not m:

--- a/src/apme_engine/graph/rules/L098_yaml_key_duplicates_graph.py
+++ b/src/apme_engine/graph/rules/L098_yaml_key_duplicates_graph.py
@@ -90,9 +90,11 @@ class YamlKeyDuplicatesGraphRule(GraphRule):
             indent_len = len(m.group(1))
             if not sequence_match:
                 sequence_items = {indent: item for indent, item in sequence_items.items() if indent_len > indent}
-            key = m.group(2).strip()
-            if sequence_match and key.startswith("-"):
-                key = key[1:].strip()
+            raw_key = m.group(2).strip()
+            inline_sequence_key = sequence_match and raw_key.startswith("-")
+            key = raw_key[1:].strip() if inline_sequence_key else raw_key
+            if inline_sequence_key:
+                indent_len = sequence_indent + 2
             scope = tuple(sorted((indent, item) for indent, item in sequence_items.items() if indent <= indent_len))
             loc = (indent_len, key, scope)
             if loc in seen:

--- a/tests/test_yaml_lines_graph_rules.py
+++ b/tests/test_yaml_lines_graph_rules.py
@@ -369,6 +369,64 @@ class TestL098YamlKeyDuplicatesGraphRule:
         assert result is not None
         assert result.verdict is False
 
+    def test_pass_repeated_keys_in_sequence_items(self, rule: YamlKeyDuplicatesGraphRule) -> None:
+        """Repeated keys in separate list mappings are not duplicates.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None.
+        """
+        g, tid = _make_task(yaml_lines=("loop:\n  - key: first\n    value: one\n  - key: second\n    value: two\n"))
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is False
+
+    def test_violation_repeated_key_in_same_sequence_item(self, rule: YamlKeyDuplicatesGraphRule) -> None:
+        """Repeated keys within one list mapping remain violations.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None.
+        """
+        g, tid = _make_task(yaml_lines=("loop:\n  - key: first\n    value: one\n    value: two\n"))
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is True
+        assert result.detail is not None
+        assert "value" in str(result.detail.get("duplicates", []))
+
+    def test_pass_repeated_keys_in_expanded_sequence_items(self, rule: YamlKeyDuplicatesGraphRule) -> None:
+        """Repeated keys in expanded list mappings are not duplicates.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None.
+        """
+        g, tid = _make_task(yaml_lines=("loop:\n  -\n    key: first\n  -\n    key: second\n"))
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is False
+
+    def test_pass_key_starting_with_hyphen(self, rule: YamlKeyDuplicatesGraphRule) -> None:
+        """A mapping key beginning with a hyphen is not a sequence item.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None.
+        """
+        g, tid = _make_task(yaml_lines="-foo: first\nfoo: second\n")
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is False
+
 
 # ---------------------------------------------------------------------------
 # L099 — YamlQuotedStrings

--- a/tests/test_yaml_lines_graph_rules.py
+++ b/tests/test_yaml_lines_graph_rules.py
@@ -427,6 +427,22 @@ class TestL098YamlKeyDuplicatesGraphRule:
         assert result is not None
         assert result.verdict is False
 
+    def test_violation_duplicate_key_after_indentless_sequence(self, rule: YamlKeyDuplicatesGraphRule) -> None:
+        """Duplicate keys after an indentless sequence item are still violations.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None.
+        """
+        g, tid = _make_task(yaml_lines="key: first\nitems:\n- value\nkey: second\n")
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is True
+        assert result.detail is not None
+        assert "key" in str(result.detail.get("duplicates", []))
+
 
 # ---------------------------------------------------------------------------
 # L099 — YamlQuotedStrings

--- a/tests/test_yaml_lines_graph_rules.py
+++ b/tests/test_yaml_lines_graph_rules.py
@@ -399,6 +399,22 @@ class TestL098YamlKeyDuplicatesGraphRule:
         assert result.detail is not None
         assert "value" in str(result.detail.get("duplicates", []))
 
+    def test_violation_repeated_key_in_inline_sequence_mapping(self, rule: YamlKeyDuplicatesGraphRule) -> None:
+        """Repeated keys in inline and nested sequence mappings remain violations.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None.
+        """
+        g, tid = _make_task(yaml_lines="- key: first\n  key: second\n")
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is True
+        assert result.detail is not None
+        assert "key" in str(result.detail.get("duplicates", []))
+
     def test_pass_repeated_keys_in_expanded_sequence_items(self, rule: YamlKeyDuplicatesGraphRule) -> None:
         """Repeated keys in expanded list mappings are not duplicates.
 

--- a/tests/test_yaml_lines_graph_rules.py
+++ b/tests/test_yaml_lines_graph_rules.py
@@ -443,6 +443,20 @@ class TestL098YamlKeyDuplicatesGraphRule:
         assert result.detail is not None
         assert "key" in str(result.detail.get("duplicates", []))
 
+    def test_pass_repeated_keys_in_sibling_sequences(self, rule: YamlKeyDuplicatesGraphRule) -> None:
+        """Repeated keys in sibling sequences at the same indent are not duplicates.
+
+        Args:
+            rule: Rule instance under test.
+
+        Returns:
+            None.
+        """
+        g, tid = _make_task(yaml_lines="a:\n- key: first\nb:\n- key: second\n")
+        result = rule.process(g, tid)
+        assert result is not None
+        assert result.verdict is False
+
 
 # ---------------------------------------------------------------------------
 # L099 — YamlQuotedStrings


### PR DESCRIPTION
## Summary

- Scope L098 duplicate-key detection by YAML sequence item.
- Repeated fields in separate loop entries no longer trigger findings.
- Genuine duplicate keys within one mapping remain findings.
- Stale sequence scopes are cleared when mapping resumes at the same or outer indent.
- Sibling sequences at the same indent use monotonic sequence IDs so repeated keys across separate lists are not false positives.
- Inline sequence mappings (`- key:`) normalize to the nested mapping indent so duplicates split across inline and indented lines are detected.

## Changes

- Track sequence-item scope while scanning raw YAML lines.
- Handle inline and expanded sequence items.
- Clear sequence scopes when a non-sequence mapping key resumes.
- Assign monotonic sequence IDs so restarted sequences at the same indent stay distinct.
- Normalize inline sequence key indentation to `sequence_indent + 2`.
- Add regression coverage for valid repeated loop-entry keys, true duplicates, hyphen-prefixed mapping keys, indentless sequences between duplicate keys, sibling sequences at the same indent, and inline sequence mapping duplicates.

## Validation

- `tox -e lint` passed.
- L098 unit tests: 9 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved YAML duplicate-key detection within lists and nested mappings.
  - Duplicate keys are now reported only when they occur within the same list item context.
  - Improved handling for inline and expanded list mappings, hyphen-prefixed keys, indentless lists, and sibling lists.
  - Prevented unrelated keys in separate list items or nesting levels from being incorrectly flagged as duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->