### PR TITLE
fix(security)!: deny unauthenticated Abbenay secret-store access

### DIFF
--- a/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
+++ b/.sdlc/adrs/ADR-070-gateway-abbenay-admin-proxy.md
@@ -66,8 +66,18 @@ Abbenay surfaces (ADR-046 inference stays Engine). Reject path traversal
 (`..` / encoded forms). Abbenay remains the source of truth for config.
 
 Allowlist: `GET/POST /config`, `GET /engines`, `GET /providers`,
-`POST /provider/{id}/configure`, `DELETE /provider/{id}`,
-`GET/POST /secrets`, `DELETE /secrets/{key}`.
+`POST /provider/{id}/configure`, `DELETE /provider/{id}`.
+
+**Secret-store denial (amended 2026-09-09):** `GET/POST /secrets` and
+`DELETE /secrets/{key}` are **not** proxied. The Gateway allowlist rejects
+`GET/POST /api/v1/ai/secrets` and `DELETE /api/v1/ai/secrets/{key}` with
+404 before contacting Abbenay. With no Gateway caller authentication yet
+(#1), unauthenticated secret-store reads *and writes* are a security
+exposure; operators inject, list, and delete secrets directly against
+Abbenay HTTP on loopback (see `ABBENAY_AI.md`). This is a documented
+**ADR-060 security exception**: the v1 URLs are intentionally unavailable
+through the Gateway until caller auth lands; restore proxying only with
+authenticated compatibility behavior and a new ADR.
 
 **3. Enable Abbenay HTTP on loopback when Abbenay is enabled.**  
 In addition to gRPC `:50057` (Engine), start Abbenay’s HTTP admin surface on
@@ -146,8 +156,10 @@ After the first successful configure, the writable file is SoT — Helm value /
 ConfigMap changes do not overwrite an existing runtime config.
 
 **7. Secrets source of truth remains Abbenay (not Gateway).**  
-Runtime API keys injected via `POST /api/v1/ai/secrets` are stored by
-Abbenay. Gateway reverse-proxies the secrets API and does **not** persist
+Runtime API keys are injected directly against Abbenay HTTP (`POST
+/api/secrets`); the Gateway secret-store surface (`GET/POST
+/api/v1/ai/secrets`, `DELETE /api/v1/ai/secrets/{key}`) is denied with
+404 at the allowlist until caller auth (#1). Gateway does **not** persist
 provider keys. Durable keys in containers use Abbenay's filesystem store
 (`secretStore: "file"`, Abbenay ≥ v2026.8.6), which writes
 `<configDir>/secrets.json` (mode `0600` as written by Abbenay) on the same
@@ -299,8 +311,8 @@ Gateway stays a proxy. Default Helm `emptyDir` is still ephemeral — enable
   Gateway `info.description` references ADR-070.
 - **Tests**: path rewrite, Bearer inject, Cookie strip, 502, models/chat not
   proxied, traversal rejected, missing token 503, Set-Cookie stripped; secrets
-  GET/POST/DELETE proxy tests; helm asserts ordered
-  `--host`/`127.0.0.1`/`--port`/`8787` and Gateway HTTP URL.
+  GET/POST/DELETE denied at allowlist (404, upstream never contacted); helm
+  asserts ordered `--host`/`127.0.0.1`/`--port`/`8787` and Gateway HTTP URL.
 - **Portal UI**: out of scope for the first implementation PR; catalog proxy +
   Quality settings follow in a later change.
 - **Config durability** ([#498](https://github.com/ansible/apme/issues/498)):
@@ -344,3 +356,4 @@ Gateway stays a proxy. Default Helm `emptyDir` is still ephemeral — enable
 | 2026-08-04 | bthornto | §4: document Simple caller-trust + loopback token threat model (Helm/Podman evidence) |
 | 2026-08-13 | bthornto | Amended allowlist: added `GET/POST /secrets`, `DELETE /secrets/{key}` for Abbenay ≥ v2026.8.5 memory secret store |
 | 2026-08-14 | bthornto | §7 secrets remain Abbenay SoT: file store (`secretStore: "file"`, ≥ v2026.8.6) on a durable config volume (Helm PVC / Podman cache); Gateway stays proxy-only (rejects Gateway DB SoT, #560) |
+| 2026-09-09 | bthornto | Amended §2/§7: deny secret-store routes at Gateway allowlist (404) until caller auth (#1); ADR-060 security exception; direct-to-Abbenay secret management |

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -27,8 +27,15 @@ The Gateway reverse-proxies an
 | `GET /api/v1/ai/providers` | `/api/providers` |
 | `POST /api/v1/ai/provider/{id}/configure` | `/api/provider/{id}/configure` |
 | `DELETE /api/v1/ai/provider/{id}` | `/api/provider/{id}` |
-| `GET/POST /api/v1/ai/secrets` | `/api/secrets` |
-| `DELETE /api/v1/ai/secrets/{key}` | `/api/secrets/{key}` |
+
+The Abbenay secret store is **not** proxied: `GET/POST
+/api/v1/ai/secrets` and `DELETE /api/v1/ai/secrets/{key}` are denied with
+404 at the Gateway allowlist. The Gateway has no caller authentication yet
+(#1), so unauthenticated secret-store reads *and writes* are rejected —
+writes were denied alongside reads because an unauthenticated client able
+to overwrite or delete secrets is the more severe exposure. Manage secrets
+directly against Abbenay (same host/port as `APME_ABBENAY_HTTP_URL`)
+until Gateway caller auth lands.
 
 `GET /api/v1/ai/models` remains Engine → Abbenay gRPC (`ListAIModels`). Chat
 is **not** proxied. Set `APME_ABBENAY_HTTP_URL` (default
@@ -41,36 +48,42 @@ Gateway proxy keeps TLS certificate validation enabled.
 ### Memory secret store (Abbenay >= v2026.8.5)
 
 Abbenay supports a process-lifetime in-memory secret store for containerized
-environments where a system keychain is unavailable. Secrets (API keys) can be
-injected at runtime via the Gateway proxy instead of requiring env vars or Helm
-Secrets at deploy time.
+environments where a system keychain is unavailable. Secrets (API keys) are
+injected at runtime directly against Abbenay — not via the Gateway proxy,
+which denies the whole secret-store surface (see above).
 
-**Inject a secret at runtime:**
+**Inject a secret at runtime (Abbenay directly):**
+
+> **Token hygiene:** the examples below pass the Abbenay Bearer token and
+> raw API keys on the command line. Command lines are saved in shell
+> history (`~/.bash_history`, `~/.zsh_history`) and visible in `ps`
+> output — prefer `read -s ABBEBAY_API_TOKEN` / `read -s API_KEY` or an
+> env-var file, redact pasted output before sharing, and clear history
+> entries that contain secrets. `:8787` must remain loopback-bound
+> (`127.0.0.1`); never expose Abbenay HTTP beyond localhost without its
+> Bearer auth in front.
 
 ```bash
-curl -X POST http://gateway:8080/api/v1/ai/secrets \
+curl -X POST http://127.0.0.1:8787/api/secrets \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ABBENAY_API_TOKEN" \
   -d '{"key": "OPENROUTER_API_KEY", "value": "sk-or-...", "secretStore": "memory"}'
 ```
 
-**List stored secret names:**
+**Secret listing is not proxied:**
 
-```bash
-curl http://gateway:8080/api/v1/ai/secrets
-```
-
-The response lists engine API-key slots (name, engine, `hasValue`, and
-`secretStore` when a registry backend holds the value). It does **not**
-return secret values. Helm env-injected keys typically show
-`hasValue: false` here because env is not a registry backend. Custom keys
-that are not an engine's default env var name are not listed.
+`GET /api/v1/ai/secrets` is denied with 404 at the Gateway allowlist
+(no unauthenticated secret-store reads). Inject via Abbenay directly as
+above; inspect stored secret names via Abbenay directly when listing is
+required.
 
 **Remove a secret:** Abbenay defaults omitted `secretStore` to **keychain**.
 Always pass the store you used when injecting, or the delete will no-op
 against the wrong backend (and still return success):
 
 ```bash
-curl -X DELETE 'http://gateway:8080/api/v1/ai/secrets/OPENROUTER_API_KEY?secretStore=memory'
+curl -X DELETE 'http://127.0.0.1:8787/api/secrets/OPENROUTER_API_KEY?secretStore=memory' \
+  -H "Authorization: Bearer $ABBENAY_API_TOKEN"
 ```
 
 After injecting a secret, configure a provider to use it via
@@ -98,11 +111,12 @@ Gateway reverse-proxies the JSON body unchanged and does **not** store keys
 | **Podman (Linux)** | RW cache `${XDG_CACHE_HOME:-$HOME/.cache}/apme/abbenay/config/` | `tox -e down` / container restart. `tox -e wipe` deletes `secrets.json`. |
 | **Podman (macOS)** | Same hostPath; virtiofs | File store unsupported until [#562](https://github.com/ansible/apme/issues/562). Use env or memory. |
 
-**Inject a secret into the file store:**
+**Inject a secret into the file store (Abbenay directly):**
 
 ```bash
-curl -X POST http://gateway:8080/api/v1/ai/secrets \
+curl -X POST http://127.0.0.1:8787/api/secrets \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ABBENAY_API_TOKEN" \
   -d '{"key": "OPENROUTER_API_KEY", "value": "sk-or-...", "secretStore": "file"}'
 ```
 
@@ -112,22 +126,25 @@ keys (`secret_store: env` in the seed ConfigMap) are **separate** backends:
 injecting `secretStore: file` does not override an env-backed provider until
 you reconfigure `secretStore`. Deploy-time Helm Secrets / env are unchanged.
 
-**Remove a file-store secret:**
+**Remove a file-store secret (Abbenay directly):**
 
 ```bash
-curl -X DELETE 'http://gateway:8080/api/v1/ai/secrets/OPENROUTER_API_KEY?secretStore=file'
+curl -X DELETE 'http://127.0.0.1:8787/api/secrets/OPENROUTER_API_KEY?secretStore=file' \
+  -H "Authorization: Bearer $ABBENAY_API_TOKEN"
 ```
 
 If `secrets.json` exists but is not valid JSON, Abbenay treats reads as empty
 and **refuses writes** (it will not overwrite a corrupt file). Fix or remove
 the file on the config volume, then re-inject.
 
-> **Security note:** `GET /api/v1/ai/secrets` returns engine key **names**
-> and store metadata (not values) to any client that can reach Gateway
-> `:8080`. The Gateway REST API relies on network-isolation auth (ADR-048)
-> — operators must ensure an outer auth layer (Ingress, Route, reverse
-> proxy) before exposing `:8080` outside the cluster. Treat the Abbenay
-> config volume as secret material (`secrets.json`).
+> **Security note:** the whole Gateway secret-store surface (`GET/POST
+> /api/v1/ai/secrets`, `DELETE /api/v1/ai/secrets/{key}`) is denied with
+> 404 — manage secrets directly against Abbenay with its Bearer token
+> until Gateway caller auth (#1) lands. The Gateway REST API otherwise
+> relies on network-isolation auth (ADR-048) — operators must
+> ensure an outer auth layer (Ingress, Route, reverse proxy) before
+> exposing `:8080` outside the cluster. Treat the Abbenay config volume
+> as secret material (`secrets.json`).
 
 ### Writable config volume (#498)
 

--- a/docs/guides/ABBENAY_AI.md
+++ b/docs/guides/ABBENAY_AI.md
@@ -52,12 +52,30 @@ environments where a system keychain is unavailable. Secrets (API keys) are
 injected at runtime directly against Abbenay — not via the Gateway proxy,
 which denies the whole secret-store surface (see above).
 
+**Helm vs Podman access:** Podman (`tox -e up`) publishes Abbenay HTTP on
+host loopback (`127.0.0.1:8787`); the curl examples below work as shown
+(`ABBENAY_HTTP_AUTH=0` disables Bearer auth for local dev only). Helm Simple
+has no Service or hostPort for `:8787` — port-forward the engine pod and
+retrieve the chart token before running the examples:
+
+```bash
+# Substitute your release name and namespace (e.g. apme / apme).
+export ABBENAY_API_TOKEN=$(kubectl get secret apme-secrets -n apme \
+  -o jsonpath='{.data.abbenay-token}' | base64 -d)
+kubectl port-forward pod/$(kubectl get pod -n apme -l app.kubernetes.io/name=apme \
+  -o jsonpath='{.items[0].metadata.name}') 8787:8787 -n apme
+```
+
+Alternatively, `kubectl exec` into the pod and curl
+`http://127.0.0.1:8787` directly (the Abbenay container already has
+`ABBENAY_API_TOKEN` in its environment).
+
 **Inject a secret at runtime (Abbenay directly):**
 
 > **Token hygiene:** the examples below pass the Abbenay Bearer token and
 > raw API keys on the command line. Command lines are saved in shell
 > history (`~/.bash_history`, `~/.zsh_history`) and visible in `ps`
-> output — prefer `read -s ABBEBAY_API_TOKEN` / `read -s API_KEY` or an
+> output — prefer `read -s ABBENAY_API_TOKEN` / `read -s API_KEY` or an
 > env-var file, redact pasted output before sharing, and clear history
 > entries that contain secrets. `:8787` must remain loopback-bound
 > (`127.0.0.1`); never expose Abbenay HTTP beyond localhost without its

--- a/src/apme_gateway/api/abbenay_proxy.py
+++ b/src/apme_gateway/api/abbenay_proxy.py
@@ -6,10 +6,14 @@ through caller ``Authorization``. Inference (``GET /api/v1/ai/models`` and
 Abbenay chat) is **not** proxied — chat stays Engine → Abbenay gRPC.
 ``GET /api/v1/ai/engines`` proxies Abbenay's engine registry (read-only
 discovery path, ADR-070 amendment 2026-08-03).
-``GET/POST /api/v1/ai/secrets`` and ``DELETE /api/v1/ai/secrets/{key}`` proxy
-Abbenay's secret store. Memory store: Abbenay ≥ v2026.8.5. File store:
-Abbenay ≥ v2026.8.6. Gateway does not persist keys and does not parse
-``secretStore`` (JSON body and query string are forwarded unchanged).
+The Abbenay secret store (``GET/POST /api/v1/ai/secrets``,
+``DELETE /api/v1/ai/secrets/{key}``) is **not** proxied: the Gateway has
+no caller authentication yet (#1), so unauthenticated secret-store reads
+and writes are denied at the allowlist rather than relayed upstream. Reads
+were denied first (finding #11); writes follow the same rule because an
+unauthenticated client that can overwrite or delete secrets is a more
+severe exposure than listing them. Manage secrets directly against
+Abbenay until caller auth lands.
 """
 
 from __future__ import annotations
@@ -70,13 +74,17 @@ _RESPONSE_DROP: Final = frozenset(
 )
 
 # Admin-only path allowlist (decoded, no leading slash). Matches ADR-070 /
-# ABBENAY_AI.md — no chat/sessions/templates.
-_GET_PATHS: Final = frozenset({"config", "engines", "providers", "secrets"})
+# ABBENAY_AI.md — no chat/sessions/templates. The ``secrets`` store is
+# excluded from GET, POST, and DELETE alike: the whole secret-store
+# surface must not be reachable through the currently unauthenticated
+# Gateway (finding #11 for reads; writes denied by the same rule — an
+# unauthenticated client able to overwrite/delete secrets is the more
+# severe exposure. Full caller auth is #1).
+_GET_PATHS: Final = frozenset({"config", "engines", "providers"})
 _GET_PROVIDER_RE: Final = re.compile(r"^provider/[^/]+$")
-_POST_PATHS: Final = frozenset({"config", "secrets"})
+_POST_PATHS: Final = frozenset({"config"})
 _POST_CONFIGURE_RE: Final = re.compile(r"^provider/[^/]+/configure$")
 _DELETE_PROVIDER_RE: Final = re.compile(r"^provider/[^/]+$")
-_DELETE_SECRET_RE: Final = re.compile(r"^secrets/[^/]+$")
 
 router = APIRouter(prefix="/api/v1", tags=["abbenay-admin"])
 
@@ -172,7 +180,7 @@ def _method_allows_path(method: str, admin_path: str) -> bool:
     if method == "POST":
         return admin_path in _POST_PATHS or bool(_POST_CONFIGURE_RE.fullmatch(admin_path))
     if method == "DELETE":
-        return bool(_DELETE_PROVIDER_RE.fullmatch(admin_path)) or bool(_DELETE_SECRET_RE.fullmatch(admin_path))
+        return bool(_DELETE_PROVIDER_RE.fullmatch(admin_path))
     return False
 
 
@@ -245,8 +253,9 @@ async def proxy_abbenay_admin(path: str, request: Request) -> Response:
 
     Allowed (examples): ``GET/POST /ai/config``, ``GET /ai/engines``,
     ``GET /ai/providers``, ``POST /ai/provider/{id}/configure``,
-    ``DELETE /ai/provider/{id}``, ``GET/POST /ai/secrets``,
-    ``DELETE /ai/secrets/{key}``.
+    ``DELETE /ai/provider/{id}``. The secret store (``GET/POST
+    /ai/secrets``, ``DELETE /ai/secrets/{key}``) is denied: manage
+    secrets directly against Abbenay until Gateway caller auth (#1) lands.
     ``GET /api/v1/ai/models`` remains on the main router (Engine). Chat and
     other Abbenay surfaces are not proxied.
 

--- a/tests/test_gateway_abbenay_proxy.py
+++ b/tests/test_gateway_abbenay_proxy.py
@@ -232,33 +232,35 @@ async def test_chat_path_not_proxied(app_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
-async def test_get_secrets_proxied(app_client: AsyncClient) -> None:
-    """GET /api/v1/ai/secrets proxies to Abbenay /api/secrets.
+async def test_get_secrets_not_proxied(app_client: AsyncClient) -> None:
+    """GET /api/v1/ai/secrets is denied (no secret listing via the proxy).
+
+    The Gateway has no caller authentication yet, so unauthenticated
+    secret-store reads are rejected at the allowlist (finding #11).
 
     Args:
         app_client: Async HTTP test client.
     """
-    secrets_body = b'{"secrets":["OPENROUTER_API_KEY"]}'
-    client = _mock_upstream(content=secrets_body)
+    client = _mock_upstream(content=b'{"secrets":["OPENROUTER_API_KEY"]}')
     with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
         resp = await app_client.get("/api/v1/ai/secrets")
 
-    assert resp.status_code == 200
-    assert resp.content == secrets_body
-    assert client.request.await_args is not None
-    assert client.request.await_args.args[1] == "http://127.0.0.1:8787/api/secrets"
-    assert client.request.await_args.kwargs["headers"]["Authorization"] == "Bearer admin-http-token"
-    assert "Cookie" not in client.request.await_args.kwargs["headers"]
+    assert resp.status_code == 404
+    client.request.assert_not_awaited()
 
 
 @pytest.mark.parametrize("secret_store", ["memory", "file"])  # type: ignore[untyped-decorator]
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
-async def test_post_secrets_proxied(app_client: AsyncClient, secret_store: str) -> None:
-    """POST /api/v1/ai/secrets forwards JSON including secretStore unchanged.
+async def test_post_secrets_not_proxied(app_client: AsyncClient, secret_store: str) -> None:
+    """POST /api/v1/ai/secrets is denied (no unauthenticated secret writes).
+
+    Reads were denied first (finding #11); writes follow the same rule
+    because an unauthenticated client able to overwrite secrets is the
+    more severe exposure. Manage secrets directly against Abbenay (#1).
 
     Args:
         app_client: Async HTTP test client.
-        secret_store: Abbenay store name forwarded as-is (``memory`` or ``file``).
+        secret_store: Abbenay store name (``memory`` or ``file``).
     """
     client = _mock_upstream(content=b'{"ok":true}')
     body = {
@@ -273,51 +275,25 @@ async def test_post_secrets_proxied(app_client: AsyncClient, secret_store: str) 
             headers={"Cookie": "session=caller-cookie"},
         )
 
-    assert resp.status_code == 200
-    assert client.request.await_args is not None
-    assert client.request.await_args.args[1] == "http://127.0.0.1:8787/api/secrets"
-    assert client.request.await_args.kwargs["headers"]["Authorization"] == "Bearer admin-http-token"
-    assert "Cookie" not in client.request.await_args.kwargs["headers"]
-    content = client.request.await_args.kwargs.get("content") or b""
-    assert b"sk-or-test" in content
-    assert b"secretStore" in content
-    assert secret_store.encode() in content
+    assert resp.status_code == 404
+    client.request.assert_not_awaited()
 
 
-@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
-    ("query", "expected_suffix"),
-    [
-        ("", ""),
-        ("secretStore=memory", "?secretStore=memory"),
-        ("secretStore=file", "?secretStore=file"),
-    ],
-)
+@pytest.mark.parametrize("query", ["", "?secretStore=memory", "?secretStore=file"])  # type: ignore[untyped-decorator]
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
-async def test_delete_secret_by_key_proxied(
-    app_client: AsyncClient,
-    query: str,
-    expected_suffix: str,
-) -> None:
-    """DELETE /api/v1/ai/secrets/{key} forwards secretStore query unchanged.
+async def test_delete_secret_by_key_not_proxied(app_client: AsyncClient, query: str) -> None:
+    """DELETE /api/v1/ai/secrets/{key} is denied for all query shapes.
 
     Args:
         app_client: Async HTTP test client.
-        query: Raw query string (empty, or ``secretStore=…``).
-        expected_suffix: Expected ``?…`` suffix on the upstream URL.
+        query: Query string suffix (``""``, ``"?secretStore=memory"``, or ``"?secretStore=file"``).
     """
     client = _mock_upstream(content=b'{"deleted":true}')
-    path = "/api/v1/ai/secrets/OPENROUTER_API_KEY"
-    if query:
-        path = f"{path}?{query}"
     with patch("apme_gateway.api.abbenay_proxy.httpx.AsyncClient", return_value=client):
-        resp = await app_client.delete(path)
+        resp = await app_client.delete(f"/api/v1/ai/secrets/OPENROUTER_API_KEY{query}")
 
-    assert resp.status_code == 200
-    assert client.request.await_args is not None
-    assert client.request.await_args.args[1] == (
-        f"http://127.0.0.1:8787/api/secrets/OPENROUTER_API_KEY{expected_suffix}"
-    )
-    assert client.request.await_args.kwargs["headers"]["Authorization"] == "Bearer admin-http-token"
+    assert resp.status_code == 404
+    client.request.assert_not_awaited()
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]


### PR DESCRIPTION
## Summary

Remove the Abbenay secret store from the Gateway proxy allowlist: `GET/POST /api/v1/ai/secrets` and `DELETE /api/v1/ai/secrets/{key}` now return 404 without contacting Abbenay. Split out of #646 for independent review.

## Breaking changes

Secret management via the Gateway (`POST` inject, `DELETE` remove, `GET` list) no longer works. Manage secrets directly against Abbenay (Bearer token, loopback) until Gateway caller auth (#1) lands. Reads were the original finding (#11); writes are denied by the same rule because an unauthenticated client able to overwrite or delete secrets is the more severe exposure. Audit note: the remaining proxied surfaces (`POST /ai/config`, `POST /ai/provider/{id}/configure`) carry secret *references* (`secretName`/`secretStore`), not values, so the deny is not bypassable. ADR-070 amended with an ADR-060 security exception documenting this intentional v1 URL denial.

## Changes

- `abbenay_proxy.py`: `secrets` removed from GET/POST/DELETE allowlists
- `ABBENAY_AI.md`: allowlist table, direct-to-Abbenay curl examples, Helm port-forward + token retrieval, token-hygiene + loopback notes, rewritten security note
- `ADR-070`: secret-store denial, ADR-060 security exception, updated §7 and test notes
- Tests assert 404 + upstream never contacted (GET, POST × stores, DELETE × query shapes)

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` passes (targeted: abbenay proxy tests)
- [x] Docs updated
- [x] ADR-070 amended (security exception; references #1 for caller auth)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changed Behavior**
  - Secret-store reads, writes, and key deletions no longer route through the Gateway and return 404 responses.
  - Other allowlisted administrative endpoints remain available.

- **Documentation**
  - Updated guidance for managing secrets directly through Abbenay with Bearer authentication.
  - Added warnings about command-line secret exposure, loopback-only HTTP access, and unauthenticated requests.

- **Tests**
  - Updated coverage to verify secret-management requests are denied without contacting Abbenay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->