### PR TITLE
fix(review): harden gateway/engine/proxy per review findings

### DIFF
--- a/docs/api/openapi.v1.json
+++ b/docs/api/openapi.v1.json
@@ -1596,7 +1596,7 @@
         "type": "object"
       },
       "ProposalDetail": {
-        "description": "Proposal row (ephemeral working set or historically rebuilt; ADR-062).\n\nAttributes:\n    id: Auto-increment ID (0 when rebuilt in memory).\n    proposal_id: Gateway-stable proposal id within the scan.\n    rule_id: Primary rule that triggered the proposal.\n    file: File the proposal targets.\n    tier: Proposal tier (1 deterministic, 2+ AI).\n    confidence: AI confidence score.\n    status: approved, rejected, declined, or pending.\n    path: Node identity path (optional additive).\n    node_type: ContentGraph NodeType value (task, block, play, \u2026).\n    source: deterministic, ai, ai-candidate, or outcome (optional additive).\n    gate: tier1 or ai (optional additive).\n    rule_ids: All rule ids on this approval unit (optional additive).\n    violation_ids: Linked violation PKs (optional additive).\n    line_start: First line of the node/finding (optional additive).\n    diff_hunk: Unified diff when available (optional additive).\n    explanation: AI explanation when available (optional additive).\n    suggestion: Manual suggestion when available (optional additive).\n    engine_proposal_id: Live engine proposal id when bridged (optional).\n    draft: True while optimistic UI edits are not yet gate-committed.",
+        "description": "Proposal row (ephemeral working set or historically rebuilt; ADR-062).\n\nAttributes:\n    id: Auto-increment ID (0 when rebuilt in memory).\n    proposal_id: Gateway-stable proposal id within the scan.\n    rule_id: Primary rule that triggered the proposal.\n    file: File the proposal targets.\n    tier: Proposal tier (1 deterministic, 2+ AI).\n    confidence: AI confidence score.\n    status: proposed, approved, rejected, declined, or pending.\n    path: Node identity path (optional additive).\n    node_type: ContentGraph NodeType value (task, block, play, \u2026).\n    source: deterministic, ai, ai-candidate, or outcome (optional additive).\n    gate: tier1 or ai (optional additive).\n    rule_ids: All rule ids on this approval unit (optional additive).\n    violation_ids: Linked violation PKs (optional additive).\n    line_start: First line of the node/finding, 0 when unknown (optional additive).\n    line_end: Last line of the node/finding, 0 when unknown (optional additive).\n    diff_hunk: Unified diff when available (optional additive).\n    explanation: AI explanation when available (optional additive).\n    suggestion: Manual suggestion when available (optional additive).\n    engine_proposal_id: Live engine proposal id when bridged (optional).\n    draft: True while optimistic UI edits are not yet gate-committed.",
         "properties": {
           "confidence": {
             "title": "Confidence",
@@ -1641,8 +1641,15 @@
             "title": "Id",
             "type": "integer"
           },
+          "line_end": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Line End",
+            "type": "integer"
+          },
           "line_start": {
             "default": 0,
+            "minimum": 0.0,
             "title": "Line Start",
             "type": "integer"
           },

--- a/frontend/packages/ui-workflow/src/components/OperationPanel.tsx
+++ b/frontend/packages/ui-workflow/src/components/OperationPanel.tsx
@@ -267,6 +267,7 @@ export function OperationPanel({
       status: p.status,
       suggestion: p.suggestion,
       line_start: p.line_start,
+      line_end: p.line_end,
       path: p.path,
       node_type: p.node_type,
       source: p.source,

--- a/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useProjectOperationState.ts
@@ -70,6 +70,8 @@ export interface Proposal {
   status?: "proposed" | "declined" | "pending" | "approved" | "rejected";
   suggestion?: string;
   line_start?: number;
+  /** 1-based end line of the proposal span; 0/undefined = unknown (same guard as line_start). */
+  line_end?: number;
   path?: string;
   /** ContentGraph NodeType (task, block, play, …); empty when not graph-backed. */
   node_type?: string;

--- a/frontend/packages/ui-workflow/src/hooks/useSessionStream.test.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useSessionStream.test.ts
@@ -1,0 +1,954 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSessionStream } from "./useSessionStream";
+
+const STORAGE_KEY = "apme_active_session";
+
+/** Minimal WebSocket stand-in capturing instances and sent frames. */
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readyState = MockWebSocket.OPEN;
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: ((ev: { code: number }) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn((_code?: number) => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+}
+
+function lastSocket(): MockWebSocket {
+  const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  if (!ws) throw new Error("expected a WebSocket to have been created");
+  return ws;
+}
+
+function sendMsg(ws: MockWebSocket, msg: unknown): void {
+  act(() => {
+    ws.onmessage?.({ data: JSON.stringify(msg) });
+  });
+}
+
+async function startSessionWithSocket() {
+  const { result, unmount } = renderHook(() => useSessionStream());
+  await act(async () => {
+    await result.current.startSession([], {});
+  });
+  const ws = lastSocket();
+  act(() => {
+    ws.onopen?.(new Event("open"));
+  });
+  return { result, unmount, ws };
+}
+
+function validTier1() {
+  return {
+    type: "tier1_complete",
+    idempotency_ok: true,
+    patches: [],
+    format_diffs: [],
+    report: null,
+  };
+}
+
+function proposalBase() {
+  return {
+    id: "p1",
+    file: "site.yml",
+    rule_id: "R1",
+    before_text: "before",
+    after_text: "after",
+    diff_hunk: "@@",
+    confidence: 0.9,
+    explanation: "fix",
+    tier: 2,
+  };
+}
+
+describe("useSessionStream hardening", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    sessionStorage.clear();
+  });
+
+  it("accepts proposals omitting line_start and normalizes to 0", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      sendMsg(lastSocket(), {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(lastSocket(), validTier1());
+      sendMsg(lastSocket(), {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_end: 5 }],
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.status).toBe("awaiting_approval");
+      expect(result.current.proposals).toHaveLength(1);
+      expect(result.current.proposals[0]?.line_start).toBe(0);
+      expect(result.current.proposals[0]?.line_end).toBe(5);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("accepts proposals omitting line_end and both line fields", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      sendMsg(lastSocket(), {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(lastSocket(), validTier1());
+      sendMsg(lastSocket(), {
+        type: "proposals",
+        proposals: [
+          { ...proposalBase(), line_start: 3 },
+          { ...proposalBase(), id: "p2" },
+        ],
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.proposals).toHaveLength(2);
+      expect(result.current.proposals[0]?.line_end).toBe(0);
+      expect(result.current.proposals[1]?.line_start).toBe(0);
+      expect(result.current.proposals[1]?.line_end).toBe(0);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("malformed proposals preserves the persisted session and reconnect affordance", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+      expect(result.current.status).toBe("tier1_done");
+
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 123 }] });
+
+      expect(result.current.error).toBe("Received malformed proposals from server");
+      // Server session is alive: resume material must survive.
+      expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      expect(ws.close).not.toHaveBeenCalled();
+      // tier1_done is reconnectable → reconnect affordance per phase logic.
+      expect(result.current.canReconnect).toBe(true);
+      expect(result.current.status).toBe("disconnected");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("malformed tier1_complete closes the socket but preserves the persisted session", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+
+      sendMsg(ws, {
+        type: "tier1_complete",
+        idempotency_ok: "yes",
+        patches: [],
+        format_diffs: [],
+        report: null,
+      });
+
+      expect(result.current.error).toBe(
+        "Received malformed tier1 result from server",
+      );
+      expect(result.current.tier1).toBeNull();
+      // Non-reconnectable ("checking"): the socket must close so a later
+      // valid frame cannot flip error→complete behind a dead UI.
+      expect(ws.close).toHaveBeenCalledWith(1000);
+      // The server session is still alive: resume material must survive
+      // (unlike the terminal teardown).
+      expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      // "checking" is not reconnectable → error without reconnect.
+      expect(result.current.canReconnect).toBe(false);
+      expect(result.current.status).toBe("error");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("malformed terminal result still tears down the session", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+      sendMsg(ws, {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_start: 1, line_end: 2 }],
+      });
+      expect(result.current.status).toBe("awaiting_approval");
+
+      sendMsg(ws, {
+        type: "result",
+        scan_id: 123,
+        patches: [],
+        report: null,
+        remaining_violations: [],
+      });
+
+      expect(result.current.error).toBe("Received malformed result from server");
+      expect(result.current.status).toBe("error");
+      expect(result.current.canReconnect).toBe(false);
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(ws.close).toHaveBeenCalledWith(1000);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("rejects an array report on tier1_complete", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, {
+        type: "tier1_complete",
+        idempotency_ok: true,
+        patches: [],
+        format_diffs: [],
+        report: [],
+      });
+
+      expect(result.current.tier1).toBeNull();
+      expect(result.current.error).toBe(
+        "Received malformed tier1 result from server",
+      );
+      // Non-terminal: resume material survives, but the non-reconnectable
+      // socket still closes so the dead UI cannot flip to complete later.
+      expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      expect(ws.close).toHaveBeenCalledWith(1000);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("rejects an array report on terminal result with teardown", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, {
+        type: "result",
+        scan_id: "scan-1",
+        patches: [],
+        report: [],
+        remaining_violations: [],
+      });
+
+      expect(result.current.result).toBeNull();
+      expect(result.current.error).toBe("Received malformed result from server");
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(ws.close).toHaveBeenCalledWith(1000);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("treats session_created with empty ids as malformed without persisting", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, { type: "session_created", session_id: "", scan_id: "scan-1" });
+
+      expect(result.current.error).toBe("Received malformed session from server");
+      expect(result.current.sessionId).toBeNull();
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+
+      sendMsg(ws, { type: "session_created", session_id: "sess-1", scan_id: "" });
+
+      expect(result.current.sessionId).toBeNull();
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("persists valid session_created ids", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      sendMsg(lastSocket(), {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+
+      expect(result.current.sessionId).toBe("sess-1");
+      expect(result.current.scanId).toBe("scan-1");
+      const raw = sessionStorage.getItem(STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw as string)).toMatchObject({
+        sessionId: "sess-1",
+        scanId: "scan-1",
+      });
+    } finally {
+      unmount();
+    }
+  });
+
+  it("accepts explicit-null line fields (Python None) and normalizes to 0", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      sendMsg(lastSocket(), {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(lastSocket(), validTier1());
+      sendMsg(lastSocket(), {
+        type: "proposals",
+        proposals: [
+          { ...proposalBase(), line_start: null, line_end: null },
+          { ...proposalBase(), id: "p2", line_start: null, line_end: 7 },
+        ],
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.status).toBe("awaiting_approval");
+      expect(result.current.proposals).toHaveLength(2);
+      expect(result.current.proposals[0]?.line_start).toBe(0);
+      expect(result.current.proposals[0]?.line_end).toBe(0);
+      expect(result.current.proposals[1]?.line_start).toBe(0);
+      expect(result.current.proposals[1]?.line_end).toBe(7);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("accepts patches omitting applied_rules and normalizes to []", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      // Old servers omit applied_rules on tier1_complete patches.
+      sendMsg(ws, {
+        type: "tier1_complete",
+        idempotency_ok: true,
+        patches: [{ file: "site.yml", diff: "@@ -1 +1 @@" }],
+        format_diffs: [],
+        report: null,
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.status).toBe("tier1_done");
+      expect(result.current.tier1?.patches).toHaveLength(1);
+      expect(result.current.tier1?.patches[0]?.applied_rules).toEqual([]);
+
+      sendMsg(ws, {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_start: 1, line_end: 2 }],
+      });
+      // Old servers omit applied_rules on terminal result patches too.
+      sendMsg(ws, {
+        type: "result",
+        scan_id: "scan-1",
+        patches: [{ file: "site.yml", diff: "@@ -1 +1 @@" }],
+        report: null,
+        remaining_violations: [],
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.status).toBe("complete");
+      expect(result.current.result?.patches).toHaveLength(1);
+      expect(result.current.result?.patches[0]?.applied_rules).toEqual([]);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("malformed proposals clears a previously accepted stale set", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+      sendMsg(ws, {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_start: 1, line_end: 2 }],
+      });
+      expect(result.current.status).toBe("awaiting_approval");
+      expect(result.current.proposals).toHaveLength(1);
+
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 123 }] });
+
+      // Approving the stale set must be impossible.
+      expect(result.current.proposals).toHaveLength(0);
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(ws.close).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("ignores a consecutive same-type malformed frame after taint (no re-error)", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+      sendMsg(ws, {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_start: 1, line_end: 2 }],
+      });
+
+      // First malformed frame: surfaces and clears the stale set.
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 123 }] });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(result.current.proposals).toHaveLength(0);
+
+      // A consecutive same-type malformed frame is tainted: fully ignored —
+      // no re-error, no extra close, socket kept open.
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 456 }] });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(result.current.proposals).toHaveLength(0);
+      expect(result.current.status).toBe("disconnected");
+      expect(ws.close).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("routes JSON.parse failures into the malformed path without closing", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+      expect(result.current.status).toBe("tier1_done");
+
+      act(() => {
+        ws.onmessage?.({ data: "{not-json" });
+      });
+
+      expect(result.current.error).toBe(
+        "Received malformed message from server",
+      );
+      // Non-terminal: resume material survives and the socket stays open.
+      expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      expect(ws.close).not.toHaveBeenCalled();
+      expect(result.current.canReconnect).toBe(true);
+      expect(result.current.status).toBe("disconnected");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("routes non-record JSON into the malformed path", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+
+      act(() => {
+        ws.onmessage?.({ data: "[1,2]" });
+      });
+
+      expect(result.current.error).toBe(
+        "Received malformed message from server",
+      );
+      // Non-reconnectable ("checking"): the socket closes so a later valid
+      // frame cannot flip error→complete, but resume material survives.
+      expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      expect(ws.close).toHaveBeenCalledWith(1000);
+      expect(result.current.status).toBe("error");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("taint is per-type: a different malformed type still surfaces", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+
+      act(() => {
+        ws.onmessage?.({ data: "{not-json" });
+      });
+      expect(result.current.error).toBe(
+        "Received malformed message from server",
+      );
+
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 123 }] });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+    } finally {
+      unmount();
+    }
+  });
+
+  it("valid proposals after taint clears the error and untaints", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+      sendMsg(ws, {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_start: 1, line_end: 2 }],
+      });
+      expect(result.current.status).toBe("awaiting_approval");
+
+      // Malformed frame: surfaces, taints, clears the stale set.
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 123 }] });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(result.current.proposals).toHaveLength(0);
+
+      // Valid recovery: clears the error and drops the taint.
+      sendMsg(ws, {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_start: 1, line_end: 2 }],
+      });
+      expect(result.current.error).toBeNull();
+      expect(result.current.status).toBe("awaiting_approval");
+      expect(result.current.proposals).toHaveLength(1);
+
+      // Taint was dropped: a repeat malformed frame surfaces again and
+      // clears the recovered set instead of being ignored forever.
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 456 }] });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(result.current.proposals).toHaveLength(0);
+      expect(result.current.status).toBe("disconnected");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("normalizes explicit-null text fields (Python None) to empty strings", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      sendMsg(lastSocket(), {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(lastSocket(), validTier1());
+      sendMsg(lastSocket(), {
+        type: "proposals",
+        proposals: [
+          {
+            ...proposalBase(),
+            before_text: null,
+            after_text: null,
+            diff_hunk: null,
+          },
+        ],
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.status).toBe("awaiting_approval");
+      expect(result.current.proposals).toHaveLength(1);
+      expect(result.current.proposals[0]?.before_text).toBe("");
+      expect(result.current.proposals[0]?.after_text).toBe("");
+      expect(result.current.proposals[0]?.diff_hunk).toBe("");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("normalizes explicit-null tier/confidence to 0", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      sendMsg(lastSocket(), {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(lastSocket(), validTier1());
+      sendMsg(lastSocket(), {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), tier: null, confidence: null }],
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.status).toBe("awaiting_approval");
+      expect(result.current.proposals).toHaveLength(1);
+      expect(result.current.proposals[0]?.tier).toBe(0);
+      expect(result.current.proposals[0]?.confidence).toBe(0);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("rejects NaN line_start as malformed", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+      // JSON cannot encode NaN, so bypass the stringify helper: the guard
+      // is defense-in-depth for non-JSON producers reaching the validator.
+      const spy = vi.spyOn(JSON, "parse").mockReturnValueOnce({
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_start: NaN, line_end: 2 }],
+      });
+      try {
+        act(() => {
+          ws.onmessage?.({ data: "ignored" });
+        });
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(result.current.proposals).toHaveLength(0);
+      // tier1_done is reconnectable → reconnect affordance, socket open.
+      expect(result.current.status).toBe("disconnected");
+      expect(ws.close).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("rejects NaN tier as malformed", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+      const spy = vi.spyOn(JSON, "parse").mockReturnValueOnce({
+        type: "proposals",
+        proposals: [{ ...proposalBase(), tier: NaN }],
+      });
+      try {
+        act(() => {
+          ws.onmessage?.({ data: "ignored" });
+        });
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(result.current.proposals).toHaveLength(0);
+      expect(result.current.status).toBe("disconnected");
+      expect(ws.close).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("non-reconnectable malformed proposals closes the socket but preserves the session", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      // Still "checking" (non-reconnectable): no tier1_complete yet.
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 123 }] });
+
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(result.current.status).toBe("error");
+      expect(result.current.canReconnect).toBe(false);
+      expect(ws.close).toHaveBeenCalledWith(1000);
+      // The server session is still alive: resume material must survive
+      // (unlike the terminal teardown).
+      expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  function seedPersistedSession(): void {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        sessionId: "dead-sess",
+        scanId: "scan-9",
+        timestamp: Date.now(),
+        ttlSeconds: 1800,
+      }),
+    );
+  }
+
+  async function resumeToChecking() {
+    const hook = renderHook(() => useSessionStream());
+    act(() => {
+      hook.result.current.resumeSession("dead-sess", "scan-9");
+    });
+    const ws = lastSocket();
+    expect(ws.url).toContain("resume=dead-sess");
+    act(() => {
+      ws.onopen?.(new Event("open"));
+    });
+    expect(hook.result.current.status).toBe("checking");
+    return { hook, ws };
+  }
+
+  it("clamps negative proposal numerics to 0 (hostile server)", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      sendMsg(lastSocket(), {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(lastSocket(), validTier1());
+      sendMsg(lastSocket(), {
+        type: "proposals",
+        proposals: [
+          {
+            ...proposalBase(),
+            line_start: -5,
+            line_end: -1,
+            tier: -2,
+            confidence: -0.5,
+          },
+          {
+            ...proposalBase(),
+            id: "p2",
+            line_start: 3,
+            line_end: 7,
+            tier: 1,
+            confidence: 0.9,
+          },
+        ],
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.status).toBe("awaiting_approval");
+      expect(result.current.proposals).toHaveLength(2);
+      expect(result.current.proposals[0]?.line_start).toBe(0);
+      expect(result.current.proposals[0]?.line_end).toBe(0);
+      expect(result.current.proposals[0]?.tier).toBe(0);
+      expect(result.current.proposals[0]?.confidence).toBe(0);
+      // Non-negative values pass through untouched.
+      expect(result.current.proposals[1]?.line_start).toBe(3);
+      expect(result.current.proposals[1]?.line_end).toBe(7);
+      expect(result.current.proposals[1]?.tier).toBe(1);
+      expect(result.current.proposals[1]?.confidence).toBe(0.9);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("valid progress clears a transient JSON-parse error and untaints", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+
+      act(() => {
+        ws.onmessage?.({ data: "{not-json" });
+      });
+      expect(result.current.error).toBe(
+        "Received malformed message from server",
+      );
+
+      // Progress is the most frequent frame: it proves transport recovery
+      // and must drop the parse-failure taint even though progress has no
+      // typed validator.
+      sendMsg(ws, { type: "progress", phase: "scan", message: "working" });
+      expect(result.current.error).toBeNull();
+      expect(result.current.progress).toHaveLength(1);
+
+      // Taint was dropped: a repeat parse failure surfaces again instead of
+      // being ignored forever.
+      act(() => {
+        ws.onmessage?.({ data: "{not-json" });
+      });
+      expect(result.current.error).toBe(
+        "Received malformed message from server",
+      );
+    } finally {
+      unmount();
+    }
+  });
+
+  it("valid progress does not clear a typed proposals error", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+      sendMsg(ws, {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_start: 1, line_end: 2 }],
+      });
+      expect(result.current.status).toBe("awaiting_approval");
+
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 123 }] });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(result.current.proposals).toHaveLength(0);
+
+      // Progress clears only the parse-failure taint: the typed proposals
+      // error and taint must survive.
+      sendMsg(ws, { type: "progress", phase: "scan", message: "working" });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(result.current.proposals).toHaveLength(0);
+
+      // Taint survived: a repeat malformed proposals frame is still ignored.
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 456 }] });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+      expect(result.current.proposals).toHaveLength(0);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("resume socket error before session_created clears the persisted session", async () => {
+    seedPersistedSession();
+    const { hook, ws } = await resumeToChecking();
+    try {
+      act(() => {
+        ws.onerror?.();
+      });
+
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(hook.result.current.status).toBe("error");
+      expect(hook.result.current.error).toBe("WebSocket connection error");
+    } finally {
+      hook.unmount();
+    }
+  });
+
+  it("resume error event before session_created clears the persisted session", async () => {
+    seedPersistedSession();
+    const { hook, ws } = await resumeToChecking();
+    try {
+      sendMsg(ws, { type: "error", message: "session not found" });
+
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(hook.result.current.status).toBe("error");
+      expect(hook.result.current.error).toBe("session not found");
+    } finally {
+      hook.unmount();
+    }
+  });
+
+  it("resume clean close before session_created clears storage and surfaces", async () => {
+    seedPersistedSession();
+    const { hook, ws } = await resumeToChecking();
+    try {
+      act(() => {
+        ws.onclose?.({ code: 1000 });
+      });
+
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(hook.result.current.status).toBe("error");
+      expect(hook.result.current.error).toBe(
+        "Connection closed unexpectedly",
+      );
+    } finally {
+      hook.unmount();
+    }
+  });
+});

--- a/frontend/packages/ui-workflow/src/hooks/useSessionStream.test.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useSessionStream.test.ts
@@ -951,4 +951,99 @@ describe("useSessionStream hardening", () => {
       hook.unmount();
     }
   });
+
+  it("resume clears malformed taint so repeat frames surface again", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const ws = lastSocket();
+      sendMsg(ws, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(ws, validTier1());
+      sendMsg(ws, {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_start: 1, line_end: 2 }],
+      });
+      expect(result.current.status).toBe("awaiting_approval");
+
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 123 }] });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+
+      // Second malformed frame is tainted and ignored.
+      sendMsg(ws, { type: "proposals", proposals: [{ id: 456 }] });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+
+      act(() => {
+        result.current.resumeSession("sess-1", "scan-1");
+      });
+      const resumeWs = lastSocket();
+      expect(resumeWs).not.toBe(ws);
+      act(() => {
+        resumeWs.onopen?.(new Event("open"));
+      });
+      expect(result.current.error).toBeNull();
+
+      sendMsg(resumeWs, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(resumeWs, validTier1());
+
+      // Taint was cleared on resume: malformed proposals surface again.
+      sendMsg(resumeWs, { type: "proposals", proposals: [{ id: 789 }] });
+      expect(result.current.error).toBe(
+        "Received malformed proposals from server",
+      );
+    } finally {
+      unmount();
+    }
+  });
+
+  it("stale socket onclose after resume does not clear storage or set error", async () => {
+    const { result, unmount } = await startSessionWithSocket();
+    try {
+      const oldWs = lastSocket();
+      sendMsg(oldWs, {
+        type: "session_created",
+        session_id: "sess-1",
+        scan_id: "scan-1",
+      });
+      sendMsg(oldWs, validTier1());
+      sendMsg(oldWs, {
+        type: "proposals",
+        proposals: [{ ...proposalBase(), line_start: 1, line_end: 2 }],
+      });
+      expect(result.current.status).toBe("awaiting_approval");
+      expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+      act(() => {
+        result.current.resumeSession("sess-1", "scan-1");
+      });
+      const newWs = lastSocket();
+      expect(newWs).not.toBe(oldWs);
+      act(() => {
+        newWs.onopen?.(new Event("open"));
+      });
+      expect(result.current.status).toBe("checking");
+      expect(result.current.error).toBeNull();
+
+      // Old socket close fires after replacement: must not affect new connection.
+      act(() => {
+        oldWs.onclose?.({ code: 1006 });
+      });
+
+      expect(sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+      expect(result.current.error).toBeNull();
+      expect(result.current.status).toBe("checking");
+    } finally {
+      unmount();
+    }
+  });
 });

--- a/frontend/packages/ui-workflow/src/hooks/useSessionStream.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useSessionStream.ts
@@ -41,8 +41,16 @@ export interface Proposal {
   id: string;
   file: string;
   rule_id: string;
-  line_start: number;
-  line_end: number;
+  // Additive: old servers and third-party producers may omit these (or send
+  // JSON null for Python None). State always holds finite numbers
+  // post-normalization (see the proposals handler), so readers can treat 0
+  // as unknown.
+  line_start?: number;
+  line_end?: number;
+  // Same additive contract as the line fields: missing/null tier/confidence
+  // normalize to 0 and missing/null text normalizes to "". State always
+  // holds a finite number / string post-normalization, so readers can treat
+  // 0 as unknown and "" as absent without null checks.
   before_text: string;
   after_text: string;
   diff_hunk: string;
@@ -93,6 +101,105 @@ export interface SessionOptions {
 }
 
 // ── Helpers ────────────────────────────────────────────────────────
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isPatchArray(v: unknown): v is Patch[] {
+  return (
+    Array.isArray(v) &&
+    v.every(
+      (p) =>
+        isRecord(p) &&
+        typeof p.file === "string" &&
+        typeof p.diff === "string" &&
+        // applied_rules is additive: old servers omit it. Accept
+        // undefined/null here and normalize to [] where patches enter state
+        // so mixed-version rollouts degrade instead of tearing down.
+        (typeof p.applied_rules === "undefined" ||
+          p.applied_rules === null ||
+          (Array.isArray(p.applied_rules) &&
+            (p.applied_rules as unknown[]).every(
+              (r) => typeof r === "string",
+            ))),
+    )
+  );
+}
+
+/** Fill additive patch fields old servers omit so state always holds arrays. */
+function normalizePatches(patches: Patch[]): Patch[] {
+  return patches.map((p) => ({
+    ...p,
+    applied_rules: Array.isArray(p.applied_rules) ? p.applied_rules : [],
+  }));
+}
+
+/** Validate a tier1_complete payload before it reaches state. */
+function isTier1Result(v: unknown): v is Tier1Result {
+  if (!isRecord(v)) return false;
+  return (
+    typeof v.idempotency_ok === "boolean" &&
+    isPatchArray(v.patches) &&
+    Array.isArray(v.format_diffs) &&
+    (v.report === null || isRecord(v.report))
+  );
+}
+
+/** Finite number or an additive missing marker (undefined / JSON null). */
+function isFiniteOrNullish(v: unknown): boolean {
+  return (
+    typeof v === "undefined" ||
+    v === null ||
+    (typeof v === "number" && Number.isFinite(v))
+  );
+}
+
+/** String or an additive missing marker (undefined / JSON null). */
+function isStringOrNullish(v: unknown): boolean {
+  return typeof v === "undefined" || v === null || typeof v === "string";
+}
+
+/** Validate a proposals payload before it reaches state. */
+function isProposalArray(v: unknown): v is Proposal[] {
+  return (
+    Array.isArray(v) &&
+    v.every(
+      (p) =>
+        isRecord(p) &&
+        typeof p.id === "string" &&
+        typeof p.file === "string" &&
+        typeof p.rule_id === "string" &&
+        // line_start/line_end/tier/confidence are additive: old servers and
+        // third-party producers may omit them, and Python None serializes as
+        // JSON null (not omission). Accept undefined/null here and normalize
+        // to 0 at setProposals so mixed-version rollouts degrade instead of
+        // tearing down. Numbers must be finite: NaN/Infinity would poison
+        // downstream math (confidence %) and gate comparisons (tier).
+        isFiniteOrNullish(p.line_start) &&
+        isFiniteOrNullish(p.line_end) &&
+        isFiniteOrNullish(p.tier) &&
+        isFiniteOrNullish(p.confidence) &&
+        // Text fields follow the same additive pattern: JSON null (Python
+        // None) normalizes to "" at setProposals so state typed `string`
+        // never holds null into downstream string ops.
+        isStringOrNullish(p.before_text) &&
+        isStringOrNullish(p.after_text) &&
+        isStringOrNullish(p.diff_hunk),
+    )
+  );
+}
+
+/** Validate a result payload before it reaches state. */
+function isSessionResult(v: unknown): v is SessionResult {
+  if (!isRecord(v)) return false;
+  return (
+    typeof v.scan_id === "string" &&
+    isPatchArray(v.patches) &&
+    (v.report === null || isRecord(v.report)) &&
+    Array.isArray(v.remaining_violations)
+  );
+}
 
 function fileToBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -201,6 +308,18 @@ export function useSessionStream() {
   const wsRef = useRef<WebSocket | null>(null);
   const statusRef = useRef<SessionStatus>("idle");
   const sessionIdRef = useRef<string | null>(null);
+  // True once session_created arrived on the current socket. Distinguishes a
+  // live session (keep resume material on failure) from a resume/start that
+  // never established (drop the persisted key: the id is dead).
+  const sessionEstablishedRef = useRef(false);
+  // Malformed-frame taint per frame type: only the first malformed frame of
+  // a given type surfaces via setError; repeats are ignored so a looping
+  // server cannot spam errors while the socket stays open.
+  const malformedTaintRef = useRef<Set<string>>(new Set());
+  // Which tainted frame type produced the currently surfaced malformed-frame
+  // error (null when the error came from elsewhere or was cleared). The next
+  // valid frame of that type clears both the taint and the error.
+  const errorSourceRef = useRef<string | null>(null);
 
   const updateStatus = useCallback((s: SessionStatus) => {
     statusRef.current = s;
@@ -222,36 +341,164 @@ export function useSessionStream() {
     setError(null);
     setCanReconnect(false);
     sessionIdRef.current = null;
+    sessionEstablishedRef.current = false;
+    malformedTaintRef.current = new Set();
+    errorSourceRef.current = null;
     clearPersistedSession();
   }, [updateStatus]);
 
   /** Wire shared WS event handlers (used by both start and resume). */
   const wireHandlers = useCallback(
     (ws: WebSocket) => {
-      ws.onmessage = (event) => {
-        let msg: Record<string, unknown>;
+      // A malformed TERMINAL result means the server stream cannot be
+      // trusted: surface the error and close the socket instead of leaving
+      // the UI on a non-terminal spinner with no recovery path.
+      const failMalformedTerminal = (message: string) => {
+        setError(message);
+        errorSourceRef.current = null;
+        setCanReconnect(false);
+        clearPersistedSession();
+        updateStatus("error");
         try {
-          msg = JSON.parse(event.data as string);
+          ws.close(1000);
         } catch {
+          // ignore close errors
+        }
+        if (wsRef.current === ws) {
+          wsRef.current = null;
+        }
+      };
+      // A malformed NON-terminal frame (tier1_complete, proposals,
+      // session_created) must not destroy resume: the server session is
+      // still alive and the phase may be reconnectable. Surface the error
+      // but preserve the persisted session and the reconnect affordance,
+      // and keep the socket open so the server can continue the stream.
+      const failMalformedNonTerminal = (message: string, kind: string) => {
+        // Taint tracking: only the first malformed frame of a given type
+        // surfaces. Further same-type frames are fully ignored (no setError
+        // spam loop) while the socket stays open in reconnectable phases.
+        if (malformedTaintRef.current.has(kind)) {
           return;
         }
+        malformedTaintRef.current.add(kind);
+        errorSourceRef.current = kind;
+        if (kind === "proposals") {
+          // Drop any previously accepted set: approving a stale set after a
+          // malformed frame must be impossible.
+          setProposals([]);
+        }
+        setError(message);
+        if (
+          RECONNECTABLE_PHASES.has(statusRef.current) &&
+          sessionIdRef.current
+        ) {
+          setCanReconnect(true);
+          updateStatus("disconnected");
+        } else {
+          // Non-reconnectable: an open socket behind an "error" UI is dead
+          // (a later valid frame would flip error→complete). Close like the
+          // terminal path, but keep the persisted session: the server
+          // session is still alive, unlike a malformed terminal result.
+          setCanReconnect(false);
+          updateStatus("error");
+          try {
+            ws.close(1000);
+          } catch {
+            // ignore close errors
+          }
+          if (wsRef.current === ws) {
+            wsRef.current = null;
+          }
+        }
+      };
+      // A valid frame proves the stream recovered for its type: drop that
+      // type's taint so a later malformed frame surfaces again, and clear
+      // the error if it came from this type. Parse-failure ("message") taint
+      // has no typed valid frame, so any valid frame clears it — including
+      // progress (which has no typed validator and therefore never carries
+      // its own taint; see the progress case below).
+      const noteValidFrame = (kind: string) => {
+        malformedTaintRef.current.delete(kind);
+        malformedTaintRef.current.delete("message");
+        if (
+          errorSourceRef.current === kind ||
+          errorSourceRef.current === "message"
+        ) {
+          errorSourceRef.current = null;
+          setError(null);
+        }
+      };
+      // True while the current socket never delivered session_created: a
+      // resume/start that fails here points at a dead id, so the persisted
+      // key must go (reloads stop re-offering resume to it).
+      const isPreSession = () =>
+        !sessionEstablishedRef.current &&
+        (statusRef.current === "connecting" ||
+          statusRef.current === "checking");
+      ws.onmessage = (event) => {
+        let raw: unknown;
+        try {
+          raw = JSON.parse(event.data as string);
+        } catch {
+          failMalformedNonTerminal(
+            "Received malformed message from server",
+            "message",
+          );
+          return;
+        }
+        if (!isRecord(raw)) {
+          failMalformedNonTerminal(
+            "Received malformed message from server",
+            "message",
+          );
+          return;
+        }
+        const msg = raw;
 
         switch (msg.type) {
-          case "session_created":
-            setSessionId(msg.session_id as string);
-            sessionIdRef.current = msg.session_id as string;
-            setScanId(msg.scan_id as string);
+          case "session_created": {
+            const sid = msg.session_id;
+            const scid = msg.scan_id;
+            if (
+              typeof sid !== "string" ||
+              sid.length === 0 ||
+              typeof scid !== "string" ||
+              scid.length === 0
+            ) {
+              failMalformedNonTerminal(
+                "Received malformed session from server",
+                "session_created",
+              );
+              break;
+            }
+            setSessionId(sid);
+            sessionIdRef.current = sid;
+            sessionEstablishedRef.current = true;
+            noteValidFrame("session_created");
+            setScanId(scid);
             persistSession(
-              msg.session_id as string,
-              msg.scan_id as string,
+              sid,
+              scid,
               typeof msg.ttl_seconds === "number"
                 ? msg.ttl_seconds
                 : undefined,
             );
             updateStatus("checking");
             break;
+          }
 
           case "progress":
+            // Progress has no typed validator (fields degrade to ""/2), so
+            // it cannot prove recovery for a typed taint. Clearing via
+            // noteValidFrame("progress") is still safe: it drops only the
+            // "progress" (never-tainted, noop) and "message" parse-failure
+            // taints, and clears the surfaced error only when its source is
+            // "progress" (impossible) or "message". Typed taints/errors
+            // (proposals, tier1_complete, …) survive until their own valid
+            // frame arrives. Without this, a transient JSON-parse error
+            // would pin the error UI even while progress frames prove the
+            // stream recovered (progress is the most frequent frame).
+            noteValidFrame("progress");
             setProgress((prev) => [
               ...prev,
               {
@@ -264,13 +511,71 @@ export function useSessionStream() {
             break;
 
           case "tier1_complete":
-            setTier1(msg as unknown as Tier1Result);
-            updateStatus("tier1_done");
+            if (isTier1Result(msg)) {
+              noteValidFrame("tier1_complete");
+              setTier1({ ...msg, patches: normalizePatches(msg.patches) });
+              updateStatus("tier1_done");
+            } else {
+              failMalformedNonTerminal(
+                "Received malformed tier1 result from server",
+                "tier1_complete",
+              );
+            }
             break;
 
           case "proposals":
-            setProposals(msg.proposals as Proposal[]);
-            updateStatus("awaiting_approval");
+            if (isProposalArray(msg.proposals)) {
+              noteValidFrame("proposals");
+              setProposals(
+                msg.proposals.map((p) => ({
+                  ...p,
+                  // Mirror backend _to_int clamping (>= 0): a hostile server
+                  // must not inject negative lines/tiers into state.
+                  // Validator still accepts finite negatives; clamp here so
+                  // mixed-version degradation (null → 0) and hardening share
+                  // one normalization path.
+                  line_start: Math.max(
+                    0,
+                    typeof p.line_start === "number" &&
+                      Number.isFinite(p.line_start)
+                      ? p.line_start
+                      : 0,
+                  ),
+                  line_end: Math.max(
+                    0,
+                    typeof p.line_end === "number" &&
+                      Number.isFinite(p.line_end)
+                      ? p.line_end
+                      : 0,
+                  ),
+                  tier: Math.max(
+                    0,
+                    typeof p.tier === "number" && Number.isFinite(p.tier)
+                      ? p.tier
+                      : 0,
+                  ),
+                  confidence: Math.max(
+                    0,
+                    typeof p.confidence === "number" &&
+                      Number.isFinite(p.confidence)
+                      ? p.confidence
+                      : 0,
+                  ),
+                  before_text:
+                    typeof p.before_text === "string" ? p.before_text : "",
+                  after_text:
+                    typeof p.after_text === "string" ? p.after_text : "",
+                  diff_hunk:
+                    typeof p.diff_hunk === "string" ? p.diff_hunk : "",
+                })),
+              );
+              updateStatus("awaiting_approval");
+            } else {
+              failMalformedNonTerminal(
+                "Received malformed proposals from server",
+                "proposals",
+              );
+            }
             break;
 
           case "approval_ack":
@@ -282,7 +587,12 @@ export function useSessionStream() {
             break;
 
           case "result":
-            setResult(msg as unknown as SessionResult);
+            if (!isSessionResult(msg)) {
+              failMalformedTerminal("Received malformed result from server");
+              break;
+            }
+            setResult({ ...msg, patches: normalizePatches(msg.patches) });
+            noteValidFrame("result");
             setCanReconnect(false);
             clearPersistedSession();
             updateStatus("complete");
@@ -304,10 +614,19 @@ export function useSessionStream() {
 
           case "error":
             setError((msg.message as string) || "Unknown error");
+            // Transport/server errors are not taint-tracked: neutralize any
+            // stale malformed source so a later valid tainted-type frame
+            // cannot clear an unrelated error.
+            errorSourceRef.current = null;
             if (RECONNECTABLE_PHASES.has(statusRef.current) && sessionIdRef.current) {
               setCanReconnect(true);
               updateStatus("disconnected");
             } else {
+              // A resume that fails before session_created points at a dead
+              // id: drop the persisted key so reloads stop offering it.
+              if (isPreSession()) {
+                clearPersistedSession();
+              }
               updateStatus("error");
             }
             break;
@@ -325,17 +644,30 @@ export function useSessionStream() {
       };
 
       ws.onerror = () => {
+        errorSourceRef.current = null;
         if (RECONNECTABLE_PHASES.has(statusRef.current) && sessionIdRef.current) {
           setError("Connection lost. Your session is still active on the server.");
           setCanReconnect(true);
           updateStatus("disconnected");
         } else {
+          // A resume that fails before session_created points at a dead id:
+          // drop the persisted key so reloads stop offering resume to it.
+          if (isPreSession()) {
+            clearPersistedSession();
+          }
           setError("WebSocket connection error");
           updateStatus("error");
         }
       };
 
       ws.onclose = (event) => {
+        // A close before session_created means the resume/start never
+        // established: the persisted id is dead, drop it so reloads stop
+        // re-offering resume to it.
+        const preSession = isPreSession();
+        if (preSession) {
+          clearPersistedSession();
+        }
         if (
           event.code !== 1000 &&
           statusRef.current !== "complete" &&
@@ -348,8 +680,16 @@ export function useSessionStream() {
             updateStatus("disconnected");
           } else {
             setError("Connection closed unexpectedly");
+            errorSourceRef.current = null;
             updateStatus("error");
           }
+        } else if (event.code === 1000 && preSession) {
+          // Clean close with no session_created and no other signal (e.g. a
+          // resume the server rejected): surface it instead of hanging on a
+          // spinner with resume material already dropped.
+          setError("Connection closed unexpectedly");
+          errorSourceRef.current = null;
+          updateStatus("error");
         }
       };
     },
@@ -401,8 +741,12 @@ export function useSessionStream() {
         wsRef.current = null;
       }
       setError(null);
+      errorSourceRef.current = null;
       setCanReconnect(false);
       updateStatus("connecting");
+      // New socket: nothing established on it yet. Taint intentionally
+      // survives resume (same session lifecycle; only reset() clears it).
+      sessionEstablishedRef.current = false;
 
       let url = `/api/v1/ws/session?resume=${encodeURIComponent(sid)}`;
       if (originalScanId) {
@@ -431,6 +775,7 @@ export function useSessionStream() {
         setError(
           "Connection lost — cannot send approval. Try reconnecting.",
         );
+        errorSourceRef.current = null;
         if (sessionIdRef.current) {
           setCanReconnect(true);
           updateStatus("disconnected");

--- a/frontend/packages/ui-workflow/src/hooks/useSessionStream.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useSessionStream.ts
@@ -436,6 +436,7 @@ export function useSessionStream() {
         (statusRef.current === "connecting" ||
           statusRef.current === "checking");
       ws.onmessage = (event) => {
+        if (wsRef.current !== ws) return;
         let raw: unknown;
         try {
           raw = JSON.parse(event.data as string);
@@ -644,6 +645,7 @@ export function useSessionStream() {
       };
 
       ws.onerror = () => {
+        if (wsRef.current !== ws) return;
         errorSourceRef.current = null;
         if (RECONNECTABLE_PHASES.has(statusRef.current) && sessionIdRef.current) {
           setError("Connection lost. Your session is still active on the server.");
@@ -661,6 +663,7 @@ export function useSessionStream() {
       };
 
       ws.onclose = (event) => {
+        if (wsRef.current !== ws) return;
         // A close before session_created means the resume/start never
         // established: the persisted id is dead, drop it so reloads stop
         // re-offering resume to it.
@@ -742,10 +745,10 @@ export function useSessionStream() {
       }
       setError(null);
       errorSourceRef.current = null;
+      malformedTaintRef.current = new Set();
       setCanReconnect(false);
       updateStatus("connecting");
-      // New socket: nothing established on it yet. Taint intentionally
-      // survives resume (same session lifecycle; only reset() clears it).
+      // New socket: nothing established on it yet.
       sessionEstablishedRef.current = false;
 
       let url = `/api/v1/ws/session?resume=${encodeURIComponent(sid)}`;

--- a/frontend/packages/ui-workflow/src/hooks/useSessionStream.ts
+++ b/frontend/packages/ui-workflow/src/hooks/useSessionStream.ts
@@ -555,12 +555,15 @@ export function useSessionStream() {
                       ? p.tier
                       : 0,
                   ),
-                  confidence: Math.max(
-                    0,
-                    typeof p.confidence === "number" &&
-                      Number.isFinite(p.confidence)
-                      ? p.confidence
-                      : 0,
+                  confidence: Math.min(
+                    1,
+                    Math.max(
+                      0,
+                      typeof p.confidence === "number" &&
+                        Number.isFinite(p.confidence)
+                        ? p.confidence
+                        : 0,
+                    ),
                   ),
                   before_text:
                     typeof p.before_text === "string" ? p.before_text : "",

--- a/frontend/packages/ui-workflow/src/types/operation.ts
+++ b/frontend/packages/ui-workflow/src/types/operation.ts
@@ -36,6 +36,8 @@ export interface OperationProposal {
   status?: "proposed" | "declined" | "pending" | "approved" | "rejected";
   suggestion?: string;
   line_start?: number;
+  /** 1-based end line of the proposal span; 0/undefined = unknown (same guard as line_start). */
+  line_end?: number;
   /** Stable graph node path (ADR-062 / Option C Gate 1 grouping key). */
   path?: string;
   /** ContentGraph NodeType (task, block, play, …); empty when not graph-backed. */

--- a/src/apme_engine/cli/remediate.py
+++ b/src/apme_engine/cli/remediate.py
@@ -131,6 +131,7 @@ def run_remediate(args: argparse.Namespace) -> None:
     result_patches: list[FilePatch] = []
     result_files_written = 0
     got_result = False
+    write_failed = False
 
     def _run_uploads(
         cmd_queue: queue.Queue[SessionCommand | None],
@@ -376,8 +377,6 @@ def run_remediate(args: argparse.Namespace) -> None:
             # Deferred until the producer is proven clean above: a partial
             # or synthetic result must never mutate disk on a failed run.
             result_files_written, write_failed = _write_patches(target, result_patches)
-            if write_failed:
-                sys.exit(EXIT_ERROR)
             break
         if retry:
             time.sleep(1.0 + random.uniform(0, 1.0))
@@ -399,7 +398,9 @@ def run_remediate(args: argparse.Namespace) -> None:
 
     if use_json:
         _emit_json(result_violations, result_patches, tier1_report, result_files_written)
-    elif result_violations:
+    if write_failed:
+        sys.exit(EXIT_ERROR)
+    if not use_json and result_violations:
         ai_count = sum(1 for v in result_violations if v.get("remediation_class") == "ai-candidate")
         manual_count = len(result_violations) - ai_count
         if ai_count:
@@ -457,7 +458,7 @@ def _emit_json(
 def _render_tier1(summary: Tier1Summary) -> None:
     format_diffs = list(summary.format_diffs)
     applied = list(summary.applied_patches)
-    report = summary.report
+    report = summary.report if summary.HasField("report") else None  # type: ignore[attr-defined]
 
     if format_diffs:
         sys.stderr.write(f"Formatted {len(format_diffs)} file(s)\n")

--- a/src/apme_engine/cli/remediate.py
+++ b/src/apme_engine/cli/remediate.py
@@ -136,6 +136,7 @@ def run_remediate(args: argparse.Namespace) -> None:
         cmd_queue: queue.Queue[SessionCommand | None],
         producer_errors: list[Exception],
         attempt_scan_ids: list[str],
+        stop_event: threading.Event,
     ) -> None:
         """Stream upload chunks into the command queue in a background thread.
 
@@ -159,6 +160,8 @@ def run_remediate(args: argparse.Namespace) -> None:
                 chunk's scan_id, recorded before enqueue so the main
                 thread can attribute a retry to the failed attempt's
                 server-side scan row.
+            stop_event: When set, the producer exits without enqueueing
+                further chunks (used during per-attempt teardown).
 
         Raises:
             BaseException: Re-raised after enqueueing the ``None`` sentinel
@@ -169,6 +172,8 @@ def run_remediate(args: argparse.Namespace) -> None:
         try:
             first = True
             for chunk in _make_chunks():
+                if stop_event.is_set():
+                    return
                 if not attempt_scan_ids and chunk.scan_id:
                     attempt_scan_ids.append(chunk.scan_id)
                 if first:
@@ -221,8 +226,11 @@ def run_remediate(args: argparse.Namespace) -> None:
         producer_errors: list[Exception] = []
         attempt_scan_ids: list[str] = []
 
+        stop_event = threading.Event()
         upload_thread = threading.Thread(
-            target=_run_uploads, args=(cmd_queue, producer_errors, attempt_scan_ids), daemon=True
+            target=_run_uploads,
+            args=(cmd_queue, producer_errors, attempt_scan_ids, stop_event),
+            daemon=True,
         )
         upload_thread.start()
 
@@ -353,8 +361,12 @@ def run_remediate(args: argparse.Namespace) -> None:
                 sys.exit(EXIT_ERROR)
         finally:
             # Tear down this attempt before any retry rebuilds it.
+            stop_event.set()
             cmd_queue.put(None)
             upload_thread.join(timeout=30)
+            if upload_thread.is_alive():
+                sys.stderr.write("Error: upload worker did not stop in time\n")
+                sys.exit(EXIT_ERROR)
             channel.close()
 
         if producer_errors:
@@ -363,7 +375,9 @@ def run_remediate(args: argparse.Namespace) -> None:
         if got_result:
             # Deferred until the producer is proven clean above: a partial
             # or synthetic result must never mutate disk on a failed run.
-            result_files_written = _write_patches(target, result_patches)
+            result_files_written, write_failed = _write_patches(target, result_patches)
+            if write_failed:
+                sys.exit(EXIT_ERROR)
             break
         if retry:
             time.sleep(1.0 + random.uniform(0, 1.0))
@@ -537,7 +551,7 @@ def _prompt_ynasq() -> str:
         sys.stderr.write("  Please enter y, n, a, s, or q\n")
 
 
-def _write_patches(target: Path, patches: Iterable[FilePatch]) -> int:
+def _write_patches(target: Path, patches: Iterable[FilePatch]) -> tuple[int, bool]:
     """Write patched files to disk, skipping failures.
 
     Args:
@@ -545,21 +559,24 @@ def _write_patches(target: Path, patches: Iterable[FilePatch]) -> int:
         patches: Patches to apply.
 
     Returns:
-        Number of files actually written (OSError skips excluded).
+        Tuple of (files actually written, whether any patch failed to apply).
     """
     count = 0
+    had_failures = False
     for p in patches:
         out_path = target / p.path if target.is_dir() else target
         try:
-            _safe_write(out_path, p.original, p.patched)
+            if _safe_write(out_path, p.original, p.patched):
+                rules = ", ".join(p.applied_rules) if p.applied_rules else "changes"
+                sys.stderr.write(f"  Fixed: {p.path} [{rules}]\n")
+                count += 1
+            else:
+                had_failures = True
         except OSError as exc:
             sys.stderr.write(f"WARNING: skipping {p.path}: {exc}\n")
-            continue
-        rules = ", ".join(p.applied_rules) if p.applied_rules else "changes"
-        sys.stderr.write(f"  Fixed: {p.path} [{rules}]\n")
-        count += 1
+            had_failures = True
     sys.stderr.write(f"\n{count} file(s) updated.\n")
-    return count
+    return count, had_failures
 
 
 def _render_remaining(result: SessionResult) -> None:
@@ -579,11 +596,12 @@ def _render_remaining(result: SessionResult) -> None:
         sys.stderr.write(f"{manual_count} violation(s) require manual review (Tier 3)\n")
 
 
-def _safe_write(path: Path, expected_original: bytes, new_content: bytes) -> None:
+def _safe_write(path: Path, expected_original: bytes, new_content: bytes) -> bool:
     current = path.read_bytes()
     if current != expected_original:
         sys.stderr.write(
             f"WARNING: {path} was modified since scan — skipping to avoid data loss.\n",
         )
-        return
+        return False
     path.write_bytes(new_content)
+    return True

--- a/src/apme_engine/cli/remediate.py
+++ b/src/apme_engine/cli/remediate.py
@@ -10,9 +10,11 @@ import argparse
 import json
 import os
 import queue
+import random
 import sys
 import threading
-from collections.abc import Iterator
+import time
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 
 import grpc
@@ -24,11 +26,14 @@ from apme.v1.engine_pb2 import (
     ApprovalRequest,
     CloseRequest,
     ExtendRequest,
+    FilePatch,
     FixOptions,
     FixReport,
     Proposal,
     ScanChunk,
     SessionCommand,
+    SessionResult,
+    Tier1Summary,
 )
 from apme_engine.cli._exit_codes import EXIT_ERROR, EXIT_VIOLATIONS
 from apme_engine.cli._galaxy_config import discover_galaxy_servers
@@ -44,6 +49,17 @@ from apme_engine.engine.models import ViolationDict
 
 def run_remediate(args: argparse.Namespace) -> None:
     """Execute the remediate subcommand.
+
+    A transient transport failure before any result is retried once with
+    jittered backoff; every attempt builds and tears down its own channel,
+    producer thread, and command queue so no state leaks across retries.
+    A background upload failure fails the run even when a server result
+    arrived first (a partial upload must never silently pass). Patches are
+    written to disk only after the producer is verified clean, so a failed
+    upload never mutates the tree. A transport drop after a result arrived
+    keeps the buffered result instead of discarding success. The retry
+    log carries the failed attempt's scan_id and attempt number so the
+    two server-side scan rows for one invocation stay attributable.
 
     Args:
         args: Parsed CLI arguments.
@@ -63,8 +79,25 @@ def run_remediate(args: argparse.Namespace) -> None:
     galaxy_servers = discover_galaxy_servers(project_root) or None
     rule_cfgs = load_rule_configs_from_project(project_root)
 
-    try:
-        base_chunks = yield_scan_chunks(
+    def _make_chunks() -> Iterator[ScanChunk]:
+        """Build a fresh upload-chunk stream (re-runnable for reconnect retry).
+
+        Each call mints a fresh scan_id inside ``yield_scan_chunks``: a
+        retry is a brand-new server session (``SessionStore.create`` mints
+        a fresh session with no dedup on ``scan_id``; ``scan_id`` is only
+        a reporting label), so sharing an ID across attempts buys nothing
+        and risks reporting-row collision. The attempt-teardown
+        ``channel.close()`` cancels the first session's stream, and
+        interactive approvals are re-prompted on the retry.
+
+        Upload failures propagate to the caller — the background producer
+        records them and the main thread reports them, so this generator
+        never exits the process itself.
+
+        Yields:
+            ScanChunk: Scan upload chunks for the FixSession stream.
+        """
+        yield from yield_scan_chunks(
             str(target),
             project_root_name="project",
             ansible_core_version=getattr(args, "ansible_version", None),
@@ -75,9 +108,6 @@ def run_remediate(args: argparse.Namespace) -> None:
             skip_collection_health=skip_collection,
             skip_dep_audit=skip_python,
         )
-    except FileNotFoundError as e:
-        sys.stderr.write(f"{e}\n")
-        sys.exit(EXIT_ERROR)
 
     fix_opts = FixOptions(
         max_passes=getattr(args, "max_passes", 5),
@@ -90,31 +120,85 @@ def run_remediate(args: argparse.Namespace) -> None:
         interactive=getattr(args, "interactive", False),
     )
 
-    cmd_queue: queue.Queue[SessionCommand | None] = queue.Queue()
+    # ADR-068: remediate omits the client-side gRPC deadline and relies
+    # on server-side budget + stall enforcement, so a None --timeout
+    # (server adaptive budget) is intentional, not a hang.
+    stream_timeout = getattr(args, "timeout", None)
 
-    def _upload_producer() -> None:
-        """Stream upload chunks into the command queue in a background thread."""
-        first = True
-        for chunk in base_chunks:
-            if first:
-                cmd_chunk = ScanChunk(
-                    scan_id=chunk.scan_id,
-                    project_root=chunk.project_root,
-                    options=chunk.options if chunk.HasField("options") else None,
-                    files=list(chunk.files),
-                    last=chunk.last,
-                    fix_options=fix_opts,
-                )
-                first = False
-            else:
-                cmd_chunk = chunk
-            cmd_queue.put(SessionCommand(upload=cmd_chunk))
+    use_json = getattr(args, "json", False)
+    tier1_report: FixReport | None = None
+    result_violations: list[ViolationDict] = []
+    result_patches: list[FilePatch] = []
+    result_files_written = 0
+    got_result = False
 
-    upload_thread = threading.Thread(target=_upload_producer, daemon=True)
-    upload_thread.start()
+    def _run_uploads(
+        cmd_queue: queue.Queue[SessionCommand | None],
+        producer_errors: list[Exception],
+        attempt_scan_ids: list[str],
+    ) -> None:
+        """Stream upload chunks into the command queue in a background thread.
 
-    def command_iter() -> Iterator[SessionCommand]:
+        Producer failures are recorded for the main thread — never
+        ``sys.exit`` here, which would only kill this daemon thread and
+        hang the consumer on an empty queue. Abrupt thread death
+        (``SystemExit``/``KeyboardInterrupt``/``CancelledError``) still
+        enqueues the ``None`` sentinel for liveness, then re-raises to
+        preserve semantics. The ``None`` sentinel is only
+        enqueued on the error path so the consumer terminates; on success
+        the stream stays open for proposals/approvals and the outer
+        attempt-teardown ``finally`` delivers the single terminating
+        ``None``. On the error path the teardown ``finally`` enqueues a
+        second ``None`` that is left over in the discarded per-attempt
+        queue — harmless because each attempt owns a fresh queue.
+
+        Args:
+            cmd_queue: Per-attempt command queue feeding the stream.
+            producer_errors: Per-attempt holder for background failures.
+            attempt_scan_ids: Per-attempt holder for the first upload
+                chunk's scan_id, recorded before enqueue so the main
+                thread can attribute a retry to the failed attempt's
+                server-side scan row.
+
+        Raises:
+            BaseException: Re-raised after enqueueing the ``None`` sentinel
+                when the producer dies abruptly (``SystemExit``,
+                ``KeyboardInterrupt``, ``CancelledError``) so the consumer
+                never blocks forever.
+        """
+        try:
+            first = True
+            for chunk in _make_chunks():
+                if not attempt_scan_ids and chunk.scan_id:
+                    attempt_scan_ids.append(chunk.scan_id)
+                if first:
+                    cmd_chunk = ScanChunk(
+                        scan_id=chunk.scan_id,
+                        project_root=chunk.project_root,
+                        options=chunk.options if chunk.HasField("options") else None,
+                        files=list(chunk.files),
+                        last=chunk.last,
+                        fix_options=fix_opts,
+                    )
+                    first = False
+                else:
+                    cmd_chunk = chunk
+                cmd_queue.put(SessionCommand(upload=cmd_chunk))
+        except Exception as exc:  # noqa: BLE001 — recorded, reported by main thread
+            producer_errors.append(exc)
+            cmd_queue.put(None)
+        except BaseException:
+            # SystemExit/KeyboardInterrupt/CancelledError would otherwise
+            # kill this thread with no sentinel and hang _drain_commands
+            # forever — enqueue it for liveness, then re-raise.
+            cmd_queue.put(None)
+            raise
+
+    def _drain_commands(cmd_queue: queue.Queue[SessionCommand | None]) -> Iterator[SessionCommand]:
         """Yield commands from the queue (uploads + interactive commands).
+
+        Args:
+            cmd_queue: Per-attempt command queue feeding the stream.
 
         Yields:
             SessionCommand: Next command until a None sentinel stops iteration.
@@ -125,110 +209,166 @@ def run_remediate(args: argparse.Namespace) -> None:
                 return
             yield cmd
 
-    channel, _ = resolve_engine(args)
-    stub = engine_pb2_grpc.EngineStub(channel)  # type: ignore[no-untyped-call]
+    for attempt in range(2):
+        retry = False
+        # Reset per-attempt state so a stale attempt-1 report does not pair
+        # with attempt-2 violations/patches after a reconnect retry.
+        tier1_report = None
+        result_violations = []
+        result_patches = []
+        result_files_written = 0
+        cmd_queue: queue.Queue[SessionCommand | None] = queue.Queue()
+        producer_errors: list[Exception] = []
+        attempt_scan_ids: list[str] = []
 
-    use_json = getattr(args, "json", False)
-    tier1_report: FixReport | None = None
-    result_violations: list[ViolationDict] = []
-    result_patches: list[object] = []
-    got_result = False
+        upload_thread = threading.Thread(
+            target=_run_uploads, args=(cmd_queue, producer_errors, attempt_scan_ids), daemon=True
+        )
+        upload_thread.start()
 
-    try:
-        stream_timeout = getattr(args, "timeout", None)
-        responses = stub.FixSession(command_iter(), timeout=stream_timeout)
+        channel, _ = resolve_engine(args)
+        stub = engine_pb2_grpc.EngineStub(channel)  # type: ignore[no-untyped-call]
+        try:
+            responses = stub.FixSession(_drain_commands(cmd_queue), timeout=stream_timeout)
 
-        for event in responses:
-            oneof = event.WhichOneof("event")
+            for event in responses:
+                oneof = event.WhichOneof("event")
 
-            if oneof == "created":
-                pass  # session established
+                if oneof == "created":
+                    pass  # session established
 
-            elif oneof == "error":
-                err = event.error
-                sys.stderr.write(f"  Operation failed [{err.code}]: {err.message}\n")
-                sys.exit(EXIT_ERROR)
+                elif oneof == "error":
+                    err = event.error
+                    sys.stderr.write(f"  Operation failed [{err.code}]: {err.message}\n")
+                    sys.exit(EXIT_ERROR)
 
-            elif oneof == "progress":
-                p = event.progress
-                verbosity = getattr(args, "verbose", 0) or 0
-                min_level = {0: 2, 1: 2}.get(verbosity, 1)
-                if p.level < min_level:
-                    continue
-                phase = f"[{p.phase}] " if p.phase else ""
-                _LEVEL_FMT = {1: dim, 3: yellow, 4: red}
-                fmt = _LEVEL_FMT.get(p.level, str)
-                sys.stderr.write(f"  {phase}{fmt(p.message)}\n")
+                elif oneof == "progress":
+                    p = event.progress
+                    verbosity = getattr(args, "verbose", 0) or 0
+                    min_level = {0: 2, 1: 2}.get(verbosity, 1)
+                    if p.level < min_level:
+                        continue
+                    phase = f"[{p.phase}] " if p.phase else ""
+                    _LEVEL_FMT = {1: dim, 3: yellow, 4: red}
+                    fmt = _LEVEL_FMT.get(p.level, str)
+                    sys.stderr.write(f"  {phase}{fmt(p.message)}\n")
 
-            elif oneof == "tier1_complete":
-                summary = event.tier1_complete
-                tier1_report = summary.report if summary.HasField("report") else FixReport()
-                if not use_json:
-                    _render_tier1(summary)
+                elif oneof == "tier1_complete":
+                    summary = event.tier1_complete
+                    tier1_report = summary.report if summary.HasField("report") else FixReport()
+                    if not use_json:
+                        _render_tier1(summary)
 
-            elif oneof == "proposals":
-                proposals = list(event.proposals.proposals)
-                if not proposals:
-                    continue
+                elif oneof == "proposals":
+                    proposals = list(event.proposals.proposals)
+                    if not proposals:
+                        continue
 
-                if getattr(args, "auto_approve", False):
-                    approved = [p.id for p in proposals]
-                elif use_json:
-                    approved = []
-                else:
-                    approved = _interactive_review(proposals)
+                    if getattr(args, "auto_approve", False):
+                        approved = [p.id for p in proposals]
+                    elif use_json:
+                        approved = []
+                    else:
+                        approved = _interactive_review(proposals)
 
-                cmd_queue.put(
-                    SessionCommand(
-                        approve=ApprovalRequest(approved_ids=approved),
+                    cmd_queue.put(
+                        SessionCommand(
+                            approve=ApprovalRequest(approved_ids=approved),
+                        )
                     )
-                )
 
-            elif oneof == "ai_triage":
-                # CLI has no Include/Skip UI (SPA owns that). Escalate every
-                # candidate path so --ai --interactive matches pre-triage behavior.
-                paths = sorted({c.path for c in event.ai_triage.candidates if c.path})
-                if not use_json:
+                elif oneof == "ai_triage":
+                    # CLI has no Include/Skip UI (SPA owns that). Escalate every
+                    # candidate path so --ai --interactive matches pre-triage behavior.
+                    paths = sorted({c.path for c in event.ai_triage.candidates if c.path})
+                    if not use_json:
+                        sys.stderr.write(
+                            f"  AI escalation: including {len(paths)} location(s)\n",
+                        )
+                    targets = [AiEscalateTarget(path=p, rule_ids=[]) for p in paths]
+                    cmd_queue.put(
+                        SessionCommand(ai_escalate=AiEscalateRequest(targets=targets)),
+                    )
+
+                elif oneof == "approval_ack":
+                    ack = event.approval_ack
+                    sys.stderr.write(f"  Applied {ack.applied_count} proposal(s)\n")
+
+                elif oneof == "result":
+                    result = event.result
+                    result_violations = [violation_proto_to_dict(v) for v in result.remaining_violations]
+                    result_patches = list(result.patches)
+                    got_result = True
+                    # Patches stay buffered: _write_patches runs only after
+                    # the producer is verified clean (below), so a partial
+                    # upload never mutates disk.
+                    cmd_queue.put(SessionCommand(close=CloseRequest()))
+
+                elif oneof == "expiring":
                     sys.stderr.write(
-                        f"  AI escalation: including {len(paths)} location(s)\n",
+                        f"  Session expires in {event.expiring.ttl_seconds}s\n",
                     )
-                targets = [AiEscalateTarget(path=p, rule_ids=[]) for p in paths]
-                cmd_queue.put(
-                    SessionCommand(ai_escalate=AiEscalateRequest(targets=targets)),
-                )
+                    cmd_queue.put(SessionCommand(extend=ExtendRequest()))
 
-            elif oneof == "approval_ack":
-                ack = event.approval_ack
-                sys.stderr.write(f"  Applied {ack.applied_count} proposal(s)\n")
+                elif oneof == "data":
+                    payload = event.data
+                    if not use_json:
+                        sys.stderr.write(f"  [{payload.kind}]\n")
 
-            elif oneof == "result":
-                result = event.result
-                result_violations = [violation_proto_to_dict(v) for v in result.remaining_violations]
-                result_patches = list(result.patches)
-                got_result = True
-                _write_patches(target, result.patches)
-                cmd_queue.put(SessionCommand(close=CloseRequest()))
+                elif oneof == "closed":
+                    break
 
-            elif oneof == "expiring":
+        except grpc.RpcError as e:
+            # Only UNAVAILABLE is retried. With stream_timeout=None a
+            # DEADLINE_EXCEEDED is the server adaptive budget expiring —
+            # retrying would re-run the whole scan and double load.
+            transient = e.code() == grpc.StatusCode.UNAVAILABLE
+            # Uploads re-stream deterministically from disk and patches are
+            # only written once a result arrives and the producer is proven
+            # clean, so retrying before any result is safe. A retry starts
+            # a fresh server session with a fresh scan_id; the
+            # attempt-teardown channel.close() cancels the first session's
+            # stream, and interactive approvals are re-prompted on the new
+            # session.
+            if got_result:
+                # Transport drop after a result arrived: keep the buffered
+                # result and fall through to the producer check + deferred
+                # write below instead of discarding success.
                 sys.stderr.write(
-                    f"  Session expires in {event.expiring.ttl_seconds}s\n",
+                    dim(
+                        f"  Connection {e.code().name} after result; using received result\n",
+                    )
                 )
-                cmd_queue.put(SessionCommand(extend=ExtendRequest()))
+            elif transient and attempt == 0:
+                prior_scan = attempt_scan_ids[0] if attempt_scan_ids else "unknown"
+                sys.stderr.write(
+                    dim(
+                        f"  Connection {e.code().name} before result "
+                        f"(attempt {attempt + 1}, scan_id={prior_scan}); retrying session once...\n"
+                    )
+                )
+                retry = True
+            else:
+                sys.stderr.write(f"Engine error: {e.details()}\n")
+                sys.exit(EXIT_ERROR)
+        finally:
+            # Tear down this attempt before any retry rebuilds it.
+            cmd_queue.put(None)
+            upload_thread.join(timeout=30)
+            channel.close()
 
-            elif oneof == "data":
-                payload = event.data
-                if not use_json:
-                    sys.stderr.write(f"  [{payload.kind}]\n")
-
-            elif oneof == "closed":
-                break
-
-    except grpc.RpcError as e:
-        sys.stderr.write(f"Engine error: {e.details()}\n")
-        sys.exit(EXIT_ERROR)
-    finally:
-        cmd_queue.put(None)
-        channel.close()
+        if producer_errors:
+            sys.stderr.write(f"{producer_errors[0]}\n")
+            sys.exit(EXIT_ERROR)
+        if got_result:
+            # Deferred until the producer is proven clean above: a partial
+            # or synthetic result must never mutate disk on a failed run.
+            result_files_written = _write_patches(target, result_patches)
+            break
+        if retry:
+            time.sleep(1.0 + random.uniform(0, 1.0))
+            continue
+        break
 
     if not got_result:
         sys.stderr.write("Error: no session result received from engine\n")
@@ -244,7 +384,7 @@ def run_remediate(args: argparse.Namespace) -> None:
         result_violations = suppression_result.active
 
     if use_json:
-        _emit_json(result_violations, result_patches, tier1_report)
+        _emit_json(result_violations, result_patches, tier1_report, result_files_written)
     elif result_violations:
         ai_count = sum(1 for v in result_violations if v.get("remediation_class") == "ai-candidate")
         manual_count = len(result_violations) - ai_count
@@ -262,15 +402,19 @@ def run_remediate(args: argparse.Namespace) -> None:
 
 def _emit_json(
     violations: list[ViolationDict],
-    patches: list[object],
+    patches: list[FilePatch],
     report: FixReport | None,
+    files_updated: int | None = None,
 ) -> None:
     """Write structured JSON to stdout.
 
     Args:
         violations: Remaining violations as dicts.
-        patches: Applied patches (proto objects).
+        patches: Applied patches (FilePatch protos).
         report: Tier 1 remediation report.
+        files_updated: Files actually written to disk. Defaults to the
+            patch count when not provided (callers that did not go through
+            ``_write_patches``).
     """
     from apme_engine.cli.output import deduplicate_violations, sort_violations
     from apme_engine.remediation.partition import count_by_remediation_class, count_by_resolution
@@ -278,12 +422,9 @@ def _emit_json(
     violations = deduplicate_violations(sort_violations(violations))
     rem_counts = count_by_remediation_class(violations)
     res_counts = count_by_resolution(violations)
-    diffs = [
-        {"path": p.path, "diff": p.diff}  # type: ignore[attr-defined]
-        for p in patches
-        if getattr(p, "diff", "")
-    ]
+    diffs = [{"path": p.path, "diff": p.diff} for p in patches if p.diff]
     fixable = int(report.fixed) if report else 0
+    written = files_updated if files_updated is not None else sum(1 for _ in patches)
     out: dict[str, object] = {
         "violations": violations,
         "count": len(violations),
@@ -294,19 +435,19 @@ def _emit_json(
         },
         "resolution_summary": dict(res_counts),
         "diffs": diffs,
-        "files_updated": sum(1 for _ in patches),
+        "files_updated": written,
     }
     print(json.dumps(out, indent=2))
 
 
-def _render_tier1(summary: object) -> None:
-    format_diffs = list(summary.format_diffs)  # type: ignore[attr-defined]
-    applied = list(summary.applied_patches)  # type: ignore[attr-defined]
-    report = summary.report  # type: ignore[attr-defined]
+def _render_tier1(summary: Tier1Summary) -> None:
+    format_diffs = list(summary.format_diffs)
+    applied = list(summary.applied_patches)
+    report = summary.report
 
     if format_diffs:
         sys.stderr.write(f"Formatted {len(format_diffs)} file(s)\n")
-    if not summary.idempotency_ok:  # type: ignore[attr-defined]
+    if not summary.idempotency_ok:
         sys.stderr.write("WARNING: Formatter is not idempotent on this input.\n")
     if report:
         sys.stderr.write(
@@ -396,23 +537,39 @@ def _prompt_ynasq() -> str:
         sys.stderr.write("  Please enter y, n, a, s, or q\n")
 
 
-def _write_patches(target: Path, patches: list[object]) -> None:
+def _write_patches(target: Path, patches: Iterable[FilePatch]) -> int:
+    """Write patched files to disk, skipping failures.
+
+    Args:
+        target: Scan target directory or single file.
+        patches: Patches to apply.
+
+    Returns:
+        Number of files actually written (OSError skips excluded).
+    """
     count = 0
     for p in patches:
-        out_path = target / p.path if target.is_dir() else target  # type: ignore[attr-defined]
-        _safe_write(out_path, p.original, p.patched)  # type: ignore[attr-defined]
-        rules = ", ".join(p.applied_rules) if p.applied_rules else "changes"  # type: ignore[attr-defined]
-        sys.stderr.write(f"  Fixed: {p.path} [{rules}]\n")  # type: ignore[attr-defined]
+        out_path = target / p.path if target.is_dir() else target
+        try:
+            _safe_write(out_path, p.original, p.patched)
+        except OSError as exc:
+            sys.stderr.write(f"WARNING: skipping {p.path}: {exc}\n")
+            continue
+        rules = ", ".join(p.applied_rules) if p.applied_rules else "changes"
+        sys.stderr.write(f"  Fixed: {p.path} [{rules}]\n")
         count += 1
     sys.stderr.write(f"\n{count} file(s) updated.\n")
+    return count
 
 
-def _render_remaining(result: object) -> None:
-    remaining = list(result.remaining_violations)  # type: ignore[attr-defined]
+def _render_remaining(result: SessionResult) -> None:
+    remaining = list(result.remaining_violations)
     if not remaining:
         return
     ai_count = sum(
-        getattr(v, "remediation_class", 0) == common_pb2.REMEDIATION_CLASS_AI_CANDIDATE  # type: ignore[attr-defined]
+        # Ignore tracks the stale checked-in stub (missing enum constant);
+        # same pattern as violation_convert.py. Proper fix is upstream #506.
+        v.remediation_class == common_pb2.REMEDIATION_CLASS_AI_CANDIDATE  # type: ignore[attr-defined]
         for v in remaining
     )
     manual_count = len(remaining) - ai_count

--- a/src/apme_engine/daemon/engine_server.py
+++ b/src/apme_engine/daemon/engine_server.py
@@ -1512,6 +1512,15 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         except Exception as e:
             logger.exception("FixSession failed (session=%s): %s", scan_id, e)
             raise
+        finally:
+            # Client cancellation raises CancelledError (a BaseException),
+            # which bypasses both the except chain and the explicit close
+            # path above — remove here so a cancelled stream never leaks
+            # its session until TTL (exhaustible: _MAX_SESSIONS=10).
+            # SessionStore.remove() is idempotent (pop-with-default), so a
+            # second remove after an explicit close is a harmless no-op.
+            if session:
+                store.remove(session.session_id)
 
     # ── FixSession helpers ─────────────────────────────────────────────
 

--- a/src/apme_engine/daemon/engine_server.py
+++ b/src/apme_engine/daemon/engine_server.py
@@ -1504,6 +1504,10 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
                 elif oneof == "close":
                     if session:
                         store.remove(session.session_id)
+                    if upload_created_session_id and (
+                        session is None or upload_created_session_id != session.session_id
+                    ):
+                        store.remove(upload_created_session_id)
                     upload_created_session_id = None
                     yield SessionEvent(closed=SessionClosed())
                     return

--- a/src/apme_engine/daemon/engine_server.py
+++ b/src/apme_engine/daemon/engine_server.py
@@ -1397,10 +1397,13 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
             SessionEvent: Events streamed to the client.
 
         Raises:
+            asyncio.CancelledError: Re-raised after cleaning up upload-created
+                sessions on client disconnect.
             Exception: Propagates unexpected errors after logging.
         """
         store = self._get_session_store()
         session: SessionState | None = None
+        session_created_by_stream = False
         scan_id = ""
 
         try:
@@ -1415,6 +1418,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
                             store,
                             chunk,
                         )
+                        session_created_by_stream = True
                         yield SessionEvent(
                             created=SessionCreated(
                                 session_id=session.session_id,
@@ -1500,9 +1504,17 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
                 elif oneof == "close":
                     if session:
                         store.remove(session.session_id)
+                        session_created_by_stream = False
                     yield SessionEvent(closed=SessionClosed())
                     return
 
+        except asyncio.CancelledError:
+            # Client disconnect raises CancelledError (a BaseException), which
+            # bypasses the explicit close path.  Remove only sessions this stream
+            # created so gateway reconnect can ResumeRequest without NOT_FOUND.
+            if session and session_created_by_stream:
+                store.remove(session.session_id)
+            raise
         except ResourceExhaustedError as e:
             await context.abort(grpc.StatusCode.RESOURCE_EXHAUSTED, str(e))
         except RequiredValidatorDependencyError as e:
@@ -1512,15 +1524,6 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         except Exception as e:
             logger.exception("FixSession failed (session=%s): %s", scan_id, e)
             raise
-        finally:
-            # Client cancellation raises CancelledError (a BaseException),
-            # which bypasses both the except chain and the explicit close
-            # path above — remove here so a cancelled stream never leaks
-            # its session until TTL (exhaustible: _MAX_SESSIONS=10).
-            # SessionStore.remove() is idempotent (pop-with-default), so a
-            # second remove after an explicit close is a harmless no-op.
-            if session:
-                store.remove(session.session_id)
 
     # ── FixSession helpers ─────────────────────────────────────────────
 

--- a/src/apme_engine/daemon/engine_server.py
+++ b/src/apme_engine/daemon/engine_server.py
@@ -1403,7 +1403,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
         """
         store = self._get_session_store()
         session: SessionState | None = None
-        session_created_by_stream = False
+        upload_created_session_id: str | None = None
         scan_id = ""
 
         try:
@@ -1418,7 +1418,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
                             store,
                             chunk,
                         )
-                        session_created_by_stream = True
+                        upload_created_session_id = session.session_id
                         yield SessionEvent(
                             created=SessionCreated(
                                 session_id=session.session_id,
@@ -1504,7 +1504,7 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
                 elif oneof == "close":
                     if session:
                         store.remove(session.session_id)
-                        session_created_by_stream = False
+                    upload_created_session_id = None
                     yield SessionEvent(closed=SessionClosed())
                     return
 
@@ -1512,8 +1512,8 @@ class EngineServicer(engine_pb2_grpc.EngineServicer):
             # Client disconnect raises CancelledError (a BaseException), which
             # bypasses the explicit close path.  Remove only sessions this stream
             # created so gateway reconnect can ResumeRequest without NOT_FOUND.
-            if session and session_created_by_stream:
-                store.remove(session.session_id)
+            if upload_created_session_id:
+                store.remove(upload_created_session_id)
             raise
         except ResourceExhaustedError as e:
             await context.abort(grpc.StatusCode.RESOURCE_EXHAUSTED, str(e))

--- a/src/apme_engine/daemon/gitleaks_validator_server.py
+++ b/src/apme_engine/daemon/gitleaks_validator_server.py
@@ -202,6 +202,7 @@ class GitleaksValidatorServicer(validate_pb2_grpc.ValidatorServicer):
             HealthResponse with status including gitleaks version or error.
         """
         try:
+            deadline = time.monotonic() + _HEALTH_TIMEOUT_S
             proc = await asyncio.create_subprocess_exec(
                 GITLEAKS_BIN,
                 "version",
@@ -209,21 +210,19 @@ class GitleaksValidatorServicer(validate_pb2_grpc.ValidatorServicer):
                 stderr=asyncio.subprocess.PIPE,
             )
             try:
-                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_HEALTH_TIMEOUT_S)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    with contextlib.suppress(OSError):
+                        proc.kill()
+                    return HealthResponse(status="gitleaks health timeout")
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=remaining)
             except TimeoutError:
                 with contextlib.suppress(OSError):
                     proc.kill()
-                try:
-                    await asyncio.wait_for(proc.wait(), timeout=_HEALTH_TIMEOUT_S)
-                except TimeoutError:
-                    # The first kill did not reap the child; re-kill (this
-                    # codebase only uses kill, so no terminate escalation
-                    # applies) and do a final bounded wait. Never return
-                    # while a child may be unreaped without a warning.
-                    with contextlib.suppress(OSError):
-                        proc.kill()
+                remaining = deadline - time.monotonic()
+                if remaining > 0:
                     try:
-                        await asyncio.wait_for(proc.wait(), timeout=_HEALTH_TIMEOUT_S)
+                        await asyncio.wait_for(proc.wait(), timeout=remaining)
                     except TimeoutError:
                         logger.warning("Gitleaks: health probe still unreaped after kill; possible zombie")
                 return HealthResponse(status="gitleaks health timeout")

--- a/src/apme_engine/daemon/gitleaks_validator_server.py
+++ b/src/apme_engine/daemon/gitleaks_validator_server.py
@@ -6,6 +6,7 @@ files are written.
 """
 
 import asyncio
+import contextlib
 import contextvars
 import json
 import logging
@@ -28,6 +29,9 @@ from apme_engine.validators.gitleaks.scanner import GITLEAKS_BIN, run_gitleaks_n
 logger = logging.getLogger("apme.gitleaks")
 
 _MAX_CONCURRENT_RPCS = int(os.environ.get("APME_GITLEAKS_MAX_RPCS", "16"))
+
+#: Bound for the gitleaks ``version`` probe and for reaping it after a timeout.
+_HEALTH_TIMEOUT_S = 5.0
 
 
 def _extract_nodes_from_graph_data(raw: bytes) -> tuple[list[tuple[str, str]], set[str]]:
@@ -204,7 +208,25 @@ class GitleaksValidatorServicer(validate_pb2_grpc.ValidatorServicer):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            try:
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_HEALTH_TIMEOUT_S)
+            except TimeoutError:
+                with contextlib.suppress(OSError):
+                    proc.kill()
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=_HEALTH_TIMEOUT_S)
+                except TimeoutError:
+                    # The first kill did not reap the child; re-kill (this
+                    # codebase only uses kill, so no terminate escalation
+                    # applies) and do a final bounded wait. Never return
+                    # while a child may be unreaped without a warning.
+                    with contextlib.suppress(OSError):
+                        proc.kill()
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=_HEALTH_TIMEOUT_S)
+                    except TimeoutError:
+                        logger.warning("Gitleaks: health probe still unreaped after kill; possible zombie")
+                return HealthResponse(status="gitleaks health timeout")
             if proc.returncode == 0:
                 version = stdout.decode().strip()
                 return HealthResponse(status=f"ok (gitleaks {version})")

--- a/src/apme_engine/engine/risk_assessment_model.py
+++ b/src/apme_engine/engine/risk_assessment_model.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
+from pathlib import PurePath, PureWindowsPath
 from typing import cast
 
 import jsonpickle
@@ -39,6 +40,20 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _findings_path_parts(findings_path: str) -> tuple[str, ...]:
+    """Split a findings JSON path into components on any OS separator.
+
+    Args:
+        findings_path: Absolute or relative path to a findings.json file.
+
+    Returns:
+        Path components using the native or Windows separator as appropriate.
+    """
+    if os.sep == "\\" or "\\" in findings_path:
+        return PureWindowsPath(findings_path).parts
+    return PurePath(findings_path).parts
 
 
 def _safe_str(v: YAMLValue, default: str = "") -> str:
@@ -759,7 +774,7 @@ class RAMClient:
                     if m.fqcn == search_name or m.fqcn == name or m.fqcn.endswith(f".{short_name}"):
                         matched = True
                 if matched:
-                    parts = findings_json.split("/")
+                    parts = _findings_path_parts(findings_json)
                     if len(parts) < 6:
                         logger.debug("Skipping module with short findings path: %r", findings_json)
                         continue
@@ -854,7 +869,7 @@ class RAMClient:
                     if r.fqcn == name or r.fqcn.endswith(f".{name}"):
                         matched = True
                 if matched:
-                    parts = findings_json.split("/")
+                    parts = _findings_path_parts(findings_json)
                     if len(parts) < 5:
                         logger.debug("Skipping role with short findings path: %r", findings_json)
                         continue
@@ -1004,7 +1019,7 @@ class RAMClient:
 
                 # TODO: support taskfile reference with variables
                 if matched:
-                    parts = findings_json.split("/")
+                    parts = _findings_path_parts(findings_json)
                     if len(parts) < 5:
                         logger.debug("Skipping taskfile with short findings path: %r", findings_json)
                         continue
@@ -1113,7 +1128,7 @@ class RAMClient:
                         if t.name == name or (t.name and name in t.name):
                             matched = True
                 if matched:
-                    parts = findings_json.split("/")
+                    parts = _findings_path_parts(findings_json)
                     if len(parts) < 5:
                         logger.debug("Skipping task with short findings path: %r", findings_json)
                         continue
@@ -1213,7 +1228,7 @@ class RAMClient:
             objs = ObjectList.from_json(fpath=obj_json)
             obj = objs.find_by_key(obj_key)
             if obj is not None:
-                parts = obj_json.split("/")
+                parts = _findings_path_parts(obj_json)
                 if len(parts) < 6:
                     logger.debug("Skipping object with short JSON path: %r", obj_json)
                     continue
@@ -1269,7 +1284,7 @@ class RAMClient:
             target_version = "*"
         found_path_list = []
         for findings_path in self._findings_json_list_cache:
-            parts = findings_path.split("/")
+            parts = _findings_path_parts(findings_path)
             if len(parts) < 5:
                 logger.debug("Skipping findings with short path: %r", findings_path)
                 continue

--- a/src/apme_engine/engine/risk_assessment_model.py
+++ b/src/apme_engine/engine/risk_assessment_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from dataclasses import dataclass, field
 from typing import cast
@@ -36,6 +37,8 @@ from .utils import (
     remove_lock_file,
     unlock_file,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _safe_str(v: YAMLValue, default: str = "") -> str:
@@ -757,6 +760,9 @@ class RAMClient:
                         matched = True
                 if matched:
                     parts = findings_json.split("/")
+                    if len(parts) < 6:
+                        logger.debug("Skipping module with short findings path: %r", findings_json)
+                        continue
 
                     matched_modules.append(
                         {
@@ -849,6 +855,9 @@ class RAMClient:
                         matched = True
                 if matched:
                     parts = findings_json.split("/")
+                    if len(parts) < 5:
+                        logger.debug("Skipping role with short findings path: %r", findings_json)
+                        continue
                     offspring_objects = []
                     for taskfile_key in r.taskfiles:
                         tf_key = taskfile_key.key if isinstance(taskfile_key, TaskFile) else str(taskfile_key)
@@ -996,6 +1005,9 @@ class RAMClient:
                 # TODO: support taskfile reference with variables
                 if matched:
                     parts = findings_json.split("/")
+                    if len(parts) < 5:
+                        logger.debug("Skipping taskfile with short findings path: %r", findings_json)
+                        continue
                     offspring_objects = []
                     for task_key in tf.tasks:
                         t_key = task_key.key if isinstance(task_key, Task) else str(task_key)
@@ -1102,7 +1114,13 @@ class RAMClient:
                             matched = True
                 if matched:
                     parts = findings_json.split("/")
+                    if len(parts) < 5:
+                        logger.debug("Skipping task with short findings path: %r", findings_json)
+                        continue
                     offspring_objects = []
+                    # Unknown executable types yield no offspring (a Task with
+                    # a missing/unrecognized type must not crash the search).
+                    _tmp_offspring_objects: list[YAMLDict] = []
                     if t.executable_type == ExecutableType.MODULE_TYPE:
                         _tmp_offspring_objects = self.search_module(t.executable, used_in=t.defined_in)
                     elif t.executable_type == ExecutableType.ROLE_TYPE:
@@ -1110,6 +1128,12 @@ class RAMClient:
                     elif t.executable_type == ExecutableType.TASKFILE_TYPE:
                         _tmp_offspring_objects = self.search_taskfile(
                             t.executable, from_path=t.defined_in, from_key=t.key, used_in=t.defined_in
+                        )
+                    else:
+                        logger.debug(
+                            "Task %r has unrecognized executable_type %r; no offspring collected",
+                            t.key,
+                            t.executable_type,
                         )
                     if len(_tmp_offspring_objects) > 0:
                         child = _tmp_offspring_objects[0]
@@ -1190,6 +1214,9 @@ class RAMClient:
             obj = objs.find_by_key(obj_key)
             if obj is not None:
                 parts = obj_json.split("/")
+                if len(parts) < 6:
+                    logger.debug("Skipping object with short JSON path: %r", obj_json)
+                    continue
                 matched_obj = {
                     "object": obj,
                     "defined_in": {
@@ -1243,12 +1270,15 @@ class RAMClient:
         found_path_list = []
         for findings_path in self._findings_json_list_cache:
             parts = findings_path.split("/")
+            if len(parts) < 5:
+                logger.debug("Skipping findings with short path: %r", findings_path)
+                continue
             _type = parts[-5][:-1]
             _name = parts[-4]
             _version = parts[-3]
             if _name != target_name:
                 continue
-            if target_version and target_version != "*" and _version != target_name:
+            if target_version and target_version != "*" and _version != target_version:
                 continue
             if target_type and target_type != "*" and _type != target_type:
                 continue

--- a/src/apme_engine/remediation/abbenay_provider.py
+++ b/src/apme_engine/remediation/abbenay_provider.py
@@ -8,14 +8,18 @@ Alternate (version pin only): ``pip install apme-engine[ai]``.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import functools
 import json
 import logging
 import os
+import random
 from importlib.resources import files as pkg_files
 from pathlib import Path
 
+import grpc
+import grpc.aio
 import yaml
 
 from apme_engine.fingerprint import canonicalize_rule_id
@@ -29,6 +33,32 @@ from apme_engine.remediation.ai_provider import (
 from apme_engine.rule_catalog import _parse_ai_prompt_map
 
 logger = logging.getLogger(__name__)
+
+#: Base delay before the single chat reconnect retry (single retry, so no exponential growth).
+_CHAT_RETRY_BASE_S = 2.0
+#: Added jitter upper bound so concurrent AI nodes do not retry in lockstep.
+_CHAT_RETRY_JITTER_S = 1.0
+#: Client-side bound for one streaming chat attempt.
+_CHAT_ATTEMPT_TIMEOUT_S = 300.0
+
+#: gRPC codes that may heal on reconnect and are safe to retry once.
+#: INTERNAL covers the most common blip (an HTTP/2 RST_STREAM surfacing
+#: as INTERNAL). DEADLINE_EXCEEDED stays retryable because each chat
+#: attempt carries its own client-side 300s bound
+#: (``_CHAT_ATTEMPT_TIMEOUT_S``): one slow call deserves one retry, unlike
+#: whole-scan retries where DEADLINE_EXCEEDED means the server budget
+#: expired and retrying would double load. RESOURCE_EXHAUSTED (quota)
+#: must fail fast — a retry cannot free quota. All other non-transient
+#: codes (UNAUTHENTICATED, PERMISSION_DENIED, NOT_FOUND,
+#: INVALID_ARGUMENT, ...) fail fast without reconnect.
+_CHAT_TRANSIENT_CODES: frozenset[grpc.StatusCode] = frozenset(
+    {
+        grpc.StatusCode.UNAVAILABLE,
+        grpc.StatusCode.INTERNAL,
+        grpc.StatusCode.UNKNOWN,
+        grpc.StatusCode.DEADLINE_EXCEEDED,
+    }
+)
 
 _BEST_PRACTICES: dict[str, list[str]] | None = None
 
@@ -784,6 +814,11 @@ class AbbenayProvider:
     ) -> str:
         """Call chat, reconnecting once on connection failure.
 
+        The single retry waits out a base delay plus jitter so an
+        Abbenay flap is not amplified by every AI node reconnecting at
+        once, and each attempt is bounded by a client-side timeout so a
+        hung chat stream cannot block the caller indefinitely.
+
         Args:
             model: Model identifier.
             prompt: User prompt text.
@@ -793,27 +828,99 @@ class AbbenayProvider:
             Concatenated response text from the model.
 
         Raises:
-            Exception: If the chat call fails after one reconnect retry.
+            TimeoutError: If a chat attempt exceeds the client-side bound
+                (a slow stream, not a disconnect — never retried).
+            OSError: If the reconnect retry also fails with a transport
+                error (covers builtin ``ConnectionError``).
+            grpc.aio.AioRpcError: If the retry attempt RPC fails with a
+                transient code, or immediately on the first attempt with a
+                permanent code (RESOURCE_EXHAUSTED, UNAUTHENTICATED,
+                PERMISSION_DENIED, NOT_FOUND, INVALID_ARGUMENT, and all
+                other non-transient codes fail fast without reconnect).
+            AssertionError: If the retry loop exhausts without returning
+                (unreachable defense-in-depth).
+            Exception: If the chat call fails for permanent
+                (non-connection) errors — auth, quota, not-found,
+                validation — which fail fast without retry.
         """
         for attempt in range(2):
+            if attempt > 0:
+                # Single retry, so the delay is constant (base + jitter) —
+                # no exponential factor: the loop runs at most twice, so an
+                # exponential term would always be 1 here.
+                await asyncio.sleep(_CHAT_RETRY_BASE_S + random.uniform(0, _CHAT_RETRY_JITTER_S))
             try:
-                response_text = ""
-                async for chunk in self._client.chat(  # type: ignore[attr-defined]
-                    model=model,
-                    message=prompt,
-                    policy=policy,
-                    token=self._token,
-                ):
-                    if hasattr(chunk, "text") and chunk.text:
-                        response_text += chunk.text
-                return response_text
-            except Exception:
-                if attempt == 0:
-                    logger.debug("Chat failed, reconnecting to Abbenay and retrying")
-                    await self.reconnect()
-                else:
+                return await asyncio.wait_for(
+                    self._consume_chat(model, prompt, policy),
+                    timeout=_CHAT_ATTEMPT_TIMEOUT_S,
+                )
+            except TimeoutError:
+                # A slow-but-healthy stream tripping the attempt bound is not
+                # a disconnect — retrying would burn the single attempt on
+                # the same slow call. This must stay before the transient
+                # handler: builtin TimeoutError subclasses OSError.
+                raise
+            except grpc.aio.AioRpcError as exc:
+                # Only transient gRPC codes may heal on reconnect. Permanent
+                # codes (auth, not-found, invalid-argument, ...) fail fast
+                # without reconnect.
+                if exc.code() not in _CHAT_TRANSIENT_CODES:
                     raise
-        return ""  # unreachable but satisfies mypy
+                if attempt > 0:
+                    raise
+                logger.debug("Chat transient gRPC failure, reconnecting to Abbenay and retrying")
+                # A failed reconnect must not mask the original error or
+                # consume the remaining attempt: suppress it and retry the
+                # chat anyway.
+                with contextlib.suppress(Exception):
+                    await self.reconnect()
+            # This path is purely gRPC: _consume_chat streams
+            # AbbenayClient.chat (abbenay_grpc, unix-socket or TCP) and
+            # reconnect rebuilds that same client — no httpx client exists
+            # here (the only HTTP/httpx Abbenay usage is the Gateway's
+            # admin proxy, a different service and path). Socket-level
+            # dial failures surface as OSError and may heal on reconnect.
+            except OSError:
+                if attempt > 0:
+                    raise
+                logger.debug("Chat connection failed, reconnecting to Abbenay and retrying")
+                # A failed reconnect must not mask the original error or
+                # consume the remaining attempt: suppress it and retry the
+                # chat anyway.
+                with contextlib.suppress(Exception):
+                    await self.reconnect()
+            except Exception:
+                # Permanent failures (auth, not-found/invalid-model,
+                # validation) will not heal on reconnect — fail fast.
+                raise
+        raise AssertionError("unreachable: chat retry loop exhausted")
+
+    async def _consume_chat(
+        self,
+        model: str,
+        prompt: str,
+        policy: dict[str, object],
+    ) -> str:
+        """Stream one chat response into concatenated text.
+
+        Args:
+            model: Model identifier.
+            prompt: User prompt text.
+            policy: Sampling/output policy dict.
+
+        Returns:
+            Concatenated response text from the model.
+        """
+        response_text = ""
+        async for chunk in self._client.chat(  # type: ignore[attr-defined]
+            model=model,
+            message=prompt,
+            policy=policy,
+            token=self._token,
+        ):
+            if hasattr(chunk, "text") and chunk.text:
+                response_text += chunk.text
+        return response_text
 
     async def propose_node_fix(
         self,

--- a/src/apme_engine/remediation/graph_engine.py
+++ b/src/apme_engine/remediation/graph_engine.py
@@ -802,10 +802,14 @@ class GraphRemediationEngine:
         """
         dirty = graph.dirty_nodes
         effective_dirty = expand_dirty_node_ids(graph, self._rules, dirty)
+        # NOTE: both rescan paths receive the *expanded* set.  Recording and
+        # resolution below already operate on effective_dirty, and the
+        # built-in rescan expands internally as well — scanning only the raw
+        # dirty set would resolve ancestors that were never re-evaluated.
         if self._rescan_fn is not None:
-            new_violations = await self._rescan_fn(graph, dirty)
+            new_violations = await self._rescan_fn(graph, effective_dirty)
         else:
-            rescan_report = rescan_dirty(graph, self._rules, dirty)
+            rescan_report = rescan_dirty(graph, self._rules, effective_dirty)
             new_violations = graph_report_to_violations(rescan_report)
 
         _record_violations(

--- a/src/apme_engine/venv_manager/session.py
+++ b/src/apme_engine/venv_manager/session.py
@@ -27,12 +27,14 @@ Storage layout::
 
 from __future__ import annotations
 
+import contextlib
 import fcntl
 import json
 import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -164,6 +166,91 @@ class PipInstallTimeout(TimeoutError):
     """
 
 
+#: Brief bound for reaping a pip/uv process group after SIGTERM/SIGKILL.
+_SUBPROCESS_REAP_TIMEOUT_S = 5.0
+
+
+def _terminate_process_group(proc: subprocess.Popen[str]) -> None:
+    """Send SIGTERM to ``proc`` and its descendants (when supported).
+
+    Args:
+        proc: Running subprocess handle.
+    """
+    if proc.pid is None:
+        return
+    if hasattr(os, "killpg"):
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        return
+    with contextlib.suppress(OSError):
+        proc.terminate()
+
+
+def _kill_process_group(proc: subprocess.Popen[str]) -> None:
+    """Force-kill ``proc`` and its descendants (when supported).
+
+    Args:
+        proc: Running subprocess handle.
+    """
+    if proc.pid is None:
+        return
+    if hasattr(os, "killpg"):
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        return
+    with contextlib.suppress(OSError):
+        proc.kill()
+
+
+def _run_subprocess_timed(
+    cmd: list[str],
+    *,
+    timeout: float,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``cmd`` in an isolated process group with a wall-clock bound.
+
+    ``subprocess.run(..., timeout=...)`` kills only the direct child; pip/uv
+    workers can survive and keep the session lock pinned.  This helper starts
+    the command in a new session/process group and terminates the whole group
+    on timeout.
+
+    Args:
+        cmd: Command argv.
+        timeout: Wall-clock bound in seconds.
+        check: If True, raise ``CalledProcessError`` on non-zero exit.
+
+    Returns:
+        CompletedProcess with stdout/stderr captured.
+
+    Raises:
+        subprocess.TimeoutExpired: If the command exceeds ``timeout``.
+        subprocess.CalledProcessError: If ``check`` is True and exit code is non-zero.
+    """
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        _terminate_process_group(proc)
+        try:
+            stdout, stderr = proc.communicate(timeout=_SUBPROCESS_REAP_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            _kill_process_group(proc)
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                stdout, stderr = proc.communicate(timeout=_SUBPROCESS_REAP_TIMEOUT_S)
+        raise subprocess.TimeoutExpired(cmd, timeout, output=exc.output, stderr=exc.stderr) from exc
+
+    if check and proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, cmd, stdout, stderr)
+    return subprocess.CompletedProcess(cmd, proc.returncode or 0, stdout, stderr)
+
+
 def _run_pip_install(
     pip_python: Path,
     pip_specs: list[str],
@@ -228,7 +315,7 @@ def _run_pip_install(
             cmd.extend(["--only-binary", ":all:"])
         cmd.extend(pip_specs)
     try:
-        return subprocess.run(cmd, capture_output=True, text=True, timeout=_PIP_INSTALL_TIMEOUT_S)
+        return _run_subprocess_timed(cmd, timeout=_PIP_INSTALL_TIMEOUT_S)
     except subprocess.TimeoutExpired as exc:
         logger.warning(
             "pip/uv install timed out after %ds, failing fast (no exclude/no-build retry)",
@@ -466,7 +553,7 @@ def _run_base_venv_cmd(cmd: list[str]) -> subprocess.CompletedProcess[str]:
         PipInstallTimeout: If the command exceeds its wall-clock bound.
     """
     try:
-        return subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=_PIP_INSTALL_TIMEOUT_S)
+        return _run_subprocess_timed(cmd, timeout=_PIP_INSTALL_TIMEOUT_S, check=True)
     except subprocess.TimeoutExpired as exc:
         logger.warning(
             "base venv setup timed out after %ds, failing fast",

--- a/src/apme_engine/venv_manager/session.py
+++ b/src/apme_engine/venv_manager/session.py
@@ -149,6 +149,20 @@ def _spec_to_pip(spec: str) -> str:
 
 _FAILED_BUILD_RE = re.compile(r"Failed to build `([^`]+)`")
 
+#: Wall-clock bound for a single pip/uv install invocation.  Without it a
+#: stalled index fetch hangs ``subprocess.run`` forever, pinning the
+#: ``run_in_executor`` worker until the session lifetime cap fires.
+_PIP_INSTALL_TIMEOUT_S = 600
+
+
+class PipInstallTimeout(TimeoutError):
+    """A pip/uv install exceeded its wall-clock bound.
+
+    Distinct from a build failure: retrying with excludes or ``--no-build``
+    cannot help a stalled index, so callers must fail fast instead of
+    walking the fallback chain.
+    """
+
 
 def _run_pip_install(
     pip_python: Path,
@@ -176,6 +190,13 @@ def _run_pip_install(
 
     Returns:
         CompletedProcess with stdout/stderr captured.
+
+    Raises:
+        PipInstallTimeout: If the install exceeds its wall-clock bound.
+            The message carries the stalled command argv (including the
+            specs) so the failure identifies what hung. Callers must fail
+            fast — the exclude/no-build fallback chain only helps build
+            failures, not stalled indexes.
     """
     if use_uv:
         cmd = [
@@ -206,7 +227,14 @@ def _run_pip_install(
         if no_build:
             cmd.extend(["--only-binary", ":all:"])
         cmd.extend(pip_specs)
-    return subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=_PIP_INSTALL_TIMEOUT_S)
+    except subprocess.TimeoutExpired as exc:
+        logger.warning(
+            "pip/uv install timed out after %ds, failing fast (no exclude/no-build retry)",
+            _PIP_INSTALL_TIMEOUT_S,
+        )
+        raise PipInstallTimeout(f"pip/uv install timed out after {_PIP_INSTALL_TIMEOUT_S}s: {' '.join(cmd)}") from exc
 
 
 def _is_build_failure(output: str) -> bool:
@@ -278,6 +306,10 @@ def _install_collections_via_proxy(
 
     Returns:
         List of collection specs that failed to install (empty on full success).
+
+    Note:
+        A stalled pip/uv install propagates ``PipInstallTimeout`` from the
+        install helpers — failing fast instead of walking the fallback chain.
     """
     simple_url = proxy_url.rstrip("/") + "/simple/"
     pip_specs = [_spec_to_pip(s) for s in collection_specs]
@@ -415,12 +447,44 @@ def _retry_without_native(
         shutil.rmtree(excludes_dir, ignore_errors=True)
 
 
+def _run_base_venv_cmd(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run one base-venv setup command with the shared wall-clock bound.
+
+    Mirrors :func:`_run_pip_install`: a stalled ``uv venv`` / ``venv`` /
+    ``ansible-core`` install must fail fast with :class:`PipInstallTimeout`
+    instead of pinning the ``run_in_executor`` worker forever.  Callers
+    (``VenvSessionManager.acquire``) already record timeout metrics and
+    release the session lock on ``PipInstallTimeout``.
+
+    Args:
+        cmd: Command argv to run.
+
+    Returns:
+        CompletedProcess with stdout/stderr captured.
+
+    Raises:
+        PipInstallTimeout: If the command exceeds its wall-clock bound.
+    """
+    try:
+        return subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=_PIP_INSTALL_TIMEOUT_S)
+    except subprocess.TimeoutExpired as exc:
+        logger.warning(
+            "base venv setup timed out after %ds, failing fast",
+            _PIP_INSTALL_TIMEOUT_S,
+        )
+        raise PipInstallTimeout(f"base venv setup timed out after {_PIP_INSTALL_TIMEOUT_S}s") from exc
+
+
 def create_base_venv(
     venv_dir: Path,
     ansible_core_version: str,
     python_exe: str | None = None,
 ) -> None:
     """Create a virtual environment and install ansible-core into it.
+
+    Each setup command shares the pip/uv wall-clock bound and fails fast
+    with ``PipInstallTimeout`` on stalls, so ``VenvSessionManager.acquire``
+    can record timeout metrics and release the session lock.
 
     Args:
         venv_dir: Exact directory for the virtualenv (created if absent).
@@ -432,27 +496,21 @@ def create_base_venv(
         cmd = ["uv", "venv", str(venv_dir)]
         if python_exe:
             cmd.extend(["--python", python_exe])
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        _run_base_venv_cmd(cmd)
     else:
         cmd = [sys.executable, "-m", "venv", str(venv_dir)]
         if python_exe:
             cmd = [python_exe, "-m", "venv", str(venv_dir)]
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        _run_base_venv_cmd(cmd)
 
     pip_python = get_venv_python(venv_dir)
     if use_uv:
-        subprocess.run(
+        _run_base_venv_cmd(
             ["uv", "pip", "install", "--python", str(pip_python), f"ansible-core=={ansible_core_version}"],
-            check=True,
-            capture_output=True,
-            text=True,
         )
     else:
-        subprocess.run(
+        _run_base_venv_cmd(
             [str(pip_python), "-m", "pip", "install", f"ansible-core=={ansible_core_version}"],
-            check=True,
-            capture_output=True,
-            text=True,
         )
 
 
@@ -816,6 +874,8 @@ class VenvSessionManager:
             A ``VenvSession`` with a ready-to-use venv.
 
         Raises:
+            PipInstallTimeout: If a pip/uv install stalls past its bound —
+                fails fast instead of walking the fallback chain.
             Exception: Re-raises unexpected acquire failures after recording
                 error metrics.
         """
@@ -941,6 +1001,17 @@ class VenvSessionManager:
                     return session
                 finally:
                     fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        except PipInstallTimeout:
+            # Fail fast: a stalled index must not serialize into the
+            # exclude/no-build and per-spec fallback chain under the lock.
+            self._record_acquire_metrics(
+                t0,
+                outcome="timeout",
+                ansible_version=pip_version,
+                collections_requested=len(specs),
+                status="error",
+            )
+            raise
         except Exception:
             self._record_acquire_metrics(
                 t0,

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -33,6 +33,7 @@ from apme_gateway.operation_types import (
     OperationStatus,
     ProgressEntry,
     Proposal,
+    is_must_deliver,
     is_terminal,
 )
 
@@ -834,7 +835,7 @@ async def operation_events(project_id: str, request: Request) -> StreamingRespon
                         pending = queue.get_nowait()
                         if pending.get("_close"):
                             break
-                        if is_terminal(pending):
+                        if is_must_deliver(pending):
                             terminal_msgs.append(pending)
                 for terminal_msg in terminal_msgs:
                     terminal_event = terminal_msg.get("event", "message")
@@ -877,7 +878,7 @@ async def operation_events(project_id: str, request: Request) -> StreamingRespon
                             trailing = queue.get_nowait()
                             if trailing.get("_close"):
                                 break
-                            if is_terminal(trailing):
+                            if is_must_deliver(trailing):
                                 trailing_event = trailing.get("event", "message")
                                 if not isinstance(trailing_event, str):
                                     trailing_event = "message"

--- a/src/apme_gateway/api/operation_router.py
+++ b/src/apme_gateway/api/operation_router.py
@@ -13,7 +13,7 @@ import json
 import logging
 import time
 import uuid
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -33,6 +33,7 @@ from apme_gateway.operation_types import (
     OperationStatus,
     ProgressEntry,
     Proposal,
+    is_terminal,
 )
 
 logger = logging.getLogger(__name__)
@@ -811,12 +812,38 @@ async def operation_events(project_id: str, request: Request) -> StreamingRespon
     if queue is None:
         raise HTTPException(status_code=404, detail="Operation not found")
 
-    async def _event_stream() -> Any:
+    async def _event_stream() -> AsyncIterator[str]:
+        """Yield snapshot then delta events until terminal or disconnect.
+
+        Yields:
+            str: SSE-formatted message strings.
+        """
         try:
             snapshot = state.to_snapshot()
             yield _sse_format("snapshot", snapshot)
 
             if state.status in TERMINAL_STATUSES:
+                # The snapshot already reflects the full current state, so
+                # buffered pre-snapshot deltas are stale: discard non-terminal
+                # ones and forward all terminal messages in order (production
+                # order is result-with-patches then bare status_changed, so
+                # last-wins would drop the patches).
+                terminal_msgs: list[dict[str, object]] = []
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    while True:
+                        pending = queue.get_nowait()
+                        if pending.get("_close"):
+                            break
+                        if is_terminal(pending):
+                            terminal_msgs.append(pending)
+                for terminal_msg in terminal_msgs:
+                    terminal_event = terminal_msg.get("event", "message")
+                    if not isinstance(terminal_event, str):
+                        terminal_event = "message"
+                    terminal_data = terminal_msg.get("data") or {}
+                    if not isinstance(terminal_data, dict):
+                        terminal_data = {}
+                    yield _sse_format(terminal_event, terminal_data)
                 return
 
             while True:
@@ -832,10 +859,32 @@ async def operation_events(project_id: str, request: Request) -> StreamingRespon
                     break
 
                 event_type = msg.get("event", "message")
-                data = msg.get("data", {})
+                if not isinstance(event_type, str):
+                    event_type = "message"
+                data = msg.get("data") or {}
+                if not isinstance(data, dict):
+                    data = {}
                 yield _sse_format(event_type, data)
 
-                if data.get("status") in {s.value for s in TERMINAL_STATUSES}:
+                if is_terminal(msg):
+                    # A terminal status_changed may already have a trailing
+                    # result/pr_created queued behind it (e.g. set_pr_url
+                    # transitions before broadcasting). Drain and forward
+                    # trailing terminals so patches/violations are not lost;
+                    # stale non-terminal deltas are discarded.
+                    with contextlib.suppress(asyncio.QueueEmpty):
+                        while True:
+                            trailing = queue.get_nowait()
+                            if trailing.get("_close"):
+                                break
+                            if is_terminal(trailing):
+                                trailing_event = trailing.get("event", "message")
+                                if not isinstance(trailing_event, str):
+                                    trailing_event = "message"
+                                trailing_data = trailing.get("data") or {}
+                                if not isinstance(trailing_data, dict):
+                                    trailing_data = {}
+                                yield _sse_format(trailing_event, trailing_data)
                     break
         finally:
             registry.unsubscribe(state.operation_id, queue)
@@ -1173,6 +1222,7 @@ async def _drive_operation(
                         node_type=getattr(p, "node_type", "") or "",
                         suggestion=p.suggestion,
                         line_start=p.line_start,
+                        line_end=p.line_end,
                         before_text=p.before_text or "",
                         after_text=p.after_text or "",
                     )
@@ -1198,6 +1248,7 @@ async def _drive_operation(
                         "status": p.status,
                         "suggestion": p.suggestion,
                         "line_start": p.line_start,
+                        "line_end": p.line_end,
                         "path": p.path,
                         "node_type": getattr(p, "node_type", "") or "",
                         "source": getattr(p, "source", "") or ("ai" if p.tier >= 2 else "deterministic"),

--- a/src/apme_gateway/api/schemas.py
+++ b/src/apme_gateway/api/schemas.py
@@ -125,14 +125,15 @@ class ProposalDetail(BaseModel):  # type: ignore[misc]
         file: File the proposal targets.
         tier: Proposal tier (1 deterministic, 2+ AI).
         confidence: AI confidence score.
-        status: approved, rejected, declined, or pending.
+        status: proposed, approved, rejected, declined, or pending.
         path: Node identity path (optional additive).
         node_type: ContentGraph NodeType value (task, block, play, …).
         source: deterministic, ai, ai-candidate, or outcome (optional additive).
         gate: tier1 or ai (optional additive).
         rule_ids: All rule ids on this approval unit (optional additive).
         violation_ids: Linked violation PKs (optional additive).
-        line_start: First line of the node/finding (optional additive).
+        line_start: First line of the node/finding, 0 when unknown (optional additive).
+        line_end: Last line of the node/finding, 0 when unknown (optional additive).
         diff_hunk: Unified diff when available (optional additive).
         explanation: AI explanation when available (optional additive).
         suggestion: Manual suggestion when available (optional additive).
@@ -153,7 +154,8 @@ class ProposalDetail(BaseModel):  # type: ignore[misc]
     gate: str = ""
     rule_ids: list[str] = Field(default_factory=list)
     violation_ids: list[int] = Field(default_factory=list)
-    line_start: int = 0
+    line_start: int = Field(default=0, ge=0)
+    line_end: int = Field(default=0, ge=0)
     diff_hunk: str = ""
     explanation: str = ""
     suggestion: str = ""

--- a/src/apme_gateway/db/__init__.py
+++ b/src/apme_gateway/db/__init__.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from sqlalchemy import event, inspect, text
+from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
 from apme_gateway.db.dialect import in_clause_chunk_size
 from apme_gateway.db.models import Base
 from apme_gateway.db.url import is_database_url, is_sqlite_url, resolve_database_url, sqlite_url_from_path
+from apme_gateway.scm.repo_url import normalize_repo_url
 
 _engine: AsyncEngine | None = None
 _session_factory: async_sessionmaker[AsyncSession] | None = None
@@ -63,6 +65,7 @@ async def init_db(database_url_or_path: str) -> None:
         await conn.run_sync(_migrate_violations_table)
         await conn.run_sync(_migrate_proposals_table)
         await conn.run_sync(_migrate_scans_table)
+        await conn.run_sync(_migrate_projects_table)
 
 
 async def init_db_from_config(*, database_url: str | None = None, db_path: str | None = None) -> str:
@@ -96,6 +99,7 @@ async def reset_db() -> None:
         await conn.run_sync(_migrate_violations_table)
         await conn.run_sync(_migrate_proposals_table)
         await conn.run_sync(_migrate_scans_table)
+        await conn.run_sync(_migrate_projects_table)
 
 
 def get_engine() -> AsyncEngine:
@@ -218,6 +222,8 @@ def _migrate_proposals_table(conn: object) -> None:
         migrations.append("ALTER TABLE proposals ADD COLUMN violation_ids_json TEXT NOT NULL DEFAULT '[]'")
     if "line_start" not in existing:
         migrations.append("ALTER TABLE proposals ADD COLUMN line_start INTEGER NOT NULL DEFAULT 0")
+    if "line_end" not in existing:
+        migrations.append("ALTER TABLE proposals ADD COLUMN line_end INTEGER NOT NULL DEFAULT 0")
     if "diff_hunk" not in existing:
         migrations.append("ALTER TABLE proposals ADD COLUMN diff_hunk TEXT NOT NULL DEFAULT ''")
     if "explanation" not in existing:
@@ -266,6 +272,43 @@ def _migrate_scans_table(conn: object) -> None:
 
     for stmt in migrations:
         conn.execute(text(stmt))
+
+
+def _migrate_projects_table(conn: Connection) -> None:
+    """Add the indexed ``normalized_repo_url`` column to ``projects``.
+
+    ``create_all`` only creates missing *tables* — it does not add columns
+    to existing tables.  This function adds the column, ensures the lookup
+    index exists, and (re)computes the canonical URL for every row whose
+    stored value is empty or stale (e.g. legacy rows, or rows written before
+    the normalizer preserved scheme/port).
+
+    Args:
+        conn: Synchronous SQLAlchemy connection (from ``run_sync``).
+
+    Raises:
+        TypeError: If *conn* is not a SQLAlchemy connection — a wiring
+            error that must fail loudly, never silently skip the migration.
+    """
+    if not isinstance(conn, Connection):
+        raise TypeError(f"_migrate_projects_table requires a SQLAlchemy Connection, got {type(conn).__name__}")
+    insp = inspect(conn)
+    if not insp.has_table("projects"):
+        return
+    existing = {c["name"] for c in insp.get_columns("projects")}
+
+    if "normalized_repo_url" not in existing:
+        conn.execute(text("ALTER TABLE projects ADD COLUMN normalized_repo_url TEXT NOT NULL DEFAULT ''"))
+    conn.execute(text("CREATE INDEX IF NOT EXISTS ix_projects_normalized_repo_url ON projects (normalized_repo_url)"))
+
+    rows = conn.execute(text("SELECT id, repo_url, normalized_repo_url FROM projects")).all()
+    for row in rows:
+        canonical = normalize_repo_url(row[1] or "")
+        if (row[2] or "") != canonical:
+            conn.execute(
+                text("UPDATE projects SET normalized_repo_url = :normalized WHERE id = :pid"),
+                {"normalized": canonical, "pid": row[0]},
+            )
 
 
 async def close_db() -> None:

--- a/src/apme_gateway/db/models.py
+++ b/src/apme_gateway/db/models.py
@@ -24,6 +24,8 @@ class Project(Base):
         id: UUID hex primary key.
         name: User-facing display label.
         repo_url: HTTPS clone URL for the repository.
+        normalized_repo_url: Canonical URL for indexed lookup (finding #55).
+            Maintained on create/update; backfilled at startup for legacy rows.
         branch: Branch to clone (default ``main``).
         created_at: ISO 8601 creation timestamp.
         health_score: Computed 0-100 health score from latest scan.
@@ -38,6 +40,7 @@ class Project(Base):
     id: Mapped[str] = mapped_column(Text, primary_key=True)
     name: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     repo_url: Mapped[str] = mapped_column(Text, nullable=False)
+    normalized_repo_url: Mapped[str] = mapped_column(Text, nullable=False, default="", index=True)
     branch: Mapped[str] = mapped_column(Text, nullable=False, default="main")
     created_at: Mapped[str] = mapped_column(Text, nullable=False)
     health_score: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
@@ -220,7 +223,8 @@ class Proposal(Base):
         gate: tier1, ai, or empty.
         rule_ids_json: JSON array of all rule ids on this node.
         violation_ids_json: JSON array of linked violation PKs.
-        line_start: First line of the node/finding.
+        line_start: First line of the node/finding (0 when unknown).
+        line_end: Last line of the node/finding (0 when unknown).
         diff_hunk: Unified diff while actionable (ephemeral).
         explanation: AI explanation while actionable (ephemeral).
         suggestion: Manual suggestion text.
@@ -250,6 +254,7 @@ class Proposal(Base):
     rule_ids_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
     violation_ids_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
     line_start: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    line_end: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     diff_hunk: Mapped[str] = mapped_column(Text, nullable=False, default="")
     explanation: Mapped[str] = mapped_column(Text, nullable=False, default="")
     suggestion: Mapped[str] = mapped_column(Text, nullable=False, default="")

--- a/src/apme_gateway/db/queries.py
+++ b/src/apme_gateway/db/queries.py
@@ -299,10 +299,7 @@ async def update_project(db: AsyncSession, project_id: str, **fields: str | None
         ValueError: If ``repo_url`` is explicitly ``None``, empty, or blank.
     """
     if "normalized_repo_url" in fields:
-        logger.warning(
-            "update_project: ignoring caller-supplied normalized_repo_url %r",
-            fields.get("normalized_repo_url"),
-        )
+        logger.warning("update_project: ignoring caller-supplied normalized_repo_url")
         fields.pop("normalized_repo_url", None)
     if "repo_url" in fields:
         repo_value = fields["repo_url"]

--- a/src/apme_gateway/db/queries.py
+++ b/src/apme_gateway/db/queries.py
@@ -32,6 +32,7 @@ from apme_gateway.db.models import (
     Suppression,
     Violation,
 )
+from apme_gateway.scm.repo_url import normalize_repo_url
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +128,7 @@ async def create_project(
         id=project_id,
         name=name,
         repo_url=repo_url,
+        normalized_repo_url=normalize_repo_url(repo_url),
         branch=branch,
         created_at=now,
         scm_token=scm_token or None,
@@ -182,17 +184,49 @@ async def find_project_by_repo_url(
     Returns:
         Matching project, or ``None`` when no normalized URL matches.
     """
-    from apme_gateway.scm.repo_url import normalize_repo_url
-
     target = normalize_repo_url(repo_url)
-    stmt = select(Project)
+    if not target:
+        return None
+    conditions = [Project.normalized_repo_url == target]
+    if branch is not None:
+        conditions.append(Project.branch == branch)
+    stmt = select(Project).where(*conditions).order_by(Project.id).limit(1)
     result = await db.execute(stmt)
-    for project in result.scalars().all():
-        if normalize_repo_url(project.repo_url) != target:
-            continue
-        if branch is not None and project.branch != branch:
-            continue
-        return cast(Project, project)
+    found = result.scalars().first()
+    if found is not None:
+        return cast(Project, found)
+    # Legacy fallback for rows written out-of-band without the startup
+    # backfill running (bounded batches; scheduled for removal once all
+    # writers go through create_project/update_project).
+    fallback = [Project.normalized_repo_url == ""]
+    if branch is not None:
+        fallback.append(Project.branch == branch)
+    batch_size = 500
+    last_seen_id = ""
+    while True:
+        result = await db.execute(
+            select(Project).where(*fallback, Project.id > last_seen_id).order_by(Project.id).limit(batch_size)
+        )
+        batch = list(result.scalars().all())
+        if not batch:
+            break
+        for project in batch:
+            if normalize_repo_url(project.repo_url) != target:
+                continue
+            # Heal legacy rows so the next lookup hits the primary path
+            # instead of re-scanning the fallback batches every time.
+            project.normalized_repo_url = target
+            try:
+                await db.commit()
+            except Exception:
+                # Roll back so the failed heal does not poison the session
+                # for the caller (PendingRollbackError on next use).
+                await db.rollback()
+                logger.debug("find_project_by_repo_url: failed to heal normalized_repo_url", exc_info=True)
+            return cast(Project, project)
+        if len(batch) < batch_size:
+            break
+        last_seen_id = batch[-1].id
     return None
 
 
@@ -234,6 +268,9 @@ async def resolve_project(db: AsyncSession, id_or_name: str) -> Project | None:
 async def update_project(db: AsyncSession, project_id: str, **fields: str | None) -> Project | None:
     """Partial-update a project.
 
+    Caller-supplied ``normalized_repo_url`` is ignored; the canonical URL is
+    always recomputed from ``repo_url`` when it changes.
+
     Args:
         db: Active async database session.
         project_id: UUID or name of the project.
@@ -241,13 +278,32 @@ async def update_project(db: AsyncSession, project_id: str, **fields: str | None
 
     Returns:
         Updated Project or None if not found.
+
+    Raises:
+        ValueError: If ``repo_url`` is explicitly ``None``, empty, or blank.
     """
+    if "normalized_repo_url" in fields:
+        logger.warning(
+            "update_project: ignoring caller-supplied normalized_repo_url %r",
+            fields.get("normalized_repo_url"),
+        )
+        fields.pop("normalized_repo_url", None)
+    if "repo_url" in fields:
+        repo_value = fields["repo_url"]
+        if repo_value is None:
+            msg = "repo_url cannot be None"
+            raise ValueError(msg)
+        if isinstance(repo_value, str) and not normalize_repo_url(repo_value):
+            msg = "repo_url cannot be empty or blank"
+            raise ValueError(msg)
     project = await resolve_project(db, project_id)
     if project is None:
         return None
     for key, value in fields.items():
         if hasattr(project, key):
             setattr(project, key, value)
+    if "repo_url" in fields and isinstance(fields["repo_url"], str):
+        project.normalized_repo_url = normalize_repo_url(fields["repo_url"])
     await db.commit()
     await db.refresh(project)
     return project

--- a/src/apme_gateway/db/queries.py
+++ b/src/apme_gateway/db/queries.py
@@ -169,6 +169,26 @@ async def list_projects(
     return list(result.scalars().all())
 
 
+async def _heal_project_normalized_url(project_id: str, target: str) -> None:
+    """Persist canonical ``normalized_repo_url`` in an isolated write session.
+
+    Uses a separate session so heal failures never commit or roll back the
+    caller's transaction.
+
+    Args:
+        project_id: Project primary key.
+        target: Canonical normalized URL to store.
+    """
+    from apme_gateway.db import get_session  # noqa: PLC0415
+
+    try:
+        async with get_session() as heal_db:
+            await heal_db.execute(update(Project).where(Project.id == project_id).values(normalized_repo_url=target))
+            await heal_db.commit()
+    except Exception:
+        logger.debug("find_project_by_repo_url: failed to heal normalized_repo_url", exc_info=True)
+
+
 async def find_project_by_repo_url(
     db: AsyncSession,
     repo_url: str,
@@ -193,12 +213,15 @@ async def find_project_by_repo_url(
     stmt = select(Project).where(*conditions).order_by(Project.id).limit(1)
     result = await db.execute(stmt)
     found = result.scalars().first()
-    if found is not None:
+    if found is not None and normalize_repo_url(found.repo_url) == target:
+        if found.normalized_repo_url != target:
+            await _heal_project_normalized_url(found.id, target)
         return cast(Project, found)
-    # Legacy fallback for rows written out-of-band without the startup
-    # backfill running (bounded batches; scheduled for removal once all
-    # writers go through create_project/update_project).
-    fallback = [Project.normalized_repo_url == ""]
+    # Indexed normalized value may be stale — fall through to raw-url scan.
+    # Legacy / stale fallback for rows written out-of-band (empty normalized
+    # or normalized out of sync with ``repo_url``). Bounded batches; scheduled
+    # for removal once all writers go through create_project/update_project.
+    fallback = [or_(Project.normalized_repo_url == "", Project.normalized_repo_url != target)]
     if branch is not None:
         fallback.append(Project.branch == branch)
     batch_size = 500
@@ -213,16 +236,8 @@ async def find_project_by_repo_url(
         for project in batch:
             if normalize_repo_url(project.repo_url) != target:
                 continue
-            # Heal legacy rows so the next lookup hits the primary path
-            # instead of re-scanning the fallback batches every time.
-            project.normalized_repo_url = target
-            try:
-                await db.commit()
-            except Exception:
-                # Roll back so the failed heal does not poison the session
-                # for the caller (PendingRollbackError on next use).
-                await db.rollback()
-                logger.debug("find_project_by_repo_url: failed to heal normalized_repo_url", exc_info=True)
+            if project.normalized_repo_url != target:
+                await _heal_project_normalized_url(project.id, target)
             return cast(Project, project)
         if len(batch) < batch_size:
             break

--- a/src/apme_gateway/db/queries.py
+++ b/src/apme_gateway/db/queries.py
@@ -210,10 +210,11 @@ async def find_project_by_repo_url(
     conditions = [Project.normalized_repo_url == target]
     if branch is not None:
         conditions.append(Project.branch == branch)
-    stmt = select(Project).where(*conditions).order_by(Project.id).limit(1)
+    stmt = select(Project).where(*conditions).order_by(Project.id)
     result = await db.execute(stmt)
-    found = result.scalars().first()
-    if found is not None and normalize_repo_url(found.repo_url) == target:
+    for found in result.scalars():
+        if normalize_repo_url(found.repo_url) != target:
+            continue
         if found.normalized_repo_url != target:
             await _heal_project_normalized_url(found.id, target)
         return cast(Project, found)

--- a/src/apme_gateway/operation_registry.py
+++ b/src/apme_gateway/operation_registry.py
@@ -26,7 +26,7 @@ from apme_gateway.operation_types import (
     ProgressEntry,
     Proposal,
     SSEEventType,
-    is_terminal,
+    is_must_deliver,
 )
 
 logger = logging.getLogger(__name__)
@@ -513,13 +513,13 @@ class OperationRegistry:
             data: Event payload.
         """
         msg = {"event": event_type.value, "data": data}
-        terminal = is_terminal(msg)
+        must_deliver = is_must_deliver(msg)
         dead: list[asyncio.Queue[dict[str, Any]]] = []
         for q in op.sse_subscribers:
             try:
                 q.put_nowait(msg)
             except asyncio.QueueFull:
-                if not terminal:
+                if not must_deliver:
                     dead.append(q)
                     logger.warning("Dropping slow SSE subscriber for operation %s", op.operation_id[:12])
                     continue
@@ -533,7 +533,7 @@ class OperationRegistry:
                         buffered.append(q.get_nowait())
                 while q.maxsize > 0 and len(buffered) >= q.maxsize:
                     for index, item in enumerate(buffered):
-                        if not is_terminal(item):
+                        if not is_must_deliver(item):
                             del buffered[index]
                             break
                     else:

--- a/src/apme_gateway/operation_registry.py
+++ b/src/apme_gateway/operation_registry.py
@@ -26,6 +26,7 @@ from apme_gateway.operation_types import (
     ProgressEntry,
     Proposal,
     SSEEventType,
+    is_terminal,
 )
 
 logger = logging.getLogger(__name__)
@@ -398,6 +399,7 @@ class OperationRegistry:
                         "node_type": p.node_type,
                         "suggestion": p.suggestion,
                         "line_start": p.line_start,
+                        "line_end": p.line_end,
                         "before_text": p.before_text,
                         "after_text": p.after_text,
                     }
@@ -498,19 +500,47 @@ class OperationRegistry:
     def _broadcast(self, op: OperationState, event_type: SSEEventType, data: dict[str, Any]) -> None:
         """Push an event to all SSE subscriber queues for an operation.
 
+        Terminal broadcasts (``result`` / ``pr_created`` / terminal
+        ``status_changed``) are must-deliver: when a slow subscriber's
+        queue is full, the oldest non-terminal delta is dropped to make
+        room instead of evicting the subscriber and losing the terminal
+        message. A queued terminal is evicted only when the queue holds
+        nothing else.
+
         Args:
             op: The operation state.
             event_type: SSE event type identifier.
             data: Event payload.
         """
         msg = {"event": event_type.value, "data": data}
+        terminal = is_terminal(msg)
         dead: list[asyncio.Queue[dict[str, Any]]] = []
         for q in op.sse_subscribers:
             try:
                 q.put_nowait(msg)
             except asyncio.QueueFull:
-                dead.append(q)
-                logger.warning("Dropping slow SSE subscriber for operation %s", op.operation_id[:12])
+                if not terminal:
+                    dead.append(q)
+                    logger.warning("Dropping slow SSE subscriber for operation %s", op.operation_id[:12])
+                    continue
+                # Must-deliver terminal: drop oldest non-terminals first so
+                # a queued result (with patches) survives a trailing bare
+                # status. Drain synchronously with no await between get and
+                # put, so the re-queue below cannot raise QueueFull.
+                buffered: list[dict[str, Any]] = []
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    while True:
+                        buffered.append(q.get_nowait())
+                while q.maxsize > 0 and len(buffered) >= q.maxsize:
+                    for index, item in enumerate(buffered):
+                        if not is_terminal(item):
+                            del buffered[index]
+                            break
+                    else:
+                        del buffered[0]
+                for item in buffered:
+                    q.put_nowait(item)
+                q.put_nowait(msg)
         for q in dead:
             with contextlib.suppress(ValueError):
                 op.sse_subscribers.remove(q)

--- a/src/apme_gateway/operation_types.py
+++ b/src/apme_gateway/operation_types.py
@@ -8,6 +8,7 @@ REST/SSE endpoints for project operations.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
@@ -107,6 +108,7 @@ class Proposal:
         node_type: ContentGraph NodeType value (task, block, play, …).
         suggestion: Suggested replacement text.
         line_start: Starting line number in the file.
+        line_end: Ending line number in the file (0 when unknown).
         before_text: Node YAML before the proposed change.
         after_text: Node YAML after the proposed change.
     """
@@ -124,6 +126,7 @@ class Proposal:
     node_type: str = ""
     suggestion: str = ""
     line_start: int = 0
+    line_end: int = 0
     before_text: str = ""
     after_text: str = ""
 
@@ -252,6 +255,7 @@ class OperationState:
                     "node_type": p.node_type,
                     "suggestion": p.suggestion,
                     "line_start": p.line_start,
+                    "line_end": p.line_end,
                     "before_text": p.before_text,
                     "after_text": p.after_text,
                 }
@@ -314,3 +318,34 @@ class SSEEventType(str, Enum):
     APPROVAL_ACK = "approval_ack"
     PR_CREATED = "pr_created"
     ERROR = "error_event"
+
+
+_TERMINAL_EVENT_VALUES: frozenset[str] = frozenset({SSEEventType.RESULT.value, SSEEventType.PR_CREATED.value})
+_TERMINAL_STATUS_VALUES: frozenset[str] = frozenset({s.value for s in TERMINAL_STATUSES})
+
+
+def is_terminal(msg: Mapping[str, object]) -> bool:
+    """Return whether an SSE message closes the stream.
+
+    A message is terminal when its event type is ``result`` or
+    ``pr_created``, or when its payload carries a terminal ``status``.
+    Shared by the registry broadcast predicate and the router's
+    snapshot-drain and live loops so ``result``/``pr_created`` payloads
+    without a ``status`` field are not misclassified.
+
+    Args:
+        msg: SSE message with ``event`` and ``data`` keys.
+
+    Returns:
+        True when the message is terminal.
+    """
+    event = msg.get("event")
+    if isinstance(event, str) and event in _TERMINAL_EVENT_VALUES:
+        return True
+    data = msg.get("data") or {}
+    if not isinstance(data, dict):
+        return False
+    status = data.get("status")
+    if not isinstance(status, str):
+        return False
+    return status in _TERMINAL_STATUS_VALUES

--- a/src/apme_gateway/operation_types.py
+++ b/src/apme_gateway/operation_types.py
@@ -320,27 +320,50 @@ class SSEEventType(str, Enum):
     ERROR = "error_event"
 
 
-_TERMINAL_EVENT_VALUES: frozenset[str] = frozenset({SSEEventType.RESULT.value, SSEEventType.PR_CREATED.value})
+_MUST_DELIVER_EVENT_VALUES: frozenset[str] = frozenset({SSEEventType.RESULT.value, SSEEventType.PR_CREATED.value})
 _TERMINAL_STATUS_VALUES: frozenset[str] = frozenset({s.value for s in TERMINAL_STATUSES})
 
 
-def is_terminal(msg: Mapping[str, object]) -> bool:
-    """Return whether an SSE message closes the stream.
+def is_must_deliver(msg: Mapping[str, object]) -> bool:
+    """Return whether an SSE message must not be dropped from subscriber queues.
 
-    A message is terminal when its event type is ``result`` or
-    ``pr_created``, or when its payload carries a terminal ``status``.
-    Shared by the registry broadcast predicate and the router's
-    snapshot-drain and live loops so ``result``/``pr_created`` payloads
-    without a ``status`` field are not misclassified.
+    ``result`` and ``pr_created`` payloads, plus ``status_changed`` events
+    carrying a terminal status, are must-deliver for broadcast eviction.
+    ``result`` is not stream-closing on its own — see :func:`is_terminal`.
 
     Args:
         msg: SSE message with ``event`` and ``data`` keys.
 
     Returns:
-        True when the message is terminal.
+        True when the message must be preserved during queue eviction.
     """
     event = msg.get("event")
-    if isinstance(event, str) and event in _TERMINAL_EVENT_VALUES:
+    if isinstance(event, str) and event in _MUST_DELIVER_EVENT_VALUES:
+        return True
+    data = msg.get("data") or {}
+    if not isinstance(data, dict):
+        return False
+    status = data.get("status")
+    if not isinstance(status, str):
+        return False
+    return status in _TERMINAL_STATUS_VALUES
+
+
+def is_terminal(msg: Mapping[str, object]) -> bool:
+    """Return whether an SSE message closes the live stream.
+
+    Only ``pr_created`` and ``status_changed`` with a terminal ``status``
+    close the stream. ``result`` is must-deliver but non-terminal because
+    production emits it before ``status_changed(completed)``.
+
+    Args:
+        msg: SSE message with ``event`` and ``data`` keys.
+
+    Returns:
+        True when the live SSE loop should close after this message.
+    """
+    event = msg.get("event")
+    if isinstance(event, str) and event == SSEEventType.PR_CREATED.value:
         return True
     data = msg.get("data") or {}
     if not isinstance(data, dict):

--- a/src/apme_gateway/proposals/draft.py
+++ b/src/apme_gateway/proposals/draft.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import math
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC
@@ -122,6 +124,9 @@ def _safe_float(value: object, default: float = 0.0) -> float:
             return 1.0
         return coerced_int
     if isinstance(value, float):
+        if not math.isfinite(value):
+            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+            return clamped_default
         if value < 0.0:
             logger.debug("Clamping confidence value %r to 0.0", value)
             return 0.0
@@ -137,6 +142,9 @@ def _safe_float(value: object, default: float = 0.0) -> float:
         try:
             coerced_str = float(text)
         except ValueError:
+            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+            return clamped_default
+        if not math.isfinite(coerced_str):
             logger.debug("Falling back confidence value %r to %r", value, clamped_default)
             return clamped_default
         if coerced_str < 0.0:
@@ -500,10 +508,44 @@ async def upsert_live_proposal_stubs(
                 .scalars()
                 .all()
             )
+            engine_groups: defaultdict[str, list[Proposal]] = defaultdict(list)
+            archival_groups: defaultdict[str, list[Proposal]] = defaultdict(list)
             for row in rows:
                 if row.engine_proposal_id:
-                    by_engine.setdefault(str(row.engine_proposal_id), row)
-                by_archival.setdefault(str(row.proposal_id), row)
+                    engine_groups[str(row.engine_proposal_id)].append(row)
+                archival_groups[str(row.proposal_id)].append(row)
+
+            for engine_id, dupes in engine_groups.items():
+                if len(dupes) > 1:
+                    keep = max(dupes, key=lambda row: row.id)
+                    for dup in dupes:
+                        if dup is not keep:
+                            await db.delete(dup)
+                    logger.warning(
+                        "Reconciled %s duplicate live proposals for engine id %s on scan %s",
+                        len(dupes) - 1,
+                        engine_id,
+                        scan_id[:12],
+                    )
+                    by_engine[engine_id] = keep
+                else:
+                    by_engine[engine_id] = dupes[0]
+
+            for archival_id, dupes in archival_groups.items():
+                if len(dupes) > 1:
+                    keep = max(dupes, key=lambda row: row.id)
+                    for dup in dupes:
+                        if dup is not keep:
+                            await db.delete(dup)
+                    logger.warning(
+                        "Reconciled %s duplicate live proposals for archival id %s on scan %s",
+                        len(dupes) - 1,
+                        archival_id,
+                        scan_id[:12],
+                    )
+                    by_archival[archival_id] = keep
+                else:
+                    by_archival[archival_id] = dupes[0]
 
     out: list[Proposal] = []
     for item in prepared:

--- a/src/apme_gateway/proposals/draft.py
+++ b/src/apme_gateway/proposals/draft.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import math
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -24,6 +23,8 @@ from apme_gateway.proposals.grouping import (
     SOURCE_AI_CANDIDATE,
     SOURCE_DETERMINISTIC,
     _coerce_violation_ids,
+    _safe_float,
+    _to_int,
     analytics_increments,
     parse_json_list,
     review_status_for_proposal,
@@ -35,130 +36,6 @@ from apme_gateway.proposals.grouping import (
 logger = logging.getLogger(__name__)
 
 _ALLOWED_DRAFT_STATUSES = frozenset({"pending", "approved", "declined", "proposed", "rejected"})
-
-
-def _safe_int(value: object, default: int = 0) -> int:
-    """Coerce JSON-ish input to int, mapping unknowns to default.
-
-    Clamps results at ``>= 0`` since line numbers and tiers are never
-    negative.
-
-    Args:
-        value: Raw value (int, float, numeric string, bool, None, …).
-        default: Fallback when coercion fails.
-
-    Returns:
-        Coerced integer clamped at ``>= 0``, or clamped ``default``.
-    """
-    fallback = max(0, default)
-    if isinstance(value, bool):
-        logger.debug("Falling back line/tier value %r to %r", value, fallback)
-        return fallback
-    if isinstance(value, int):
-        if value < 0:
-            logger.debug("Clamping negative line/tier value %r to 0", value)
-            return 0
-        return value
-    if isinstance(value, float):
-        if value.is_integer():
-            coerced = int(value)
-            if coerced < 0:
-                logger.debug("Clamping negative line/tier value %r to 0", value)
-                return 0
-            return coerced
-        logger.debug("Falling back line/tier value %r to %r", value, fallback)
-        return fallback
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            logger.debug("Falling back line/tier value %r to %r", value, fallback)
-            return fallback
-        try:
-            coerced_str = int(text)
-            if coerced_str < 0:
-                logger.debug("Clamping negative line/tier value %r to 0", value)
-                return 0
-            return coerced_str
-        except ValueError:
-            try:
-                parsed = float(text)
-            except ValueError:
-                logger.debug("Falling back line/tier value %r to %r", value, fallback)
-                return fallback
-            if parsed.is_integer():
-                coerced_float = int(parsed)
-                if coerced_float < 0:
-                    logger.debug("Clamping negative line/tier value %r to 0", value)
-                    return 0
-                return coerced_float
-            logger.debug("Falling back line/tier value %r to %r", value, fallback)
-            return fallback
-    if value is None:
-        logger.debug("Falling back line/tier value %r to %r", value, fallback)
-        return fallback
-    logger.debug("Falling back line/tier value %r to %r", value, fallback)
-    return fallback
-
-
-def _safe_float(value: object, default: float = 0.0) -> float:
-    """Coerce JSON-ish input to float, clamped to 0..1.
-
-    Args:
-        value: Raw value (int, float, numeric string, bool, None, …).
-        default: Fallback when coercion fails.
-
-    Returns:
-        Coerced float in ``[0.0, 1.0]``, or clamped ``default``.
-    """
-    clamped_default = min(1.0, max(0.0, default))
-    if isinstance(value, bool):
-        logger.debug("Falling back confidence value %r to %r", value, clamped_default)
-        return clamped_default
-    if isinstance(value, int):
-        coerced_int = float(value)
-        if coerced_int < 0.0:
-            logger.debug("Clamping confidence value %r to 0.0", value)
-            return 0.0
-        if coerced_int > 1.0:
-            logger.debug("Clamping confidence value %r to 1.0", value)
-            return 1.0
-        return coerced_int
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
-            return clamped_default
-        if value < 0.0:
-            logger.debug("Clamping confidence value %r to 0.0", value)
-            return 0.0
-        if value > 1.0:
-            logger.debug("Clamping confidence value %r to 1.0", value)
-            return 1.0
-        return value
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
-            return clamped_default
-        try:
-            coerced_str = float(text)
-        except ValueError:
-            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
-            return clamped_default
-        if not math.isfinite(coerced_str):
-            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
-            return clamped_default
-        if coerced_str < 0.0:
-            logger.debug("Clamping confidence value %r to 0.0", value)
-            return 0.0
-        if coerced_str > 1.0:
-            logger.debug("Clamping confidence value %r to 1.0", value)
-            return 1.0
-        return coerced_str
-    if value is None:
-        logger.debug("Falling back confidence value %r to %r", value, clamped_default)
-        return clamped_default
-    logger.debug("Falling back confidence value %r to %r", value, clamped_default)
-    return clamped_default
 
 
 def _gate_for_source(source: str, tier: int) -> str:
@@ -426,7 +303,7 @@ def _prepare_stub_payload(raw: Mapping[str, Any]) -> StubPayload | None:
     file_ = str(raw.get("file") or "")
     rule_id = str(raw.get("rule_id") or "")
     path = str(raw.get("path") or "")
-    tier = _safe_int(raw.get("tier"), 0)
+    tier = _to_int(raw.get("tier"), 0)
     source = str(raw.get("source") or (SOURCE_AI if tier >= 2 else SOURCE_DETERMINISTIC))
     gate = str(raw.get("gate") or "") or _gate_for_source(source, tier)
     rule_parts = tuple(p.strip() for p in rule_id.split(",") if p.strip()) or ((rule_id,) if rule_id else ())
@@ -451,8 +328,8 @@ def _prepare_stub_payload(raw: Mapping[str, Any]) -> StubPayload | None:
             rule_id=primary_rule or rule_id,
             engine_id=engine_id,
         ),
-        line_start=_safe_int(raw.get("line_start"), 0),
-        line_end=_safe_int(raw.get("line_end"), 0),
+        line_start=_to_int(raw.get("line_start"), 0),
+        line_end=_to_int(raw.get("line_end"), 0),
     )
 
 
@@ -620,16 +497,16 @@ async def upsert_live_proposal_stubs(
             # explicit, so test identity and blank strings instead.
             raw_line_start = raw.get("line_start") if "line_start" in raw else None
             if raw_line_start is not None and not (isinstance(raw_line_start, str) and not raw_line_start.strip()):
-                existing.line_start = _safe_int(raw_line_start, existing.line_start)
+                existing.line_start = _to_int(raw_line_start, existing.line_start)
             raw_line_end = raw.get("line_end") if "line_end" in raw else None
             if raw_line_end is not None and not (isinstance(raw_line_end, str) and not raw_line_end.strip()):
-                existing.line_end = _safe_int(raw_line_end, existing.line_end)
+                existing.line_end = _to_int(raw_line_end, existing.line_end)
             raw_confidence = raw.get("confidence") if "confidence" in raw else None
             if raw_confidence is not None and not (isinstance(raw_confidence, str) and not raw_confidence.strip()):
                 existing.confidence = _safe_float(raw_confidence, existing.confidence)
             raw_tier = raw.get("tier") if "tier" in raw else None
             if raw_tier is not None and not (isinstance(raw_tier, str) and not raw_tier.strip()):
-                existing.tier = _safe_int(raw_tier, existing.tier)
+                existing.tier = _to_int(raw_tier, existing.tier)
             if rule_parts:
                 existing.rule_ids_json = serialize_rule_ids(rule_parts)
                 existing.stamp_rule_ids_json = serialize_rule_ids(rule_parts)

--- a/src/apme_gateway/proposals/draft.py
+++ b/src/apme_gateway/proposals/draft.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import hashlib
 import logging
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import UTC
 from typing import Any
 
 from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from apme_gateway.db import get_in_clause_chunk_size
 from apme_gateway.db.models import Proposal, Scan
 from apme_gateway.proposals.flush import fetch_violations_by_ids, upsert_analytics_increment
 from apme_gateway.proposals.grouping import (
@@ -19,6 +21,7 @@ from apme_gateway.proposals.grouping import (
     SOURCE_AI,
     SOURCE_AI_CANDIDATE,
     SOURCE_DETERMINISTIC,
+    _coerce_violation_ids,
     analytics_increments,
     parse_json_list,
     review_status_for_proposal,
@@ -30,6 +33,124 @@ from apme_gateway.proposals.grouping import (
 logger = logging.getLogger(__name__)
 
 _ALLOWED_DRAFT_STATUSES = frozenset({"pending", "approved", "declined", "proposed", "rejected"})
+
+
+def _safe_int(value: object, default: int = 0) -> int:
+    """Coerce JSON-ish input to int, mapping unknowns to default.
+
+    Clamps results at ``>= 0`` since line numbers and tiers are never
+    negative.
+
+    Args:
+        value: Raw value (int, float, numeric string, bool, None, …).
+        default: Fallback when coercion fails.
+
+    Returns:
+        Coerced integer clamped at ``>= 0``, or clamped ``default``.
+    """
+    fallback = max(0, default)
+    if isinstance(value, bool):
+        logger.debug("Falling back line/tier value %r to %r", value, fallback)
+        return fallback
+    if isinstance(value, int):
+        if value < 0:
+            logger.debug("Clamping negative line/tier value %r to 0", value)
+            return 0
+        return value
+    if isinstance(value, float):
+        if value.is_integer():
+            coerced = int(value)
+            if coerced < 0:
+                logger.debug("Clamping negative line/tier value %r to 0", value)
+                return 0
+            return coerced
+        logger.debug("Falling back line/tier value %r to %r", value, fallback)
+        return fallback
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            logger.debug("Falling back line/tier value %r to %r", value, fallback)
+            return fallback
+        try:
+            coerced_str = int(text)
+            if coerced_str < 0:
+                logger.debug("Clamping negative line/tier value %r to 0", value)
+                return 0
+            return coerced_str
+        except ValueError:
+            try:
+                parsed = float(text)
+            except ValueError:
+                logger.debug("Falling back line/tier value %r to %r", value, fallback)
+                return fallback
+            if parsed.is_integer():
+                coerced_float = int(parsed)
+                if coerced_float < 0:
+                    logger.debug("Clamping negative line/tier value %r to 0", value)
+                    return 0
+                return coerced_float
+            logger.debug("Falling back line/tier value %r to %r", value, fallback)
+            return fallback
+    if value is None:
+        logger.debug("Falling back line/tier value %r to %r", value, fallback)
+        return fallback
+    logger.debug("Falling back line/tier value %r to %r", value, fallback)
+    return fallback
+
+
+def _safe_float(value: object, default: float = 0.0) -> float:
+    """Coerce JSON-ish input to float, clamped to 0..1.
+
+    Args:
+        value: Raw value (int, float, numeric string, bool, None, …).
+        default: Fallback when coercion fails.
+
+    Returns:
+        Coerced float in ``[0.0, 1.0]``, or clamped ``default``.
+    """
+    clamped_default = min(1.0, max(0.0, default))
+    if isinstance(value, bool):
+        logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+        return clamped_default
+    if isinstance(value, int):
+        coerced_int = float(value)
+        if coerced_int < 0.0:
+            logger.debug("Clamping confidence value %r to 0.0", value)
+            return 0.0
+        if coerced_int > 1.0:
+            logger.debug("Clamping confidence value %r to 1.0", value)
+            return 1.0
+        return coerced_int
+    if isinstance(value, float):
+        if value < 0.0:
+            logger.debug("Clamping confidence value %r to 0.0", value)
+            return 0.0
+        if value > 1.0:
+            logger.debug("Clamping confidence value %r to 1.0", value)
+            return 1.0
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+            return clamped_default
+        try:
+            coerced_str = float(text)
+        except ValueError:
+            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+            return clamped_default
+        if coerced_str < 0.0:
+            logger.debug("Clamping confidence value %r to 0.0", value)
+            return 0.0
+        if coerced_str > 1.0:
+            logger.debug("Clamping confidence value %r to 1.0", value)
+            return 1.0
+        return coerced_str
+    if value is None:
+        logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+        return clamped_default
+    logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+    return clamped_default
 
 
 def _gate_for_source(source: str, tier: int) -> str:
@@ -244,6 +365,89 @@ async def ensure_scan_row(
     return scan
 
 
+@dataclass
+class StubPayload:
+    """Normalized live proposal payload for upsert matching.
+
+    Attributes:
+        raw: Original proposal mapping.
+        engine_id: Engine proposal id (match key).
+        file: Target file path.
+        rule_id: Raw rule id string as received.
+        primary_rule: Primary/display rule (never the coupled CSV).
+        rule_parts: Parsed rule id tuple.
+        path: Node identity path.
+        tier: Numeric remediation tier.
+        source: Proposal source string.
+        gate: Archival gate label.
+        status: Normalized status string.
+        archival_id: Archival-style proposal id (second match key).
+        line_start: First line of the node/finding (0 when unknown).
+        line_end: Last line of the node/finding (0 when unknown).
+    """
+
+    raw: Mapping[str, Any]
+    engine_id: str
+    file: str
+    rule_id: str
+    primary_rule: str
+    rule_parts: tuple[str, ...]
+    path: str
+    tier: int
+    source: str
+    gate: str
+    status: str
+    archival_id: str
+    line_start: int
+    line_end: int
+
+
+def _prepare_stub_payload(raw: Mapping[str, Any]) -> StubPayload | None:
+    """Normalize one live proposal mapping for upsert matching.
+
+    Args:
+        raw: Proposal mapping with id/file/rule_id/tier/status/source/….
+
+    Returns:
+        Normalized payload including the match keys, or ``None`` when the
+        mapping carries no engine proposal id.
+    """
+    engine_id = str(raw.get("id") or raw.get("engine_proposal_id") or "").strip()
+    if not engine_id:
+        return None
+    file_ = str(raw.get("file") or "")
+    rule_id = str(raw.get("rule_id") or "")
+    path = str(raw.get("path") or "")
+    tier = _safe_int(raw.get("tier"), 0)
+    source = str(raw.get("source") or (SOURCE_AI if tier >= 2 else SOURCE_DETERMINISTIC))
+    gate = str(raw.get("gate") or "") or _gate_for_source(source, tier)
+    rule_parts = tuple(p.strip() for p in rule_id.split(",") if p.strip()) or ((rule_id,) if rule_id else ())
+    # Proposal.rule_id is the primary/display rule — never the coupled CSV.
+    primary_rule = rule_parts[0] if rule_parts else ""
+    return StubPayload(
+        raw=raw,
+        engine_id=engine_id,
+        file=file_,
+        rule_id=rule_id,
+        primary_rule=primary_rule,
+        rule_parts=rule_parts,
+        path=path,
+        tier=tier,
+        source=source,
+        gate=gate,
+        status=_normalize_status(str(raw.get("status") or "pending")),
+        archival_id=_archival_proposal_id(
+            file=file_,
+            path=path,
+            gate=gate,
+            rule_id=primary_rule or rule_id,
+            engine_id=engine_id,
+        ),
+        line_start=_safe_int(raw.get("line_start"), 0),
+        line_end=_safe_int(raw.get("line_end"), 0),
+    )
+
+
 async def upsert_live_proposal_stubs(
     db: AsyncSession,
     *,
@@ -266,34 +470,65 @@ async def upsert_live_proposal_stubs(
         Upserted ORM Proposal rows.
     """
     await ensure_scan_row(db, scan_id=scan_id, project_id=project_id, scan_type="remediate")
-    out: list[Proposal] = []
-    for raw in proposals:
-        engine_id = str(raw.get("id") or raw.get("engine_proposal_id") or "").strip()
-        if not engine_id:
-            continue
-        file_ = str(raw.get("file") or "")
-        rule_id = str(raw.get("rule_id") or "")
-        path = str(raw.get("path") or "")
-        tier = int(raw.get("tier") or 0)
-        source = str(raw.get("source") or (SOURCE_AI if tier >= 2 else SOURCE_DETERMINISTIC))
-        gate = str(raw.get("gate") or "") or _gate_for_source(source, tier)
-        status = _normalize_status(str(raw.get("status") or "pending"))
-        rule_parts = tuple(p.strip() for p in rule_id.split(",") if p.strip()) or ((rule_id,) if rule_id else ())
-        # Proposal.rule_id is the primary/display rule — never the coupled CSV.
-        primary_rule = rule_parts[0] if rule_parts else ""
-        stamp_rules = rule_parts
-        archival_id = _archival_proposal_id(
-            file=file_, path=path, gate=gate, rule_id=primary_rule or rule_id, engine_id=engine_id
-        )
+    prepared = [item for item in (_prepare_stub_payload(raw) for raw in proposals) if item is not None]
 
-        existing = (
-            await db.execute(
-                select(Proposal).where(
-                    Proposal.scan_id == scan_id,
-                    or_(Proposal.engine_proposal_id == engine_id, Proposal.proposal_id == archival_id),
+    # Preloaded queries instead of a SELECT per proposal: match the same
+    # (engine_proposal_id, proposal_id) pairs the loop used to fetch singly.
+    # Each query binds 2N ids plus 1 for scan_id ==, so per_query*2 + 1 <=
+    # chunk (e.g. 449*2 + 1 = 899 <= 900; 450*2 + 1 = 901 would exceed).
+    by_engine: dict[str, Proposal] = {}
+    by_archival: dict[str, Proposal] = {}
+    if prepared:
+        chunk = get_in_clause_chunk_size()
+        per_query = max(1, (chunk - 1) // 2)
+        for start in range(0, len(prepared), per_query):
+            batch = prepared[start : start + per_query]
+            engine_ids = [item.engine_id for item in batch]
+            archival_ids = [item.archival_id for item in batch]
+            rows = (
+                (
+                    await db.execute(
+                        select(Proposal).where(
+                            Proposal.scan_id == scan_id,
+                            or_(
+                                Proposal.engine_proposal_id.in_(engine_ids),
+                                Proposal.proposal_id.in_(archival_ids),
+                            ),
+                        )
+                    )
                 )
+                .scalars()
+                .all()
             )
-        ).scalar_one_or_none()
+            for row in rows:
+                if row.engine_proposal_id:
+                    by_engine.setdefault(str(row.engine_proposal_id), row)
+                by_archival.setdefault(str(row.proposal_id), row)
+
+    out: list[Proposal] = []
+    for item in prepared:
+        raw = item.raw
+        engine_id = item.engine_id
+        file_ = item.file
+        primary_rule = item.primary_rule
+        rule_parts = item.rule_parts
+        path = item.path
+        tier = item.tier
+        source = item.source
+        gate = item.gate
+        status = item.status
+        archival_id = item.archival_id
+
+        # Engine-id hits win. An archival-id hit is only a match when it
+        # belongs to the same engine proposal (or has no engine id yet) —
+        # otherwise two live proposals would silently merge into one row.
+        existing = by_engine.get(engine_id)
+        if existing is None:
+            archival_hit = by_archival.get(archival_id)
+            if archival_hit is not None:
+                hit_engine = (archival_hit.engine_proposal_id or "").strip()
+                if not hit_engine or hit_engine == engine_id:
+                    existing = archival_hit
         if existing is None:
             existing = Proposal(
                 scan_id=scan_id,
@@ -301,7 +536,7 @@ async def upsert_live_proposal_stubs(
                 rule_id=primary_rule,
                 file=file_,
                 tier=tier,
-                confidence=float(raw.get("confidence") or 0.0),
+                confidence=_safe_float(raw.get("confidence"), 0.0),
                 status=status,
                 path=path,
                 node_type=str(raw.get("node_type") or ""),
@@ -309,22 +544,26 @@ async def upsert_live_proposal_stubs(
                 gate=gate,
                 rule_ids_json=serialize_rule_ids(rule_parts),
                 violation_ids_json="[]",
-                line_start=int(raw.get("line_start") or 0),
+                line_start=item.line_start,
+                line_end=item.line_end,
                 diff_hunk=str(raw.get("diff_hunk") or ""),
                 explanation=str(raw.get("explanation") or ""),
                 suggestion=str(raw.get("suggestion") or ""),
                 analytics_flushed=0,
                 engine_proposal_id=engine_id,
                 draft=0,
-                stamp_rule_ids_json=serialize_rule_ids(stamp_rules),
+                stamp_rule_ids_json=serialize_rule_ids(rule_parts),
             )
             db.add(existing)
+            # Seed the maps so a duplicate engine id later in the same
+            # batch updates this row instead of inserting a second one.
+            by_engine.setdefault(engine_id, existing)
+            by_archival.setdefault(archival_id, existing)
         else:
             existing.engine_proposal_id = engine_id
             existing.file = file_ or existing.file
             if primary_rule:
                 existing.rule_id = primary_rule
-            existing.tier = tier or existing.tier
             existing.path = path or existing.path
             nt = str(raw.get("node_type") or "")
             if nt:
@@ -334,13 +573,24 @@ async def upsert_live_proposal_stubs(
             existing.diff_hunk = str(raw.get("diff_hunk") or existing.diff_hunk)
             existing.explanation = str(raw.get("explanation") or existing.explanation)
             existing.suggestion = str(raw.get("suggestion") or existing.suggestion)
-            existing.line_start = int(raw.get("line_start") or existing.line_start)
-            existing.confidence = float(raw.get("confidence") or existing.confidence)
-            if "tier" in raw and raw.get("tier") is not None:
-                existing.tier = int(raw["tier"])
+            # Explicit 0 clears stale spans/scores; None/missing/"" preserves.
+            # Truthiness would treat numeric 0 as missing but string "0" as
+            # explicit, so test identity and blank strings instead.
+            raw_line_start = raw.get("line_start") if "line_start" in raw else None
+            if raw_line_start is not None and not (isinstance(raw_line_start, str) and not raw_line_start.strip()):
+                existing.line_start = _safe_int(raw_line_start, existing.line_start)
+            raw_line_end = raw.get("line_end") if "line_end" in raw else None
+            if raw_line_end is not None and not (isinstance(raw_line_end, str) and not raw_line_end.strip()):
+                existing.line_end = _safe_int(raw_line_end, existing.line_end)
+            raw_confidence = raw.get("confidence") if "confidence" in raw else None
+            if raw_confidence is not None and not (isinstance(raw_confidence, str) and not raw_confidence.strip()):
+                existing.confidence = _safe_float(raw_confidence, existing.confidence)
+            raw_tier = raw.get("tier") if "tier" in raw else None
+            if raw_tier is not None and not (isinstance(raw_tier, str) and not raw_tier.strip()):
+                existing.tier = _safe_int(raw_tier, existing.tier)
             if rule_parts:
                 existing.rule_ids_json = serialize_rule_ids(rule_parts)
-                existing.stamp_rule_ids_json = serialize_rule_ids(stamp_rules)
+                existing.stamp_rule_ids_json = serialize_rule_ids(rule_parts)
             # Do not clobber an in-progress draft status from a re-emit.
             if not existing.draft:
                 existing.status = status
@@ -487,7 +737,7 @@ async def commit_gate_decisions(
             rule_ids_json=prop.rule_ids_json,
         )
         v_ids = parse_json_list(prop.violation_ids_json)
-        int_ids = [int(v) for v in v_ids if str(v).isdigit() or isinstance(v, int)]
+        int_ids = _coerce_violation_ids(v_ids)
         if not int_ids:
             continue
         for violation in await fetch_violations_by_ids(db, int_ids):

--- a/src/apme_gateway/proposals/draft.py
+++ b/src/apme_gateway/proposals/draft.py
@@ -333,6 +333,18 @@ def _prepare_stub_payload(raw: Mapping[str, Any]) -> StubPayload | None:
     )
 
 
+def _preload_per_query_limit(chunk: int) -> int:
+    """Max proposals per preload SELECT while reserving one bind for scan_id.
+
+    Args:
+        chunk: SQLite IN-clause bind limit from ``get_in_clause_chunk_size``.
+
+    Returns:
+        Maximum proposals per preload batch (``(chunk - 1) // 2``).
+    """
+    return max(1, (chunk - 1) // 2)
+
+
 async def upsert_live_proposal_stubs(
     db: AsyncSession,
     *,
@@ -363,9 +375,10 @@ async def upsert_live_proposal_stubs(
     # chunk (e.g. 449*2 + 1 = 899 <= 900; 450*2 + 1 = 901 would exceed).
     by_engine: dict[str, Proposal] = {}
     by_archival: dict[str, Proposal] = {}
+    discarded: set[int] = set()
     if prepared:
         chunk = get_in_clause_chunk_size()
-        per_query = max(1, (chunk - 1) // 2)
+        per_query = _preload_per_query_limit(chunk)
         for start in range(0, len(prepared), per_query):
             batch = prepared[start : start + per_query]
             engine_ids = [item.engine_id for item in batch]
@@ -398,6 +411,7 @@ async def upsert_live_proposal_stubs(
                     for dup in dupes:
                         if dup is not keep:
                             await db.delete(dup)
+                            discarded.add(dup.id)
                     logger.warning(
                         "Reconciled %s duplicate live proposals for engine id %s on scan %s",
                         len(dupes) - 1,
@@ -414,6 +428,7 @@ async def upsert_live_proposal_stubs(
                     for dup in dupes:
                         if dup is not keep:
                             await db.delete(dup)
+                            discarded.add(dup.id)
                     logger.warning(
                         "Reconciled %s duplicate live proposals for archival id %s on scan %s",
                         len(dupes) - 1,
@@ -423,6 +438,10 @@ async def upsert_live_proposal_stubs(
                     by_archival[archival_id] = keep
                 else:
                     by_archival[archival_id] = dupes[0]
+
+        if discarded:
+            by_engine = {k: v for k, v in by_engine.items() if v.id not in discarded}
+            by_archival = {k: v for k, v in by_archival.items() if v.id not in discarded}
 
     out: list[Proposal] = []
     for item in prepared:

--- a/src/apme_gateway/proposals/flush.py
+++ b/src/apme_gateway/proposals/flush.py
@@ -13,6 +13,9 @@ from apme_gateway.db import get_in_clause_chunk_size
 from apme_gateway.db.dialect import dialect_insert
 from apme_gateway.db.models import Proposal, ProposalRuleAnalytics, Scan, Violation
 from apme_gateway.proposals.grouping import (
+    _coerce_violation_ids,
+    _safe_float,
+    _to_int,
     analytics_increments,
     parse_json_list,
     review_status_for_proposal,
@@ -237,7 +240,7 @@ async def _flush_proposals(
         review = review_status_for_proposal(prop.source, prop.status)
         if review:
             v_ids = parse_json_list(prop.violation_ids_json)
-            int_ids = [int(v) for v in v_ids if str(v).isdigit() or isinstance(v, int)]
+            int_ids = _coerce_violation_ids(v_ids)
             if int_ids:
                 stamp_rules = stamp_rule_allowlist(
                     stamp_rule_ids_json=getattr(prop, "stamp_rule_ids_json", None),
@@ -319,26 +322,42 @@ async def replace_scan_proposals(
 
     prior_rows = list((await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalars().all())
     await db.execute(delete(Proposal).where(Proposal.scan_id == scan_id))
-    # Bridge live stubs → archival groups. Key by file+source+primary_rule+line
-    # because engine.Proposal has no path field — stubs always have path="".
+    # Bridge live stubs → archival groups. Key by file+source+primary_rule+
+    # line_start+line_end because engine.Proposal has no path field — stubs
+    # always have path="". line_end keeps two proposals that share
+    # (file, source, rule, line_start) but cover different spans distinct.
     # Normalize: coupled stubs may store "L007,L013" while groups use "L007";
     # ai-candidate groups must match stub source "ai".
     # Carry analytics_flushed / terminal status / stamp_rule_ids so gate-commit
     # survives FixCompleted rebuild without double-counting analytics.
 
-    def _bridge_key(file_: str, source: str, rule_id: str, line_start: int) -> tuple[str, str, str, int]:
+    def _bridge_key(
+        file_: str, source: str, rule_id: str, line_start: object, line_end: object = 0
+    ) -> tuple[str, str, str, int, int]:
+        """Build the stub-to-group bridge key including both span ends.
+
+        Args:
+            file_: Target file path.
+            source: Proposal source string.
+            rule_id: Raw rule id (possibly coupled CSV).
+            line_start: First line of the span (JSON-ish, coerced defensively).
+            line_end: Last line of the span (JSON-ish, coerced defensively).
+
+        Returns:
+            Bridge key tuple with primary rule and coerced span.
+        """
         primary_rule = (rule_id or "").split(",")[0].strip()
         src = source or ""
         if src == "ai-candidate":
             src = "ai"
-        return (file_ or "", src, primary_rule, int(line_start or 0))
+        return (file_ or "", src, primary_rule, _to_int(line_start, 0), _to_int(line_end, 0))
 
-    prior: dict[tuple[str, str, str, int], tuple[str | None, int, int, str, str]] = {}
-    ambiguous: set[tuple[str, str, str, int]] = set()
+    prior: dict[tuple[str, str, str, int, int], tuple[str | None, int, int, str, str]] = {}
+    ambiguous: set[tuple[str, str, str, int, int]] = set()
     for r in prior_rows:
         if not (r.engine_proposal_id or r.draft or r.analytics_flushed):
             continue
-        key = _bridge_key(str(r.file or ""), str(r.source or ""), str(r.rule_id or ""), int(r.line_start or 0))
+        key = _bridge_key(str(r.file or ""), str(r.source or ""), str(r.rule_id or ""), r.line_start, r.line_end)
         if key in ambiguous:
             continue
         if key in prior:
@@ -349,8 +368,8 @@ async def replace_scan_proposals(
             continue
         prior[key] = (
             r.engine_proposal_id,
-            int(r.draft or 0),
-            int(r.analytics_flushed or 0),
+            _to_int(r.draft or 0),
+            _to_int(r.analytics_flushed or 0),
             str(r.status or ""),
             str(r.stamp_rule_ids_json or "[]"),
         )
@@ -359,11 +378,17 @@ async def replace_scan_proposals(
         status = prop.status
         if status == "pending" and prop.source == "deterministic" and prop.fixed_yaml:
             status = "approved"
-        key = _bridge_key(prop.file or "", prop.source, prop.rule_id or "", int(prop.line_start or 0))
+        key = _bridge_key(
+            prop.file or "",
+            prop.source,
+            prop.rule_id or "",
+            getattr(prop, "line_start", 0),
+            getattr(prop, "line_end", 0),
+        )
         bridge = prior.get(key, (None, 0, 0, "", "[]"))
         engine_id = getattr(prop, "engine_proposal_id", None) or bridge[0]
-        draft_flag = int(getattr(prop, "draft", 0) or bridge[1] or 0)
-        flushed = int(bridge[2] or 0)
+        draft_flag = _to_int(getattr(prop, "draft", 0) or bridge[1] or 0)
+        flushed = _to_int(bridge[2] or 0)
         bridged_status = str(bridge[3] or "")
         if bridged_status in {"approved", "declined"} and status in {"pending", "proposed", ""}:
             status = bridged_status
@@ -376,16 +401,17 @@ async def replace_scan_proposals(
                 proposal_id=prop.proposal_id,
                 rule_id=prop.rule_id,
                 file=prop.file,
-                tier=prop.tier,
-                confidence=prop.confidence,
+                tier=_to_int(prop.tier, 0),
+                confidence=_safe_float(prop.confidence, 0.0),
                 status=status,
                 path=prop.path,
                 node_type=getattr(prop, "node_type", "") or "",
                 source=prop.source,
                 gate=prop.gate,
                 rule_ids_json=serialize_rule_ids(prop.rule_ids),
-                violation_ids_json=serialize_violation_ids(prop.violation_ids),
-                line_start=prop.line_start,
+                violation_ids_json=serialize_violation_ids(_coerce_violation_ids(list(prop.violation_ids))),
+                line_start=_to_int(prop.line_start, 0),
+                line_end=_to_int(getattr(prop, "line_end", 0), 0),
                 diff_hunk=prop.diff_hunk,
                 explanation=prop.explanation,
                 suggestion=prop.suggestion,
@@ -422,8 +448,9 @@ def proposal_to_detail_dict(prop: Proposal | object) -> dict[str, object]:
             "source": prop.source,
             "gate": prop.gate,
             "rule_ids": [str(r) for r in rule_ids],
-            "violation_ids": [int(v) for v in violation_ids if str(v).isdigit() or isinstance(v, int)],
+            "violation_ids": _coerce_violation_ids(violation_ids),
             "line_start": prop.line_start,
+            "line_end": prop.line_end,
             "diff_hunk": prop.diff_hunk,
             "explanation": prop.explanation,
             "suggestion": prop.suggestion,
@@ -438,16 +465,17 @@ def proposal_to_detail_dict(prop: Proposal | object) -> dict[str, object]:
         "proposal_id": getattr(prop, "proposal_id", ""),
         "rule_id": getattr(prop, "rule_id", ""),
         "file": getattr(prop, "file", ""),
-        "tier": int(getattr(prop, "tier", 0) or 0),
-        "confidence": float(getattr(prop, "confidence", 0.0) or 0.0),
+        "tier": _to_int(getattr(prop, "tier", 0), 0),
+        "confidence": _safe_float(getattr(prop, "confidence", 0.0), 0.0),
         "status": getattr(prop, "status", "pending"),
         "path": getattr(prop, "path", ""),
         "node_type": getattr(prop, "node_type", "") or "",
         "source": getattr(prop, "source", "outcome"),
         "gate": getattr(prop, "gate", ""),
         "rule_ids": [str(r) for r in rule_ids],
-        "violation_ids": [int(v) for v in violation_ids],
-        "line_start": int(getattr(prop, "line_start", 0) or 0),
+        "violation_ids": _coerce_violation_ids(violation_ids),
+        "line_start": _to_int(getattr(prop, "line_start", 0), 0),
+        "line_end": _to_int(getattr(prop, "line_end", 0), 0),
         "diff_hunk": getattr(prop, "diff_hunk", "") or "",
         "explanation": getattr(prop, "explanation", "") or "",
         "suggestion": getattr(prop, "suggestion", "") or "",

--- a/src/apme_gateway/proposals/flush.py
+++ b/src/apme_gateway/proposals/flush.py
@@ -407,7 +407,18 @@ async def replace_scan_proposals(
             getattr(prop, "line_start", 0),
             getattr(prop, "line_end", 0),
         )
-        bridge = prior.get(key, (None, 0, 0, "", "[]"))
+        bridge = prior.get(key)
+        if bridge is None:
+            bridge = prior.get(
+                _bridge_key(
+                    prop.file or "",
+                    prop.source,
+                    prop.rule_id or "",
+                    getattr(prop, "line_start", 0),
+                    0,
+                ),
+                (None, 0, 0, "", "[]"),
+            )
         engine_id = getattr(prop, "engine_proposal_id", None) or bridge[0]
         draft_flag = _to_int(getattr(prop, "draft", 0) or bridge[1] or 0)
         flushed = _to_int(bridge[2] or 0)

--- a/src/apme_gateway/proposals/flush.py
+++ b/src/apme_gateway/proposals/flush.py
@@ -333,8 +333,12 @@ async def replace_scan_proposals(
 
     def _bridge_key(
         file_: str, source: str, rule_id: str, line_start: object, line_end: object = 0
-    ) -> tuple[str, str, str, int, int]:
-        """Build the stub-to-group bridge key including both span ends.
+    ) -> tuple[str, str, str, int, int | None]:
+        """Build the stub-to-group bridge key.
+
+        When ``line_end`` is unknown (0), the key omits the end line so
+        FixCompleted rebuilds from violations (no end line) still match live
+        stubs that carried a span.
 
         Args:
             file_: Target file path.
@@ -350,29 +354,47 @@ async def replace_scan_proposals(
         src = source or ""
         if src == "ai-candidate":
             src = "ai"
-        return (file_ or "", src, primary_rule, _to_int(line_start, 0), _to_int(line_end, 0))
+        le = _to_int(line_end, 0)
+        return (file_ or "", src, primary_rule, _to_int(line_start, 0), le if le > 0 else None)
 
-    prior: dict[tuple[str, str, str, int, int], tuple[str | None, int, int, str, str]] = {}
-    ambiguous: set[tuple[str, str, str, int, int]] = set()
-    for r in prior_rows:
-        if not (r.engine_proposal_id or r.draft or r.analytics_flushed):
-            continue
-        key = _bridge_key(str(r.file or ""), str(r.source or ""), str(r.rule_id or ""), r.line_start, r.line_end)
+    prior: dict[tuple[str, str, str, int, int | None], tuple[str | None, int, int, str, str]] = {}
+    ambiguous: set[tuple[str, str, str, int, int | None]] = set()
+
+    def _register_bridge(
+        key: tuple[str, str, str, int, int | None],
+        row: Proposal,
+    ) -> None:
+        """Register one prior stub under a bridge key, tracking ambiguity.
+
+        Args:
+            key: Bridge lookup key.
+            row: Prior proposal row supplying bridge metadata.
+        """
         if key in ambiguous:
-            continue
+            return
         if key in prior:
-            # Duplicate key — refuse to guess which stub owns the archival row.
             ambiguous.add(key)
             prior.pop(key, None)
             logger.warning("Ambiguous proposal bridge key for scan %s: %s", scan_id[:12], key)
-            continue
+            return
         prior[key] = (
-            r.engine_proposal_id,
-            _to_int(r.draft or 0),
-            _to_int(r.analytics_flushed or 0),
-            str(r.status or ""),
-            str(r.stamp_rule_ids_json or "[]"),
+            row.engine_proposal_id,
+            _to_int(row.draft or 0),
+            _to_int(row.analytics_flushed or 0),
+            str(row.status or ""),
+            str(row.stamp_rule_ids_json or "[]"),
         )
+
+    for r in prior_rows:
+        if not (r.engine_proposal_id or r.draft or r.analytics_flushed):
+            continue
+        file_ = str(r.file or "")
+        source = str(r.source or "")
+        rule_id = str(r.rule_id or "")
+        key = _bridge_key(file_, source, rule_id, r.line_start, r.line_end)
+        _register_bridge(key, r)
+        if _to_int(r.line_end, 0) > 0:
+            _register_bridge(_bridge_key(file_, source, rule_id, r.line_start, 0), r)
     for prop in typed:
         # Non-interactive deterministic with fixed yaml → approved for analytics.
         status = prop.status

--- a/src/apme_gateway/proposals/grouping.py
+++ b/src/apme_gateway/proposals/grouping.py
@@ -8,10 +8,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # Proto RemediationClass numeric values (apme.v1.common).
 _RC_AUTO_FIXABLE = 1
@@ -61,6 +64,7 @@ class GroupedProposal:
         stamp_rule_ids: When non-empty, only these rule ids may receive
             ``review_status`` stamps (set from matched outcome rule list).
         node_type: ContentGraph NodeType value (task, block, play, …).
+        line_end: Last line of the finding/node (0 when unknown).
     """
 
     proposal_id: str
@@ -83,6 +87,7 @@ class GroupedProposal:
     coupled: bool = False
     stamp_rule_ids: tuple[str, ...] = ()
     node_type: str = ""
+    line_end: int = 0
 
 
 @dataclass
@@ -98,6 +103,157 @@ class _Bucket:
     key: str = ""
 
 
+def _to_int(value: object, default: int = 0) -> int:
+    """Coerce JSON-ish line values to int, mapping unknowns to default.
+
+    Clamps results at ``>= 0`` since line numbers and tiers are never
+    negative.
+
+    Args:
+        value: Raw line value (int, float, numeric string, bool, None, …).
+        default: Fallback when coercion fails.
+
+    Returns:
+        Coerced integer clamped at ``>= 0``, or clamped ``default``.
+    """
+    fallback = max(0, default)
+    if isinstance(value, bool):
+        logger.debug("Falling back line/tier value %r to %r", value, fallback)
+        return fallback
+    if isinstance(value, int):
+        if value < 0:
+            logger.debug("Clamping negative line/tier value %r to 0", value)
+            return 0
+        return value
+    if isinstance(value, float):
+        if value.is_integer():
+            coerced = int(value)
+            if coerced < 0:
+                logger.debug("Clamping negative line/tier value %r to 0", value)
+                return 0
+            return coerced
+        logger.debug("Falling back line/tier value %r to %r", value, fallback)
+        return fallback
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            logger.debug("Falling back line/tier value %r to %r", value, fallback)
+            return fallback
+        try:
+            coerced_str = int(text)
+            if coerced_str < 0:
+                logger.debug("Clamping negative line/tier value %r to 0", value)
+                return 0
+            return coerced_str
+        except ValueError:
+            try:
+                parsed = float(text)
+            except ValueError:
+                logger.debug("Falling back line/tier value %r to %r", value, fallback)
+                return fallback
+            if parsed.is_integer():
+                coerced_float = int(parsed)
+                if coerced_float < 0:
+                    logger.debug("Clamping negative line/tier value %r to 0", value)
+                    return 0
+                return coerced_float
+            logger.debug("Falling back line/tier value %r to %r", value, fallback)
+            return fallback
+    if value is None:
+        logger.debug("Falling back line/tier value %r to %r", value, fallback)
+        return fallback
+    logger.debug("Falling back line/tier value %r to %r", value, fallback)
+    return fallback
+
+
+def _parse_violation_id(value: object) -> int | None:
+    """Parse a violation primary key, rejecting bools and non-integral values.
+
+    Reuses :func:`_to_int` validation so ``True`` maps to invalid (not 1)
+    and ``12.9``/``"12.5"`` map to invalid (not truncated to 12), unlike
+    raw ``int()``. Failures return ``None`` instead of a default so callers
+    skip invalid ids rather than inventing id 0.
+
+    Args:
+        value: Raw id value (int, float, numeric string, bool, None, …).
+
+    Returns:
+        Positive integer id, or ``None`` when invalid or non-positive.
+    """
+    coerced = _to_int(value)
+    return coerced if coerced > 0 else None
+
+
+def _coerce_violation_ids(values: Sequence[object]) -> list[int]:
+    """Filter raw violation id values down to valid positive PKs.
+
+    Args:
+        values: Raw id values from JSON columns or duck-typed objects.
+
+    Returns:
+        Sorted list of valid positive integer ids.
+    """
+    return sorted(parsed for v in values if (parsed := _parse_violation_id(v)) is not None)
+
+
+def _safe_float(value: object, default: float = 0.0) -> float:
+    """Coerce JSON-ish confidence values to float, clamped to 0..1.
+
+    Mirrors the draft stub coercion semantics so outcome overlays tolerate
+    numeric strings without raising.
+
+    Args:
+        value: Raw confidence value (int, float, numeric string, bool, None, …).
+        default: Fallback when coercion fails.
+
+    Returns:
+        Coerced float in ``[0.0, 1.0]``, or clamped ``default``.
+    """
+    clamped_default = min(1.0, max(0.0, default))
+    if isinstance(value, bool):
+        logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+        return clamped_default
+    if isinstance(value, int):
+        coerced_int = float(value)
+        if coerced_int < 0.0:
+            logger.debug("Clamping confidence value %r to 0.0", value)
+            return 0.0
+        if coerced_int > 1.0:
+            logger.debug("Clamping confidence value %r to 1.0", value)
+            return 1.0
+        return coerced_int
+    if isinstance(value, float):
+        if value < 0.0:
+            logger.debug("Clamping confidence value %r to 0.0", value)
+            return 0.0
+        if value > 1.0:
+            logger.debug("Clamping confidence value %r to 1.0", value)
+            return 1.0
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+            return clamped_default
+        try:
+            coerced_str = float(text)
+        except ValueError:
+            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+            return clamped_default
+        if coerced_str < 0.0:
+            logger.debug("Clamping confidence value %r to 0.0", value)
+            return 0.0
+        if coerced_str > 1.0:
+            logger.debug("Clamping confidence value %r to 1.0", value)
+            return 1.0
+        return coerced_str
+    if value is None:
+        logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+        return clamped_default
+    logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+    return clamped_default
+
+
 def _as_mapping(v: object) -> Mapping[str, Any]:
     """Normalize ORM / dict / object with attributes into a mapping view.
 
@@ -108,15 +264,21 @@ def _as_mapping(v: object) -> Mapping[str, Any]:
         Mapping of grouping fields.
     """
     if isinstance(v, Mapping):
-        return v
+        coerced = dict(v)
+        for field in ("line", "node_line_start", "line_end", "node_line_end", "remediation_class"):
+            if field in coerced:
+                coerced[field] = _to_int(coerced[field])
+        return coerced
     return {
         "id": getattr(v, "id", None),
         "rule_id": getattr(v, "rule_id", "") or "",
         "file": getattr(v, "file", "") or "",
         "path": getattr(v, "path", "") or "",
-        "line": getattr(v, "line", None),
-        "node_line_start": getattr(v, "node_line_start", 0) or 0,
-        "remediation_class": getattr(v, "remediation_class", 0) or 0,
+        "line": _to_int(getattr(v, "line", None)),
+        "node_line_start": _to_int(getattr(v, "node_line_start", 0)),
+        "line_end": _to_int(getattr(v, "line_end", 0)),
+        "node_line_end": _to_int(getattr(v, "node_line_end", 0)),
+        "remediation_class": _to_int(getattr(v, "remediation_class", 0)),
         "original_yaml": getattr(v, "original_yaml", "") or "",
         "fixed_yaml": getattr(v, "fixed_yaml", "") or "",
         "node_type": getattr(v, "node_type", "") or "",
@@ -133,7 +295,7 @@ def _class_lane(item: Mapping[str, Any]) -> str:
     Returns:
         ``tier1``, ``ai``, or ``other``.
     """
-    rem_class = int(item.get("remediation_class") or 0)
+    rem_class = _to_int(item.get("remediation_class"))
     if rem_class == _RC_AI_CANDIDATE:
         return "ai"
     if rem_class == _RC_AUTO_FIXABLE or str(item.get("fixed_yaml") or "").strip():
@@ -173,7 +335,7 @@ def _classify(items: Sequence[Mapping[str, Any]]) -> tuple[str, str, int]:
     Returns:
         ``(source, gate, tier)``.
     """
-    classes = {int(i.get("remediation_class") or 0) for i in items}
+    classes = {_to_int(i.get("remediation_class")) for i in items}
     has_fixed = any(str(i.get("fixed_yaml") or "").strip() for i in items)
     # Prefer remediation_class over fixed_yaml so an AI-candidate row with
     # leftover fixed text is not mislabeled as Tier 1 deterministic.
@@ -274,21 +436,7 @@ def group_violations(
         rule_ids = tuple(sorted({str(i.get("rule_id") or "") for i in items if i.get("rule_id")}))
         if not rule_ids:
             rule_ids = ("",)
-        violation_ids = tuple(
-            sorted(int(i["id"]) for i in items if isinstance(i.get("id"), int) or str(i.get("id", "")).isdigit())
-        )
-        # Re-parse ids that came as numeric strings from JSON-ish sources.
-        if not violation_ids:
-            parsed: list[int] = []
-            for i in items:
-                raw_id = i.get("id")
-                if raw_id is None:
-                    continue
-                try:
-                    parsed.append(int(raw_id))
-                except (TypeError, ValueError):
-                    continue
-            violation_ids = tuple(sorted(parsed))
+        violation_ids = tuple(_coerce_violation_ids([i.get("id") for i in items]))
 
         source, gate, tier = _classify(items)
         # Keys are path:{path}:lane:{lane} or singleton:…
@@ -297,16 +445,27 @@ def group_violations(
             rest = key[len("path:") :]
             path = rest.rsplit(":lane:", 1)[0] if ":lane:" in rest else rest
         file_path = str(items[0].get("file") or "")
+        # Select span from the SAME item so start/end cannot mismatch across
+        # grouped rows. Prefer the first nonzero node span, else the first
+        # int-like line with its same-item end. Keep line_end=0 unknown.
+        # Violations predate line_end storage, so grouped historical rows
+        # keep 0 until violation storage also carries it; live items that
+        # already carry line_end preserve it here.
         line_start = 0
+        line_end = 0
         for i in items:
-            nls = i.get("node_line_start")
-            if isinstance(nls, int) and nls:
-                line_start = nls
+            node_start = _to_int(i.get("node_line_start"))
+            if node_start:
+                line_start = node_start
+                line_end = _to_int(i.get("line_end")) or _to_int(i.get("node_line_end"))
                 break
-            line = i.get("line")
-            if isinstance(line, int):
-                line_start = line
-                break
+        else:
+            for i in items:
+                coerced_line = _to_int(i.get("line"))
+                if coerced_line:
+                    line_start = coerced_line
+                    line_end = _to_int(i.get("line_end")) or _to_int(i.get("node_line_end"))
+                    break
 
         original = next((str(i.get("original_yaml") or "") for i in items if i.get("original_yaml")), "")
         fixed = next((str(i.get("fixed_yaml") or "") for i in items if i.get("fixed_yaml")), "")
@@ -343,6 +502,7 @@ def group_violations(
                 file=file_path,
                 path=path,
                 line_start=line_start,
+                line_end=line_end,
                 tier=tier,
                 source=source,
                 gate=gate,
@@ -417,8 +577,11 @@ def merge_outcomes(
         status = str(getattr(outcome, "status", "") or prop.status)
         if status == "rejected":
             status = "declined"
-        confidence = float(getattr(outcome, "confidence", prop.confidence) or 0.0)
-        tier = int(getattr(outcome, "tier", prop.tier) or prop.tier)
+        # Defensive coercion: outcomes may carry JSON-ish strings ("12", "0.9",
+        # "12.0"). _safe_float/_to_int fall back to the grouped value instead
+        # of raising and aborting the whole merge.
+        confidence = _safe_float(getattr(outcome, "confidence", prop.confidence), prop.confidence)
+        tier = _to_int(getattr(outcome, "tier", prop.tier), prop.tier)
         source = prop.source
         gate = prop.gate
         # Outcome tier wins: keep source/gate aligned with tier so analytics
@@ -446,6 +609,7 @@ def merge_outcomes(
                 file=prop.file,
                 path=prop.path,
                 line_start=prop.line_start,
+                line_end=_to_int(getattr(outcome, "line_end", prop.line_end), prop.line_end) or prop.line_end,
                 tier=tier or prop.tier,
                 source=source,
                 gate=gate,
@@ -522,7 +686,7 @@ def analytics_increments(proposal: GroupedProposal | Mapping[str, Any]) -> list[
             rule_ids = [str(proposal["rule_id"])]
         source = str(proposal.get("source") or SOURCE_OUTCOME)
         gate = str(proposal.get("gate") or "")
-        tier = int(proposal.get("tier") or 0)
+        tier = _to_int(proposal.get("tier"))
         coupled = bool(proposal.get("coupled")) or len(rule_ids) > 1
 
     # Normalize analytics source to deterministic|ai for both input shapes.
@@ -613,8 +777,12 @@ def violation_accepts_review_status(
     Returns:
         Whether this violation is compatible with the proposal source.
     """
-    fixed = str(getattr(violation, "fixed_yaml", "") or "").strip()
-    rem_class = int(getattr(violation, "remediation_class", 0) or 0)
+    if isinstance(violation, Mapping):
+        fixed = str(violation.get("fixed_yaml", "") or "").strip()
+        rem_class = _to_int(violation.get("remediation_class"))
+    else:
+        fixed = str(getattr(violation, "fixed_yaml", "") or "").strip()
+        rem_class = _to_int(getattr(violation, "remediation_class", 0))
     is_ai_source = source in {SOURCE_AI, SOURCE_AI_CANDIDATE}
     accepted, declined = decision_delta(decision or "")
     if is_ai_source:

--- a/src/apme_gateway/proposals/grouping.py
+++ b/src/apme_gateway/proposals/grouping.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
@@ -223,6 +224,9 @@ def _safe_float(value: object, default: float = 0.0) -> float:
             return 1.0
         return coerced_int
     if isinstance(value, float):
+        if not math.isfinite(value):
+            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+            return clamped_default
         if value < 0.0:
             logger.debug("Clamping confidence value %r to 0.0", value)
             return 0.0
@@ -238,6 +242,9 @@ def _safe_float(value: object, default: float = 0.0) -> float:
         try:
             coerced_str = float(text)
         except ValueError:
+            logger.debug("Falling back confidence value %r to %r", value, clamped_default)
+            return clamped_default
+        if not math.isfinite(coerced_str):
             logger.debug("Falling back confidence value %r to %r", value, clamped_default)
             return clamped_default
         if coerced_str < 0.0:

--- a/src/apme_gateway/scan/driver.py
+++ b/src/apme_gateway/scan/driver.py
@@ -22,7 +22,7 @@ import time
 import uuid
 from collections.abc import AsyncIterator, Callable, Coroutine
 from typing import Any
-from urllib.parse import quote, urlparse, urlunparse
+from urllib.parse import quote, unquote, urlparse, urlunparse
 
 import grpc
 import grpc.aio
@@ -180,13 +180,104 @@ def _git_origin(repo_url: str) -> str:
 
     Returns:
         Origin string used to scope git ``http.<origin>.extraHeader`` keys.
+
+    Raises:
+        ValueError: When the URL contains a malformed port.
     """
     parsed = urlparse(repo_url)
     host = parsed.hostname or ""
     origin = f"{parsed.scheme}://{host}"
-    if parsed.port:
-        origin += f":{parsed.port}"
+    try:
+        port = parsed.port
+    except ValueError:
+        raise
+    if port:
+        origin += f":{port}"
     return origin
+
+
+def _url_embedded_userpass(repo_url: str) -> tuple[str, str] | None:
+    """Return username/password embedded in a clone URL's userinfo.
+
+    Args:
+        repo_url: Raw clone URL, possibly with embedded userinfo.
+
+    Returns:
+        ``(username, password)`` tuple, or ``None`` when no userinfo is present.
+    """
+    try:
+        parsed = urlparse(repo_url)
+    except ValueError:
+        return None
+    if not parsed.username:
+        return None
+    user = unquote(parsed.username)
+    password = unquote(parsed.password or "")
+    return user, password
+
+
+def _auth_cache_marker(scm_token: str | None, url_userpass: tuple[str, str] | None) -> str:
+    """Build a stable cache marker for credential-aware SCM lookups.
+
+    Args:
+        scm_token: Explicit SCM token, if any.
+        url_userpass: URL-embedded ``(username, password)`` credentials.
+
+    Returns:
+        Empty string when unauthenticated, otherwise ``:auth:<hash>``.
+    """
+    if scm_token:
+        material = scm_token
+    elif url_userpass is not None:
+        material = f"{url_userpass[0]}:{url_userpass[1]}"
+    else:
+        return ""
+    token_hash = hashlib.sha256(material.encode()).hexdigest()[:16]
+    return f":auth:{token_hash}"
+
+
+def _apply_git_auth_env(
+    env: dict[str, str],
+    repo_url: str,
+    scm_token: str | None,
+    url_userpass: tuple[str, str] | None = None,
+    *,
+    scm_provider: str | None = None,
+) -> dict[str, str]:
+    """Merge per-origin git auth headers into *env* when a token is available.
+
+    Args:
+        env: Base git subprocess environment.
+        repo_url: Stripped HTTPS clone URL.
+        scm_token: Explicit SCM token, if any.
+        url_userpass: URL-embedded credentials when *scm_token* is absent.
+        scm_provider: Optional explicit SCM provider.
+
+    Returns:
+        Environment with auth headers merged, unchanged when no token.
+    """
+    if scm_token:
+        auth = _git_auth_env(repo_url, scm_token, scm_provider=scm_provider)
+    elif url_userpass is not None:
+        username, password = url_userpass
+        encoded = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+        auth = {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": f"http.{_git_origin(repo_url)}.extraHeader",
+            "GIT_CONFIG_VALUE_0": f"AUTHORIZATION: Basic {encoded}",
+        }
+    else:
+        return env
+    try:
+        auth_count = int(auth.get("GIT_CONFIG_COUNT", "0"))
+    except ValueError:
+        auth_count = 0
+    pairs = [
+        (auth[f"GIT_CONFIG_KEY_{i}"], auth[f"GIT_CONFIG_VALUE_{i}"])
+        for i in range(auth_count)
+        if f"GIT_CONFIG_KEY_{i}" in auth and f"GIT_CONFIG_VALUE_{i}" in auth
+    ]
+    return _merge_git_config_env(env, pairs)
 
 
 def _strip_url_userinfo(repo_url: str) -> str:
@@ -319,8 +410,12 @@ def _inject_token_in_url(
     username, password = _scm_basic_credentials(repo_url, token, scm_provider=scm_provider)
     # Percent-encode credentials to handle special characters (@, :, /, etc.)
     netloc_with_auth = f"{quote(username, safe='')}:{quote(password, safe='')}@{hostname}"
-    if parsed.port:
-        netloc_with_auth += f":{parsed.port}"
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port:
+        netloc_with_auth += f":{port}"
     return urlunparse(parsed._replace(netloc=netloc_with_auth))
 
 
@@ -381,14 +476,14 @@ async def fetch_remote_head(
     Returns:
         40-char hex SHA, or ``None`` if the lookup fails.
     """
+    url_userpass = _url_embedded_userpass(repo_url) if not scm_token else None
     repo_url = _strip_url_userinfo(repo_url)
     if not any(repo_url.startswith(scheme) for scheme in _ALLOWED_SCHEMES):
         return None
 
     # Key authenticated lookups on a credential hash: two tokens with
     # different access must not share one entry.
-    token_hash = hashlib.sha256(scm_token.encode()).hexdigest()[:16] if scm_token else ""
-    token_marker = f":auth:{token_hash}" if scm_token else ""
+    token_marker = _auth_cache_marker(scm_token, url_userpass)
     cache_key = f"{normalize_repo_url(repo_url)}:{branch}{token_marker}:{scm_provider or ''}"
     now = time.monotonic()
     cached = _REMOTE_HEAD_CACHE.get(cache_key)
@@ -401,18 +496,17 @@ async def fetch_remote_head(
     # Pass the token via a per-origin http.extraHeader env entry so it never
     # appears in argv; pre-existing GIT_CONFIG_* entries are preserved.
     env = _git_subprocess_env()
-    if scm_token:
-        auth = _git_auth_env(repo_url, scm_token, scm_provider=scm_provider)
-        try:
-            auth_count = int(auth.get("GIT_CONFIG_COUNT", "0"))
-        except ValueError:
-            auth_count = 0
-        pairs = [
-            (auth[f"GIT_CONFIG_KEY_{i}"], auth[f"GIT_CONFIG_VALUE_{i}"])
-            for i in range(auth_count)
-            if f"GIT_CONFIG_KEY_{i}" in auth and f"GIT_CONFIG_VALUE_{i}" in auth
-        ]
-        env = _merge_git_config_env(env, pairs)
+    try:
+        env = _apply_git_auth_env(
+            env,
+            repo_url,
+            scm_token,
+            url_userpass,
+            scm_provider=scm_provider,
+        )
+    except ValueError:
+        logger.debug("ls-remote auth env failed for %s branch %s", repo_url, branch, exc_info=True)
+        return None
     cmd = ["git", "ls-remote", "--exit-code", repo_url, f"refs/heads/{branch}"]
     loop = asyncio.get_running_loop()
     sha: str | None = None
@@ -494,6 +588,7 @@ async def clone_repo(
         ValueError: If *repo_url* uses a disallowed scheme.
         RuntimeError: If ``git clone`` fails or times out.
     """
+    url_userpass = _url_embedded_userpass(repo_url) if not scm_token else None
     repo_url = _strip_url_userinfo(repo_url)
     if not any(repo_url.startswith(scheme) for scheme in _ALLOWED_SCHEMES):
         msg = f"Only https:// clone URLs are allowed, got: {repo_url[:60]}"
@@ -506,18 +601,17 @@ async def clone_repo(
     # Pass the token via a per-origin http.extraHeader env entry so it never
     # appears in argv; pre-existing GIT_CONFIG_* entries are preserved.
     env = _git_subprocess_env()
-    if scm_token:
-        auth = _git_auth_env(repo_url, scm_token, scm_provider=scm_provider)
-        try:
-            auth_count = int(auth.get("GIT_CONFIG_COUNT", "0"))
-        except ValueError:
-            auth_count = 0
-        pairs = [
-            (auth[f"GIT_CONFIG_KEY_{i}"], auth[f"GIT_CONFIG_VALUE_{i}"])
-            for i in range(auth_count)
-            if f"GIT_CONFIG_KEY_{i}" in auth and f"GIT_CONFIG_VALUE_{i}" in auth
-        ]
-        env = _merge_git_config_env(env, pairs)
+    try:
+        env = _apply_git_auth_env(
+            env,
+            repo_url,
+            scm_token,
+            url_userpass,
+            scm_provider=scm_provider,
+        )
+    except ValueError as exc:
+        msg = f"Invalid repository URL for authentication: {repo_url[:60]}"
+        raise ValueError(msg) from exc
     cmd = [
         "git",
         "clone",

--- a/src/apme_gateway/scan/driver.py
+++ b/src/apme_gateway/scan/driver.py
@@ -10,6 +10,7 @@ them on the first chunk).
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import hashlib
 import logging
@@ -30,6 +31,7 @@ from apme.v1 import engine_pb2, engine_pb2_grpc
 from apme.v1.common_pb2 import GalaxyServerDef
 from apme_engine.daemon.chunked_fs import yield_scan_chunks
 from apme_gateway.scm.redaction import redact_credentials as _redact_credentials
+from apme_gateway.scm.repo_url import normalize_repo_url
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +90,11 @@ _ALLOWED_SCHEMES = ("https://",)
 _REMOTE_HEAD_CACHE: dict[str, tuple[float, str | None]] = {}
 _REMOTE_HEAD_TTL = 60.0  # seconds
 _REMOTE_HEAD_CACHE_MAX = 256
+#: Short TTL for negative ``ls-remote`` results: a transient failure must not
+#: poison refreshes for a full minute, but hammering the SCM on every poll
+#: during an outage is a self-inflicted retry storm.
+_REMOTE_HEAD_NEG_TTL = 10.0  # seconds
+_REMOTE_HEAD_NEG_CACHE: dict[str, float] = {}
 
 
 def _git_subprocess_env() -> dict[str, str]:
@@ -114,6 +121,166 @@ def _git_subprocess_env() -> dict[str, str]:
     return env
 
 
+def _scm_basic_credentials(
+    repo_url: str,
+    token: str,
+    *,
+    scm_provider: str | None = None,
+) -> tuple[str, str]:
+    """Select the HTTP Basic (username, password) pair for an SCM token.
+
+    Supports multiple SCM providers with their respective auth schemes:
+    - GitHub: ``x-access-token:TOKEN``
+    - GitLab: ``oauth2:TOKEN``
+    - Bitbucket access token: ``x-token-auth:TOKEN``
+    - Bitbucket app password (``user:pass``): ``user:pass`` as credentials
+    - Others: ``git:TOKEN`` (generic fallback)
+
+    When *scm_provider* is set, it takes precedence over hostname heuristics
+    so self-hosted Bitbucket/GitLab hosts authenticate correctly.
+
+    Args:
+        repo_url: Original HTTPS clone URL (used for provider heuristics).
+        token: SCM token (e.g., PAT, OAuth token, or ``user:pass``).
+        scm_provider: Optional explicit provider (``github`` / ``gitlab`` /
+            ``bitbucket``).
+
+    Returns:
+        Raw (username, password) tuple — callers encode as needed.
+    """
+    from apme_gateway.scm.urls import split_user_pass_token
+
+    parsed = urlparse(repo_url)
+    hostname = parsed.hostname or ""
+    provider = (scm_provider or "").lower().strip()
+    host_l = hostname.lower()
+
+    user_pass = split_user_pass_token(token)
+    if user_pass is not None:
+        use_user_pass = provider in {"bitbucket", "gitlab"} or (
+            not provider and ("bitbucket" in host_l or "gitlab" in host_l)
+        )
+        if use_user_pass:
+            return user_pass
+
+    if provider == "github" or (not provider and "github" in host_l):
+        return ("x-access-token", token)
+    if provider == "gitlab" or (not provider and "gitlab" in host_l):
+        return ("oauth2", token)
+    if provider == "bitbucket" or (not provider and "bitbucket" in host_l):
+        return ("x-token-auth", token)
+    return ("git", token)
+
+
+def _git_origin(repo_url: str) -> str:
+    """Return the ``scheme://host[:port]`` origin for *repo_url*.
+
+    Args:
+        repo_url: HTTPS clone URL.
+
+    Returns:
+        Origin string used to scope git ``http.<origin>.extraHeader`` keys.
+    """
+    parsed = urlparse(repo_url)
+    host = parsed.hostname or ""
+    origin = f"{parsed.scheme}://{host}"
+    if parsed.port:
+        origin += f":{parsed.port}"
+    return origin
+
+
+def _strip_url_userinfo(repo_url: str) -> str:
+    """Remove embedded ``user:pass@`` credentials from a clone URL.
+
+    Stored project URLs may contain userinfo; passing them verbatim into
+    ``git clone``/``ls-remote`` argv exposes the secret in process listings.
+    Token auth travels via the per-origin ``http.extraHeader`` env entry
+    instead, so the userinfo component is always safe to drop.
+
+    Args:
+        repo_url: Raw clone URL, possibly with embedded userinfo.
+
+    Returns:
+        URL with the userinfo component removed; unchanged when none present.
+    """
+    try:
+        parsed = urlparse(repo_url)
+    except ValueError:
+        return repo_url
+    netloc = parsed.netloc
+    if "@" not in netloc:
+        return repo_url
+    host = parsed.hostname or ""
+    if not host:
+        return repo_url
+    logger.warning("Stripping embedded credentials from repo URL for host %s", host)
+    return urlunparse(parsed._replace(netloc=netloc.rsplit("@", 1)[-1]))
+
+
+def _merge_git_config_env(base: dict[str, str], extra_pairs: list[tuple[str, str]]) -> dict[str, str]:
+    """Merge ``GIT_CONFIG_KEY_n/VALUE_n`` pairs into a copy of *base*.
+
+    Existing numbered entries are preserved; new pairs are appended at the
+    next indices and ``GIT_CONFIG_COUNT`` is updated. A missing or
+    unparseable count is treated as zero (numbered entries are still kept).
+
+    Args:
+        base: Base environment mapping (e.g. from :func:`_git_subprocess_env`).
+        extra_pairs: ``(key, value)`` config pairs to append.
+
+    Returns:
+        New environment mapping with the merged git-config entries.
+    """
+    merged = dict(base)
+    try:
+        count = int(merged.get("GIT_CONFIG_COUNT", "0"))
+    except ValueError:
+        count = 0
+    if count < 0:
+        count = 0
+    for key, value in extra_pairs:
+        merged[f"GIT_CONFIG_KEY_{count}"] = key
+        merged[f"GIT_CONFIG_VALUE_{count}"] = value
+        count += 1
+    merged["GIT_CONFIG_COUNT"] = str(count)
+    return merged
+
+
+def _git_auth_env(
+    repo_url: str,
+    token: str,
+    *,
+    scm_provider: str | None = None,
+) -> dict[str, str]:
+    """Build git-config env carrying the SCM token as an HTTP header.
+
+    The token travels in ``GIT_CONFIG_*`` environment (a per-origin
+    ``http.<origin>.extraHeader`` with an ``AUTHORIZATION: Basic`` value)
+    instead of the clone URL, so it never appears in subprocess argv,
+    process listings, or error output. Scoping to the repo origin keeps the
+    credential from being sent to any other host git contacts (e.g.
+    redirects, submodules). Merge with :func:`_merge_git_config_env` so
+    pre-existing ``GIT_CONFIG_*`` entries are preserved.
+
+    Args:
+        repo_url: HTTPS clone URL (used for provider heuristics and origin
+            scoping).
+        token: SCM token.
+        scm_provider: Optional explicit provider.
+
+    Returns:
+        Env mapping with ``GIT_CONFIG_COUNT/KEY_0/VALUE_0`` to merge into
+        the git subprocess environment.
+    """
+    username, password = _scm_basic_credentials(repo_url, token, scm_provider=scm_provider)
+    encoded = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+    return {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": f"http.{_git_origin(repo_url)}.extraHeader",
+        "GIT_CONFIG_VALUE_0": f"AUTHORIZATION: Basic {encoded}",
+    }
+
+
 def _inject_token_in_url(
     repo_url: str,
     token: str,
@@ -121,6 +288,12 @@ def _inject_token_in_url(
     scm_provider: str | None = None,
 ) -> str:
     """Inject an authentication token into an HTTPS git URL.
+
+    .. deprecated::
+        Prefer :func:`_git_auth_env` for subprocess calls so tokens stay out
+        of argv, process listings, and error output. This helper remains only
+        for contexts where a URL is required, and for its unit tests — do not
+        adopt it for new subprocess call sites.
 
     Supports multiple SCM providers with their respective auth schemes:
     - GitHub: ``x-access-token:TOKEN``
@@ -141,42 +314,48 @@ def _inject_token_in_url(
     Returns:
         URL with embedded credentials.
     """
-    from apme_gateway.scm.urls import split_user_pass_token
-
     parsed = urlparse(repo_url)
     hostname = parsed.hostname or ""
-    provider = (scm_provider or "").lower().strip()
-    host_l = hostname.lower()
-
-    user_pass = split_user_pass_token(token)
-    if user_pass is not None:
-        use_user_pass = provider in {"bitbucket", "gitlab"} or (
-            not provider and ("bitbucket" in host_l or "gitlab" in host_l)
-        )
-        if use_user_pass:
-            username, password = user_pass
-            encoded_user = quote(username, safe="")
-            encoded_token = quote(password, safe="")
-            netloc_with_auth = f"{encoded_user}:{encoded_token}@{hostname}"
-            if parsed.port:
-                netloc_with_auth += f":{parsed.port}"
-            return urlunparse(parsed._replace(netloc=netloc_with_auth))
-
-    if provider == "github" or (not provider and "github" in host_l):
-        username = "x-access-token"
-    elif provider == "gitlab" or (not provider and "gitlab" in host_l):
-        username = "oauth2"
-    elif provider == "bitbucket" or (not provider and "bitbucket" in host_l):
-        username = "x-token-auth"
-    else:
-        username = "git"
-
-    # Percent-encode token to handle special characters (@, :, /, etc.)
-    encoded_token = quote(token, safe="")
-    netloc_with_auth = f"{username}:{encoded_token}@{hostname}"
+    username, password = _scm_basic_credentials(repo_url, token, scm_provider=scm_provider)
+    # Percent-encode credentials to handle special characters (@, :, /, etc.)
+    netloc_with_auth = f"{quote(username, safe='')}:{quote(password, safe='')}@{hostname}"
     if parsed.port:
         netloc_with_auth += f":{parsed.port}"
     return urlunparse(parsed._replace(netloc=netloc_with_auth))
+
+
+def _evict_remote_head_entries(now: float) -> None:
+    """Make room in the ``ls-remote`` caches without dropping everything.
+
+    Expired positive entries go first; when still full, the single oldest
+    entry (positive or negative) is evicted. Clearing the whole map on one
+    miss turns a full cache into a subprocess-per-poll storm.
+
+    Args:
+        now: Current ``time.monotonic()`` reading.
+    """
+    expired = [k for k, (ts, _) in _REMOTE_HEAD_CACHE.items() if (now - ts) >= _REMOTE_HEAD_TTL]
+    for k in expired:
+        del _REMOTE_HEAD_CACHE[k]
+    expired_neg = [k for k, ts in _REMOTE_HEAD_NEG_CACHE.items() if (now - ts) >= _REMOTE_HEAD_NEG_TTL]
+    for k in expired_neg:
+        del _REMOTE_HEAD_NEG_CACHE[k]
+    while len(_REMOTE_HEAD_CACHE) + len(_REMOTE_HEAD_NEG_CACHE) >= _REMOTE_HEAD_CACHE_MAX:
+        oldest_key: str | None = None
+        oldest_ts = float("inf")
+        for k, (ts, _) in _REMOTE_HEAD_CACHE.items():
+            if ts < oldest_ts:
+                oldest_ts, oldest_key = ts, k
+        oldest_neg: str | None = None
+        for k, ts in _REMOTE_HEAD_NEG_CACHE.items():
+            if ts < oldest_ts:
+                oldest_ts, oldest_key, oldest_neg = ts, k, k
+        if oldest_key is None:
+            break
+        if oldest_neg is not None and oldest_key == oldest_neg:
+            del _REMOTE_HEAD_NEG_CACHE[oldest_key]
+        else:
+            del _REMOTE_HEAD_CACHE[oldest_key]
 
 
 async def fetch_remote_head(
@@ -189,8 +368,9 @@ async def fetch_remote_head(
     """Query the remote for the HEAD commit SHA of *branch* without cloning.
 
     Uses ``git ls-remote`` which only contacts the server for ref advertisement.
-    Results are cached for 60 seconds per (repo_url, branch) to avoid repeated
-    outbound calls on frequent UI refreshes.
+    Hits are cached for 60 seconds per (repo_url, branch, credential); misses
+    are cached for 10 seconds so a flapping SCM does not cause a subprocess
+    per poll while still recovering quickly.
 
     Args:
         repo_url: HTTPS clone URL.
@@ -201,20 +381,39 @@ async def fetch_remote_head(
     Returns:
         40-char hex SHA, or ``None`` if the lookup fails.
     """
+    repo_url = _strip_url_userinfo(repo_url)
     if not any(repo_url.startswith(scheme) for scheme in _ALLOWED_SCHEMES):
         return None
 
-    # Include token presence in cache key to avoid mixing authenticated/unauthenticated results
-    token_marker = ":auth" if scm_token else ""
-    cache_key = f"{repo_url}:{branch}{token_marker}:{scm_provider or ''}"
+    # Key authenticated lookups on a credential hash: two tokens with
+    # different access must not share one entry.
+    token_hash = hashlib.sha256(scm_token.encode()).hexdigest()[:16] if scm_token else ""
+    token_marker = f":auth:{token_hash}" if scm_token else ""
+    cache_key = f"{normalize_repo_url(repo_url)}:{branch}{token_marker}:{scm_provider or ''}"
     now = time.monotonic()
     cached = _REMOTE_HEAD_CACHE.get(cache_key)
     if cached and (now - cached[0]) < _REMOTE_HEAD_TTL:
         return cached[1]
+    neg_ts = _REMOTE_HEAD_NEG_CACHE.get(cache_key)
+    if neg_ts is not None and (now - neg_ts) < _REMOTE_HEAD_NEG_TTL:
+        return None
 
-    # Inject token for private repo access
-    effective_url = _inject_token_in_url(repo_url, scm_token, scm_provider=scm_provider) if scm_token else repo_url
-    cmd = ["git", "ls-remote", "--exit-code", effective_url, f"refs/heads/{branch}"]
+    # Pass the token via a per-origin http.extraHeader env entry so it never
+    # appears in argv; pre-existing GIT_CONFIG_* entries are preserved.
+    env = _git_subprocess_env()
+    if scm_token:
+        auth = _git_auth_env(repo_url, scm_token, scm_provider=scm_provider)
+        try:
+            auth_count = int(auth.get("GIT_CONFIG_COUNT", "0"))
+        except ValueError:
+            auth_count = 0
+        pairs = [
+            (auth[f"GIT_CONFIG_KEY_{i}"], auth[f"GIT_CONFIG_VALUE_{i}"])
+            for i in range(auth_count)
+            if f"GIT_CONFIG_KEY_{i}" in auth and f"GIT_CONFIG_VALUE_{i}" in auth
+        ]
+        env = _merge_git_config_env(env, pairs)
+    cmd = ["git", "ls-remote", "--exit-code", repo_url, f"refs/heads/{branch}"]
     loop = asyncio.get_running_loop()
     sha: str | None = None
     try:
@@ -225,7 +424,7 @@ async def fetch_remote_head(
                 capture_output=True,
                 text=True,
                 timeout=30,
-                env=_git_subprocess_env(),
+                env=env,
             ),
         )
         if result.returncode == 0 and result.stdout.strip():
@@ -233,14 +432,17 @@ async def fetch_remote_head(
     except Exception:  # noqa: BLE001
         logger.debug("ls-remote failed for %s branch %s", repo_url, branch, exc_info=True)
 
-    if len(_REMOTE_HEAD_CACHE) >= _REMOTE_HEAD_CACHE_MAX:
-        expired = [k for k, (ts, _) in _REMOTE_HEAD_CACHE.items() if (now - ts) >= _REMOTE_HEAD_TTL]
-        for k in expired:
-            del _REMOTE_HEAD_CACHE[k]
-        if len(_REMOTE_HEAD_CACHE) >= _REMOTE_HEAD_CACHE_MAX:
-            _REMOTE_HEAD_CACHE.clear()
+    now = time.monotonic()
+    if len(_REMOTE_HEAD_CACHE) + len(_REMOTE_HEAD_NEG_CACHE) >= _REMOTE_HEAD_CACHE_MAX:
+        _evict_remote_head_entries(now)
 
-    _REMOTE_HEAD_CACHE[cache_key] = (now, sha)
+    if sha is not None:
+        _REMOTE_HEAD_NEG_CACHE.pop(cache_key, None)
+        _REMOTE_HEAD_CACHE[cache_key] = (now, sha)
+    else:
+        # Short-TTL negative entry: throttle failure storms without
+        # poisoning refreshes for a full minute.
+        _REMOTE_HEAD_NEG_CACHE[cache_key] = now
     return sha
 
 
@@ -290,8 +492,9 @@ async def clone_repo(
 
     Raises:
         ValueError: If *repo_url* uses a disallowed scheme.
-        RuntimeError: If ``git clone`` fails.
+        RuntimeError: If ``git clone`` fails or times out.
     """
+    repo_url = _strip_url_userinfo(repo_url)
     if not any(repo_url.startswith(scheme) for scheme in _ALLOWED_SCHEMES):
         msg = f"Only https:// clone URLs are allowed, got: {repo_url[:60]}"
         raise ValueError(msg)
@@ -300,8 +503,21 @@ async def clone_repo(
         msg = f"Invalid branch name: {branch[:60]}"
         raise ValueError(msg)
 
-    # Inject token for private repo access
-    effective_url = _inject_token_in_url(repo_url, scm_token, scm_provider=scm_provider) if scm_token else repo_url
+    # Pass the token via a per-origin http.extraHeader env entry so it never
+    # appears in argv; pre-existing GIT_CONFIG_* entries are preserved.
+    env = _git_subprocess_env()
+    if scm_token:
+        auth = _git_auth_env(repo_url, scm_token, scm_provider=scm_provider)
+        try:
+            auth_count = int(auth.get("GIT_CONFIG_COUNT", "0"))
+        except ValueError:
+            auth_count = 0
+        pairs = [
+            (auth[f"GIT_CONFIG_KEY_{i}"], auth[f"GIT_CONFIG_VALUE_{i}"])
+            for i in range(auth_count)
+            if f"GIT_CONFIG_KEY_{i}" in auth and f"GIT_CONFIG_VALUE_{i}" in auth
+        ]
+        env = _merge_git_config_env(env, pairs)
     cmd = [
         "git",
         "clone",
@@ -310,22 +526,25 @@ async def clone_repo(
         "--single-branch",
         "--depth",
         "1",
-        effective_url,
+        repo_url,
         dest,
     ]
     loop = asyncio.get_running_loop()
-    result = await loop.run_in_executor(
-        None,
-        lambda: subprocess.run(  # noqa: S603
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=120,
-            env=_git_subprocess_env(),
-        ),
-    )
+    try:
+        result = await loop.run_in_executor(
+            None,
+            lambda: subprocess.run(  # noqa: S603
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env=env,
+            ),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"git clone timed out after 120s for branch {branch[:60]}") from exc
     if result.returncode != 0:
-        safe_stderr = _redact_credentials(result.stderr[:500])
+        safe_stderr = _redact_credentials(result.stderr)[:500]
         raise RuntimeError(f"git clone failed (exit {result.returncode}): {safe_stderr}")
 
 

--- a/src/apme_gateway/scm/redaction.py
+++ b/src/apme_gateway/scm/redaction.py
@@ -5,13 +5,22 @@ from __future__ import annotations
 import re
 
 _CRED_REDACT_RE = re.compile(r"(https?://)[^@]+@")
+# Floors ({8,}/{12,}) apply only to anchored `authorization:`/`bearer` patterns so short English prose is never mangled.
+_BASIC_AUTH_HEADER_RE = re.compile(r"(?i)(authorization:\s*basic\s+)[A-Za-z0-9+/=]{8,}")
+_BEARER_RE = re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/-]{12,}")
 
 
 def redact_credentials(text: str) -> str:
-    """Redact embedded credentials from URLs in text.
+    """Redact embedded credentials from URLs and auth headers in text.
 
     Replaces ``https://user:token@host`` with ``https://[REDACTED]@host``
-    to prevent token exposure in logs or error messages.
+    and masks ``Authorization: Basic <base64>`` header tokens (including
+    ``AUTHORIZATION: Basic`` ``http.extraHeader`` values surfaced via
+    ``GIT_TRACE`` / ``GIT_CURL_VERBOSE`` stderr) with
+    ``Authorization: Basic [REDACTED]`` to prevent token exposure in logs
+    or error messages. ``Bearer <token>`` values are masked the same way.
+    Bare ``Basic`` prose without an ``Authorization:`` prefix is left
+    untouched to avoid English false positives.
 
     Args:
         text: Text potentially containing URLs with credentials.
@@ -19,4 +28,6 @@ def redact_credentials(text: str) -> str:
     Returns:
         Text with credentials redacted.
     """
-    return _CRED_REDACT_RE.sub(r"\1[REDACTED]@", text)
+    redacted = _CRED_REDACT_RE.sub(r"\1[REDACTED]@", text)
+    redacted = _BASIC_AUTH_HEADER_RE.sub(r"\1[REDACTED]", redacted)
+    return _BEARER_RE.sub(r"\1[REDACTED]", redacted)

--- a/src/apme_gateway/scm/redaction.py
+++ b/src/apme_gateway/scm/redaction.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import re
 
 _CRED_REDACT_RE = re.compile(r"(https?://)[^@]+@")
-# Floors ({8,}/{12,}) apply only to anchored `authorization:`/`bearer` patterns so short English prose is never mangled.
-_BASIC_AUTH_HEADER_RE = re.compile(r"(?i)(authorization:\s*basic\s+)[A-Za-z0-9+/=]{8,}")
-_BEARER_RE = re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/-]{12,}")
+# Basic tokens redact from length 1 — the ``authorization: basic`` prefix is specific
+# enough to avoid prose false positives. Bearer keeps a small floor so ``Bearer of``
+# is not mangled while short access tokens still mask.
+_BASIC_AUTH_HEADER_RE = re.compile(r"(?i)(authorization:\s*basic\s+)[A-Za-z0-9+/=]{1,}")
+_BEARER_RE = re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/-]{4,}")
 
 
 def redact_credentials(text: str) -> str:

--- a/src/apme_gateway/scm/repo_url.py
+++ b/src/apme_gateway/scm/repo_url.py
@@ -36,7 +36,8 @@ def normalize_repo_url(repo_url: str) -> str:
         except ValueError:
             # Malformed port (e.g. ``:notaport``) — still strip userinfo from host.
             port = None
-        host = parsed.hostname.lower() if parsed.hostname else parsed.netloc.lower()
+        netloc_no_userinfo = parsed.netloc.rsplit("@", 1)[-1]
+        host = parsed.hostname.lower() if parsed.hostname else netloc_no_userinfo.lower()
         if port is not None:
             is_default = (scheme == "https" and port == 443) or (scheme == "http" and port == 80)
             if not is_default:

--- a/src/apme_gateway/scm/repo_url.py
+++ b/src/apme_gateway/scm/repo_url.py
@@ -8,14 +8,19 @@ from urllib.parse import urlparse
 def normalize_repo_url(repo_url: str) -> str:
     """Normalize a clone URL for stable comparison across portal and gateway.
 
-    Strips trailing slashes, ``.git`` suffix, and lowercases the hostname.
-    Non-URL inputs are returned trimmed without scheme normalization.
+    Strips trailing slashes, ``.git`` suffix, userinfo (``user:pass@``), and
+    lowercases the hostname. Default ports are stripped (443 for ``https``,
+    80 for ``http``) so explicit-default and implicit spellings share one
+    identity; all other scheme/port combinations stay distinct (``http`` vs
+    ``https``, non-default ports). The path keeps its case: ``Org/Repo``
+    and ``org/repo`` are treated as distinct projects. Non-URL inputs are
+    returned trimmed without scheme normalization.
 
     Args:
         repo_url: Raw SCM clone URL from catalog or API clients.
 
     Returns:
-        Canonical ``https://host/org/repo`` form when parseable.
+        Canonical ``scheme://host[:port]/org/repo`` form when parseable.
     """
     value = repo_url.strip().rstrip("/")
     if value.endswith(".git"):
@@ -25,8 +30,14 @@ def normalize_repo_url(repo_url: str) -> str:
         parsed = urlparse(value)
         if not parsed.scheme or not parsed.netloc:
             return value
+        scheme = parsed.scheme.lower()
         host = parsed.hostname.lower() if parsed.hostname else parsed.netloc.lower()
+        port = parsed.port
+        if port is not None:
+            is_default = (scheme == "https" and port == 443) or (scheme == "http" and port == 80)
+            if not is_default:
+                host = f"{host}:{port}"
         path = parsed.path.rstrip("/")
-        return f"https://{host}{path}"
+        return f"{scheme}://{host}{path}"
     except ValueError:
         return value

--- a/src/apme_gateway/scm/repo_url.py
+++ b/src/apme_gateway/scm/repo_url.py
@@ -31,8 +31,12 @@ def normalize_repo_url(repo_url: str) -> str:
         if not parsed.scheme or not parsed.netloc:
             return value
         scheme = parsed.scheme.lower()
+        try:
+            port = parsed.port
+        except ValueError:
+            # Malformed port (e.g. ``:notaport``) — still strip userinfo from host.
+            port = None
         host = parsed.hostname.lower() if parsed.hostname else parsed.netloc.lower()
-        port = parsed.port
         if port is not None:
             is_default = (scheme == "https" and port == 443) or (scheme == "http" and port == 80)
             if not is_default:

--- a/src/apme_gateway/session_client.py
+++ b/src/apme_gateway/session_client.py
@@ -424,6 +424,7 @@ async def _forward_events(
                             "source": p.source,
                             "suggestion": p.suggestion,
                             "path": p.path,
+                            "node_type": getattr(p, "node_type", "") or "",
                         }
                         for p in pr.proposals
                     ],
@@ -446,7 +447,12 @@ async def _forward_events(
                             "file": v.file,
                             "path": v.path or "",
                             "node_type": getattr(v, "node_type", "") or "",
+                            "remediation_class": (int(v.remediation_class) if v.remediation_class else 0),
                             "source": v.source or "",
+                            "original_yaml": v.original_yaml or "",
+                            "fixed_yaml": v.fixed_yaml or "",
+                            "co_fixes": list(v.co_fixes) if v.co_fixes else [],
+                            "node_line_start": (int(getattr(v, "node_line_start", 0) or 0) or None),
                         }
                         for v in triage.candidates
                     ],

--- a/src/galaxy_proxy/__init__.py
+++ b/src/galaxy_proxy/__init__.py
@@ -1,3 +1,8 @@
 """Galaxy Proxy — PEP 503 bridge converting Galaxy tarballs to Python wheels."""
 
 __version__ = "0.1.0"
+
+#: Bound on version-list pagination (100 entries/page), shared by the
+#: deprecated :mod:`galaxy_proxy.galaxy_client` and
+#: :mod:`galaxy_proxy.proxy.server` so the truncation behavior cannot drift.
+MAX_VERSION_PAGES = 50

--- a/src/galaxy_proxy/galaxy_client.py
+++ b/src/galaxy_proxy/galaxy_client.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass, field
 
 import httpx
 
+from galaxy_proxy import MAX_VERSION_PAGES
+
 DEFAULT_GALAXY_URL = "https://galaxy.ansible.com"
 
 COLLECTIONS_PATH = "/api/v3/plugin/ansible/content/published/collections/index"
@@ -164,23 +166,18 @@ class GalaxyClient:
             List of version strings from the first successful upstream.
 
         Raises:
-            httpx.HTTPStatusError: When the last attempted server returns an error status.
-            httpx.RequestError: When the last attempted server's request fails.
-            RuntimeError: When no Galaxy servers are configured.
+            RuntimeError: When no Galaxy servers are configured, when every
+                server's version listing was truncated at the page bound, or
+                when every server failed (the last failure is chained via
+                ``__cause__`` so callers never see a bare
+                ``ValueError``/``KeyError`` from malformed payloads).
         """  # noqa: DOC503
         last_exc: Exception | None = None
+        truncated = False
         for srv, client in zip(self._servers, self._clients, strict=True):
             try:
                 versions = await self._list_versions_from(client, namespace, name)
-                logger.debug(
-                    "list_versions %s.%s: %d version(s) from %s",
-                    namespace,
-                    name,
-                    len(versions),
-                    srv.label(),
-                )
-                return versions
-            except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            except (httpx.HTTPStatusError, httpx.RequestError, ValueError, KeyError) as exc:
                 logger.debug(
                     "list_versions %s.%s: %s failed: %s",
                     namespace,
@@ -189,7 +186,32 @@ class GalaxyClient:
                     exc,
                 )
                 last_exc = exc
-        raise last_exc or RuntimeError("No Galaxy servers configured")
+                continue
+            if versions is None:
+                # Truncated listing: not a complete answer, fail over.
+                logger.debug(
+                    "list_versions %s.%s: %s truncated version listing, trying next server",
+                    namespace,
+                    name,
+                    srv.label(),
+                )
+                truncated = True
+                continue
+            logger.debug(
+                "list_versions %s.%s: %d version(s) from %s",
+                namespace,
+                name,
+                len(versions),
+                srv.label(),
+            )
+            return versions
+        if last_exc is not None:
+            msg = f"Galaxy version listing failed for {namespace}.{name}: {last_exc}"
+            raise RuntimeError(msg) from last_exc
+        if truncated:
+            msg = f"Galaxy version listing truncated at {MAX_VERSION_PAGES} pages for {namespace}.{name}"
+            raise RuntimeError(msg)
+        raise RuntimeError("No Galaxy servers configured")
 
     async def get_version_detail(
         self,
@@ -210,9 +232,11 @@ class GalaxyClient:
             Parsed ``CollectionVersion`` from the first successful upstream.
 
         Raises:
-            httpx.HTTPStatusError: When the last attempted server returns an error status.
-            httpx.RequestError: When the last attempted server's request fails.
-            RuntimeError: When no Galaxy servers are configured.
+            RuntimeError: When no Galaxy servers are configured, or when
+                every server failed (the last failure is chained via
+                ``__cause__`` so callers never see a bare
+                ``httpx.HTTPStatusError``/``httpx.RequestError`` or
+                ``ValueError``/``KeyError`` from malformed payloads).
         """  # noqa: DOC503
         last_exc: Exception | None = None
         for srv, client in zip(self._servers, self._clients, strict=True):
@@ -226,7 +250,7 @@ class GalaxyClient:
                     srv.label(),
                 )
                 return detail
-            except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            except (httpx.HTTPStatusError, httpx.RequestError, ValueError, KeyError) as exc:
                 logger.debug(
                     "get_version_detail %s.%s:%s: %s failed: %s",
                     namespace,
@@ -236,7 +260,10 @@ class GalaxyClient:
                     exc,
                 )
                 last_exc = exc
-        raise last_exc or RuntimeError("No Galaxy servers configured")
+        if last_exc is not None:
+            msg = f"Galaxy version detail failed for {namespace}.{name}:{version}: {last_exc}"
+            raise RuntimeError(msg) from last_exc
+        raise RuntimeError("No Galaxy servers configured")
 
     async def download_tarball(self, download_url: str) -> bytes:
         """Download a collection tarball by its absolute URL.
@@ -249,10 +276,19 @@ class GalaxyClient:
 
         Returns:
             Raw tarball bytes.
-        """
-        resp = await self._download_client.get(download_url)
-        resp.raise_for_status()
-        return resp.content  # type: ignore[no-any-return]
+
+        Raises:
+            RuntimeError: When the download fails (the ``httpx`` failure
+                is chained via ``__cause__`` so callers never see a bare
+                transport error), symmetric with :meth:`list_versions`.
+        """  # noqa: DOC503
+        try:
+            resp = await self._download_client.get(download_url)
+            resp.raise_for_status()
+            return resp.content  # type: ignore[no-any-return]
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            msg = f"Galaxy tarball download failed for {download_url}: {exc}"
+            raise RuntimeError(msg) from exc
 
     async def get_version_and_download(
         self,
@@ -269,10 +305,22 @@ class GalaxyClient:
 
         Returns:
             Tuple of version metadata and tarball bytes.
-        """
-        detail = await self.get_version_detail(namespace, name, version)
-        tarball = await self.download_tarball(detail.download_url)
-        return detail, tarball
+
+        Raises:
+            RuntimeError: When metadata lookup or tarball download fails
+                (failures from the underlying calls are already
+                ``RuntimeError`` and propagate unchanged; any other
+                transport or malformed-payload failure is wrapped with the
+                original chained via ``__cause__``), symmetric with
+                :meth:`list_versions`.
+        """  # noqa: DOC503
+        try:
+            detail = await self.get_version_detail(namespace, name, version)
+            tarball = await self.download_tarball(detail.download_url)
+            return detail, tarball
+        except (httpx.HTTPStatusError, httpx.RequestError, ValueError, KeyError) as exc:
+            msg = f"Galaxy download failed for {namespace}.{name}:{version}: {exc}"
+            raise RuntimeError(msg) from exc
 
     # ── internal per-client helpers ──────────────────────────────────
 
@@ -281,19 +329,55 @@ class GalaxyClient:
         client: httpx.AsyncClient,
         namespace: str,
         name: str,
-    ) -> list[str]:
+    ) -> list[str] | None:
+        """List versions, or ``None`` when the listing is truncated.
+
+        A server that keeps returning ``links.next`` past
+        ``MAX_VERSION_PAGES`` yields a partial list that must not be
+        mistaken for a complete answer, so truncation is a failure signal
+        the caller fails over on.
+
+        Args:
+            client: Authenticated httpx client for one Galaxy server.
+            namespace: Collection namespace.
+            name: Collection name.
+
+        Returns:
+            Version strings, or ``None`` when truncated at the page bound
+            or when a page body is not a JSON object (both are failure
+            signals the caller fails over on).
+        """
         versions: list[str] = []
         url = f"{COLLECTIONS_PATH}/{namespace}/{name}/versions/"
         params: dict[str, str | int] = {"limit": 100, "offset": 0}
-        while True:
+        for _page in range(MAX_VERSION_PAGES):
             resp = await client.get(url, params=params)
             resp.raise_for_status()
             payload = resp.json()
+            if not isinstance(payload, dict):
+                # A non-dict JSON body (e.g. a list or string) has no
+                # ``.get`` — treat it as a failure so the caller fails
+                # over to the next server instead of raising AttributeError.
+                logger.debug(
+                    "Galaxy version listing for %s.%s returned non-dict payload (%s); treating as failure",
+                    namespace,
+                    name,
+                    type(payload).__name__,
+                )
+                return None
             for entry in payload.get("data", []):
                 versions.append(entry["version"])
             if not payload.get("links", {}).get("next"):
                 break
             params["offset"] = int(params["offset"]) + int(params["limit"])
+        else:
+            logger.warning(
+                "Galaxy version pagination exceeded %d pages for %s.%s; treating as failure",
+                MAX_VERSION_PAGES,
+                namespace,
+                name,
+            )
+            return None
         return versions
 
     @staticmethod
@@ -303,10 +387,35 @@ class GalaxyClient:
         name: str,
         version: str,
     ) -> CollectionVersion:
+        """Fetch and parse version metadata from a single Galaxy server.
+
+        Args:
+            client: Authenticated httpx client for one Galaxy server.
+            namespace: Collection namespace.
+            name: Collection name.
+            version: Collection version string.
+
+        Returns:
+            Parsed ``CollectionVersion``.
+
+        Raises:
+            ValueError: When the response body is not a JSON object (a
+                non-dict payload has no ``.get`` — surfacing
+                ``AttributeError`` would escape the caller's failover
+                handler, so this is a ``ValueError`` the caller fails
+                over on).
+            KeyError: When the payload lacks required fields.
+        """  # noqa: DOC503
         url = f"{COLLECTIONS_PATH}/{namespace}/{name}/versions/{version}/"
         resp = await client.get(url)
         resp.raise_for_status()
         data = resp.json()
+        if not isinstance(data, dict):
+            msg = (
+                f"Galaxy version detail for {namespace}.{name}:{version} "
+                f"returned non-dict payload ({type(data).__name__})"
+            )
+            raise ValueError(msg)
         meta = data.get("metadata", {})
         return CollectionVersion(
             namespace=namespace,

--- a/src/galaxy_proxy/galaxy_client.py
+++ b/src/galaxy_proxy/galaxy_client.py
@@ -442,7 +442,14 @@ class GalaxyClient:
                 f"returned non-dict payload ({type(data).__name__})"
             )
             raise ValueError(msg)
-        meta = data.get("metadata", {})
+        raw_meta = data.get("metadata")
+        if raw_meta is not None and not isinstance(raw_meta, dict):
+            msg = (
+                f"Galaxy version detail for {namespace}.{name}:{version} "
+                f"returned non-object metadata ({type(raw_meta).__name__})"
+            )
+            raise ValueError(msg)
+        meta = raw_meta or {}
         return CollectionVersion(
             namespace=namespace,
             name=name,

--- a/src/galaxy_proxy/galaxy_client.py
+++ b/src/galaxy_proxy/galaxy_client.py
@@ -365,9 +365,35 @@ class GalaxyClient:
                     type(payload).__name__,
                 )
                 return None
-            for entry in payload.get("data", []):
+            entries = payload.get("data")
+            if not isinstance(entries, list):
+                logger.debug(
+                    "Galaxy version listing for %s.%s returned non-list data; treating as failure",
+                    namespace,
+                    name,
+                )
+                return None
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    logger.debug(
+                        "Galaxy version listing for %s.%s returned non-object entry; treating as failure",
+                        namespace,
+                        name,
+                    )
+                    return None
                 versions.append(entry["version"])
-            if not payload.get("links", {}).get("next"):
+            if "links" in payload:
+                links = payload["links"]
+                if not isinstance(links, dict):
+                    logger.debug(
+                        "Galaxy version listing for %s.%s returned non-object links; treating as failure",
+                        namespace,
+                        name,
+                    )
+                    return None
+                if not links.get("next"):
+                    break
+            else:
                 break
             params["offset"] = int(params["offset"]) + int(params["limit"])
         else:

--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -28,6 +28,7 @@ from fastapi.responses import HTMLResponse, Response
 from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel
 
+from galaxy_proxy import MAX_VERSION_PAGES
 from galaxy_proxy.collection_downloader import (
     GalaxyServerConfig,
     download_collections,
@@ -666,8 +667,10 @@ async def _fetch_versions_from(
         token: Optional auth token for the server.
 
     Returns:
-        List of version strings on success, or ``None`` on failure so
-        the caller can fall through to the next server.
+        List of version strings on success, or ``None`` on failure — or
+        when the listing is truncated at ``MAX_VERSION_PAGES`` — so the
+        caller can fall through to the next server. A truncated listing is
+        not a complete answer and must never resolve as one.
     """
     versions: list[str] = []
     normalized = _normalize_galaxy_url(base_url)
@@ -685,15 +688,36 @@ async def _fetch_versions_from(
             follow_redirects=True,
             headers=headers,
         ) as client:
-            while True:
+            for _page in range(MAX_VERSION_PAGES):
                 resp = await client.get(url, params=params)
                 resp.raise_for_status()
                 payload = resp.json()
+                if not isinstance(payload, dict):
+                    # A non-dict JSON body (e.g. a list or string) has no
+                    # ``.get`` — treat it as a failure so the caller falls
+                    # through to the next server instead of raising
+                    # AttributeError.
+                    logger.debug(
+                        "Version fetch from %s returned non-dict payload (%s) for %s.%s",
+                        base_url,
+                        type(payload).__name__,
+                        namespace,
+                        name,
+                    )
+                    return None
                 for entry in payload.get("data", []):
                     versions.append(entry["version"])
                 if not payload.get("links", {}).get("next"):
                     break
                 params["offset"] = int(params["offset"]) + int(params["limit"])
+            else:
+                logger.warning(
+                    "Galaxy version pagination exceeded %d pages for %s.%s; treating as failure",
+                    MAX_VERSION_PAGES,
+                    namespace,
+                    name,
+                )
+                return None
         status = "ok"
         return versions
     except (httpx.HTTPError, KeyError, ValueError) as exc:

--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -711,9 +711,38 @@ async def _fetch_versions_from(
                         name,
                     )
                     return None
-                for entry in payload.get("data", []):
+                entries = payload.get("data")
+                if not isinstance(entries, list):
+                    logger.debug(
+                        "Version fetch from %s returned non-list data for %s.%s",
+                        base_url,
+                        namespace,
+                        name,
+                    )
+                    return None
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        logger.debug(
+                            "Version fetch from %s returned non-object entry for %s.%s",
+                            base_url,
+                            namespace,
+                            name,
+                        )
+                        return None
                     versions.append(entry["version"])
-                if not payload.get("links", {}).get("next"):
+                if "links" in payload:
+                    links = payload["links"]
+                    if not isinstance(links, dict):
+                        logger.debug(
+                            "Version fetch from %s returned non-object links for %s.%s",
+                            base_url,
+                            namespace,
+                            name,
+                        )
+                        return None
+                    if not links.get("next"):
+                        break
+                else:
                     break
                 params["offset"] = int(params["offset"]) + int(params["limit"])
             else:

--- a/src/galaxy_proxy/proxy/server.py
+++ b/src/galaxy_proxy/proxy/server.py
@@ -266,8 +266,13 @@ def create_app(
                 name,
                 servers=servers_cfg,
             )
-            cache.put_metadata(namespace, name, galaxy_versions)
-            versions = galaxy_versions
+            if galaxy_versions is not None:
+                cache.put_metadata(namespace, name, galaxy_versions)
+                versions = galaxy_versions
+            else:
+                # Truncation or total server failure — do not cache an empty
+                # listing that would masquerade as a valid zero-version catalog.
+                versions = []
 
         if not versions and not cached_wheel_set:
             lock_key = f"{namespace}.{name}:latest"
@@ -584,7 +589,7 @@ async def _fetch_galaxy_versions(
     name: str,
     *,
     servers: list[GalaxyServerConfig] | None = None,
-) -> list[str]:
+) -> list[str] | None:
     """Fetch all published version strings for a collection from Galaxy.
 
     When *servers* is provided, each configured server is tried in order
@@ -602,7 +607,8 @@ async def _fetch_galaxy_versions(
         servers: Ordered list of Galaxy server configs (optional).
 
     Returns:
-        Sorted list of version strings, empty on error.
+        Sorted list of version strings on success (possibly empty), or
+        ``None`` when every server fails (including pagination truncation).
     """
     base_urls: list[tuple[str, str | None]] = []
     for srv in servers or []:
@@ -621,7 +627,7 @@ async def _fetch_galaxy_versions(
         name,
         ", ".join(tried),
     )
-    return []
+    return None
 
 
 def _normalize_galaxy_url(raw_url: str) -> str:

--- a/tests/test_ai_escalation.py
+++ b/tests/test_ai_escalation.py
@@ -8,8 +8,11 @@ import sys
 import types
 from collections.abc import AsyncIterator
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import grpc
+import grpc.aio
 import pytest
 
 from apme.v1.engine_pb2 import FixOptions
@@ -527,6 +530,185 @@ class TestLoadAiPrompts:
             prompt = _build_node_prompt(ctx)
         assert "Rule-Specific Guidance" not in prompt
         _load_ai_prompts.cache_clear()
+
+
+def _make_provider_with_client(mock_client: MagicMock) -> AbbenayProvider:
+    """Build an AbbenayProvider bypassing __init__ with a mocked chat client.
+
+    Args:
+        mock_client: Mocked chat client assigned to ``_client``.
+
+    Returns:
+        Provider wired to the mocked client.
+    """
+    provider: AbbenayProvider = AbbenayProvider.__new__(AbbenayProvider)
+    provider._client = mock_client
+    provider._addr = "unix:///tmp/fake-abbenay.sock"
+    provider._token = None
+    provider._model = None
+    return provider
+
+
+async def _ok_chunks() -> AsyncIterator[SimpleNamespace]:
+    """Yield one successful chat chunk.
+
+    Yields:
+        SimpleNamespace: Chunk namespace with fixed text.
+    """
+    yield SimpleNamespace(text="fixed")
+
+
+class TestChatWithReconnectTransient:
+    """Transient chat transport errors retry once after reconnect."""
+
+    async def test_transient_errors_retry_then_succeed(self) -> None:
+        """Each transient type reconnects and succeeds on retry."""
+        transients: list[BaseException] = [
+            ConnectionError("refused"),
+            OSError("socket down"),
+            grpc.aio.AioRpcError(
+                grpc.StatusCode.UNAVAILABLE,
+                grpc.aio.Metadata(),
+                grpc.aio.Metadata(),
+                "unavailable",
+                "debug",
+            ),
+        ]
+        for exc in transients:
+            mock_client: MagicMock = MagicMock()
+            mock_client.chat.side_effect = [exc, _ok_chunks()]
+            provider = _make_provider_with_client(mock_client)
+            with (
+                patch.object(provider, "reconnect", new_callable=AsyncMock) as mock_reconnect,
+                patch(
+                    "apme_engine.remediation.abbenay_provider.asyncio.sleep",
+                    new_callable=AsyncMock,
+                ),
+            ):
+                result = await provider._chat_with_reconnect("model", "prompt", {})
+            assert result == "fixed"
+            assert mock_client.chat.call_count == 2
+            mock_reconnect.assert_awaited_once()
+
+    async def test_transient_retry_exhausted_raises(self) -> None:
+        """A second transient failure propagates without further retry."""
+        mock_client: MagicMock = MagicMock()
+        mock_client.chat.side_effect = [OSError("down"), OSError("still down")]
+        provider = _make_provider_with_client(mock_client)
+        with (
+            patch.object(provider, "reconnect", new_callable=AsyncMock),
+            patch(
+                "apme_engine.remediation.abbenay_provider.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+            pytest.raises(OSError, match="still down"),
+        ):
+            await provider._chat_with_reconnect("model", "prompt", {})
+        assert mock_client.chat.call_count == 2
+
+    async def test_attempt_timeout_never_retries(self) -> None:
+        """Builtin TimeoutError is an attempt bound, not a disconnect."""
+        mock_client: MagicMock = MagicMock()
+        mock_client.chat.side_effect = TimeoutError("slow stream")
+        provider = _make_provider_with_client(mock_client)
+        with (
+            patch.object(provider, "reconnect", new_callable=AsyncMock) as mock_reconnect,
+            patch(
+                "apme_engine.remediation.abbenay_provider.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+            pytest.raises(TimeoutError, match="slow stream"),
+        ):
+            await provider._chat_with_reconnect("model", "prompt", {})
+        assert mock_client.chat.call_count == 1
+        mock_reconnect.assert_not_awaited()
+
+
+def _grpc_error(code: grpc.StatusCode, message: str = "rpc failed") -> grpc.aio.AioRpcError:
+    """Build an ``AioRpcError`` carrying the given status code.
+
+    Args:
+        code: gRPC status code for the fake failure.
+        message: Human-readable error details.
+
+    Returns:
+        Configured ``AioRpcError`` instance.
+    """
+    return grpc.aio.AioRpcError(
+        code,
+        grpc.aio.Metadata(),
+        grpc.aio.Metadata(),
+        message,
+        "debug",
+    )
+
+
+class TestChatWithReconnectGrpcCodes:
+    """Only transient gRPC codes retry; permanent codes fail fast."""
+
+    @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+        "code",
+        [
+            grpc.StatusCode.UNAVAILABLE,
+            grpc.StatusCode.INTERNAL,
+            grpc.StatusCode.UNKNOWN,
+            grpc.StatusCode.DEADLINE_EXCEEDED,
+        ],
+    )
+    async def test_transient_grpc_codes_retry_once(self, code: grpc.StatusCode) -> None:
+        """Each transient gRPC code reconnects once then succeeds.
+
+        Args:
+            code: Transient status code under test.
+        """
+        mock_client: MagicMock = MagicMock()
+        mock_client.chat.side_effect = [_grpc_error(code), _ok_chunks()]
+        provider = _make_provider_with_client(mock_client)
+        with (
+            patch.object(provider, "reconnect", new_callable=AsyncMock) as mock_reconnect,
+            patch(
+                "apme_engine.remediation.abbenay_provider.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await provider._chat_with_reconnect("model", "prompt", {})
+        assert result == "fixed"
+        assert mock_client.chat.call_count == 2
+        mock_reconnect.assert_awaited_once()
+
+    @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+        "code",
+        [
+            grpc.StatusCode.UNAUTHENTICATED,
+            grpc.StatusCode.PERMISSION_DENIED,
+            grpc.StatusCode.NOT_FOUND,
+            grpc.StatusCode.INVALID_ARGUMENT,
+            grpc.StatusCode.RESOURCE_EXHAUSTED,
+        ],
+    )
+    async def test_permanent_grpc_codes_fail_fast(self, code: grpc.StatusCode) -> None:
+        """Each permanent gRPC code raises immediately without reconnect.
+
+        Quota exhaustion (RESOURCE_EXHAUSTED) must fail fast: a reconnect
+        cannot free quota.
+
+        Args:
+            code: Permanent status code under test.
+        """
+        mock_client: MagicMock = MagicMock()
+        mock_client.chat.side_effect = _grpc_error(code)
+        provider = _make_provider_with_client(mock_client)
+        with (
+            patch.object(provider, "reconnect", new_callable=AsyncMock) as mock_reconnect,
+            patch(
+                "apme_engine.remediation.abbenay_provider.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+            pytest.raises(grpc.aio.AioRpcError),
+        ):
+            await provider._chat_with_reconnect("model", "prompt", {})
+        assert mock_client.chat.call_count == 1
+        mock_reconnect.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_surface_coverage.py
+++ b/tests/test_cli_surface_coverage.py
@@ -2775,3 +2775,5 @@ def test_remediate_json_files_updated_reflects_written(tmp_path: Path, capsys: p
     ):
         run_remediate(_rem_args(str(tmp_path), json=True, show_suppressed=True))
     assert exc.value.code == EXIT_ERROR
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["files_updated"] == 1

--- a/tests/test_cli_surface_coverage.py
+++ b/tests/test_cli_surface_coverage.py
@@ -1,0 +1,2755 @@
+"""Unit tests for CLI surface coverage: check, remediate, format, suppress, output."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import threading
+import time
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import grpc
+import pytest
+
+from apme.v1 import common_pb2, engine_pb2
+from apme.v1.common_pb2 import ProgressUpdate
+from apme.v1.engine_pb2 import (
+    FileDiff,
+    FilePatch,
+    FixReport,
+    ScanChunk,
+    SessionResult,
+    Tier1Summary,
+)
+from apme_engine.cli._exit_codes import EXIT_ERROR, EXIT_VIOLATIONS
+
+
+class _FakeRpcError(grpc.RpcError):
+    """Minimal RpcError carrying a status code and details string."""
+
+    def __init__(self, code: grpc.StatusCode, details: str = "boom") -> None:
+        """Store code and details.
+
+        Args:
+            code: gRPC status code to report.
+            details: Human-readable error details.
+        """
+        super().__init__()
+        self._code = code
+        self._details = details
+
+    def code(self) -> grpc.StatusCode:
+        """Return the configured status code.
+
+        Returns:
+            The gRPC status code.
+        """
+        return self._code
+
+    def details(self) -> str:
+        """Return the configured details string.
+
+        Returns:
+            Details string.
+        """
+        return self._details
+
+
+def _rem_args(target: str, **overrides: object) -> argparse.Namespace:
+    """Build a remediate namespace with sane defaults.
+
+    Args:
+        target: Scan target path string.
+        **overrides: Attribute overrides.
+
+    Returns:
+        Populated argparse namespace.
+
+    """
+    defaults: dict[str, object] = {
+        "target": target,
+        "session": None,
+        "max_passes": 5,
+        "ansible_version": None,
+        "collections": None,
+        "ai": False,
+        "model": None,
+        "interactive": False,
+        "timeout": None,
+        "json": False,
+        "verbose": 0,
+        "auto_approve": False,
+        "show_suppressed": False,
+        "skip_dep_scan": False,
+        "skip_collection_scan": False,
+        "skip_python_audit": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _check_args_ns(target: str, **overrides: object) -> argparse.Namespace:
+    """Build a check namespace with sane defaults.
+
+    Args:
+        target: Scan target path string.
+        **overrides: Attribute overrides.
+
+    Returns:
+        Populated argparse namespace.
+
+    """
+    defaults: dict[str, object] = {
+        "command": "check",
+        "target": target,
+        "verbose": 0,
+        "json": False,
+        "sarif": False,
+        "diff": False,
+        "session": None,
+        "timeout": 300,
+        "ansible_version": None,
+        "collections": None,
+        "no_ansi": False,
+        "skip_dep_scan": False,
+        "skip_collection_scan": False,
+        "skip_python_audit": False,
+        "show_suppressed": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _format_args_ns(target: str, **overrides: object) -> argparse.Namespace:
+    """Build a format namespace with sane defaults.
+
+    Args:
+        target: Format target path string.
+        **overrides: Attribute overrides.
+
+    Returns:
+        Populated argparse namespace.
+
+    """
+    defaults: dict[str, object] = {
+        "command": "format",
+        "target": target,
+        "verbose": 0,
+        "check": False,
+        "apply": False,
+        "session": None,
+        "no_ansi": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _mk_event(kind: str) -> MagicMock:
+    """Create a SessionEvent mock reporting the given oneof kind.
+
+    Args:
+        kind: Value for ``WhichOneof("event")``.
+
+    Returns:
+        Configured MagicMock event.
+
+    """
+    ev = MagicMock()
+    ev.WhichOneof.return_value = kind
+    return ev
+
+
+def _scan_chunk(scan_id: str = "scan-1") -> ScanChunk:
+    """Build a minimal ScanChunk proto.
+
+    Args:
+        scan_id: Scan identifier.
+
+    Returns:
+        ScanChunk proto.
+
+    """
+    return ScanChunk(scan_id=scan_id, project_root="project", last=True)
+
+
+# ── output.py ─────────────────────────────────────────────────────────────
+
+
+def test_render_logs_verbosity_zero_filters_info(capsys: pytest.CaptureFixture[str]) -> None:
+    """Verbosity 0 shows warning and above only.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.output import render_logs
+
+    logs = [
+        ProgressUpdate(message="debug-msg", phase="engine", level=1),
+        ProgressUpdate(message="info-msg", phase="engine", level=2),
+        ProgressUpdate(message="warn-msg", phase="engine", level=3),
+        ProgressUpdate(message="err-msg", phase="", level=4),
+    ]
+    render_logs(logs, 0)
+    err = capsys.readouterr().err
+    assert "debug-msg" not in err
+    assert "info-msg" not in err
+    assert "warn-msg" in err
+    assert "err-msg" in err
+
+
+def test_render_logs_verbosity_one_and_two(capsys: pytest.CaptureFixture[str]) -> None:
+    """Verbosity 1 shows info+, verbosity 2 shows everything.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.output import render_logs
+
+    logs = [
+        ProgressUpdate(message="m1", phase="p", level=1),
+        ProgressUpdate(message="m2", phase="", level=2),
+    ]
+    render_logs(logs, 1)
+    err1 = capsys.readouterr().err
+    assert "m1" not in err1
+    assert "m2" in err1
+    render_logs(logs, 2)
+    err2 = capsys.readouterr().err
+    assert "m1" in err2
+    assert "m2" in err2
+
+
+def test_sort_violations_list_line_and_missing() -> None:
+    """List/tuple lines sort by first element; missing lines sort as zero."""
+    from apme_engine.cli.output import sort_violations
+
+    violations = [
+        {"rule_id": "L1", "file": "b.yml", "line": [10, 12]},
+        {"rule_id": "L2", "file": "a.yml", "line": 3},
+        {"rule_id": "L3", "file": "a.yml", "line": None},
+        {"rule_id": "L4", "file": "a.yml", "line": (1, 2)},
+        {"rule_id": "L5", "file": "a.yml", "line": ["x", "y"]},
+        {"rule_id": "L6", "file": "a.yml", "line": 1.5},
+    ]
+    out = sort_violations(violations)  # type: ignore[arg-type]
+    assert out[0]["file"] == "a.yml"
+    assert out[-1]["file"] == "b.yml"
+
+
+def test_deduplicate_violations_tuple_and_list() -> None:
+    """List lines normalize to tuples so duplicates collapse."""
+    from apme_engine.cli.output import deduplicate_violations
+
+    violations = [
+        {"rule_id": "L1", "file": "a.yml", "line": [1, 2]},
+        {"rule_id": "L1", "file": "a.yml", "line": [1, 2]},
+        {"rule_id": "L1", "file": "a.yml", "line": (1, 2)},
+        {"rule_id": "L2", "file": "a.yml", "line": 5},
+    ]
+    out = deduplicate_violations(violations)  # type: ignore[arg-type]
+    assert len(out) == 2
+
+
+def test_count_by_severity_unknown_goes_info() -> None:
+    """Unknown and missing severities count as info."""
+    from apme_engine.cli.output import count_by_severity
+
+    counts = count_by_severity(
+        [
+            {"severity": "critical"},
+            {"severity": "bogus"},
+            {"severity": ""},
+            {"severity": "HIGH"},
+            {},
+        ]
+    )
+    assert counts["critical"] == 1
+    assert counts["high"] == 1
+    assert counts["info"] == 3
+
+
+def test_format_remediation_summary_none() -> None:
+    """None summary formats as 'none'."""
+    from apme_engine.cli.output import format_remediation_summary
+
+    assert format_remediation_summary(None) == "none"
+
+
+def test_format_remediation_summary_counts_and_resolutions() -> None:
+    """Auto/AI/manual counts and non-unresolved resolutions render."""
+    from apme_engine.cli.output import format_remediation_summary
+
+    class _S:
+        auto_fixable = 2
+        ai_candidate = 1
+        manual_review = 0
+        by_resolution = {"fixed": 2, "unresolved": 5, "manual": 1}
+
+    text = format_remediation_summary(_S())
+    assert "2 auto-fixable" in text
+    assert "1 AI-candidate" in text
+    assert "fixed" in text
+    assert "unresolved" not in text
+
+
+def test_format_remediation_summary_empty_is_none() -> None:
+    """Zero counts with only unresolved resolutions formats as 'none'."""
+    from apme_engine.cli.output import format_remediation_summary
+
+    class _S:
+        auto_fixable = 0
+        ai_candidate = 0
+        manual_review = 0
+        by_resolution = {"unresolved": 3}
+
+    assert format_remediation_summary(_S()) == "none"
+
+
+def test_render_check_results_passed_no_violations(capsys: pytest.CaptureFixture[str]) -> None:
+    """Empty violations render PASSED with no issues.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.output import render_check_results
+
+    render_check_results([], scan_id="s1", scan_time_ms=5.0, summary=None)
+    out = capsys.readouterr().out
+    assert "PASSED" in out
+    assert "No issues found" in out
+
+
+def test_render_check_results_failed_table_and_tree(capsys: pytest.CaptureFixture[str]) -> None:
+    """Failed results render table rows, truncation, locations, and tree.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.output import render_check_results
+
+    violations = [
+        {
+            "rule_id": "L001",
+            "severity": "error",
+            "remediation_class": "auto-fixable",
+            "message": "x" * 60,
+            "file": "b.yml",
+            "line": [3, 5],
+        },
+        {
+            "rule_id": "L002",
+            "severity": "medium",
+            "remediation_class": "manual-review",
+            "message": "short",
+            "file": "a.yml",
+            "line": 7,
+        },
+        {
+            "rule_id": "L003",
+            "severity": "low",
+            "remediation_class": "ai-candidate",
+            "message": "noloc",
+            "file": "a.yml",
+            "line": None,
+        },
+        {
+            "rule_id": "L004",
+            "severity": "critical",
+            "remediation_class": "ai-candidate",
+            "message": "single-list",
+            "file": "a.yml",
+            "line": [9],
+        },
+        {
+            "rule_id": "L005",
+            "severity": "info",
+            "remediation_class": "ai-candidate",
+            "message": "high-sev",
+            "file": "c.yml",
+            "line": 1,
+        },
+    ]
+    render_check_results(violations, scan_id="abc", scan_time_ms=1500.0, summary=None)  # type: ignore[arg-type]
+    out = capsys.readouterr().out
+    assert "FAILED" in out
+    assert "Issues" in out
+    assert "Issues by File" in out
+    assert "abc" in out
+    assert "..." in out
+
+
+def test_print_diagnostics_v_full(capsys: pytest.CaptureFixture[str]) -> None:
+    """print_diagnostics_v covers engine detail, files, validators, top rules.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.output import print_diagnostics_v
+
+    vd1 = common_pb2.ValidatorDiagnostics(
+        validator_name="native",
+        total_ms=10.0,
+        violations_found=2,
+        rule_timings=[
+            common_pb2.RuleTiming(rule_id="L001", elapsed_ms=5.0, violations=1),
+            common_pb2.RuleTiming(rule_id="opa_query", elapsed_ms=9.0, violations=0),
+            common_pb2.RuleTiming(rule_id="gitleaks_subprocess_x", elapsed_ms=8.0, violations=0),
+        ],
+        metadata={"k1": "v1", "opa_response_size": "big", "files_written": "0"},
+    )
+    vd2 = common_pb2.ValidatorDiagnostics(
+        validator_name="opa",
+        total_ms=3.0,
+        violations_found=0,
+        metadata={},
+    )
+    diag = engine_pb2.ScanDiagnostics(
+        engine_parse_ms=2.0,
+        engine_annotate_ms=1.0,
+        engine_total_ms=5.0,
+        files_scanned=4,
+        validators=[vd1, vd2],
+        fan_out_ms=6.0,
+        total_ms=12.0,
+    )
+    print_diagnostics_v(diag)
+    err = capsys.readouterr().err
+    assert "Engine:" in err
+    assert "Files:" in err
+    assert "Top slowest rules" in err
+    assert "L001" in err
+    assert "k1=v1" in err
+    assert "opa_response_size" not in err
+
+
+def test_print_diagnostics_v_no_validators_no_top(capsys: pytest.CaptureFixture[str]) -> None:
+    """No validators and no timings skips validator and top-rule sections.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.output import print_diagnostics_v
+
+    diag = engine_pb2.ScanDiagnostics(engine_total_ms=1.0, fan_out_ms=1.0, total_ms=2.0)
+    print_diagnostics_v(diag)
+    err = capsys.readouterr().err
+    assert "Total:" in err
+    assert "Top slowest rules" not in err
+
+
+def test_print_diagnostics_vv_full(capsys: pytest.CaptureFixture[str]) -> None:
+    """print_diagnostics_vv covers files, graph nodes, timings, metadata.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.output import print_diagnostics_vv
+
+    vd = common_pb2.ValidatorDiagnostics(
+        validator_name="native",
+        total_ms=4.0,
+        violations_found=1,
+        rule_timings=[
+            common_pb2.RuleTiming(rule_id="L001", elapsed_ms=2.0, violations=1),
+            common_pb2.RuleTiming(rule_id="L002", elapsed_ms=0.0, violations=0),
+        ],
+        metadata={"a": "b"},
+    )
+    diag = engine_pb2.ScanDiagnostics(
+        engine_parse_ms=1.0,
+        engine_annotate_ms=1.0,
+        engine_total_ms=3.0,
+        files_scanned=2,
+        graph_nodes_built=7,
+        validators=[vd],
+        fan_out_ms=2.0,
+        total_ms=5.0,
+    )
+    print_diagnostics_vv(diag)
+    err = capsys.readouterr().err
+    assert "file(s)" in err
+    assert "graph node(s)" in err
+    assert "metadata:" in err
+    assert "Fan-out:" in err
+
+
+def test_print_diagnostics_vv_no_metadata(capsys: pytest.CaptureFixture[str]) -> None:
+    """Validators without metadata skip the metadata line.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.output import print_diagnostics_vv
+
+    vd = common_pb2.ValidatorDiagnostics(validator_name="opa", total_ms=1.0, violations_found=0)
+    diag = engine_pb2.ScanDiagnostics(engine_total_ms=1.0, validators=[vd], fan_out_ms=1.0, total_ms=2.0)
+    print_diagnostics_vv(diag)
+    err = capsys.readouterr().err
+    assert "metadata:" not in err
+
+
+def test_diag_to_dict_rounds_and_lists() -> None:
+    """diag_to_dict converts validators, timings, and metadata."""
+    from apme_engine.cli.output import diag_to_dict
+
+    vd = common_pb2.ValidatorDiagnostics(
+        validator_name="native",
+        total_ms=10.55,
+        files_received=3,
+        violations_found=1,
+        rule_timings=[common_pb2.RuleTiming(rule_id="L001", elapsed_ms=1.234, violations=1)],
+        metadata={"k": "v"},
+    )
+    diag = engine_pb2.ScanDiagnostics(
+        engine_parse_ms=1.11,
+        engine_annotate_ms=2.22,
+        engine_total_ms=3.33,
+        files_scanned=2,
+        graph_nodes_built=5,
+        total_violations=1,
+        validators=[vd],
+        fan_out_ms=4.44,
+        total_ms=9.99,
+    )
+    d = diag_to_dict(diag)
+    assert d["files_scanned"] == 2
+    assert d["graph_nodes_built"] == 5
+    validators = d["validators"]
+    assert isinstance(validators, list)
+    first = validators[0]
+    assert isinstance(first, dict)
+    assert first["validator_name"] == "native"
+    assert first["metadata"] == {"k": "v"}
+
+
+# ── format_cmd.py ─────────────────────────────────────────────────────────
+
+
+def test_format_uses_explicit_session(tmp_path: Path) -> None:
+    """Explicit --session bypasses project-root discovery.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.format_cmd import run_format
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    resp = MagicMock()
+    resp.logs = []
+    resp.diffs = []
+    channel = MagicMock()
+    with (
+        patch("apme_engine.cli.format_cmd.yield_scan_chunks", return_value=iter([_scan_chunk()])) as y,
+        patch("apme_engine.cli.format_cmd.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.format_cmd.engine_pb2_grpc.EngineStub") as stub_cls,
+        patch("apme_engine.cli.format_cmd.discover_project_root") as disc,
+    ):
+        stub_cls.return_value.FormatStream.return_value = resp
+        run_format(_format_args_ns(str(target), session="explicit-1"))
+        disc.assert_not_called()
+        y.assert_called_once()
+        assert y.call_args.kwargs.get("session_id") == "explicit-1"
+
+
+def test_format_derives_session_when_missing(tmp_path: Path) -> None:
+    """Missing --session derives the id from the project root.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.format_cmd import run_format
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    resp = MagicMock()
+    resp.logs = []
+    resp.diffs = []
+    channel = MagicMock()
+    with (
+        patch("apme_engine.cli.format_cmd.discover_project_root", return_value=tmp_path) as disc,
+        patch("apme_engine.cli.format_cmd.derive_session_id", return_value="derived-1") as der,
+        patch("apme_engine.cli.format_cmd.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.format_cmd.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.format_cmd.engine_pb2_grpc.EngineStub") as stub_cls,
+    ):
+        stub_cls.return_value.FormatStream.return_value = resp
+        run_format(_format_args_ns(str(target)))
+        disc.assert_called_once()
+        der.assert_called_once_with(tmp_path)
+
+
+def test_format_chunk_not_found_exits_error(tmp_path: Path) -> None:
+    """FileNotFoundError from chunking exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.format_cmd import run_format
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    with (
+        patch("apme_engine.cli.format_cmd.yield_scan_chunks", side_effect=FileNotFoundError("gone")),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_format(_format_args_ns(str(target)))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_format_grpc_error_exits_error(tmp_path: Path) -> None:
+    """FormatStream RpcError exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.format_cmd import run_format
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    channel = MagicMock()
+    with (
+        patch("apme_engine.cli.format_cmd.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.format_cmd.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.format_cmd.engine_pb2_grpc.EngineStub") as stub_cls,
+        pytest.raises(SystemExit) as exc,
+    ):
+        stub_cls.return_value.FormatStream.side_effect = _FakeRpcError(grpc.StatusCode.UNAVAILABLE, "down")
+        run_format(_format_args_ns(str(target)))
+    assert exc.value.code == EXIT_ERROR
+    channel.close.assert_called_once()
+
+
+def test_format_no_diffs_reports_clean(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Empty diff list reports already-formatted and renders logs.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.format_cmd import run_format
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    resp = engine_pb2.FormatResponse(
+        diffs=[],
+        logs=[ProgressUpdate(message="hello", phase="engine", level=3)],
+    )
+    channel = MagicMock()
+    with (
+        patch("apme_engine.cli.format_cmd.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.format_cmd.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.format_cmd.engine_pb2_grpc.EngineStub") as stub_cls,
+    ):
+        stub_cls.return_value.FormatStream.return_value = resp
+        run_format(_format_args_ns(str(target), verbose=0))
+    err = capsys.readouterr().err
+    assert "already formatted" in err
+
+
+def test_format_check_mode_exits_violations(tmp_path: Path) -> None:
+    """--check lists would-reformat files and exits 1.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.format_cmd import run_format
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    resp = engine_pb2.FormatResponse(
+        diffs=[FileDiff(path="site.yml", original=b"a", formatted=b"b", diff="d")],
+        logs=[],
+    )
+    channel = MagicMock()
+    with (
+        patch("apme_engine.cli.format_cmd.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.format_cmd.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.format_cmd.engine_pb2_grpc.EngineStub") as stub_cls,
+        pytest.raises(SystemExit) as exc,
+    ):
+        stub_cls.return_value.FormatStream.return_value = resp
+        run_format(_format_args_ns(str(target), check=True))
+    assert exc.value.code == EXIT_VIOLATIONS
+
+
+def test_format_apply_writes_files(tmp_path: Path) -> None:
+    """--apply writes formatted bytes via _safe_write.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.format_cmd import run_format
+
+    target = tmp_path / "site.yml"
+    target.write_bytes(b"orig")
+    resp = engine_pb2.FormatResponse(
+        diffs=[FileDiff(path="site.yml", original=b"orig", formatted=b"new", diff="d")],
+        logs=[],
+    )
+    channel = MagicMock()
+    with (
+        patch("apme_engine.cli.format_cmd.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.format_cmd.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.format_cmd.engine_pb2_grpc.EngineStub") as stub_cls,
+    ):
+        stub_cls.return_value.FormatStream.return_value = resp
+        run_format(_format_args_ns(str(target), apply=True))
+    assert target.read_bytes() == b"new"
+
+
+def test_format_show_diffs_without_apply(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Default mode prints diffs to stdout without writing.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.format_cmd import run_format
+
+    target = tmp_path / "site.yml"
+    target.write_bytes(b"orig")
+    resp = engine_pb2.FormatResponse(
+        diffs=[FileDiff(path="site.yml", original=b"orig", formatted=b"new", diff="DIFF-TEXT")],
+        logs=[],
+    )
+    channel = MagicMock()
+    with (
+        patch("apme_engine.cli.format_cmd.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.format_cmd.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.format_cmd.engine_pb2_grpc.EngineStub") as stub_cls,
+    ):
+        stub_cls.return_value.FormatStream.return_value = resp
+        run_format(_format_args_ns(str(target)))
+    out = capsys.readouterr().out
+    assert "DIFF-TEXT" in out
+    assert target.read_bytes() == b"orig"
+
+
+def test_format_safe_write_match_and_mismatch(tmp_path: Path) -> None:
+    """_safe_write writes on match and skips on mismatch.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.format_cmd import _safe_write
+
+    p = tmp_path / "f.yml"
+    p.write_bytes(b"orig")
+    _safe_write(p, b"orig", b"new")
+    assert p.read_bytes() == b"new"
+    _safe_write(p, b"stale", b"other")
+    assert p.read_bytes() == b"new"
+
+
+# ── suppress_cmd.py ─────────────────────────────────────────────────────
+
+
+def test_suppress_requires_subcommand() -> None:
+    """Missing subcommand exits with EXIT_ERROR."""
+    from apme_engine.cli.suppress_cmd import run_suppress
+
+    with pytest.raises(SystemExit) as exc:
+        run_suppress(argparse.Namespace())
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_suppress_add_invalid_fingerprint(tmp_path: Path) -> None:
+    """Non-hex fingerprint exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.suppress_cmd import _suppress_add
+
+    args = argparse.Namespace(
+        target=str(tmp_path),
+        rule_id="L001",
+        mode="full",
+        reason="",
+        original_yaml="x: 1",
+        module_fqcn="",
+        fingerprint="not-hex",
+    )
+    with pytest.raises(SystemExit) as exc:
+        _suppress_add(args)
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_suppress_add_full_requires_original_yaml(tmp_path: Path) -> None:
+    """Full mode without yaml or fingerprint exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.suppress_cmd import _suppress_add
+
+    args = argparse.Namespace(
+        target=str(tmp_path),
+        rule_id="L001",
+        mode="full",
+        reason="",
+        original_yaml=None,
+        module_fqcn="",
+        fingerprint=None,
+    )
+    with pytest.raises(SystemExit) as exc:
+        _suppress_add(args)
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_suppress_add_rule_module_requires_fqcn(tmp_path: Path) -> None:
+    """rule_module mode without fqcn exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.suppress_cmd import _suppress_add
+
+    args = argparse.Namespace(
+        target=str(tmp_path),
+        rule_id="L001",
+        mode="rule_module",
+        reason="",
+        original_yaml="",
+        module_fqcn="",
+        fingerprint=None,
+    )
+    with pytest.raises(SystemExit) as exc:
+        _suppress_add(args)
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_suppress_add_with_explicit_fingerprint(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Explicit fingerprint add writes the entry.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli._suppressions import load_suppressions
+    from apme_engine.cli.suppress_cmd import _suppress_add
+
+    fp = "a" * 64
+    args = argparse.Namespace(
+        target=str(tmp_path),
+        rule_id="L001",
+        mode="full",
+        reason="test",
+        original_yaml="",
+        module_fqcn="",
+        fingerprint=fp,
+    )
+    _suppress_add(args)
+    out = capsys.readouterr().out
+    assert "Added suppression" in out
+    assert len(load_suppressions(tmp_path)) == 1
+
+
+def test_suppress_add_duplicate_reports_exists(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Adding the same fingerprint twice reports already-exists.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.suppress_cmd import _suppress_add
+
+    fp = "b" * 64
+    args = argparse.Namespace(
+        target=str(tmp_path),
+        rule_id="L001",
+        mode="full",
+        reason="",
+        original_yaml="",
+        module_fqcn="",
+        fingerprint=fp,
+    )
+    _suppress_add(args)
+    capsys.readouterr()
+    _suppress_add(args)
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_suppress_add_computed_full_and_rule_module(tmp_path: Path) -> None:
+    """Computed fingerprints work for full and rule_module modes.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli._suppressions import load_suppressions
+    from apme_engine.cli.suppress_cmd import _suppress_add
+
+    _suppress_add(
+        argparse.Namespace(
+            target=str(tmp_path),
+            rule_id="L001",
+            mode="full",
+            reason="r",
+            original_yaml="key: value",
+            module_fqcn="",
+            fingerprint=None,
+        )
+    )
+    _suppress_add(
+        argparse.Namespace(
+            target=str(tmp_path),
+            rule_id="L002",
+            mode="rule_module",
+            reason="",
+            original_yaml="",
+            module_fqcn="ansible.builtin.debug",
+            fingerprint=None,
+        )
+    )
+    assert len(load_suppressions(tmp_path)) == 2
+
+
+def test_suppress_list_empty_and_nonempty(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """List reports empty state and then populated entries.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.suppress_cmd import _suppress_add, _suppress_list
+
+    _suppress_list(argparse.Namespace(target=str(tmp_path)))
+    assert "No suppressions" in capsys.readouterr().out
+    _suppress_add(
+        argparse.Namespace(
+            target=str(tmp_path),
+            rule_id="L001",
+            mode="rule_only",
+            reason="why",
+            original_yaml="",
+            module_fqcn="",
+            fingerprint="c" * 64,
+        )
+    )
+    capsys.readouterr()
+    _suppress_list(argparse.Namespace(target=str(tmp_path)))
+    out = capsys.readouterr().out
+    assert "suppression(s) total" in out
+    assert "why" in out
+
+
+def test_suppress_remove_no_match_exits_error(tmp_path: Path) -> None:
+    """Unknown prefix exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.suppress_cmd import _suppress_remove
+
+    with pytest.raises(SystemExit) as exc:
+        _suppress_remove(argparse.Namespace(target=str(tmp_path), fingerprint="deadbeef"))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_suppress_remove_ambiguous_exits_error(tmp_path: Path) -> None:
+    """Prefix matching multiple entries exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.suppress_cmd import _suppress_add, _suppress_remove
+
+    _suppress_add(
+        argparse.Namespace(
+            target=str(tmp_path),
+            rule_id="L001",
+            mode="full",
+            reason="",
+            original_yaml="",
+            module_fqcn="",
+            fingerprint="d" * 64,
+        )
+    )
+    _suppress_add(
+        argparse.Namespace(
+            target=str(tmp_path),
+            rule_id="L002",
+            mode="full",
+            reason="",
+            original_yaml="",
+            module_fqcn="",
+            fingerprint="d" * 63 + "e",
+        )
+    )
+    with pytest.raises(SystemExit) as exc:
+        _suppress_remove(argparse.Namespace(target=str(tmp_path), fingerprint="d"))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_suppress_remove_success(tmp_path: Path) -> None:
+    """Exact prefix removal deletes the entry.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli._suppressions import load_suppressions
+    from apme_engine.cli.suppress_cmd import _suppress_add, _suppress_remove
+
+    fp = "e" * 64
+    _suppress_add(
+        argparse.Namespace(
+            target=str(tmp_path),
+            rule_id="L001",
+            mode="full",
+            reason="",
+            original_yaml="",
+            module_fqcn="",
+            fingerprint=fp,
+        )
+    )
+    _suppress_remove(argparse.Namespace(target=str(tmp_path), fingerprint=fp[:12]))
+    assert load_suppressions(tmp_path) == []
+
+
+def test_suppress_dispatch_add_list_remove(tmp_path: Path) -> None:
+    """run_suppress dispatches to add, list, and remove.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.suppress_cmd import run_suppress
+
+    fp = "f" * 64
+    run_suppress(
+        argparse.Namespace(
+            suppress_command="add",
+            target=str(tmp_path),
+            rule_id="L001",
+            mode="full",
+            reason="",
+            original_yaml="",
+            module_fqcn="",
+            fingerprint=fp,
+        )
+    )
+    run_suppress(argparse.Namespace(suppress_command="list", target=str(tmp_path)))
+    run_suppress(argparse.Namespace(suppress_command="remove", target=str(tmp_path), fingerprint=fp))
+
+
+# ── check.py ────────────────────────────────────────────────────────────
+
+
+def test_scan_summary_compat_none_and_report() -> None:
+    """Compat wraps None as zeros and FixReport fields otherwise."""
+    from apme_engine.cli.check import _ScanSummaryCompat
+
+    empty = _ScanSummaryCompat(None)
+    assert empty.auto_fixable == 0
+    assert empty.by_resolution == {}
+    full = _ScanSummaryCompat(FixReport(fixed=3, remaining_ai=1, remaining_manual=2))
+    assert full.auto_fixable == 3
+    assert full.ai_candidate == 1
+    assert full.manual_review == 2
+
+
+def test_resolve_session_id_variants(tmp_path: Path) -> None:
+    """Explicit valid passes through; invalid exits; missing derives.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.check import _resolve_session_id
+
+    assert _resolve_session_id(argparse.Namespace(session="ok-123_abc", target=str(tmp_path))) == "ok-123_abc"
+    with pytest.raises(SystemExit) as exc:
+        _resolve_session_id(argparse.Namespace(session="bad value!", target=str(tmp_path)))
+    assert exc.value.code == EXIT_ERROR
+    derived = _resolve_session_id(argparse.Namespace(session=None, target=str(tmp_path)))
+    assert len(derived) == 16
+
+
+def test_apply_dep_scan_flags_strips_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Skip flags pop daemon env vars and return booleans.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    from apme_engine.cli.check import _apply_dep_scan_flags
+
+    monkeypatch.setenv("COLLECTION_HEALTH_GRPC_ADDRESS", "x")
+    monkeypatch.setenv("DEP_AUDIT_GRPC_ADDRESS", "y")
+    import os
+
+    skip_c, skip_p = _apply_dep_scan_flags(argparse.Namespace(skip_dep_scan=True))
+    assert (skip_c, skip_p) == (True, True)
+    assert "COLLECTION_HEALTH_GRPC_ADDRESS" not in os.environ
+    assert "DEP_AUDIT_GRPC_ADDRESS" not in os.environ
+    skip_c2, skip_p2 = _apply_dep_scan_flags(
+        argparse.Namespace(skip_dep_scan=False, skip_collection_scan=False, skip_python_audit=False)
+    )
+    assert (skip_c2, skip_p2) == (False, False)
+
+
+def test_check_full_event_flow(tmp_path: Path) -> None:
+    """run_check handles created/progress/tier1/proposals/triage/result/expiring/closed.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.check import run_check
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    created = _mk_event("created")
+    progress = _mk_event("progress")
+    progress.progress.level = 4
+    progress.progress.phase = "engine"
+    progress.progress.message = "working"
+    tier1 = _mk_event("tier1_complete")
+    tier1.tier1_complete.report = FixReport(fixed=1, remaining_ai=0, remaining_manual=0)
+    proposals = _mk_event("proposals")
+    proposals.proposals.proposals = []
+    triage = _mk_event("ai_triage")
+    triage.ai_triage.candidates = []
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    expiring = _mk_event("expiring")
+    expiring.expiring.ttl_seconds = 30
+    closed = _mk_event("closed")
+    events = [created, progress, tier1, proposals, triage, result, expiring, closed]
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = events
+    chunk = _scan_chunk()
+    with (
+        patch("apme_engine.cli.check.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.check.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.check.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.check.yield_scan_chunks", return_value=iter([chunk])),
+        patch("apme_engine.cli.check.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.check.engine_pb2_grpc.EngineStub", return_value=stub),
+    ):
+        run_check(_check_args_ns(str(target), show_suppressed=True))
+
+
+def test_check_progress_filtered_and_proposals_with_ids(tmp_path: Path) -> None:
+    """Low-level progress is filtered; proposals send empty approval.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.check import run_check
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    low = _mk_event("progress")
+    low.progress.level = 1
+    low.progress.phase = ""
+    low.progress.message = "debug-noise"
+    prop_ev = _mk_event("proposals")
+    prop = MagicMock()
+    prop.id = "p1"
+    prop_ev.proposals.proposals = [prop]
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    closed = _mk_event("closed")
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [low, prop_ev, result, closed]
+    with (
+        patch("apme_engine.cli.check.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.check.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.check.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.check.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.check.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.check.engine_pb2_grpc.EngineStub", return_value=stub),
+    ):
+        run_check(_check_args_ns(str(target), verbose=0, show_suppressed=True))
+
+
+def test_check_grpc_error_exits(tmp_path: Path) -> None:
+    """FixSession RpcError exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.check import run_check
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.side_effect = _FakeRpcError(grpc.StatusCode.UNAVAILABLE, "down")
+    with (
+        patch("apme_engine.cli.check.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.check.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.check.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.check.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.check.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.check.engine_pb2_grpc.EngineStub", return_value=stub),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_check(_check_args_ns(str(target)))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_check_no_result_exits(tmp_path: Path) -> None:
+    """Empty event stream exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.check import run_check
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [_mk_event("created"), _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.check.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.check.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.check.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.check.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.check.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.check.engine_pb2_grpc.EngineStub", return_value=stub),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_check(_check_args_ns(str(target)))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_check_json_output_and_violations_exit(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """--json prints counts/diffs and exits 1 when violations remain.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.check import run_check
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    result = _mk_event("result")
+    result.result.remaining_violations = [object(), object()]
+    mpatch = MagicMock()
+    mpatch.path = "a.yml"
+    mpatch.diff = "DIFF"
+    result.result.patches = [mpatch]
+    closed = _mk_event("closed")
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [result, closed]
+    violation_dicts = [
+        {"rule_id": "L001", "severity": "error", "remediation_class": "ai-candidate", "file": "a.yml", "line": 1},
+        {"rule_id": "L002", "severity": "low", "remediation_class": "manual-review", "file": "b.yml", "line": 2},
+    ]
+    with (
+        patch("apme_engine.cli.check.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.check.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.check.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.check.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.check.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.check.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.check.violation_proto_to_dict", side_effect=violation_dicts),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_check(_check_args_ns(str(target), json=True, show_suppressed=True))
+    assert exc.value.code == EXIT_VIOLATIONS
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["count"] == 2
+    assert doc["diffs"] == [{"path": "a.yml", "diff": "DIFF"}]
+
+
+def test_check_diff_flag_and_suppressed_message(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """--diff prints patch diffs; suppressed violations emit a hint.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli._suppressions import SuppressionResult
+    from apme_engine.cli.check import run_check
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    result = _mk_event("result")
+    result.result.remaining_violations = [object()]
+    dpatch = MagicMock()
+    dpatch.diff = "PATCH-DIFF"
+    result.result.patches = [dpatch]
+    closed = _mk_event("closed")
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [result, closed]
+    active = [{"rule_id": "L001", "severity": "error", "file": "a.yml", "line": 1, "message": "m"}]
+    suppressed = [{"rule_id": "L002", "severity": "low", "file": "b.yml", "line": 2, "message": "s"}]
+    with (
+        patch("apme_engine.cli.check.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.check.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.check.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.check.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.check.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.check.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.check.violation_proto_to_dict", side_effect=active),
+        patch("apme_engine.cli.check.load_suppressions", return_value=[]),
+        patch(
+            "apme_engine.cli.check.apply_suppressions",
+            return_value=SuppressionResult(active=active, suppressed=suppressed),  # type: ignore[arg-type]
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_check(_check_args_ns(str(target), diff=True, show_suppressed=False))
+    assert exc.value.code == EXIT_VIOLATIONS
+    captured = capsys.readouterr()
+    assert "PATCH-DIFF" in captured.out
+    assert "suppressed violation(s) hidden" in captured.err
+
+
+def test_check_sarif_flag_success_path(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """--sarif with no violations prints a document and returns.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.check import run_check
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [result, _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.check.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.check.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.check.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.check.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.check.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.check.engine_pb2_grpc.EngineStub", return_value=stub),
+    ):
+        run_check(_check_args_ns(str(target), sarif=True, show_suppressed=True))
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["version"] == "2.1.0"
+
+
+# ── remediate.py ────────────────────────────────────────────────────────
+
+
+def test_remediate_target_missing() -> None:
+    """Nonexistent target exits with EXIT_ERROR."""
+    from apme_engine.cli.remediate import run_remediate
+
+    with pytest.raises(SystemExit) as exc:
+        run_remediate(_rem_args("/nonexistent/path-xyz"))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_remediate_full_event_flow_text(tmp_path: Path) -> None:
+    """All event branches run in text mode and exit 0 with no violations.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    target = tmp_path
+    created = _mk_event("created")
+    progress_hi = _mk_event("progress")
+    progress_hi.progress.level = 4
+    progress_hi.progress.phase = "engine"
+    progress_hi.progress.message = "oops"
+    progress_lo = _mk_event("progress")
+    progress_lo.progress.level = 1
+    progress_lo.progress.phase = ""
+    progress_lo.progress.message = "skip-me"
+    tier1 = _mk_event("tier1_complete")
+    tier1.tier1_complete.report = FixReport(fixed=1, remaining_ai=0, remaining_manual=0)
+    tier1.tier1_complete.format_diffs = []
+    tier1.tier1_complete.applied_patches = []
+    tier1.tier1_complete.idempotency_ok = True
+    proposals = _mk_event("proposals")
+    proposals.proposals.proposals = []
+    triage = _mk_event("ai_triage")
+    cand = MagicMock()
+    cand.path = "site.yml"
+    triage.ai_triage.candidates = [cand]
+    ack = _mk_event("approval_ack")
+    ack.approval_ack.applied_count = 2
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    expiring = _mk_event("expiring")
+    expiring.expiring.ttl_seconds = 10
+    data = _mk_event("data")
+    data.data.kind = "custom"
+    closed = _mk_event("closed")
+    events = [created, progress_hi, progress_lo, tier1, proposals, triage, ack, result, expiring, data, closed]
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = events
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="sess-1"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+    ):
+        run_remediate(_rem_args(str(target), verbose=2, show_suppressed=True))
+
+
+def test_remediate_explicit_session_and_verbose_filter(tmp_path: Path) -> None:
+    """Explicit session is used; low progress filtered at verbosity 0.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    target = tmp_path
+    prog = _mk_event("progress")
+    prog.progress.level = 1
+    prog.progress.phase = "x"
+    prog.progress.message = "hidden"
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [prog, result, _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.remediate.derive_session_id") as der,
+    ):
+        run_remediate(_rem_args(str(target), session="explicit-s", verbose=0, show_suppressed=True))
+        der.assert_not_called()
+
+
+def test_remediate_error_event_exits(tmp_path: Path) -> None:
+    """Error event exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    err = _mk_event("error")
+    err.error.code = "BUDGET"
+    err.error.message = "nope"
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [err]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_remediate(_rem_args(str(tmp_path)))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_remediate_proposals_auto_approve(tmp_path: Path) -> None:
+    """auto_approve sends all proposal ids without prompting.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    prop1 = MagicMock()
+    prop1.id = "a1"
+    prop2 = MagicMock()
+    prop2.id = "a2"
+    proposals = _mk_event("proposals")
+    proposals.proposals.proposals = [prop1, prop2]
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [proposals, result, _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.remediate._interactive_review") as review,
+    ):
+        run_remediate(_rem_args(str(tmp_path), auto_approve=True, show_suppressed=True))
+        review.assert_not_called()
+
+
+def test_remediate_proposals_json_skips_review(tmp_path: Path) -> None:
+    """JSON mode approves nothing and skips the interactive prompt.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    prop = MagicMock()
+    prop.id = "x1"
+    proposals = _mk_event("proposals")
+    proposals.proposals.proposals = [prop]
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [proposals, result, _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.remediate._interactive_review") as review,
+    ):
+        run_remediate(_rem_args(str(tmp_path), json=True, show_suppressed=True))
+        review.assert_not_called()
+
+
+def test_remediate_proposals_interactive_review(tmp_path: Path) -> None:
+    """Interactive proposals call _interactive_review when not auto/json.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    prop = MagicMock()
+    prop.id = "y1"
+    proposals = _mk_event("proposals")
+    proposals.proposals.proposals = [prop]
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [proposals, result, _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.remediate._interactive_review", return_value=["y1"]) as review,
+    ):
+        run_remediate(_rem_args(str(tmp_path), show_suppressed=True))
+        review.assert_called_once()
+
+
+def test_remediate_retry_on_transient_then_success(tmp_path: Path) -> None:
+    """UNAVAILABLE before any result retries once and succeeds.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    events2 = [result, _mk_event("closed")]
+    channel1 = MagicMock()
+    channel2 = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.side_effect = [_FakeRpcError(grpc.StatusCode.UNAVAILABLE, "blip"), events2]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch(
+            "apme_engine.cli.remediate.resolve_engine",
+            side_effect=[(channel1, "a1"), (channel2, "a2")],
+        ),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.remediate.time.sleep", return_value=None),
+        patch("apme_engine.cli.remediate.random.uniform", return_value=0.0),
+    ):
+        run_remediate(_rem_args(str(tmp_path), show_suppressed=True))
+    channel1.close.assert_called_once()
+    channel2.close.assert_called_once()
+
+
+def test_remediate_deadline_exceeded_never_retries(tmp_path: Path) -> None:
+    """DEADLINE_EXCEEDED never retries (server budget or user timeout).
+
+    With ``stream_timeout=None`` a DEADLINE_EXCEEDED is the server
+    adaptive budget expiring — retrying would re-run the whole scan and
+    double load. Only UNAVAILABLE is retried.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    for timeout in (None, 5):
+        channel = MagicMock()
+        stub = MagicMock()
+        stub.FixSession.side_effect = _FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED, "slow")
+        with (
+            patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+            patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+            patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+            patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+            patch(
+                "apme_engine.cli.remediate.yield_scan_chunks",
+                side_effect=lambda *a, **k: iter([_scan_chunk()]),
+            ),
+            patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+            patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+            patch("apme_engine.cli.remediate.time.sleep") as slp,
+            pytest.raises(SystemExit) as exc,
+        ):
+            run_remediate(_rem_args(str(tmp_path), timeout=timeout))
+        assert exc.value.code == EXIT_ERROR
+        slp.assert_not_called()
+        assert stub.FixSession.call_count == 1
+
+
+def test_remediate_user_deadline_no_retry(tmp_path: Path) -> None:
+    """DEADLINE_EXCEEDED with user --timeout does not retry.
+
+    Kept as an alias for the never-retry behavior: DEADLINE_EXCEEDED is
+    never retried regardless of ``--timeout`` (see
+    ``test_remediate_deadline_exceeded_never_retries``).
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.side_effect = _FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED, "slow")
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.remediate.time.sleep") as slp,
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_remediate(_rem_args(str(tmp_path), timeout=5))
+    assert exc.value.code == EXIT_ERROR
+    slp.assert_not_called()
+
+
+def test_remediate_producer_error_exits(tmp_path: Path) -> None:
+    """Upload producer failure exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = []
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.remediate.yield_scan_chunks", side_effect=RuntimeError("disk-gone")),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_remediate(_rem_args(str(tmp_path)))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_remediate_producer_error_wins_over_result(tmp_path: Path) -> None:
+    """Mid-upload producer death fails even when the server yields a result.
+
+    A partial upload must never silently pass: the producer error takes
+    precedence over an arrived result.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    def _flaky_chunks(*a: object, **k: object) -> Iterator[ScanChunk]:
+        """Yield one chunk, then fail like a mid-upload disk error.
+
+        Args:
+            *a: Positional args ignored (mirrors yield_scan_chunks).
+            **k: Keyword args ignored (mirrors yield_scan_chunks).
+
+        Yields:
+            ScanChunk: A single upload chunk before failing.
+
+        Raises:
+            RuntimeError: Simulated mid-upload disk failure.
+        """
+        yield _scan_chunk("scan-prior")
+        raise RuntimeError("mid-upload boom")
+
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [result, _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.remediate.yield_scan_chunks", side_effect=_flaky_chunks),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_remediate(_rem_args(str(tmp_path), show_suppressed=True))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_remediate_producer_error_writes_nothing(tmp_path: Path) -> None:
+    """A producer failure leaves disk untouched even with server patches.
+
+    Patches stay buffered until the producer is verified clean, so a
+    partial upload that still yields a result must not mutate files.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    target_file = tmp_path / "site.yml"
+    target_file.write_bytes(b"orig")
+
+    def _flaky_chunks(*a: object, **k: object) -> Iterator[ScanChunk]:
+        """Yield one chunk, then fail like a mid-upload disk error.
+
+        Args:
+            *a: Positional args ignored (mirrors yield_scan_chunks).
+            **k: Keyword args ignored (mirrors yield_scan_chunks).
+
+        Yields:
+            ScanChunk: A single upload chunk before failing.
+
+        Raises:
+            RuntimeError: Simulated mid-upload disk failure.
+        """
+        yield _scan_chunk("scan-flaky")
+        raise RuntimeError("mid-upload boom")
+
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = [
+        FilePatch(path="site.yml", original=b"orig", patched=b"new", diff="d", applied_rules=["L001"]),
+    ]
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [result, _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.remediate.yield_scan_chunks", side_effect=_flaky_chunks),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_remediate(_rem_args(str(tmp_path), show_suppressed=True))
+    assert exc.value.code == EXIT_ERROR
+    assert target_file.read_bytes() == b"orig"
+
+
+def test_remediate_post_result_transport_drop_uses_result(tmp_path: Path) -> None:
+    """A transport drop after a result keeps the buffered result.
+
+    The run completes on the success path instead of discarding the
+    received result with an error exit.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+
+    def _drop_after_result(cmd_iter: Iterable[object], timeout: object = None) -> Iterator[MagicMock]:
+        """Yield a result, then fail like a post-result transport drop.
+
+        Args:
+            cmd_iter: Command iterator from run_remediate.
+            timeout: Stream timeout.
+
+        Yields:
+            MagicMock: The buffered result event before failing.
+
+        Raises:
+            _FakeRpcError: UNAVAILABLE transport drop after the result.
+        """
+        yield result
+        raise _FakeRpcError(grpc.StatusCode.UNAVAILABLE, "drop")
+
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.side_effect = _drop_after_result
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+    ):
+        run_remediate(_rem_args(str(tmp_path), show_suppressed=True))
+
+
+def test_remediate_retry_logs_prior_scan_id_and_attempt(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Retry log carries the failed attempt's scan_id and attempt number.
+
+    Two server-side scan rows result from one CLI invocation; the log
+    must attribute the retry to the prior row. Each attempt mints a fresh
+    scan_id, so the two attempts must differ.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    calls: list[int] = []
+    minted: list[str] = []
+
+    def _fresh_chunks(*a: object, **k: object) -> Iterator[ScanChunk]:
+        """Mint a fresh scan_id per attempt, mirroring yield_scan_chunks.
+
+        Args:
+            *a: Positional args ignored (mirrors yield_scan_chunks).
+            **k: Keyword args ignored (mirrors yield_scan_chunks).
+
+        Returns:
+            Iterator with a single chunk carrying the fresh scan_id.
+        """
+        sid = f"scan-prior-{len(minted) + 1}"
+        minted.append(sid)
+        return iter([_scan_chunk(sid)])
+
+    def _blip(cmd_iter: Iterable[object], timeout: object = None) -> list[MagicMock]:
+        """Drain one upload (pinning the attempt scan_id), then fail transiently.
+
+        First call drains a single upload command so the producer has
+        recorded the attempt scan_id, then raises; the second call
+        returns the success events.
+
+        Args:
+            cmd_iter: Command iterator from run_remediate.
+            timeout: Stream timeout.
+
+        Returns:
+            Success events on the retry call.
+
+        Raises:
+            _FakeRpcError: UNAVAILABLE transport blip before any result.
+        """
+        if not calls:
+            calls.append(1)
+            list(itertools.islice(cmd_iter, 1))
+            raise _FakeRpcError(grpc.StatusCode.UNAVAILABLE, "blip")
+        return events2
+
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    events2 = [result, _mk_event("closed")]
+    channel1 = MagicMock()
+    channel2 = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.side_effect = _blip
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=_fresh_chunks,
+        ),
+        patch(
+            "apme_engine.cli.remediate.resolve_engine",
+            side_effect=[(channel1, "a1"), (channel2, "a2")],
+        ),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.remediate.time.sleep", return_value=None),
+        patch("apme_engine.cli.remediate.random.uniform", return_value=0.0),
+    ):
+        run_remediate(_rem_args(str(tmp_path), show_suppressed=True))
+    assert minted == ["scan-prior-1", "scan-prior-2"]
+    assert minted[0] != minted[1]
+    err = capsys.readouterr().err
+    assert minted[0] in err
+    assert "attempt 1" in err
+    assert "retrying session once" in err
+
+
+def test_remediate_no_result_exits(tmp_path: Path) -> None:
+    """Stream ending without result exits with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [_mk_event("created"), _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_remediate(_rem_args(str(tmp_path)))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_remediate_json_and_violations_exit(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """JSON mode emits structured output and exits 1 on remaining violations.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    result = _mk_event("result")
+    result.result.remaining_violations = [object()]
+    result.result.patches = []
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [result, _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch(
+            "apme_engine.cli.remediate.violation_proto_to_dict",
+            return_value={"rule_id": "L001", "remediation_class": "ai-candidate", "file": "a.yml", "line": 1},
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_remediate(_rem_args(str(tmp_path), json=True, show_suppressed=True))
+    assert exc.value.code == EXIT_VIOLATIONS
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["count"] == 1
+    assert "remediation_summary" in doc
+
+
+def test_remediate_text_counts_and_suppressed_hint(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Text mode reports AI/manual counts and suppressed hint, then exits 1.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli._suppressions import SuppressionResult
+    from apme_engine.cli.remediate import run_remediate
+
+    result = _mk_event("result")
+    result.result.remaining_violations = [object(), object()]
+    result.result.patches = []
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [result, _mk_event("closed")]
+    active = [
+        {"rule_id": "L001", "remediation_class": "ai-candidate"},
+        {"rule_id": "L002", "remediation_class": "manual-review"},
+    ]
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([_scan_chunk()]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.remediate.violation_proto_to_dict", side_effect=active),
+        patch("apme_engine.cli.remediate.load_suppressions", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.apply_suppressions",
+            return_value=SuppressionResult(active=active, suppressed=[{"rule_id": "L003"}]),  # type: ignore[arg-type]
+        ),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_remediate(_rem_args(str(tmp_path), show_suppressed=False))
+    assert exc.value.code == EXIT_VIOLATIONS
+    err = capsys.readouterr().err
+    assert "Tier 2" in err
+    assert "Tier 3" in err
+    assert "suppressed" in err
+
+
+def test_emit_json_writes_structured_output(capsys: pytest.CaptureFixture[str]) -> None:
+    """_emit_json deduplicates, sorts, counts, and prints diffs.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import _emit_json
+
+    violations = [
+        {"rule_id": "L002", "file": "b.yml", "line": 2, "remediation_class": "manual-review"},
+        {"rule_id": "L001", "file": "a.yml", "line": 1, "remediation_class": "ai-candidate"},
+        {"rule_id": "L001", "file": "a.yml", "line": 1, "remediation_class": "ai-candidate"},
+    ]
+    patches = [
+        FilePatch(path="a.yml", original=b"o", patched=b"n", diff="D1", applied_rules=["L001"]),
+        FilePatch(path="b.yml", original=b"o", patched=b"n", diff="", applied_rules=[]),
+    ]
+    _emit_json(violations, patches, FixReport(fixed=2))  # type: ignore[arg-type]
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["count"] == 2
+    assert doc["remediation_summary"]["auto_fixable"] == 2
+    assert doc["diffs"] == [{"path": "a.yml", "diff": "D1"}]
+    assert doc["files_updated"] == 2
+
+
+def test_emit_json_no_report(capsys: pytest.CaptureFixture[str]) -> None:
+    """_emit_json with None report reports zero auto-fixable.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import _emit_json
+
+    _emit_json([], [], None)
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["count"] == 0
+    assert doc["remediation_summary"]["auto_fixable"] == 0
+
+
+def test_render_tier1_full(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_tier1 covers format diffs, idempotency warning, oscillation, applied.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import _render_tier1
+
+    summary = Tier1Summary(
+        format_diffs=[FileDiff(path="a.yml", original=b"o", formatted=b"n", diff="d")],
+        applied_patches=[FilePatch(path="a.yml", original=b"o", patched=b"n", diff="d")],
+        idempotency_ok=False,
+        report=FixReport(passes=2, fixed=1, remaining_ai=1, remaining_manual=1, oscillation_detected=True),
+    )
+    _render_tier1(summary)
+    err = capsys.readouterr().err
+    assert "Formatted 1" in err
+    assert "idempotent" in err
+    assert "oscillation" in err
+    assert "Tier 1 patch" in err
+
+
+def test_render_tier1_empty(capsys: pytest.CaptureFixture[str]) -> None:
+    """Default summary writes a zero remediation line without extras.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import _render_tier1
+
+    _render_tier1(Tier1Summary(idempotency_ok=True))
+    err = capsys.readouterr().err
+    assert "Remediation:" in err
+    assert "Formatted" not in err
+    assert "idempotent" not in err
+    assert "Applied" not in err
+
+
+def test_render_tier1_no_report_object(capsys: pytest.CaptureFixture[str]) -> None:
+    """Falsy report attribute skips the remediation line.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import _render_tier1
+
+    summary = MagicMock()
+    summary.format_diffs = []
+    summary.applied_patches = []
+    summary.idempotency_ok = True
+    summary.report = None
+    _render_tier1(summary)
+    assert capsys.readouterr().err == ""
+
+
+def test_interactive_review_all_branches(capsys: pytest.CaptureFixture[str]) -> None:
+    """Review loop covers y/n/a/s/q answers.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme.v1.engine_pb2 import Proposal
+    from apme_engine.cli.remediate import _interactive_review
+
+    proposals = [
+        Proposal(
+            id="p1",
+            rule_id="L001",
+            file="a.yml",
+            line_start=1,
+            line_end=2,
+            confidence=0.9,
+            explanation="e",
+            diff_hunk="d",
+        ),
+        Proposal(id="p2", rule_id="L002", file="b.yml", line_start=3, line_end=4),
+        Proposal(id="p3", rule_id="L003", file="c.yml", line_start=5, line_end=6),
+        Proposal(id="p4", rule_id="L004", file="d.yml", line_start=7, line_end=8),
+        Proposal(id="p5", rule_id="L005", file="e.yml", line_start=9, line_end=10),
+    ]
+    with patch("apme_engine.cli.remediate._prompt_ynasq", side_effect=["y", "n", "s", "y", "q"]):
+        approved = _interactive_review(proposals)
+    assert approved == ["p1"]
+
+
+def test_interactive_review_accept_all_and_quit() -> None:
+    """'a' accepts the remainder; 'q' aborts the loop."""
+    from apme.v1.engine_pb2 import Proposal
+    from apme_engine.cli.remediate import _interactive_review
+
+    proposals = [
+        Proposal(id="p1", rule_id="L001", file="a.yml", line_start=1, line_end=2),
+        Proposal(id="p2", rule_id="L002", file="b.yml", line_start=3, line_end=4),
+    ]
+    with patch("apme_engine.cli.remediate._prompt_ynasq", side_effect=["a"]):
+        assert _interactive_review(proposals) == ["p1", "p2"]
+    with patch("apme_engine.cli.remediate._prompt_ynasq", side_effect=["q"]):
+        assert _interactive_review(proposals) == []
+
+
+def test_prompt_ynasq_variants() -> None:
+    """_prompt_ynasq maps yes/no/accept/skip/quit and reprompts invalid."""
+    from apme_engine.cli.remediate import _prompt_ynasq
+
+    with patch("builtins.input", return_value="yes"):
+        assert _prompt_ynasq() == "y"
+    with patch("builtins.input", return_value="NO"):
+        assert _prompt_ynasq() == "n"
+    with patch("builtins.input", return_value="accept"):
+        assert _prompt_ynasq() == "a"
+    with patch("builtins.input", return_value="skip"):
+        assert _prompt_ynasq() == "s"
+    with patch("builtins.input", return_value="quit"):
+        assert _prompt_ynasq() == "q"
+    with patch("builtins.input", side_effect=["bogus", "y"]):
+        assert _prompt_ynasq() == "y"
+    with patch("builtins.input", side_effect=EOFError):
+        assert _prompt_ynasq() == "q"
+    with patch("builtins.input", side_effect=KeyboardInterrupt):
+        assert _prompt_ynasq() == "q"
+
+
+def test_write_patches_dir_and_file_targets(tmp_path: Path) -> None:
+    """_write_patches writes via target dir join and via direct file target.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import _write_patches
+
+    dfile = tmp_path / "play.yml"
+    dfile.write_bytes(b"orig")
+    patches = [FilePatch(path="play.yml", original=b"orig", patched=b"new", diff="d", applied_rules=["L001"])]
+    _write_patches(tmp_path, patches)
+    assert dfile.read_bytes() == b"new"
+    solo = tmp_path / "solo.yml"
+    solo.write_bytes(b"o2")
+    _write_patches(solo, [FilePatch(path="ignored.yml", original=b"o2", patched=b"n2", diff="d")])
+    assert solo.read_bytes() == b"n2"
+
+
+def test_write_patches_oserror_skips(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """OSError from _safe_write is reported and skipped.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import _write_patches
+
+    patches = [FilePatch(path="x.yml", original=b"o", patched=b"n", diff="d")]
+    with patch("apme_engine.cli.remediate._safe_write", side_effect=OSError("denied")):
+        _write_patches(tmp_path, patches)
+    assert "WARNING: skipping" in capsys.readouterr().err
+
+
+def test_render_remaining_counts() -> None:
+    """_render_remaining reports AI and manual buckets."""
+    from apme.v1.common_pb2 import Violation
+    from apme_engine.cli.remediate import _render_remaining
+
+    result = SessionResult(
+        remaining_violations=[
+            Violation(rule_id="L1", remediation_class=common_pb2.REMEDIATION_CLASS_AI_CANDIDATE),  # type: ignore[attr-defined]
+            Violation(rule_id="L2", remediation_class=common_pb2.REMEDIATION_CLASS_MANUAL_REVIEW),  # type: ignore[attr-defined]
+        ]
+    )
+    _render_remaining(result)
+    _render_remaining(SessionResult())
+
+
+def test_rem_safe_write_match_and_skip(tmp_path: Path) -> None:
+    """_safe_write writes on match and skips when modified.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import _safe_write
+
+    p = tmp_path / "w.yml"
+    p.write_bytes(b"orig")
+    _safe_write(p, b"orig", b"new")
+    assert p.read_bytes() == b"new"
+    _safe_write(p, b"stale", b"other")
+    assert p.read_bytes() == b"new"
+
+
+def test_check_chunk_not_found_exits(tmp_path: Path) -> None:
+    """Missing target chunks exit check with EXIT_ERROR.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.check import run_check
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    with (
+        patch("apme_engine.cli.check.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.check.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.check.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.check.yield_scan_chunks", side_effect=FileNotFoundError("gone")),
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_check(_check_args_ns(str(target)))
+    assert exc.value.code == EXIT_ERROR
+
+
+def test_check_two_chunks_and_draining_stub(tmp_path: Path) -> None:
+    """Two upload chunks cover first and subsequent producer iterations.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.check import run_check
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    c1 = _scan_chunk("s1")
+    c2 = _scan_chunk("s2")
+    channel = MagicMock()
+    stub = MagicMock()
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    # NOTE: the stub intentionally does not drain cmd_iter. Draining here would
+    # deadlock because check's producer never emits the None sentinel; the
+    # sentinel is only queued in the finally block after FixSession returns.
+    stub.FixSession.return_value = [result, _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.check.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.check.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.check.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.check.yield_scan_chunks", return_value=iter([c1, c2])),
+        patch("apme_engine.cli.check.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.check.engine_pb2_grpc.EngineStub", return_value=stub),
+    ):
+        run_check(_check_args_ns(str(target), show_suppressed=True))
+
+
+def test_remediate_two_chunks_and_draining_stub(tmp_path: Path) -> None:
+    """Two scan chunks and a draining stub cover first/non-first upload paths.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    c1 = _scan_chunk("s1")
+    c2 = _scan_chunk("s2")
+    channel = MagicMock()
+    stub = MagicMock()
+
+    def _drain_and_result(cmd_iter: Iterable[object], timeout: object = None) -> list[MagicMock]:
+        """Drain uploads then emit an empty result.
+
+        Only the two upload chunks are consumed: the producer no longer
+        emits a terminating None on success, so a full ``list(cmd_iter)``
+        would block forever waiting for the teardown sentinel.
+
+        Args:
+            cmd_iter: Command iterator from run_remediate.
+            timeout: Stream timeout.
+
+        Returns:
+            Event list with result and close.
+
+        """
+        drained = list(itertools.islice(cmd_iter, 2))
+        assert len(drained) >= 2
+        result = _mk_event("result")
+        result.result.remaining_violations = []
+        result.result.patches = []
+        return [result, _mk_event("closed")]
+
+    stub.FixSession.side_effect = _drain_and_result
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch(
+            "apme_engine.cli.remediate.yield_scan_chunks",
+            side_effect=lambda *a, **k: iter([c1, c2]),
+        ),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+    ):
+        run_remediate(_rem_args(str(tmp_path), show_suppressed=True))
+
+
+def test_render_remaining_manual_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """Manual-only remaining skips the AI hint but shows the manual hint.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme.v1.common_pb2 import Violation
+    from apme_engine.cli.remediate import _render_remaining
+
+    result = SessionResult(
+        remaining_violations=[
+            Violation(rule_id="L9", remediation_class=common_pb2.REMEDIATION_CLASS_MANUAL_REVIEW),  # type: ignore[attr-defined]
+        ]
+    )
+    _render_remaining(result)
+    err = capsys.readouterr().err
+    assert "manual review" in err
+    assert "Tier 2" not in err
+
+
+def test_check_json_no_violations_returns_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """JSON mode with no violations prints zero count and returns.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.check import run_check
+
+    target = tmp_path / "site.yml"
+    target.write_text("a: 1\n", encoding="utf-8")
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [result, _mk_event("closed")]
+    with (
+        patch("apme_engine.cli.check.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.check.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.check.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.check.yield_scan_chunks", return_value=iter([_scan_chunk()])),
+        patch("apme_engine.cli.check.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.check.engine_pb2_grpc.EngineStub", return_value=stub),
+    ):
+        run_check(_check_args_ns(str(target), json=True, show_suppressed=True))
+    assert json.loads(capsys.readouterr().out)["count"] == 0
+
+
+def test_remediate_producer_success_leaves_stream_open(tmp_path: Path) -> None:
+    """Producer success leaves the FixSession stream open for approvals.
+
+    Drains the two upload chunks then probes the request generator from a
+    background thread: it must stay blocked (stream open) instead of
+    raising StopIteration (premature half-close).
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    c1 = _scan_chunk("s1")
+    c2 = _scan_chunk("s2")
+    channel = MagicMock()
+    stub = MagicMock()
+    probe_outcome: list[str] = []
+    probe_thread_holder: list[threading.Thread] = []
+
+    def _capture_and_probe(cmd_iter: Iterable[object], timeout: object = None) -> list[MagicMock]:
+        """Drain uploads, probe openness, then emit an empty result.
+
+        Args:
+            cmd_iter: Command iterator from run_remediate.
+            timeout: Stream timeout.
+
+        Returns:
+            Event list with result and close.
+        """
+        it: Iterator[object] = iter(cmd_iter)
+        first = next(it)
+        second = next(it)
+        assert first is not None
+        assert second is not None
+        # Give a buggy producer time to enqueue its premature None sentinel;
+        # with the fix no sentinel ever arrives on success.
+        time.sleep(0.5)
+
+        def _probe() -> None:
+            """Attempt one more next; blocked means open, StopIteration means closed.
+
+            Returns:
+                None.
+            """
+            try:
+                next(it)
+            except StopIteration:
+                probe_outcome.append("stopped")
+            else:
+                probe_outcome.append("value")
+
+        probe = threading.Thread(target=_probe, daemon=True)
+        probe_thread_holder.append(probe)
+        probe.start()
+        probe.join(timeout=0.5)
+        assert probe.is_alive(), "request stream closed before approvals (premature None)"
+        assert probe_outcome == []
+        result = _mk_event("result")
+        result.result.remaining_violations = []
+        result.result.patches = []
+        return [result, _mk_event("closed")]
+
+    def _chunks(*args: object, **kwargs: object) -> Iterator[ScanChunk]:
+        """Return two upload chunks.
+
+        Args:
+            *args: Positional chunk args.
+            **kwargs: Chunk keyword args.
+
+        Returns:
+            Iterator of two ScanChunk protos.
+        """
+        return iter([c1, c2])
+
+    stub.FixSession.side_effect = _capture_and_probe
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.remediate.yield_scan_chunks", side_effect=_chunks),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+    ):
+        run_remediate(_rem_args(str(tmp_path), show_suppressed=True))
+    for probe in probe_thread_holder:
+        probe.join(timeout=5.0)
+
+
+def test_remediate_producer_error_terminates_stream(tmp_path: Path) -> None:
+    """Producer error terminates the request stream with a sentinel.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+
+    Raises:
+        AssertionError: If remediate does not exit as expected.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    channel = MagicMock()
+    stub = MagicMock()
+
+    def _capture_terminating(cmd_iter: Iterable[object], timeout: object = None) -> list[MagicMock]:
+        """Drain the error-path stream; it must terminate via sentinel.
+
+        Args:
+            cmd_iter: Command iterator from run_remediate.
+            timeout: Stream timeout.
+
+        Returns:
+            Empty event list (triggers no-result exit).
+        """
+        drained = list(cmd_iter)
+        assert drained == []
+        return []
+
+    stub.FixSession.side_effect = _capture_terminating
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.remediate.yield_scan_chunks", side_effect=RuntimeError("disk-gone")),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.remediate.time.sleep", return_value=None),
+    ):
+        try:
+            run_remediate(_rem_args(str(tmp_path), show_suppressed=True))
+        except SystemExit as exc:
+            assert exc.code == EXIT_ERROR
+        else:
+            raise AssertionError("expected SystemExit")
+
+
+def test_remediate_retry_resets_state_and_mints_fresh_scan_id(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Retry resets per-attempt state and mints a fresh scan_id per attempt.
+
+    First attempt reports tier1 fixed=99 then a transient UNAVAILABLE;
+    second attempt reports a result with no tier1. JSON must show
+    auto_fixable 0 (not stale 99). Each attempt calls
+    ``yield_scan_chunks`` without a shared scan_id so the server mints a
+    fresh session (``SessionStore.create`` has no dedup on ``scan_id``);
+    the retry therefore produces distinct chunk scan_ids.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    tier1_ev = _mk_event("tier1_complete")
+    tier1_ev.tier1_complete.report = FixReport(fixed=99, remaining_ai=0, remaining_manual=0)
+
+    def _first_attempt() -> Iterator[MagicMock]:
+        """Yield stale tier1 then raise transient UNAVAILABLE.
+
+        Yields:
+            MagicMock: Tier1 event from the failed first attempt.
+
+        Raises:
+            _FakeRpcError: Transient UNAVAILABLE to trigger retry.
+        """
+        yield tier1_ev
+        raise _FakeRpcError(grpc.StatusCode.UNAVAILABLE, "blip")
+
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = []
+    events2 = [result, _mk_event("closed")]
+    channel1 = MagicMock()
+    channel2 = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.side_effect = [_first_attempt(), events2]
+    seen_scan_kwargs: list[object] = []
+    seen_chunk_ids: list[str] = []
+    call_index = 0
+
+    def _chunks(*args: object, **kwargs: object) -> Iterator[ScanChunk]:
+        """Record scan_id kwarg and return one chunk with a fresh ID.
+
+        Mimics real ``yield_scan_chunks`` (mints a fresh scan_id when the
+        caller omits it) so the test proves attempts do not share an ID.
+
+        Args:
+            *args: Positional chunk args.
+            **kwargs: Chunk keyword args.
+
+        Returns:
+            Iterator with a single ScanChunk carrying a fresh scan_id.
+        """
+        nonlocal call_index
+        call_index += 1
+        seen_scan_kwargs.append(kwargs.get("scan_id"))
+        fresh_id = f"fresh-scan-{call_index}"
+        seen_chunk_ids.append(fresh_id)
+        return iter([_scan_chunk(fresh_id)])
+
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.remediate.yield_scan_chunks", side_effect=_chunks),
+        patch(
+            "apme_engine.cli.remediate.resolve_engine",
+            side_effect=[(channel1, "a1"), (channel2, "a2")],
+        ),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch("apme_engine.cli.remediate.time.sleep", return_value=None),
+        patch("apme_engine.cli.remediate.random.uniform", return_value=0.0),
+    ):
+        run_remediate(_rem_args(str(tmp_path), json=True, show_suppressed=True))
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["remediation_summary"]["auto_fixable"] == 0
+    assert len(seen_scan_kwargs) == 2
+    # No shared scan_id is passed: each attempt lets yield_scan_chunks mint one.
+    assert seen_scan_kwargs[0] is None
+    assert seen_scan_kwargs[1] is None
+    assert len(seen_chunk_ids) == 2
+    assert seen_chunk_ids[0] != ""
+    assert seen_chunk_ids[0] != seen_chunk_ids[1]
+
+
+def test_write_patches_returns_written_count(tmp_path: Path) -> None:
+    """_write_patches returns files actually written, skipping OSError.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    from apme_engine.cli.remediate import _write_patches
+
+    patches = [
+        FilePatch(path="a.yml", original=b"o", patched=b"n", diff="D1"),
+        FilePatch(path="b.yml", original=b"o", patched=b"n", diff="D2"),
+    ]
+    with patch(
+        "apme_engine.cli.remediate._safe_write",
+        side_effect=[None, OSError("denied")],
+    ):
+        written = _write_patches(tmp_path, patches)
+    assert written == 1
+
+
+def test_emit_json_uses_written_count(capsys: pytest.CaptureFixture[str]) -> None:
+    """_emit_json prefers explicit written count over patch length.
+
+    Args:
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import _emit_json
+
+    patches = [
+        FilePatch(path="a.yml", original=b"o", patched=b"n", diff="D1"),
+        FilePatch(path="b.yml", original=b"o", patched=b"n", diff="D2"),
+    ]
+    _emit_json([], patches, None, 1)
+    assert json.loads(capsys.readouterr().out)["files_updated"] == 1
+    _emit_json([], patches, None)
+    assert json.loads(capsys.readouterr().out)["files_updated"] == 2
+
+
+def test_remediate_json_files_updated_reflects_written(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """End-to-end JSON files_updated reflects actually written files.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import run_remediate
+
+    result = _mk_event("result")
+    result.result.remaining_violations = []
+    result.result.patches = [
+        FilePatch(path="a.yml", original=b"o", patched=b"n", diff="D1"),
+        FilePatch(path="b.yml", original=b"o", patched=b"n", diff="D2"),
+    ]
+    channel = MagicMock()
+    stub = MagicMock()
+    stub.FixSession.return_value = [result, _mk_event("closed")]
+
+    def _chunks(*args: object, **kwargs: object) -> Iterator[ScanChunk]:
+        """Return one upload chunk.
+
+        Args:
+            *args: Positional chunk args.
+            **kwargs: Chunk keyword args.
+
+        Returns:
+            Iterator with a single ScanChunk.
+        """
+        return iter([_scan_chunk()])
+
+    with (
+        patch("apme_engine.cli.remediate.discover_project_root", return_value=tmp_path),
+        patch("apme_engine.cli.remediate.derive_session_id", return_value="s"),
+        patch("apme_engine.cli.remediate.discover_galaxy_servers", return_value=[]),
+        patch("apme_engine.cli.remediate.load_rule_configs_from_project", return_value=[]),
+        patch("apme_engine.cli.remediate.yield_scan_chunks", side_effect=_chunks),
+        patch("apme_engine.cli.remediate.resolve_engine", return_value=(channel, "addr")),
+        patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
+        patch(
+            "apme_engine.cli.remediate._safe_write",
+            side_effect=[None, OSError("denied")],
+        ),
+    ):
+        run_remediate(_rem_args(str(tmp_path), json=True, show_suppressed=True))
+    assert json.loads(capsys.readouterr().out)["files_updated"] == 1

--- a/tests/test_cli_surface_coverage.py
+++ b/tests/test_cli_surface_coverage.py
@@ -2254,7 +2254,9 @@ def test_write_patches_oserror_skips(tmp_path: Path, capsys: pytest.CaptureFixtu
 
     patches = [FilePatch(path="x.yml", original=b"o", patched=b"n", diff="d")]
     with patch("apme_engine.cli.remediate._safe_write", side_effect=OSError("denied")):
-        _write_patches(tmp_path, patches)
+        written, failed = _write_patches(tmp_path, patches)
+    assert written == 0
+    assert failed is True
     assert "WARNING: skipping" in capsys.readouterr().err
 
 
@@ -2283,9 +2285,9 @@ def test_rem_safe_write_match_and_skip(tmp_path: Path) -> None:
 
     p = tmp_path / "w.yml"
     p.write_bytes(b"orig")
-    _safe_write(p, b"orig", b"new")
+    assert _safe_write(p, b"orig", b"new") is True
     assert p.read_bytes() == b"new"
-    _safe_write(p, b"stale", b"other")
+    assert _safe_write(p, b"stale", b"other") is False
     assert p.read_bytes() == b"new"
 
 
@@ -2669,6 +2671,24 @@ def test_remediate_retry_resets_state_and_mints_fresh_scan_id(
     assert seen_chunk_ids[0] != seen_chunk_ids[1]
 
 
+def test_write_patches_stale_skip_not_counted(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Stale files skipped by _safe_write are not counted as updated.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        capsys: Pytest capture fixture.
+    """
+    from apme_engine.cli.remediate import _write_patches
+
+    p = tmp_path / "stale.yml"
+    p.write_bytes(b"changed")
+    patches = [FilePatch(path="stale.yml", original=b"orig", patched=b"new", diff="d")]
+    written, failed = _write_patches(tmp_path, patches)
+    assert written == 0
+    assert failed is True
+    assert "Fixed:" not in capsys.readouterr().err
+
+
 def test_write_patches_returns_written_count(tmp_path: Path) -> None:
     """_write_patches returns files actually written, skipping OSError.
 
@@ -2683,10 +2703,11 @@ def test_write_patches_returns_written_count(tmp_path: Path) -> None:
     ]
     with patch(
         "apme_engine.cli.remediate._safe_write",
-        side_effect=[None, OSError("denied")],
+        side_effect=[True, OSError("denied")],
     ):
-        written = _write_patches(tmp_path, patches)
+        written, failed = _write_patches(tmp_path, patches)
     assert written == 1
+    assert failed is True
 
 
 def test_emit_json_uses_written_count(capsys: pytest.CaptureFixture[str]) -> None:
@@ -2748,8 +2769,9 @@ def test_remediate_json_files_updated_reflects_written(tmp_path: Path, capsys: p
         patch("apme_engine.cli.remediate.engine_pb2_grpc.EngineStub", return_value=stub),
         patch(
             "apme_engine.cli.remediate._safe_write",
-            side_effect=[None, OSError("denied")],
+            side_effect=[True, OSError("denied")],
         ),
+        pytest.raises(SystemExit) as exc,
     ):
         run_remediate(_rem_args(str(tmp_path), json=True, show_suppressed=True))
-    assert json.loads(capsys.readouterr().out)["files_updated"] == 1
+    assert exc.value.code == EXIT_ERROR

--- a/tests/test_cli_surface_coverage.py
+++ b/tests/test_cli_surface_coverage.py
@@ -2125,7 +2125,7 @@ def test_render_tier1_full(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 def test_render_tier1_empty(capsys: pytest.CaptureFixture[str]) -> None:
-    """Default summary writes a zero remediation line without extras.
+    """Unset report field produces no remediation line.
 
     Args:
         capsys: Pytest capture fixture.
@@ -2134,7 +2134,7 @@ def test_render_tier1_empty(capsys: pytest.CaptureFixture[str]) -> None:
 
     _render_tier1(Tier1Summary(idempotency_ok=True))
     err = capsys.readouterr().err
-    assert "Remediation:" in err
+    assert "Remediation:" not in err
     assert "Formatted" not in err
     assert "idempotent" not in err
     assert "Applied" not in err

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -1322,3 +1322,39 @@ class TestGalaxyNonDictPayload:
             )
 
         assert result is None
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"data": None, "links": {}},
+            {"data": ["1.0.0"], "links": {}},
+            {"data": [{"version": "1.0.0"}], "links": None},
+        ],
+    )  # type: ignore[untyped-decorator]
+    def test_fetch_versions_from_malformed_nested_returns_none(self, payload: dict[str, object]) -> None:
+        """Malformed nested version payloads fail over instead of raising.
+
+        Args:
+            payload: Dict body with invalid nested data/links shapes.
+        """
+        import asyncio
+
+        from galaxy_proxy.proxy.server import _fetch_versions_from
+
+        def _capture_client(**kwargs: object) -> unittest.mock.MagicMock:
+            mock_resp = unittest.mock.MagicMock()
+            mock_resp.raise_for_status.return_value = None
+            mock_resp.json.return_value = payload
+
+            client = unittest.mock.MagicMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            return client
+
+        with patch("galaxy_proxy.proxy.server.httpx.AsyncClient", side_effect=_capture_client):
+            result = asyncio.run(
+                _fetch_versions_from("ansible", "posix", "https://galaxy.ansible.com"),
+            )
+
+        assert result is None

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -558,6 +558,28 @@ class TestVersionDiscoveryWithServers:
         assert result == ["1.5.4"]
         assert mock_inner.call_count == 2
 
+    def test_fetch_versions_all_servers_fail_returns_none(self) -> None:
+        """Total server failure (including truncation) is None, not an empty list."""
+        import asyncio
+
+        from galaxy_proxy.collection_downloader import GalaxyServerConfig
+        from galaxy_proxy.proxy.server import _fetch_galaxy_versions
+
+        servers = [
+            GalaxyServerConfig(name="hub", url="https://hub.example.com", token="tok"),
+        ]
+
+        with patch(
+            "galaxy_proxy.proxy.server._fetch_versions_from",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = asyncio.run(
+                _fetch_galaxy_versions("ansible", "posix", servers=servers),
+            )
+
+        assert result is None
+
     def test_fetch_versions_sends_auth_token(self) -> None:
         """_fetch_versions_from passes the auth token in the Authorization header.
 

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -1215,6 +1215,54 @@ class TestGalaxyNonDictPayload:
 
         assert result is None
 
+    def test_get_detail_from_null_metadata_uses_empty_defaults(self) -> None:
+        """A null metadata field is treated as empty object fields."""
+        import asyncio
+        from typing import cast
+
+        import httpx
+
+        from galaxy_proxy.galaxy_client import GalaxyClient
+
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            "download_url": "https://cdn.example.com/coll.tar.gz",
+            "metadata": None,
+        }
+        fake_client = unittest.mock.MagicMock()
+        fake_client.get = AsyncMock(return_value=mock_resp)
+
+        detail = asyncio.run(
+            GalaxyClient._get_detail_from(cast(httpx.AsyncClient, fake_client), "ansible", "posix", "1.0.0"),
+        )
+
+        assert detail.dependencies == {}
+        assert detail.description == ""
+
+    def test_get_detail_from_non_object_metadata_raises_value_error(self) -> None:
+        """Non-object metadata raises ValueError, which fails over."""
+        import asyncio
+        from typing import cast
+
+        import httpx
+
+        from galaxy_proxy.galaxy_client import GalaxyClient
+
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            "download_url": "https://cdn.example.com/coll.tar.gz",
+            "metadata": ["bad"],
+        }
+        fake_client = unittest.mock.MagicMock()
+        fake_client.get = AsyncMock(return_value=mock_resp)
+
+        with pytest.raises(ValueError, match="non-object metadata"):
+            asyncio.run(
+                GalaxyClient._get_detail_from(cast(httpx.AsyncClient, fake_client), "ansible", "posix", "1.0.0"),
+            )
+
     @pytest.mark.parametrize("payload", [[{"version": "1.0.0"}], "ok"])  # type: ignore[untyped-decorator]
     def test_get_detail_from_non_dict_raises_value_error(self, payload: object) -> None:
         """A non-dict detail body raises ValueError, which fails over.

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -623,6 +623,134 @@ class TestVersionDiscoveryWithServers:
         assert result == ["2.0.0"]
         assert "Authorization" not in captured_headers
 
+    def test_fetch_versions_truncation_returns_none(self) -> None:
+        """A perpetual ``links.next`` is a failure signal, not a partial answer."""
+        import asyncio
+
+        from galaxy_proxy import MAX_VERSION_PAGES
+        from galaxy_proxy.proxy.server import _fetch_versions_from
+
+        calls = 0
+
+        def _capture_client(**kwargs: object) -> unittest.mock.MagicMock:
+            mock_resp = unittest.mock.MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"data": [{"version": "1.0.0"}], "links": {"next": "more"}}
+            mock_resp.raise_for_status.return_value = None
+
+            async def _get(url: str, **kw: object) -> unittest.mock.MagicMock:
+                nonlocal calls
+                calls += 1
+                return mock_resp
+
+            client = unittest.mock.MagicMock()
+            client.get = _get
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            return client
+
+        with patch("galaxy_proxy.proxy.server.httpx.AsyncClient", side_effect=_capture_client):
+            result = asyncio.run(
+                _fetch_versions_from("ansible", "posix", "https://galaxy.ansible.com"),
+            )
+
+        assert result is None
+        assert calls == MAX_VERSION_PAGES
+
+
+class TestGalaxyClientTruncation:
+    """All-truncated listings report truncation, not missing configuration."""
+
+    def test_list_versions_all_truncated_raises_truncation_error(self) -> None:
+        """Every server truncated with no other error names the page bound."""
+        import asyncio
+
+        from galaxy_proxy import MAX_VERSION_PAGES
+        from galaxy_proxy.galaxy_client import GalaxyClient, GalaxyServer
+
+        client = GalaxyClient(servers=[GalaxyServer(url="https://galaxy.example.com")])
+        try:
+            with (
+                patch.object(
+                    GalaxyClient,
+                    "_list_versions_from",
+                    AsyncMock(return_value=None),
+                ),
+                pytest.raises(RuntimeError, match="truncated") as excinfo,
+            ):
+                asyncio.run(client.list_versions("ansible", "posix"))
+        finally:
+            asyncio.run(client.close())
+
+        assert MAX_VERSION_PAGES > 0
+        assert "truncated" in str(excinfo.value)
+        # Pure truncation has no chained per-server failure to report.
+        assert excinfo.value.__cause__ is None
+
+    @pytest.mark.parametrize("payload_error", [ValueError("bad json"), KeyError("version")])  # type: ignore[untyped-decorator]
+    def test_list_versions_exhaustion_wraps_payload_errors_with_cause(self, payload_error: Exception) -> None:
+        """Exhausted listings surface as RuntimeError chained from the payload error.
+
+        Callers must never see a bare ``ValueError``/``KeyError`` from a
+        malformed Galaxy payload; the last failure is chained via
+        ``__cause__``.
+
+        Args:
+            payload_error: Malformed-payload error raised by the fake server.
+        """
+        import asyncio
+
+        from galaxy_proxy.galaxy_client import GalaxyClient, GalaxyServer
+
+        client = GalaxyClient(servers=[GalaxyServer(url="https://galaxy.example.com")])
+        try:
+            with (
+                patch.object(
+                    GalaxyClient,
+                    "_list_versions_from",
+                    AsyncMock(side_effect=payload_error),
+                ),
+                pytest.raises(RuntimeError, match="failed") as excinfo,
+            ):
+                asyncio.run(client.list_versions("ansible", "posix"))
+        finally:
+            asyncio.run(client.close())
+
+        assert isinstance(excinfo.value.__cause__, type(payload_error))
+        assert str(excinfo.value.__cause__) == str(payload_error)
+
+    @pytest.mark.parametrize("payload_error", [ValueError("bad json"), KeyError("download_url")])  # type: ignore[untyped-decorator]
+    def test_get_version_detail_exhaustion_wraps_errors_with_cause(self, payload_error: Exception) -> None:
+        """Exhausted detail fetches surface as RuntimeError chained from the last failure.
+
+        Symmetric with ``list_versions``: callers must never see a bare
+        ``httpx``/payload error from a malformed Galaxy response; the last
+        failure is chained via ``__cause__``.
+
+        Args:
+            payload_error: Malformed-payload error raised by the fake server.
+        """
+        import asyncio
+
+        from galaxy_proxy.galaxy_client import GalaxyClient, GalaxyServer
+
+        client = GalaxyClient(servers=[GalaxyServer(url="https://galaxy.example.com")])
+        try:
+            with (
+                patch.object(
+                    GalaxyClient,
+                    "_get_detail_from",
+                    AsyncMock(side_effect=payload_error),
+                ),
+                pytest.raises(RuntimeError, match="failed") as excinfo,
+            ):
+                asyncio.run(client.get_version_detail("ansible", "posix", "1.0.0"))
+        finally:
+            asyncio.run(client.close())
+
+        assert isinstance(excinfo.value.__cause__, type(payload_error))
+        assert str(excinfo.value.__cause__) == str(payload_error)
+
     @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
         ("raw_url", "expected"),
         [
@@ -889,3 +1017,286 @@ class TestConvertTarballs:
 
         assert resp.status_code == 400
         assert "session or temp directory" in resp.json()["detail"]
+
+
+class TestGalaxyClientDownload:
+    """download_tarball and get_version_and_download wrap failures as RuntimeError."""
+
+    def test_download_tarball_success(self) -> None:
+        """A 200 response returns the raw tarball bytes."""
+        import asyncio
+
+        from galaxy_proxy.galaxy_client import GalaxyClient, GalaxyServer
+
+        client = GalaxyClient(servers=[GalaxyServer(url="https://galaxy.example.com")])
+        try:
+            mock_resp = unittest.mock.MagicMock()
+            mock_resp.raise_for_status.return_value = None
+            mock_resp.content = b"tarball-bytes"
+            with patch.object(
+                client._download_client,
+                "get",
+                AsyncMock(return_value=mock_resp),
+            ):
+                data = asyncio.run(client.download_tarball("https://cdn.example.com/coll.tar.gz"))
+        finally:
+            asyncio.run(client.close())
+
+        assert data == b"tarball-bytes"
+
+    @pytest.mark.parametrize("error_kind", ["transport", "status"])  # type: ignore[untyped-decorator]
+    def test_download_tarball_wraps_httpx_errors(self, error_kind: str) -> None:
+        """Transport and status failures surface as RuntimeError with cause.
+
+        Args:
+            error_kind: Which httpx failure the fake transport raises.
+        """
+        import asyncio
+
+        import httpx
+
+        from galaxy_proxy.galaxy_client import GalaxyClient, GalaxyServer
+
+        url = "https://cdn.example.com/coll.tar.gz"
+        request = httpx.Request("GET", url)
+        error: Exception
+        if error_kind == "transport":
+            error = httpx.ConnectError("boom", request=request)
+        else:
+            error = httpx.HTTPStatusError(
+                "server error",
+                request=request,
+                response=httpx.Response(500, request=request),
+            )
+        client = GalaxyClient(servers=[GalaxyServer(url="https://galaxy.example.com")])
+        try:
+            with (
+                patch.object(
+                    client._download_client,
+                    "get",
+                    AsyncMock(side_effect=error),
+                ),
+                pytest.raises(RuntimeError, match="tarball download failed") as excinfo,
+            ):
+                asyncio.run(client.download_tarball(url))
+        finally:
+            asyncio.run(client.close())
+
+        assert excinfo.value.__cause__ is error
+
+    def test_get_version_and_download_success(self) -> None:
+        """Metadata and tarball are fetched in sequence and returned together."""
+        import asyncio
+
+        from galaxy_proxy.galaxy_client import CollectionVersion, GalaxyClient, GalaxyServer
+
+        detail = CollectionVersion(
+            namespace="ansible",
+            name="posix",
+            version="1.0.0",
+            download_url="https://cdn.example.com/coll.tar.gz",
+        )
+        client = GalaxyClient(servers=[GalaxyServer(url="https://galaxy.example.com")])
+        try:
+            with (
+                patch.object(
+                    GalaxyClient,
+                    "get_version_detail",
+                    AsyncMock(return_value=detail),
+                ),
+                patch.object(
+                    GalaxyClient,
+                    "download_tarball",
+                    AsyncMock(return_value=b"tarball-bytes"),
+                ) as mock_download,
+            ):
+                result = asyncio.run(client.get_version_and_download("ansible", "posix", "1.0.0"))
+        finally:
+            asyncio.run(client.close())
+
+        assert result == (detail, b"tarball-bytes")
+        mock_download.assert_awaited_once_with("https://cdn.example.com/coll.tar.gz")
+
+    def test_get_version_and_download_wraps_raw_errors(self) -> None:
+        """Raw payload failures surface as RuntimeError with cause."""
+        import asyncio
+
+        from galaxy_proxy.galaxy_client import GalaxyClient, GalaxyServer
+
+        raw = ValueError("bad json")
+        client = GalaxyClient(servers=[GalaxyServer(url="https://galaxy.example.com")])
+        try:
+            with (
+                patch.object(
+                    GalaxyClient,
+                    "get_version_detail",
+                    AsyncMock(side_effect=raw),
+                ),
+                pytest.raises(RuntimeError, match="download failed") as excinfo,
+            ):
+                asyncio.run(client.get_version_and_download("ansible", "posix", "1.0.0"))
+        finally:
+            asyncio.run(client.close())
+
+        assert excinfo.value.__cause__ is raw
+
+    def test_get_version_and_download_propagates_wrapped_errors(self) -> None:
+        """Already-wrapped RuntimeError failures propagate unchanged."""
+        import asyncio
+
+        from galaxy_proxy.galaxy_client import GalaxyClient, GalaxyServer
+
+        wrapped = RuntimeError("Galaxy version detail failed for ansible.posix:1.0.0: boom")
+        client = GalaxyClient(servers=[GalaxyServer(url="https://galaxy.example.com")])
+        try:
+            with (
+                patch.object(
+                    GalaxyClient,
+                    "get_version_detail",
+                    AsyncMock(side_effect=wrapped),
+                ),
+                pytest.raises(RuntimeError, match="version detail failed") as excinfo,
+            ):
+                asyncio.run(client.get_version_and_download("ansible", "posix", "1.0.0"))
+        finally:
+            asyncio.run(client.close())
+
+        assert excinfo.value is wrapped
+
+
+class TestGalaxyNonDictPayload:
+    """Non-dict JSON bodies fail over instead of raising AttributeError."""
+
+    @pytest.mark.parametrize("payload", [[{"version": "1.0.0"}], "ok"])  # type: ignore[untyped-decorator]
+    def test_list_versions_from_non_dict_returns_none(self, payload: object) -> None:
+        """A non-dict listing body is a failover signal, not a crash.
+
+        Args:
+            payload: Non-dict JSON body returned by the fake server.
+        """
+        import asyncio
+        from typing import cast
+
+        import httpx
+
+        from galaxy_proxy.galaxy_client import GalaxyClient
+
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = payload
+        fake_client = unittest.mock.MagicMock()
+        fake_client.get = AsyncMock(return_value=mock_resp)
+
+        result = asyncio.run(
+            GalaxyClient._list_versions_from(cast(httpx.AsyncClient, fake_client), "ansible", "posix"),
+        )
+
+        assert result is None
+
+    @pytest.mark.parametrize("payload", [[{"version": "1.0.0"}], "ok"])  # type: ignore[untyped-decorator]
+    def test_get_detail_from_non_dict_raises_value_error(self, payload: object) -> None:
+        """A non-dict detail body raises ValueError, which fails over.
+
+        Args:
+            payload: Non-dict JSON body returned by the fake server.
+        """
+        import asyncio
+        from typing import cast
+
+        import httpx
+
+        from galaxy_proxy.galaxy_client import GalaxyClient
+
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = payload
+        fake_client = unittest.mock.MagicMock()
+        fake_client.get = AsyncMock(return_value=mock_resp)
+
+        with pytest.raises(ValueError, match="non-dict payload"):
+            asyncio.run(
+                GalaxyClient._get_detail_from(cast(httpx.AsyncClient, fake_client), "ansible", "posix", "1.0.0"),
+            )
+
+    def test_list_versions_non_dict_payload_fails_over(self) -> None:
+        """A non-dict first response falls through to the next server."""
+        import asyncio
+
+        from galaxy_proxy.galaxy_client import GalaxyClient, GalaxyServer
+
+        client = GalaxyClient(
+            servers=[
+                GalaxyServer(url="https://first.example.com"),
+                GalaxyServer(url="https://second.example.com"),
+            ]
+        )
+        try:
+            with patch.object(
+                GalaxyClient,
+                "_list_versions_from",
+                AsyncMock(side_effect=[None, ["1.0.0"]]),
+            ):
+                result = asyncio.run(client.list_versions("ansible", "posix"))
+        finally:
+            asyncio.run(client.close())
+
+        assert result == ["1.0.0"]
+
+    def test_get_version_detail_non_dict_payload_fails_over(self) -> None:
+        """A non-dict detail body falls through to the next server."""
+        import asyncio
+
+        from galaxy_proxy.galaxy_client import CollectionVersion, GalaxyClient, GalaxyServer
+
+        detail = CollectionVersion(
+            namespace="ansible",
+            name="posix",
+            version="1.0.0",
+            download_url="https://cdn.example.com/coll.tar.gz",
+        )
+        client = GalaxyClient(
+            servers=[
+                GalaxyServer(url="https://first.example.com"),
+                GalaxyServer(url="https://second.example.com"),
+            ]
+        )
+        try:
+            with patch.object(
+                GalaxyClient,
+                "_get_detail_from",
+                AsyncMock(side_effect=[ValueError("non-dict payload"), detail]),
+            ):
+                result = asyncio.run(client.get_version_detail("ansible", "posix", "1.0.0"))
+        finally:
+            asyncio.run(client.close())
+
+        assert result == detail
+
+    @pytest.mark.parametrize("payload", [[{"version": "1.0.0"}], "ok"])  # type: ignore[untyped-decorator]
+    def test_fetch_versions_from_non_dict_returns_none(self, payload: object) -> None:
+        """A non-dict version body is a failover signal, not a crash.
+
+        Args:
+            payload: Non-dict JSON body returned by the fake server.
+        """
+        import asyncio
+
+        from galaxy_proxy.proxy.server import _fetch_versions_from
+
+        def _capture_client(**kwargs: object) -> unittest.mock.MagicMock:
+            mock_resp = unittest.mock.MagicMock()
+            mock_resp.raise_for_status.return_value = None
+            mock_resp.json.return_value = payload
+
+            client = unittest.mock.MagicMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            return client
+
+        with patch("galaxy_proxy.proxy.server.httpx.AsyncClient", side_effect=_capture_client):
+            result = asyncio.run(
+                _fetch_versions_from("ansible", "posix", "https://galaxy.ansible.com"),
+            )
+
+        assert result is None

--- a/tests/test_galaxy_proxy_server.py
+++ b/tests/test_galaxy_proxy_server.py
@@ -698,14 +698,14 @@ class TestGalaxyClientTruncation:
                     "_list_versions_from",
                     AsyncMock(return_value=None),
                 ),
-                pytest.raises(RuntimeError, match="truncated") as excinfo,
+                pytest.raises(RuntimeError, match=f"truncated at {MAX_VERSION_PAGES} pages") as excinfo,
             ):
                 asyncio.run(client.list_versions("ansible", "posix"))
         finally:
             asyncio.run(client.close())
 
         assert MAX_VERSION_PAGES > 0
-        assert "truncated" in str(excinfo.value)
+        assert f"truncated at {MAX_VERSION_PAGES} pages" in str(excinfo.value)
         # Pure truncation has no chained per-server failure to report.
         assert excinfo.value.__cause__ is None
 

--- a/tests/test_gateway_projects.py
+++ b/tests/test_gateway_projects.py
@@ -898,6 +898,38 @@ async def test_update_project_rejects_blank_repo_url() -> None:
             await q.update_project(db, "proj-blank", repo_url="   ")
 
 
+async def test_find_project_by_repo_url_skips_stale_indexed_duplicate() -> None:
+    """Indexed lookup skips stale rows and returns the first raw-URL match."""
+    target = normalize_repo_url("https://github.com/org/wanted.git")
+    async with get_session() as db:
+        db.add(
+            Project(
+                id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                name="Stale Indexed",
+                repo_url="https://github.com/org/other.git",
+                normalized_repo_url=target,
+                branch="main",
+                created_at="2026-03-01T00:00:00Z",
+                health_score=100,
+            )
+        )
+        db.add(
+            Project(
+                id="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                name="Valid Indexed",
+                repo_url="https://github.com/org/wanted.git",
+                normalized_repo_url=target,
+                branch="main",
+                created_at="2026-03-01T00:00:00Z",
+                health_score=100,
+            )
+        )
+        await db.commit()
+        found = await q.find_project_by_repo_url(db, "https://github.com/org/wanted.git")
+        assert found is not None
+        assert found.id == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+
 async def test_find_project_by_repo_url_deterministic_order() -> None:
     """Duplicate normalized URLs resolve to the smallest id deterministically."""
     async with get_session() as db:

--- a/tests/test_gateway_projects.py
+++ b/tests/test_gateway_projects.py
@@ -635,6 +635,11 @@ def test_normalize_repo_url_strips_userinfo() -> None:
     assert normalize_repo_url("https://user:token@host.example.com/org/repo.git") == "https://host.example.com/org/repo"
 
 
+def test_normalize_repo_url_malformed_port_strips_userinfo() -> None:
+    """Invalid ports still strip embedded credentials from the canonical URL."""
+    assert normalize_repo_url("https://user:secret@github.com:notaport/repo.git") == "https://github.com/repo"
+
+
 async def test_lookup_collapses_default_port_variants(client: AsyncClient) -> None:
     """Lookup resolves explicit-default-port spellings to one project.
 
@@ -775,8 +780,16 @@ async def test_find_project_by_repo_url_heals_legacy_row() -> None:
         assert second.id == "healed-proj-1234567890abcdef1234567890ab"
 
 
-async def test_find_project_by_repo_url_heal_failure_rolls_back() -> None:
-    """A failed heal commit rolls back so the session stays usable."""
+async def test_find_project_by_repo_url_heal_failure_rolls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed isolated heal does not poison the caller session.
+
+    Args:
+        monkeypatch: Pytest fixture used to stub the isolated heal helper.
+    """
+    from unittest.mock import AsyncMock
+
     from sqlalchemy import select
 
     target_url = "https://github.com/org/heal-fail.git"
@@ -793,22 +806,81 @@ async def test_find_project_by_repo_url_heal_failure_rolls_back() -> None:
             )
         )
         await db.commit()
-        real_commit = db.commit
 
-        async def _fail_once() -> None:
-            db.commit = real_commit
-            raise RuntimeError("boom")
+    heal_mock = AsyncMock()
+    monkeypatch.setattr(q, "_heal_project_normalized_url", heal_mock)
 
-        db.commit = _fail_once
+    async with get_session() as db:
         found = await q.find_project_by_repo_url(db, target_url)
         assert found is not None
-        # The rolled-back heal expired the row: refresh proves the session
-        # is usable (raises PendingRollbackError without the rollback).
+        heal_mock.assert_awaited()
         await db.refresh(found)
         assert found.id == "heal-fail-proj-1234567890abcdef12345678"
-        # Session usable after the rolled-back heal (no PendingRollbackError).
         rows = (await db.execute(select(Project.id))).scalars().all()
         assert "heal-fail-proj-1234567890abcdef12345678" in rows
+
+
+async def test_heal_project_normalized_url_swallows_commit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Isolated heal failures are logged and do not raise to callers.
+
+    Args:
+        monkeypatch: Pytest fixture used to stub the isolated heal session.
+    """
+    target = normalize_repo_url("https://github.com/org/heal-swallow.git")
+    assert target
+    async with get_session() as db:
+        await q.create_project(
+            db,
+            project_id="heal-swallow-proj",
+            name="Heal Swallow",
+            repo_url="https://github.com/org/heal-swallow.git",
+        )
+
+    class _FailSession:
+        """Minimal async session stub whose commit always fails."""
+
+        async def execute(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        async def commit(self) -> None:
+            raise RuntimeError("boom")
+
+        async def __aenter__(self) -> _FailSession:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    monkeypatch.setattr("apme_gateway.db.get_session", lambda: _FailSession())
+    await q._heal_project_normalized_url("heal-swallow-proj", target)
+
+
+async def test_find_project_by_repo_url_stale_normalized_index() -> None:
+    """Stale non-empty normalized values fall back to raw URL matching."""
+    new_url = "https://github.com/org/new-repo.git"
+    old_canonical = normalize_repo_url("https://github.com/org/old-repo.git")
+    assert old_canonical
+    async with get_session() as db:
+        db.add(
+            Project(
+                id="stale-norm-proj-1234567890abcdef123456",
+                name="Stale Norm Project",
+                repo_url=new_url,
+                normalized_repo_url=old_canonical,
+                branch="main",
+                created_at="2026-03-01T00:00:00Z",
+                health_score=100,
+            )
+        )
+        await db.commit()
+        found = await q.find_project_by_repo_url(db, new_url)
+        assert found is not None
+        assert found.id == "stale-norm-proj-1234567890abcdef123456"
+        await db.refresh(found)
+        assert found.normalized_repo_url == normalize_repo_url(new_url)
+        assert await q.find_project_by_repo_url(db, "https://github.com/org/old-repo") is None
 
 
 async def test_update_project_rejects_blank_repo_url() -> None:

--- a/tests/test_gateway_projects.py
+++ b/tests/test_gateway_projects.py
@@ -640,6 +640,12 @@ def test_normalize_repo_url_malformed_port_strips_userinfo() -> None:
     assert normalize_repo_url("https://user:secret@github.com:notaport/repo.git") == "https://github.com/repo"
 
 
+def test_normalize_repo_url_empty_host_strips_userinfo() -> None:
+    """Malformed URLs with userinfo but no host never retain credentials."""
+    assert normalize_repo_url("https://user:token@") == "https://"
+    assert normalize_repo_url("https://user:token@/repo") == "https:///repo"
+
+
 async def test_lookup_collapses_default_port_variants(client: AsyncClient) -> None:
     """Lookup resolves explicit-default-port spellings to one project.
 
@@ -786,11 +792,11 @@ async def test_find_project_by_repo_url_heal_failure_rolls_back(
     """A failed isolated heal does not poison the caller session.
 
     Args:
-        monkeypatch: Pytest fixture used to stub the isolated heal helper.
+        monkeypatch: Pytest fixture used to stub the isolated heal session.
     """
-    from unittest.mock import AsyncMock
-
     from sqlalchemy import select
+
+    from apme_gateway import db as db_module
 
     target_url = "https://github.com/org/heal-fail.git"
     async with get_session() as db:
@@ -807,15 +813,41 @@ async def test_find_project_by_repo_url_heal_failure_rolls_back(
         )
         await db.commit()
 
-    heal_mock = AsyncMock()
-    monkeypatch.setattr(q, "_heal_project_normalized_url", heal_mock)
+    real_get_session = db_module.get_session
+    get_session_calls = 0
 
-    async with get_session() as db:
+    class _FailHealSession:
+        """Minimal async session stub whose commit always fails."""
+
+        async def execute(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        async def commit(self) -> None:
+            raise RuntimeError("isolated heal commit failed")
+
+        async def __aenter__(self) -> _FailHealSession:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    def _get_session_router() -> object:
+        nonlocal get_session_calls
+        get_session_calls += 1
+        if get_session_calls == 1:
+            return real_get_session()
+        return _FailHealSession()
+
+    monkeypatch.setattr(db_module, "get_session", _get_session_router)
+
+    async with db_module.get_session() as db:
         found = await q.find_project_by_repo_url(db, target_url)
         assert found is not None
-        heal_mock.assert_awaited()
-        await db.refresh(found)
         assert found.id == "heal-fail-proj-1234567890abcdef12345678"
+        assert get_session_calls == 2
+        stored = await db.get(Project, found.id)
+        assert stored is not None
+        assert stored.normalized_repo_url == ""
         rows = (await db.execute(select(Project.id))).scalars().all()
         assert "heal-fail-proj-1234567890abcdef12345678" in rows
 

--- a/tests/test_gateway_projects.py
+++ b/tests/test_gateway_projects.py
@@ -9,7 +9,9 @@ from httpx import ASGITransport, AsyncClient
 
 from apme_gateway.app import create_app
 from apme_gateway.db import get_session
+from apme_gateway.db import queries as q
 from apme_gateway.db.models import Project, Scan, Session, Violation
+from apme_gateway.scm.repo_url import normalize_repo_url
 
 pytestmark = pytest.mark.usefixtures("gateway_db")
 
@@ -226,6 +228,121 @@ async def test_lookup_project_by_repo_url_and_branch(client: AsyncClient) -> Non
     assert backup_resp.json()["branch"] == "backup"
 
 
+async def test_create_project_populates_normalized_url(client: AsyncClient) -> None:
+    """POST /projects stores the canonical URL for indexed lookup.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    resp = await client.post(
+        "/api/v1/projects",
+        json={
+            "name": "Normalized Project",
+            "repo_url": "https://GitHub.com/org/Repo.git",
+            "branch": "main",
+        },
+    )
+    assert resp.status_code == 201
+    async with get_session() as db:
+        proj = await q.resolve_project(db, resp.json()["id"])
+    assert proj is not None
+    assert proj.normalized_repo_url == "https://github.com/org/Repo"
+
+
+async def test_lookup_finds_indexed_row_by_variant_url(client: AsyncClient) -> None:
+    """Lookup resolves variant spellings against the indexed column.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    created = await client.post(
+        "/api/v1/projects",
+        json={
+            "name": "Indexed Project",
+            "repo_url": "https://github.com/org/repo.git",
+            "branch": "main",
+        },
+    )
+    assert created.status_code == 201
+    resp = await client.get(
+        "/api/v1/projects/lookup",
+        params={"repo_url": "https://GITHUB.com/org/repo"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == created.json()["id"]
+
+
+async def test_normalized_url_preserves_scheme_and_port(client: AsyncClient) -> None:
+    """Canonical URLs keep scheme and explicit ports; paths keep case.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    resp = await client.post(
+        "/api/v1/projects",
+        json={
+            "name": "Port Project",
+            "repo_url": "https://git.example.com:8443/org/Repo.git",
+            "branch": "main",
+            "scm_provider": "github",
+        },
+    )
+    assert resp.status_code == 201
+    async with get_session() as db:
+        proj = await q.resolve_project(db, resp.json()["id"])
+    assert proj is not None
+    assert proj.normalized_repo_url == "https://git.example.com:8443/org/Repo"
+
+    other = await client.post(
+        "/api/v1/projects",
+        json={
+            "name": "Other Port Project",
+            "repo_url": "https://git.example.com/org/Repo.git",
+            "branch": "main",
+            "scm_provider": "github",
+        },
+    )
+    assert other.status_code == 201
+    async with get_session() as db:
+        other_proj = await q.resolve_project(db, other.json()["id"])
+    assert other_proj is not None
+    assert other_proj.normalized_repo_url != proj.normalized_repo_url
+
+
+async def test_update_project_refreshes_normalized_url(client: AsyncClient) -> None:
+    """PATCH repo_url keeps the indexed canonical URL in sync.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    created = await client.post(
+        "/api/v1/projects",
+        json={
+            "name": "Moving Project",
+            "repo_url": "https://github.com/org/old.git",
+            "branch": "main",
+        },
+    )
+    assert created.status_code == 201
+    project_id = created.json()["id"]
+    patched = await client.patch(
+        f"/api/v1/projects/{project_id}",
+        json={"repo_url": "https://github.com/org/new.git"},
+    )
+    assert patched.status_code == 200
+    found = await client.get(
+        "/api/v1/projects/lookup",
+        params={"repo_url": "https://github.com/org/new"},
+    )
+    assert found.status_code == 200
+    assert found.json()["id"] == project_id
+    gone = await client.get(
+        "/api/v1/projects/lookup",
+        params={"repo_url": "https://github.com/org/old"},
+    )
+    assert gone.status_code == 404
+
+
 async def test_get_project_not_found(client: AsyncClient) -> None:
     """Missing project returns 404.
 
@@ -259,6 +376,24 @@ async def test_update_project_no_fields(client: AsyncClient) -> None:
     await _seed_project()
     resp = await client.patch("/api/v1/projects/proj-1", json={})
     assert resp.status_code == 400
+
+
+async def test_update_project_partial_without_repo_url(client: AsyncClient) -> None:
+    """PATCH without repo_url strips unset fields instead of 500ing.
+
+    The router builds ``updates`` only from explicitly set fields, so a
+    partial update that omits ``repo_url`` must never reach
+    ``q.update_project`` with ``repo_url=None`` (which raises ValueError).
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    await _seed_project()
+    resp = await client.patch("/api/v1/projects/proj-1", json={"branch": "main"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["branch"] == "main"
+    assert body["repo_url"] == "https://github.com/test/repo.git"
 
 
 async def test_update_project_not_found(client: AsyncClient) -> None:
@@ -484,3 +619,258 @@ async def test_create_duplicate_name_rejected(client: AsyncClient) -> None:
     resp2 = await client.post("/api/v1/projects", json=payload)
     assert resp2.status_code == 409
     assert "already exists" in resp2.json()["detail"]
+
+
+def test_normalize_repo_url_strips_default_ports() -> None:
+    """Explicit default ports collapse to the implicit identity."""
+    assert normalize_repo_url("https://host.example.com:443/org/repo.git") == "https://host.example.com/org/repo"
+    assert normalize_repo_url("http://host.example.com:80/org/repo") == "http://host.example.com/org/repo"
+    assert normalize_repo_url("https://host.example.com:8443/org/repo") == "https://host.example.com:8443/org/repo"
+    assert normalize_repo_url("http://host.example.com:443/org/repo") == "http://host.example.com:443/org/repo"
+    assert normalize_repo_url("https://host.example.com/org/repo") != ("http://host.example.com/org/repo")
+
+
+def test_normalize_repo_url_strips_userinfo() -> None:
+    """Userinfo never participates in project identity."""
+    assert normalize_repo_url("https://user:token@host.example.com/org/repo.git") == "https://host.example.com/org/repo"
+
+
+async def test_lookup_collapses_default_port_variants(client: AsyncClient) -> None:
+    """Lookup resolves explicit-default-port spellings to one project.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    created = await client.post(
+        "/api/v1/projects",
+        json={
+            "name": "Default Port Project",
+            "repo_url": "https://default-port.example.com:443/org/repo.git",
+            "branch": "main",
+            "scm_provider": "github",
+        },
+    )
+    assert created.status_code == 201
+    resp = await client.get(
+        "/api/v1/projects/lookup",
+        params={"repo_url": "https://default-port.example.com/org/repo"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == created.json()["id"]
+
+
+async def test_update_project_ignores_caller_normalized_url() -> None:
+    """Caller-supplied normalized URL never bypasses canonical recompute."""
+    async with get_session() as db:
+        await q.create_project(
+            db,
+            project_id="proj-spoof",
+            name="Spoof Project",
+            repo_url="https://github.com/org/old.git",
+        )
+        updated = await q.update_project(
+            db,
+            "proj-spoof",
+            repo_url="https://github.com/org/new.git",
+            normalized_repo_url="https://evil.example.com/spoof",
+        )
+        assert updated is not None
+        assert updated.repo_url == "https://github.com/org/new.git"
+        assert updated.normalized_repo_url == normalize_repo_url("https://github.com/org/new.git")
+
+
+async def test_update_project_rejects_none_repo_url() -> None:
+    """None repo_url is rejected before a NULL write."""
+    async with get_session() as db:
+        await q.create_project(
+            db,
+            project_id="proj-null",
+            name="Null Project",
+            repo_url="https://github.com/org/repo.git",
+        )
+        with pytest.raises(ValueError, match="repo_url"):
+            await q.update_project(db, "proj-null", repo_url=None)
+
+
+async def test_find_project_by_repo_url_rejects_blank_target() -> None:
+    """Whitespace-only URLs never match a legacy row."""
+    async with get_session() as db:
+        db.add(
+            Project(
+                id="proj-legacy",
+                name="Legacy Project",
+                repo_url="https://github.com/org/real.git",
+                normalized_repo_url="",
+                branch="main",
+                created_at="2026-03-01T00:00:00Z",
+                health_score=100,
+            )
+        )
+        await db.commit()
+        found = await q.find_project_by_repo_url(db, "   ")
+        assert found is None
+
+
+async def test_find_project_by_repo_url_paginates_legacy_fallback() -> None:
+    """Legacy fallback scans past the first bounded batch."""
+    target_url = "https://github.com/org/wanted.git"
+    async with get_session() as db:
+        for idx in range(505):
+            db.add(
+                Project(
+                    id=f"filler-{idx:04d}-abcd1234abcd1234abcd1234abcd12",
+                    name=f"Filler {idx}",
+                    repo_url=f"https://github.com/org/filler-{idx}.git",
+                    normalized_repo_url="",
+                    branch="main",
+                    created_at="2026-03-01T00:00:00Z",
+                    health_score=100,
+                )
+            )
+        db.add(
+            Project(
+                id="wanted-proj-1234567890abcdef1234567890ab",
+                name="Wanted Project",
+                repo_url=target_url,
+                normalized_repo_url="",
+                branch="main",
+                created_at="2026-03-01T00:00:00Z",
+                health_score=100,
+            )
+        )
+        await db.commit()
+        found = await q.find_project_by_repo_url(db, target_url)
+        assert found is not None
+        assert found.id == "wanted-proj-1234567890abcdef1234567890ab"
+
+
+async def test_find_project_by_repo_url_heals_legacy_row() -> None:
+    """Fallback hits persist the canonical URL so the next lookup takes the primary path."""
+    target_url = "https://github.com/org/healed.git"
+    canonical = normalize_repo_url(target_url)
+    assert canonical
+    async with get_session() as db:
+        db.add(
+            Project(
+                id="healed-proj-1234567890abcdef1234567890ab",
+                name="Healed Project",
+                repo_url=target_url,
+                normalized_repo_url="",
+                branch="main",
+                created_at="2026-03-01T00:00:00Z",
+                health_score=100,
+            )
+        )
+        await db.commit()
+        found = await q.find_project_by_repo_url(db, target_url)
+        assert found is not None
+        assert found.id == "healed-proj-1234567890abcdef1234567890ab"
+
+    async with get_session() as db:
+        stored = await db.get(Project, "healed-proj-1234567890abcdef1234567890ab")
+        assert stored is not None
+        assert stored.normalized_repo_url == canonical
+        second = await q.find_project_by_repo_url(db, target_url)
+        assert second is not None
+        assert second.id == "healed-proj-1234567890abcdef1234567890ab"
+
+
+async def test_find_project_by_repo_url_heal_failure_rolls_back() -> None:
+    """A failed heal commit rolls back so the session stays usable."""
+    from sqlalchemy import select
+
+    target_url = "https://github.com/org/heal-fail.git"
+    async with get_session() as db:
+        db.add(
+            Project(
+                id="heal-fail-proj-1234567890abcdef12345678",
+                name="Heal Fail Project",
+                repo_url=target_url,
+                normalized_repo_url="",
+                branch="main",
+                created_at="2026-03-01T00:00:00Z",
+                health_score=100,
+            )
+        )
+        await db.commit()
+        real_commit = db.commit
+
+        async def _fail_once() -> None:
+            db.commit = real_commit
+            raise RuntimeError("boom")
+
+        db.commit = _fail_once
+        found = await q.find_project_by_repo_url(db, target_url)
+        assert found is not None
+        # The rolled-back heal expired the row: refresh proves the session
+        # is usable (raises PendingRollbackError without the rollback).
+        await db.refresh(found)
+        assert found.id == "heal-fail-proj-1234567890abcdef12345678"
+        # Session usable after the rolled-back heal (no PendingRollbackError).
+        rows = (await db.execute(select(Project.id))).scalars().all()
+        assert "heal-fail-proj-1234567890abcdef12345678" in rows
+
+
+async def test_update_project_rejects_blank_repo_url() -> None:
+    """Blank repo_url is rejected before colliding with the legacy sentinel."""
+    async with get_session() as db:
+        await q.create_project(
+            db,
+            project_id="proj-blank",
+            name="Blank Project",
+            repo_url="https://github.com/org/repo.git",
+        )
+        with pytest.raises(ValueError, match="repo_url"):
+            await q.update_project(db, "proj-blank", repo_url="")
+        with pytest.raises(ValueError, match="repo_url"):
+            await q.update_project(db, "proj-blank", repo_url="   ")
+
+
+async def test_find_project_by_repo_url_deterministic_order() -> None:
+    """Duplicate normalized URLs resolve to the smallest id deterministically."""
+    async with get_session() as db:
+        await q.create_project(
+            db,
+            project_id="zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+            name="Dup Z Project",
+            repo_url="https://github.com/org/dup.git",
+        )
+        await q.create_project(
+            db,
+            project_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            name="Dup A Project",
+            repo_url="https://github.com/org/dup.git",
+        )
+        first = await q.find_project_by_repo_url(db, "https://github.com/org/dup")
+        second = await q.find_project_by_repo_url(db, "https://github.com/org/dup")
+        assert first is not None
+        assert second is not None
+        assert first.id == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        assert second.id == first.id
+
+
+async def test_update_project_warns_on_normalized_url_pop(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Caller-supplied normalized_repo_url is popped with a warning.
+
+    Args:
+        caplog: Pytest log capture fixture.
+    """
+    async with get_session() as db:
+        await q.create_project(
+            db,
+            project_id="proj-warn",
+            name="Warn Project",
+            repo_url="https://github.com/org/old.git",
+        )
+        with caplog.at_level("WARNING", logger="apme_gateway.db.queries"):
+            updated = await q.update_project(
+                db,
+                "proj-warn",
+                repo_url="https://github.com/org/new.git",
+                normalized_repo_url="https://evil.example.com/spoof",
+            )
+        assert updated is not None
+        assert updated.normalized_repo_url == normalize_repo_url("https://github.com/org/new.git")
+        assert any("normalized_repo_url" in record.message for record in caplog.records)

--- a/tests/test_gateway_scan.py
+++ b/tests/test_gateway_scan.py
@@ -395,6 +395,140 @@ async def test_session_proposals_forwarded() -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_session_proposals_include_node_type() -> None:
+    """WS proposals payload includes node_type like REST/SSE/registry."""
+    created = _make_created_event()
+    proposals = _make_proposals_event(
+        [
+            {
+                "id": "p1",
+                "file": "tasks/main.yml",
+                "rule_id": "L042",
+                "line_start": 10,
+                "line_end": 15,
+                "before_text": "old",
+                "after_text": "new",
+                "diff_hunk": "- old\n+ new",
+                "confidence": 0.85,
+                "explanation": "Use FQCN",
+                "tier": 2,
+                "status": "proposed",
+                "source": "ai",
+                "suggestion": "",
+                "path": "play.tasks[0]",
+                "node_type": "task",
+            },
+        ]
+    )
+    result = _make_result_event()
+    closed = _make_closed_event()
+    mock_stream = _mock_fix_stream(created, proposals, result, closed)
+
+    file_content = base64.b64encode(b"---\n- hosts: all\n").decode()
+    ws = MockWebSocket(
+        [
+            {"type": "start", "options": {"enable_ai": True}},
+            {"type": "file", "path": "tasks/main.yml", "content": file_content},
+            {"type": "files_done"},
+        ]
+    )
+
+    with (
+        patch("apme_gateway.session_client.grpc.aio.insecure_channel") as mock_ch_fn,
+        patch("apme_gateway.session_client.engine_pb2_grpc.EngineStub") as mock_stub_cls,
+    ):
+        mock_ch = AsyncMock()
+        mock_ch_fn.return_value = mock_ch
+        mock_stub = MagicMock()
+        mock_stub.FixSession.return_value = mock_stream
+        mock_stub_cls.return_value = mock_stub
+
+        from apme_gateway.session_client import handle_session
+
+        await handle_session(ws, "localhost:50051")
+
+    proposal_msgs = [m for m in ws.sent if m["type"] == "proposals"]
+    assert len(proposal_msgs) == 1
+    raw = proposal_msgs[0]["proposals"]
+    assert isinstance(raw, list)
+    proposals_list = raw
+    assert len(proposals_list) == 1
+    assert proposals_list[0]["node_type"] == "task"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_ai_triage_bridge_forwards_remediation_fields() -> None:
+    """WS ai_triage payload carries the same remediation fields as SSE."""
+    from apme_gateway.session_client import _forward_events
+
+    cand = MagicMock()
+    cand.rule_id = "L021"
+    cand.severity = 3
+    cand.message = "Use FQCN"
+    cand.file = "tasks/main.yml"
+    cand.path = "play.tasks[0]"
+    cand.node_type = "task"
+    cand.remediation_class = 1
+    cand.source = "native"
+    cand.original_yaml = "- debug: {msg: hi}"
+    cand.fixed_yaml = "- ansible.builtin.debug: {msg: hi}"
+    cand.co_fixes = ["L042"]
+    cand.node_line_start = 12
+
+    bare = MagicMock()
+    bare.rule_id = "L042"
+    bare.severity = 2
+    bare.message = "Advisory"
+    bare.file = "roles/x/tasks/main.yml"
+    bare.path = "play.tasks[1]"
+    bare.node_type = "task"
+    bare.remediation_class = 0
+    bare.source = "native"
+    bare.original_yaml = ""
+    bare.fixed_yaml = ""
+    bare.co_fixes = []
+    bare.node_line_start = 0
+
+    event = MagicMock()
+    event.WhichOneof.return_value = "ai_triage"
+    event.ai_triage.status = 4
+    event.ai_triage.ttl_seconds = 300
+    event.ai_triage.candidates = [cand, bare]
+
+    async def _stream() -> AsyncIterator[MagicMock]:
+        yield event
+
+    ws = MockWebSocket([])
+    done = asyncio.Event()
+    await _forward_events(_stream(), ws, "scan-1", done)
+
+    triage_msgs = [m for m in ws.sent if m["type"] == "ai_triage"]
+    assert len(triage_msgs) == 1
+    candidates = triage_msgs[0]["candidates"]
+    assert isinstance(candidates, list)
+    assert len(candidates) == 2
+    first = candidates[0]
+    assert first["rule_id"] == "L021"
+    assert first["severity"] == "medium"
+    assert first["message"] == "Use FQCN"
+    assert first["file"] == "tasks/main.yml"
+    assert first["path"] == "play.tasks[0]"
+    assert first["node_type"] == "task"
+    assert first["source"] == "native"
+    assert first["remediation_class"] == 1
+    assert first["original_yaml"] == "- debug: {msg: hi}"
+    assert first["fixed_yaml"] == "- ansible.builtin.debug: {msg: hi}"
+    assert first["co_fixes"] == ["L042"]
+    assert first["node_line_start"] == 12
+    second = candidates[1]
+    assert second["remediation_class"] == 0
+    assert second["original_yaml"] == ""
+    assert second["fixed_yaml"] == ""
+    assert second["co_fixes"] == []
+    assert second["node_line_start"] is None
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_path_traversal_rejected() -> None:
     """Files with ``..`` in the path are rejected."""
     from apme_gateway.session_client import _sanitize_path

--- a/tests/test_gitleaks_scanner.py
+++ b/tests/test_gitleaks_scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -628,3 +629,60 @@ class TestRunGitleaksNodes:
             violations = run_gitleaks_nodes(nodes)
 
         assert len(violations) == 0
+
+
+class TestHealthTimeout:
+    """Timeout path bounds reaping and suppresses kill errors."""
+
+    async def test_timeout_suppresses_kill_oserror_and_bounds_wait(self) -> None:
+        """Non-ProcessLookupError OSError from kill is suppressed; wait is bounded."""
+        from apme.v1 import common_pb2
+        from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
+
+        servicer = GitleaksValidatorServicer()
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(side_effect=TimeoutError())
+        mock_proc.kill.side_effect = OSError("kill failed")
+        mock_proc.wait = AsyncMock(return_value=None)
+
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+            patch("asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait_for,
+        ):
+            resp = await servicer.Health(common_pb2.HealthRequest(), None)  # type: ignore[arg-type]
+
+        assert "timeout" in resp.status
+        mock_proc.kill.assert_called_once()
+        mock_proc.wait.assert_awaited_once()
+        assert mock_wait_for.call_count == 2
+        assert mock_wait_for.call_args_list[1][1].get("timeout") is not None
+
+    async def test_hanging_wait_still_returns_timeout(self) -> None:
+        """A hung proc.wait does not leak a zombie; Health returns promptly."""
+        from apme.v1 import common_pb2
+        from apme_engine.daemon import gitleaks_validator_server
+        from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
+
+        servicer = GitleaksValidatorServicer()
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(side_effect=TimeoutError())
+
+        async def _hang() -> int:
+            """Simulate a hung reaping wait.
+
+            Returns:
+                Never returns normally; cancelled by the bounded wait.
+            """
+            await asyncio.sleep(60)
+            return 0
+
+        mock_proc.wait = AsyncMock(side_effect=_hang)
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+            patch.object(gitleaks_validator_server, "_HEALTH_TIMEOUT_S", 0.05),
+        ):
+            resp = await asyncio.wait_for(
+                servicer.Health(common_pb2.HealthRequest(), None),  # type: ignore[arg-type]
+                timeout=5,
+            )
+        assert "timeout" in resp.status

--- a/tests/test_gitleaks_scanner.py
+++ b/tests/test_gitleaks_scanner.py
@@ -681,8 +681,31 @@ class TestHealthTimeout:
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
             patch.object(gitleaks_validator_server, "_HEALTH_TIMEOUT_S", 0.05),
         ):
-            resp = await asyncio.wait_for(
-                servicer.Health(common_pb2.HealthRequest(), None),  # type: ignore[arg-type]
-                timeout=5,
-            )
+            t0 = asyncio.get_event_loop().time()
+            resp = await servicer.Health(common_pb2.HealthRequest(), None)  # type: ignore[arg-type]
+            elapsed = asyncio.get_event_loop().time() - t0
         assert "timeout" in resp.status
+        assert elapsed < 1.0
+
+    async def test_health_timeout_respects_total_budget(self) -> None:
+        """communicate() and proc.wait() together stay within _HEALTH_TIMEOUT_S."""
+        from apme.v1 import common_pb2
+        from apme_engine.daemon import gitleaks_validator_server
+        from apme_engine.daemon.gitleaks_validator_server import GitleaksValidatorServicer
+
+        servicer = GitleaksValidatorServicer()
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(side_effect=TimeoutError())
+        mock_proc.wait = AsyncMock(side_effect=TimeoutError())
+
+        with (
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc),
+            patch.object(gitleaks_validator_server, "_HEALTH_TIMEOUT_S", 0.1),
+        ):
+            t0 = asyncio.get_event_loop().time()
+            resp = await servicer.Health(common_pb2.HealthRequest(), None)  # type: ignore[arg-type]
+            elapsed = asyncio.get_event_loop().time() - t0
+
+        assert "timeout" in resp.status
+        assert elapsed < 0.5
+        mock_proc.kill.assert_called_once()

--- a/tests/test_operation_lifecycle.py
+++ b/tests/test_operation_lifecycle.py
@@ -18,6 +18,7 @@ from apme_gateway.operation_types import (
     OperationStatus,
     ProgressEntry,
     Proposal,
+    is_must_deliver,
     is_terminal,
 )
 
@@ -224,10 +225,10 @@ def _canned_request() -> Request:
 
 
 def test_is_terminal_predicate() -> None:
-    """Result/pr_created events and terminal statuses are terminal; all else is not."""
-    assert is_terminal({"event": "result", "data": {}})
+    """Only pr_created and terminal status_changed close the live SSE stream."""
+    assert not is_terminal({"event": "result", "data": {}})
     assert is_terminal({"event": "pr_created", "data": {}})
-    assert is_terminal({"event": "result", "data": None})
+    assert not is_terminal({"event": "result", "data": None})
     assert is_terminal({"event": "status_changed", "data": {"status": "completed"}})
     assert is_terminal({"event": "status_changed", "data": {"status": "pr_submitted"}})
     assert not is_terminal({"event": "status_changed", "data": {"status": "scanning"}})
@@ -238,8 +239,16 @@ def test_is_terminal_predicate() -> None:
     assert not is_terminal({"event": "status_changed", "data": {"status": 123}})
 
 
-async def test_events_terminal_result_without_status_drained() -> None:
-    """A stateless result delta is terminal: the drain forwards it and closes."""
+def test_is_must_deliver_predicate() -> None:
+    """Result/pr_created and terminal statuses are must-deliver for queue eviction."""
+    assert is_must_deliver({"event": "result", "data": {}})
+    assert is_must_deliver({"event": "pr_created", "data": {}})
+    assert is_must_deliver({"event": "status_changed", "data": {"status": "completed"}})
+    assert not is_must_deliver({"event": "progress", "data": {}})
+
+
+async def test_events_result_then_completed_status_both_delivered() -> None:
+    """Result alone does not close the stream; completed status_changed follows."""
     project_id = "proj-lifecycle-events-result-no-status"
     registry = get_operation_registry()
     state = registry.create(
@@ -248,7 +257,7 @@ async def test_events_terminal_result_without_status_drained() -> None:
         scan_id="scan-lifecycle-events-result-no-status",
         scan_type="remediate",
     )
-    registry.transition(state.operation_id, OperationStatus.COMPLETED)
+    registry.transition(state.operation_id, OperationStatus.APPLYING)
 
     resp = await operation_events(project_id, _canned_request())
     stream = resp.body_iterator
@@ -262,6 +271,12 @@ async def test_events_terminal_result_without_status_drained() -> None:
             "data": {"total_violations": 2, "patches": [{"file": "a.yml", "diff": "--- fix"}]},
         }
     )
+    state.sse_subscribers[0].put_nowait(
+        {
+            "event": "status_changed",
+            "data": {"status": OperationStatus.COMPLETED.value, "previous": "applying"},
+        }
+    )
     rest: list[str] = []
     async with asyncio.timeout(10):
         async for chunk in stream:
@@ -270,6 +285,9 @@ async def test_events_terminal_result_without_status_drained() -> None:
     text = "".join(rest)
     assert "event: result" in text
     assert "a.yml" in text
+    assert "event: status_changed" in text
+    assert OperationStatus.COMPLETED.value in text
+    assert text.index("event: result") < text.index("event: status_changed")
 
 
 async def test_events_snapshot_drain_discards_stale_deltas() -> None:

--- a/tests/test_operation_lifecycle.py
+++ b/tests/test_operation_lifecycle.py
@@ -1,0 +1,585 @@
+"""Unit tests for the project operation lifecycle endpoints (findings #13-15)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request
+
+from apme_gateway.api.operation_router import operation_events
+from apme_gateway.app import create_app
+from apme_gateway.operation_registry import get_operation_registry
+from apme_gateway.operation_types import (
+    OperationState,
+    OperationStatus,
+    ProgressEntry,
+    Proposal,
+    is_terminal,
+)
+
+pytestmark = pytest.mark.usefixtures("gateway_db")
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+async def client() -> AsyncIterator[AsyncClient]:
+    """Build an async test client for the gateway app.
+
+    Yields:
+        AsyncClient: Configured HTTPX client targeting the in-process ASGI app.
+    """
+    app = create_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _operation_url(project_id: str, suffix: str) -> str:
+    """Build an operation endpoint URL for a project.
+
+    Args:
+        project_id: Target project UUID.
+        suffix: Endpoint suffix starting with ``/``.
+
+    Returns:
+        Full operation endpoint path.
+    """
+    return f"/api/v1/projects/{project_id}/operation{suffix}"
+
+
+def _setup_awaiting_approval(
+    *,
+    project_id: str = "proj-lifecycle-approve",
+    scan_id: str = "scan-lifecycle-approve",
+    operation_id: str = "op-lifecycle-approve",
+) -> OperationState:
+    """Register an operation waiting on proposal approval with two offers.
+
+    Args:
+        project_id: Owning project UUID.
+        scan_id: Engine scan identifier.
+        operation_id: Unique operation identifier.
+
+    Returns:
+        The registered operation state in ``AWAITING_APPROVAL``.
+    """
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id=operation_id,
+        project_id=project_id,
+        scan_id=scan_id,
+        scan_type="remediate",
+    )
+    registry.set_proposals(
+        operation_id,
+        [
+            Proposal(id="t1-aaa", rule_id="L001", file="a.yml"),
+            Proposal(id="t1-bbb", rule_id="L002", file="b.yml"),
+        ],
+    )
+    assert state.status == OperationStatus.AWAITING_APPROVAL
+    return state
+
+
+async def test_approve_ignores_unknown_ids(client: AsyncClient) -> None:
+    """Unknown approve ids are ignored; the future resolves to offered ids only.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    project_id = "proj-lifecycle-approve"
+    state = _setup_awaiting_approval(project_id=project_id)
+    resp = await client.post(
+        _operation_url(project_id, "/approve"),
+        json={"approved_ids": ["t1-aaa", "zzz-unknown"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "approved"}
+    assert state.approval_future is not None
+    assert state.approval_future.done()
+    assert state.approval_future.result() == ["t1-aaa"]
+
+
+async def test_cancel_active_operation(client: AsyncClient) -> None:
+    """Cancel tears down the grpc task and resolves pending futures.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    project_id = "proj-lifecycle-cancel"
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id="op-lifecycle-cancel",
+        project_id=project_id,
+        scan_id="scan-lifecycle-cancel",
+        scan_type="remediate",
+    )
+    registry.transition(state.operation_id, OperationStatus.SCANNING)
+    state.grpc_task = asyncio.create_task(asyncio.sleep(60))
+    loop = asyncio.get_running_loop()
+    state.approval_future = loop.create_future()
+
+    resp = await client.post(_operation_url(project_id, "/cancel"))
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "cancelled"}
+    assert state.status == OperationStatus.CANCELLED
+    assert state.grpc_task is not None
+    with contextlib.suppress(asyncio.CancelledError):
+        await state.grpc_task
+    assert state.grpc_task.cancelled()
+    assert state.approval_future is not None
+    assert state.approval_future.done()
+    assert state.approval_future.result() == []
+
+
+async def test_cancel_terminal_operation_conflicts(client: AsyncClient) -> None:
+    """Cancel on a terminal operation returns 409.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    project_id = "proj-lifecycle-cancel-terminal"
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id="op-lifecycle-cancel-terminal",
+        project_id=project_id,
+        scan_id="scan-lifecycle-cancel-terminal",
+        scan_type="check",
+    )
+    registry.transition(state.operation_id, OperationStatus.COMPLETED)
+    resp = await client.post(_operation_url(project_id, "/cancel"))
+    assert resp.status_code == 409
+
+
+async def test_cancel_missing_operation_not_found(client: AsyncClient) -> None:
+    """Cancel with no operation returns 404.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    resp = await client.post(_operation_url("proj-lifecycle-missing", "/cancel"))
+    assert resp.status_code == 404
+
+
+async def test_events_terminal_snapshot_then_close(client: AsyncClient) -> None:
+    """A terminal operation yields a snapshot and closes immediately.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    project_id = "proj-lifecycle-events-terminal"
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id="op-lifecycle-events-terminal",
+        project_id=project_id,
+        scan_id="scan-lifecycle-events-terminal",
+        scan_type="check",
+    )
+    registry.transition(state.operation_id, OperationStatus.COMPLETED)
+
+    async with client.stream("GET", _operation_url(project_id, "/events")) as resp:
+        assert resp.status_code == 200
+        body = await resp.aread()
+
+    text = body.decode()
+    assert "event: snapshot" in text
+    assert OperationStatus.COMPLETED.value in text
+
+
+async def test_events_missing_operation_not_found(client: AsyncClient) -> None:
+    """Event stream with no operation returns 404.
+
+    Args:
+        client: Async HTTPX test client.
+    """
+    async with client.stream("GET", _operation_url("proj-lifecycle-events-missing", "/events")) as resp:
+        assert resp.status_code == 404
+
+
+def _canned_request() -> Request:
+    """Build a Request whose disconnect probe always reports connected.
+
+    Returns:
+        Starlette request that never reports a client disconnect.
+    """
+
+    async def _receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    scope: dict[str, object] = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+        "query_string": b"",
+        "server": ("test", 80),
+        "scheme": "http",
+        "client": ("test", 50000),
+    }
+    return Request(scope, _receive)
+
+
+def test_is_terminal_predicate() -> None:
+    """Result/pr_created events and terminal statuses are terminal; all else is not."""
+    assert is_terminal({"event": "result", "data": {}})
+    assert is_terminal({"event": "pr_created", "data": {}})
+    assert is_terminal({"event": "result", "data": None})
+    assert is_terminal({"event": "status_changed", "data": {"status": "completed"}})
+    assert is_terminal({"event": "status_changed", "data": {"status": "pr_submitted"}})
+    assert not is_terminal({"event": "status_changed", "data": {"status": "scanning"}})
+    assert not is_terminal({"event": "progress", "data": {}})
+    assert not is_terminal({"event": "message", "data": {}})
+    assert not is_terminal({"event": "status_changed", "data": None})
+    assert not is_terminal({"event": "status_changed", "data": {"status": None}})
+    assert not is_terminal({"event": "status_changed", "data": {"status": 123}})
+
+
+async def test_events_terminal_result_without_status_drained() -> None:
+    """A stateless result delta is terminal: the drain forwards it and closes."""
+    project_id = "proj-lifecycle-events-result-no-status"
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id="op-lifecycle-events-result-no-status",
+        project_id=project_id,
+        scan_id="scan-lifecycle-events-result-no-status",
+        scan_type="remediate",
+    )
+    registry.transition(state.operation_id, OperationStatus.COMPLETED)
+
+    resp = await operation_events(project_id, _canned_request())
+    stream = resp.body_iterator
+    first = await anext(stream)
+    first_text = first if isinstance(first, str) else bytes(first).decode()
+    assert "event: snapshot" in first_text
+
+    state.sse_subscribers[0].put_nowait(
+        {
+            "event": "result",
+            "data": {"total_violations": 2, "patches": [{"file": "a.yml", "diff": "--- fix"}]},
+        }
+    )
+    rest: list[str] = []
+    async with asyncio.timeout(10):
+        async for chunk in stream:
+            rest.append(chunk if isinstance(chunk, str) else bytes(chunk).decode())
+
+    text = "".join(rest)
+    assert "event: result" in text
+    assert "a.yml" in text
+
+
+async def test_events_snapshot_drain_discards_stale_deltas() -> None:
+    """Buffered pre-snapshot deltas are discarded; only the terminal is forwarded."""
+    project_id = "proj-lifecycle-events-stale"
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id="op-lifecycle-events-stale",
+        project_id=project_id,
+        scan_id="scan-lifecycle-events-stale",
+        scan_type="remediate",
+    )
+    registry.add_progress(
+        state.operation_id,
+        ProgressEntry(phase="scanning", message="fresh-progress-marker", timestamp="2026-01-01T00:00:00+00:00"),
+    )
+    registry.transition(state.operation_id, OperationStatus.COMPLETED)
+
+    resp = await operation_events(project_id, _canned_request())
+    stream = resp.body_iterator
+    first = await anext(stream)
+    first_text = first if isinstance(first, str) else bytes(first).decode()
+    assert "event: snapshot" in first_text
+    assert "fresh-progress-marker" in first_text
+
+    state.sse_subscribers[0].put_nowait(
+        {
+            "event": "progress",
+            "data": {"phase": "scanning", "message": "stale-progress-marker"},
+        }
+    )
+    state.sse_subscribers[0].put_nowait(
+        {
+            "event": "result",
+            "data": {"total_violations": 1, "patches": [{"file": "b.yml", "diff": "--- trailing"}]},
+        }
+    )
+    rest: list[str] = []
+    async with asyncio.timeout(10):
+        async for chunk in stream:
+            rest.append(chunk if isinstance(chunk, str) else bytes(chunk).decode())
+
+    text = "".join(rest)
+    assert "stale-progress-marker" not in text
+    assert "event: result" in text
+    assert "trailing" in text
+
+
+async def test_events_live_trailing_result_after_terminal_status() -> None:
+    """A result queued behind a terminal status_changed is still delivered before close."""
+    project_id = "proj-lifecycle-events-trailing"
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id="op-lifecycle-events-trailing",
+        project_id=project_id,
+        scan_id="scan-lifecycle-events-trailing",
+        scan_type="remediate",
+    )
+    registry.transition(state.operation_id, OperationStatus.SCANNING)
+
+    resp = await operation_events(project_id, _canned_request())
+    stream = resp.body_iterator
+    first = await anext(stream)
+    first_text = first if isinstance(first, str) else bytes(first).decode()
+    assert "event: snapshot" in first_text
+
+    state.sse_subscribers[0].put_nowait(
+        {
+            "event": "status_changed",
+            "data": {"status": OperationStatus.COMPLETED.value, "previous": "scanning"},
+        }
+    )
+    state.sse_subscribers[0].put_nowait(
+        {
+            "event": "result",
+            "data": {"total_violations": 1, "patches": [{"file": "c.yml", "diff": "--- trailing-patch"}]},
+        }
+    )
+    rest: list[str] = []
+    async with asyncio.timeout(10):
+        async for chunk in stream:
+            rest.append(chunk if isinstance(chunk, str) else bytes(chunk).decode())
+
+    text = "".join(rest)
+    assert "status_changed" in text
+    assert OperationStatus.COMPLETED.value in text
+    assert "event: result" in text
+    assert "trailing-patch" in text
+    assert registry.get(state.operation_id) is not None
+    assert registry.get(state.operation_id).sse_subscribers == []  # type: ignore[union-attr]
+
+
+async def test_events_live_delta_then_terminal_close() -> None:
+    """A live stream gets snapshot, delta, terminal close, and unsubscribes."""
+    project_id = "proj-lifecycle-events-live"
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id="op-lifecycle-events-live",
+        project_id=project_id,
+        scan_id="scan-lifecycle-events-live",
+        scan_type="remediate",
+    )
+    registry.transition(state.operation_id, OperationStatus.SCANNING)
+
+    resp = await operation_events(project_id, _canned_request())
+
+    async def _collect() -> list[str]:
+        out: list[str] = []
+        async for chunk in resp.body_iterator:
+            if isinstance(chunk, str):
+                out.append(chunk)
+            else:
+                out.append(bytes(chunk).decode())
+        return out
+
+    collect_task = asyncio.create_task(_collect())
+    try:
+        async with asyncio.timeout(10):
+            while not state.sse_subscribers:
+                await asyncio.sleep(0.01)
+        # Publish straight into the subscriber queue: flipping status first
+        # would race the generator's terminal check right after the snapshot.
+        state.sse_subscribers[0].put_nowait(
+            {
+                "event": "status_changed",
+                "data": {"status": OperationStatus.CANCELLED.value},
+            }
+        )
+        async with asyncio.timeout(10):
+            chunks = await collect_task
+    finally:
+        if not collect_task.done():
+            collect_task.cancel()
+
+    text = "".join(chunks)
+    assert "event: snapshot" in text
+    assert "status_changed" in text
+    assert OperationStatus.CANCELLED.value in text
+    assert registry.get(state.operation_id) is not None
+    assert registry.get(state.operation_id).sse_subscribers == []  # type: ignore[union-attr]
+
+
+async def test_events_snapshot_drain_forwards_all_terminals_in_order() -> None:
+    """Snapshot drain forwards queued result-then-status in order with patches intact."""
+    project_id = "proj-lifecycle-events-snapshot-all-terminals"
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id="op-lifecycle-events-snapshot-all-terminals",
+        project_id=project_id,
+        scan_id="scan-lifecycle-events-snapshot-all-terminals",
+        scan_type="remediate",
+    )
+    registry.transition(state.operation_id, OperationStatus.COMPLETED)
+
+    resp = await operation_events(project_id, _canned_request())
+    stream = resp.body_iterator
+    first = await anext(stream)
+    first_text = first if isinstance(first, str) else bytes(first).decode()
+    assert "event: snapshot" in first_text
+
+    # Production order is RESULT-with-patches THEN bare status_changed;
+    # last-wins would drop the patches.
+    state.sse_subscribers[0].put_nowait(
+        {
+            "event": "progress",
+            "data": {"phase": "scanning", "message": "stale-snapshot-marker"},
+        }
+    )
+    state.sse_subscribers[0].put_nowait(
+        {
+            "event": "result",
+            "data": {"total_violations": 1, "patches": [{"file": "d.yml", "diff": "--- keep-patches"}]},
+        }
+    )
+    state.sse_subscribers[0].put_nowait(
+        {
+            "event": "status_changed",
+            "data": {"status": OperationStatus.COMPLETED.value, "previous": "applying"},
+        }
+    )
+    rest: list[str] = []
+    async with asyncio.timeout(10):
+        async for chunk in stream:
+            rest.append(chunk if isinstance(chunk, str) else bytes(chunk).decode())
+
+    text = "".join(rest)
+    assert "stale-snapshot-marker" not in text
+    assert "event: result" in text
+    assert "keep-patches" in text
+    assert "event: status_changed" in text
+    assert OperationStatus.COMPLETED.value in text
+    assert text.index("event: result") < text.index("event: status_changed")
+
+
+async def test_broadcast_eviction_preserves_queued_terminal_result() -> None:
+    """Must-deliver eviction drops oldest non-terminal first, preserving result."""
+    project_id = "proj-lifecycle-events-evict-terminal"
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id="op-lifecycle-events-evict-terminal",
+        project_id=project_id,
+        scan_id="scan-lifecycle-events-evict-terminal",
+        scan_type="remediate",
+    )
+    registry.transition(state.operation_id, OperationStatus.SCANNING)
+    queue = registry.subscribe(state.operation_id)
+    assert queue is not None
+    assert queue.empty()
+
+    queue.put_nowait(
+        {
+            "event": "result",
+            "data": {"total_violations": 1, "patches": [{"file": "e.yml", "diff": "--- keep-evicted"}]},
+        }
+    )
+    for index in range(queue.maxsize - 1):
+        queue.put_nowait(
+            {
+                "event": "progress",
+                "data": {"phase": "scanning", "message": f"evict-progress-{index}"},
+            }
+        )
+    assert queue.full()
+
+    # Terminal bare status must make room by dropping a progress delta,
+    # not the queued result carrying patches.
+    registry.transition(state.operation_id, OperationStatus.COMPLETED)
+
+    drained: list[dict[str, object]] = []
+    with contextlib.suppress(asyncio.QueueEmpty):
+        while True:
+            drained.append(queue.get_nowait())
+
+    assert len(drained) == queue.maxsize
+    assert drained[0].get("event") == "result"
+    results = [item for item in drained if item.get("event") == "result"]
+    assert len(results) == 1
+    result_data = results[0].get("data")
+    assert isinstance(result_data, dict)
+    patches = result_data.get("patches")
+    assert isinstance(patches, list)
+    assert any("keep-evicted" in str(patch) for patch in patches)
+
+    def _is_completed(item: dict[str, object]) -> bool:
+        """Return True for a completed status_changed event.
+
+        Args:
+            item: Drained queue message.
+
+        Returns:
+            True when the message is a completed status change.
+        """
+        if item.get("event") != "status_changed":
+            return False
+        data = item.get("data")
+        return isinstance(data, dict) and data.get("status") == OperationStatus.COMPLETED.value
+
+    statuses = [item for item in drained if _is_completed(item)]
+    assert len(statuses) == 1
+    flat = "".join(str(item) for item in drained)
+    assert "evict-progress-0" not in flat
+    assert "evict-progress-1" in flat
+    assert queue in state.sse_subscribers
+
+
+async def test_events_keepalive_on_queue_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Queue timeouts yield keepalives; a terminal message closes the stream.
+
+    Args:
+        monkeypatch: Pytest fixture for patching asyncio.wait_for.
+    """
+    project_id = "proj-lifecycle-events-keepalive"
+    registry = get_operation_registry()
+    state = registry.create(
+        operation_id="op-lifecycle-events-keepalive",
+        project_id=project_id,
+        scan_id="scan-lifecycle-events-keepalive",
+        scan_type="remediate",
+    )
+    registry.transition(state.operation_id, OperationStatus.SCANNING)
+
+    calls = 0
+
+    async def _fake_wait_for(awaitable: object, timeout: float | None = None) -> object:
+        nonlocal calls
+        calls += 1
+        if asyncio.iscoroutine(awaitable):
+            awaitable.close()
+        if calls <= 2:
+            raise TimeoutError()
+        return {
+            "event": "status_changed",
+            "data": {"status": OperationStatus.CANCELLED.value},
+        }
+
+    monkeypatch.setattr(asyncio, "wait_for", _fake_wait_for)
+    resp = await operation_events(project_id, _canned_request())
+    chunks: list[str] = []
+    async for chunk in resp.body_iterator:
+        if isinstance(chunk, str):
+            chunks.append(chunk)
+        else:
+            chunks.append(bytes(chunk).decode())
+
+    text = "".join(chunks)
+    assert "event: snapshot" in text
+    assert text.count(": keepalive") == 2
+    assert "status_changed" in text
+    assert calls == 3
+    assert registry.get(state.operation_id) is not None
+    assert registry.get(state.operation_id).sse_subscribers == []  # type: ignore[union-attr]

--- a/tests/test_proposal_draft.py
+++ b/tests/test_proposal_draft.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from typing import cast
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -152,6 +153,86 @@ async def test_upsert_live_stubs_sets_engine_proposal_id() -> None:
         assert rows[0].engine_proposal_id == "ai-0007"
         assert rows[0].proposal_id.startswith("prop-ai-")
         assert rows[0].status == "pending"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_upsert_persists_line_end() -> None:
+    """Live line_end survives the stub upsert instead of resetting to 0."""
+    async with get_session() as db:
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id="scan-line-end-1",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-le-1",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 1,
+                    "status": "pending",
+                    "source": "deterministic",
+                    "line_start": 10,
+                    "line_end": 14,
+                }
+            ],
+        )
+        await db.commit()
+        assert rows[0].line_start == 10
+        assert rows[0].line_end == 14
+
+        # Re-emit without line_end must not clobber the stored span.
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id="scan-line-end-1",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-le-1",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 1,
+                    "status": "pending",
+                    "source": "deterministic",
+                    "line_start": 10,
+                }
+            ],
+        )
+        await db.commit()
+        assert rows[0].line_end == 14
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_upsert_dedupes_duplicate_engine_ids_in_batch() -> None:
+    """Two payloads with one engine id in a single batch insert one row."""
+    async with get_session() as db:
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id="scan-dupe-1",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-dupe",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 1,
+                    "status": "pending",
+                    "source": "deterministic",
+                },
+                {
+                    "id": "eng-dupe",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 1,
+                    "status": "approved",
+                    "source": "deterministic",
+                },
+            ],
+        )
+        await db.commit()
+        assert len(rows) == 2
+        assert rows[0].id == rows[1].id
+        stored = list((await db.execute(select(Proposal).where(Proposal.scan_id == "scan-dupe-1"))).scalars().all())
+        assert len(stored) == 1
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
@@ -680,3 +761,374 @@ async def test_bridge_uses_file_rule_line_start() -> None:
         assert by_line[1].analytics_flushed == 1
         assert by_line[2].engine_proposal_id == "eng-b"
         assert by_line[2].status == "declined"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_upsert_live_stubs_tolerates_non_numeric_batch() -> None:
+    """One bad row defaults instead of failing the whole batch."""
+    async with get_session() as db:
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id="scan-bad-batch",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-good",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 1,
+                    "status": "pending",
+                    "source": "deterministic",
+                    "line_start": 10,
+                    "line_end": 14,
+                    "confidence": 0.8,
+                },
+                {
+                    "id": "eng-bad",
+                    "rule_id": "L008",
+                    "file": "b.yml",
+                    "tier": "high",
+                    "status": "pending",
+                    "source": "deterministic",
+                    "line_start": "high",
+                    "line_end": "high",
+                    "confidence": "high",
+                },
+            ],
+        )
+        await db.commit()
+        assert len(rows) == 2
+        by_eng = {r.engine_proposal_id: r for r in rows}
+        assert by_eng["eng-good"].line_start == 10
+        assert by_eng["eng-good"].line_end == 14
+        assert by_eng["eng-bad"].tier == 0
+        assert by_eng["eng-bad"].line_start == 0
+        assert by_eng["eng-bad"].line_end == 0
+        assert by_eng["eng-bad"].confidence == 0.0
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_upsert_live_stubs_tolerates_bad_update() -> None:
+    """Re-emit with non-numeric confidence/tier keeps stored values."""
+
+    async def _row_by_engine(scan_id: str, engine_id: str) -> Proposal:
+        """Load one stub row by scan and engine id.
+
+        Args:
+            scan_id: Operation scan UUID.
+            engine_id: Engine proposal id.
+
+        Returns:
+            Matching Proposal row.
+        """
+        async with get_session() as db:
+            row = (
+                await db.execute(
+                    select(Proposal).where(
+                        Proposal.scan_id == scan_id,
+                        Proposal.engine_proposal_id == engine_id,
+                    )
+                )
+            ).scalar_one()
+            return cast(Proposal, row)
+
+    async with get_session() as db:
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id="scan-bad-update",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-u",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 1,
+                    "status": "pending",
+                    "source": "deterministic",
+                    "confidence": 0.7,
+                }
+            ],
+        )
+        await db.commit()
+        assert rows[0].confidence == 0.7
+
+    async with get_session() as db:
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id="scan-bad-update",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-u",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": "high",
+                    "status": "pending",
+                    "source": "deterministic",
+                    "confidence": "high",
+                }
+            ],
+        )
+        await db.commit()
+        assert rows[0].confidence == 0.7
+        assert rows[0].tier == 1
+
+    row = await _row_by_engine("scan-bad-update", "eng-u")
+    assert row.confidence == 0.7
+    assert row.tier == 1
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_upsert_live_stubs_chunks_large_preload() -> None:
+    """Batched preload stays within the IN-clause bind budget."""
+    from unittest.mock import patch
+
+    from apme_gateway.proposals import draft as draft_module
+
+    count = 30
+    proposals = [
+        {
+            "id": f"eng-chunk-{i}",
+            "rule_id": "L007",
+            "file": "a.yml",
+            "tier": 1,
+            "status": "pending",
+            "source": "deterministic",
+            "line_start": i + 1,
+        }
+        for i in range(count)
+    ]
+    async with get_session() as db:
+        with patch.object(draft_module, "get_in_clause_chunk_size", return_value=6):
+            rows = await upsert_live_proposal_stubs(
+                db,
+                scan_id="scan-chunk",
+                project_id=None,
+                proposals=proposals,
+            )
+        await db.commit()
+        assert len(rows) == count
+        stored = list((await db.execute(select(Proposal).where(Proposal.scan_id == "scan-chunk"))).scalars().all())
+        assert len(stored) == count
+
+    async with get_session() as db:
+        with patch.object(draft_module, "get_in_clause_chunk_size", return_value=6):
+            rows = await upsert_live_proposal_stubs(
+                db,
+                scan_id="scan-chunk",
+                project_id=None,
+                proposals=proposals,
+            )
+        await db.commit()
+        assert len(rows) == count
+        stored = list((await db.execute(select(Proposal).where(Proposal.scan_id == "scan-chunk"))).scalars().all())
+        assert len(stored) == count
+
+
+def test_chunk_reserves_scan_id_bind() -> None:
+    """Per-query budget keeps 2N + scan_id within the IN-clause limit."""
+    chunk = 900
+    per_query = max(1, (chunk - 1) // 2)
+    assert per_query == 449
+    assert per_query * 2 + 1 <= chunk
+    # Old // 2 math forgot scan_id == and exceeded the budget.
+    assert (chunk // 2) * 2 + 1 > chunk
+
+
+def test_draft_coercers_clamp() -> None:
+    """Negative lines/tiers clamp to 0 and confidence clamps to 0..1."""
+    from apme_gateway.proposals.draft import _safe_float, _safe_int
+
+    assert _safe_int(-5, 7) == 0
+    assert _safe_int("-5", 7) == 0
+    assert _safe_int("abc", 7) == 7
+    assert _safe_float(1.5, 0.0) == 1.0
+    assert _safe_float(-0.5, 0.7) == 0.0
+    assert _safe_float("abc", 0.7) == 0.7
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_upsert_explicit_zero_clears_and_blank_preserves() -> None:
+    """Numeric 0 is explicit (clears); None/blank preserves stored values."""
+    scan_id = "scan-explicit-zero"
+    async with get_session() as db:
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id=scan_id,
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-zero",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 1,
+                    "status": "pending",
+                    "source": "deterministic",
+                    "line_start": 10,
+                    "line_end": 14,
+                    "confidence": 0.8,
+                }
+            ],
+        )
+        await db.commit()
+        assert rows[0].confidence == 0.8
+
+        # Explicit numeric 0 clears stale values.
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id=scan_id,
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-zero",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 0,
+                    "status": "pending",
+                    "source": "deterministic",
+                    "line_start": 0,
+                    "line_end": 0,
+                    "confidence": 0,
+                }
+            ],
+        )
+        await db.commit()
+        assert rows[0].line_start == 0
+        assert rows[0].line_end == 0
+        assert rows[0].confidence == 0.0
+        assert rows[0].tier == 0
+
+    async with get_session() as db:
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id="scan-blank-preserve",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-blank",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 1,
+                    "status": "pending",
+                    "source": "deterministic",
+                    "line_start": 10,
+                    "line_end": 14,
+                    "confidence": 0.8,
+                }
+            ],
+        )
+        await db.commit()
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id="scan-blank-preserve",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-blank",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": "",
+                    "status": "pending",
+                    "source": "deterministic",
+                    "line_start": "",
+                    "line_end": "",
+                    "confidence": "",
+                }
+            ],
+        )
+        await db.commit()
+        assert rows[0].line_start == 10
+        assert rows[0].line_end == 14
+        assert rows[0].confidence == 0.8
+        assert rows[0].tier == 1
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_upsert_string_zero_confidence_is_explicit() -> None:
+    """String '0' confidence is explicit and clears to 0.0."""
+    scan_id = "scan-str-zero"
+    async with get_session() as db:
+        await upsert_live_proposal_stubs(
+            db,
+            scan_id=scan_id,
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-szero",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 1,
+                    "status": "pending",
+                    "source": "deterministic",
+                    "confidence": 0.8,
+                }
+            ],
+        )
+        await db.commit()
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id=scan_id,
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-szero",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 1,
+                    "status": "pending",
+                    "source": "deterministic",
+                    "confidence": "0",
+                }
+            ],
+        )
+        await db.commit()
+        assert rows[0].confidence == 0.0
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_gate_commit_rejects_bool_violation_ids() -> None:
+    """Bool violation ids never stamp the wrong row (True must not become 1)."""
+    project_id, scan_id = await _seed_project_scan(with_draft=True)
+    async with get_session() as db:
+        for _ in range(3):
+            db.add(
+                Violation(
+                    scan_id=scan_id,
+                    rule_id="L007",
+                    level="warning",
+                    message="x",
+                    file="a.yml",
+                    line=1,
+                    path="a.yml::t[0]",
+                    remediation_class=2,
+                    remediation_resolution=0,
+                    scope=0,
+                    fixed_yaml="",
+                )
+            )
+        await db.flush()
+        violations = list((await db.execute(select(Violation).where(Violation.scan_id == scan_id))).scalars().all())
+        assert [v.id for v in violations] == [1, 2, 3]
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalar_one()
+        prop.violation_ids_json = '[true, "12.0", 3]'
+        prop.status = "pending"
+        await db.commit()
+
+    async with get_session() as db:
+        n = await commit_gate_decisions(
+            db,
+            scan_id=scan_id,
+            project_id=project_id,
+            approved_engine_ids=["ai-0001"],
+        )
+        await db.commit()
+        assert n == 1
+
+    async with get_session() as db:
+        by_id = {
+            v.id: v for v in (await db.execute(select(Violation).where(Violation.scan_id == scan_id))).scalars().all()
+        }
+        # True must not coerce to 1; "12.0" coerces to 12 (absent) — only 3 stamps.
+        assert by_id[1].review_status is None
+        assert by_id[2].review_status is None
+        assert by_id[3].review_status == "ai_approved"

--- a/tests/test_proposal_draft.py
+++ b/tests/test_proposal_draft.py
@@ -13,6 +13,7 @@ from apme_gateway.app import create_app
 from apme_gateway.db import get_session
 from apme_gateway.db.models import Project, Proposal, ProposalRuleAnalytics, Scan, Session, Violation
 from apme_gateway.proposals.draft import (
+    _preload_per_query_limit,
     abandon_project_drafts,
     apply_draft_updates,
     commit_gate_decisions,
@@ -928,7 +929,7 @@ async def test_upsert_live_stubs_chunks_large_preload() -> None:
 def test_chunk_reserves_scan_id_bind() -> None:
     """Per-query budget keeps 2N + scan_id within the IN-clause limit."""
     chunk = 900
-    per_query = max(1, (chunk - 1) // 2)
+    per_query = _preload_per_query_limit(chunk)
     assert per_query == 449
     assert per_query * 2 + 1 <= chunk
     # Old // 2 math forgot scan_id == and exceeded the budget.

--- a/tests/test_proposal_draft.py
+++ b/tests/test_proposal_draft.py
@@ -945,6 +945,92 @@ def test_draft_coercers_clamp() -> None:
     assert _safe_float(1.5, 0.0) == 1.0
     assert _safe_float(-0.5, 0.7) == 0.0
     assert _safe_float("abc", 0.7) == 0.7
+    assert _safe_float(float("nan"), 0.7) == 0.7
+    assert _safe_float("nan", 0.7) == 0.7
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_upsert_reconciles_duplicate_engine_rows() -> None:
+    """Duplicate live rows for one engine id are deleted, keeping the newest."""
+    scan_id = "scan-dupe-reconcile"
+    async with get_session() as db:
+        db.add(
+            Session(
+                session_id="sess-dupe",
+                project_path="/tmp",
+                first_seen="2026-01-01T00:00:00+00:00",
+                last_seen="2026-01-01T00:00:00+00:00",
+            )
+        )
+        db.add(
+            Scan(
+                scan_id=scan_id,
+                session_id="sess-dupe",
+                project_path="/tmp",
+                source="gateway",
+                trigger="ui",
+                created_at="2026-01-01T00:00:00+00:00",
+                scan_type="remediate",
+            )
+        )
+        await db.flush()
+        db.add(
+            Proposal(
+                scan_id=scan_id,
+                proposal_id="prop-old",
+                rule_id="L007",
+                file="a.yml",
+                tier=2,
+                confidence=0.5,
+                status="pending",
+                path="",
+                source="ai",
+                gate="ai",
+                rule_ids_json='["L007"]',
+                violation_ids_json="[]",
+                engine_proposal_id="eng-dup",
+                draft=0,
+            )
+        )
+        db.add(
+            Proposal(
+                scan_id=scan_id,
+                proposal_id="prop-new",
+                rule_id="L007",
+                file="a.yml",
+                tier=2,
+                confidence=0.9,
+                status="approved",
+                path="",
+                source="ai",
+                gate="ai",
+                rule_ids_json='["L007"]',
+                violation_ids_json="[]",
+                engine_proposal_id="eng-dup",
+                draft=0,
+            )
+        )
+        await db.commit()
+        rows = await upsert_live_proposal_stubs(
+            db,
+            scan_id=scan_id,
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-dup",
+                    "rule_id": "L007",
+                    "file": "a.yml",
+                    "tier": 2,
+                    "status": "pending",
+                    "source": "ai",
+                }
+            ],
+        )
+        await db.commit()
+        stored = list((await db.execute(select(Proposal).where(Proposal.scan_id == scan_id))).scalars().all())
+        assert len(stored) == 1
+        assert stored[0].engine_proposal_id == "eng-dup"
+        assert rows[0].id == stored[0].id
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]

--- a/tests/test_proposal_draft.py
+++ b/tests/test_proposal_draft.py
@@ -937,11 +937,11 @@ def test_chunk_reserves_scan_id_bind() -> None:
 
 def test_draft_coercers_clamp() -> None:
     """Negative lines/tiers clamp to 0 and confidence clamps to 0..1."""
-    from apme_gateway.proposals.draft import _safe_float, _safe_int
+    from apme_gateway.proposals.grouping import _safe_float, _to_int
 
-    assert _safe_int(-5, 7) == 0
-    assert _safe_int("-5", 7) == 0
-    assert _safe_int("abc", 7) == 7
+    assert _to_int(-5, 7) == 0
+    assert _to_int("-5", 7) == 0
+    assert _to_int("abc", 7) == 7
     assert _safe_float(1.5, 0.0) == 1.0
     assert _safe_float(-0.5, 0.7) == 0.0
     assert _safe_float("abc", 0.7) == 0.7

--- a/tests/test_proposal_flush.py
+++ b/tests/test_proposal_flush.py
@@ -620,6 +620,61 @@ async def test_bridge_matches_stub_when_rebuild_line_end_zero() -> None:
         assert rebuilt.analytics_flushed == 1
 
 
+async def test_bridge_matches_stub_when_rebuild_line_end_differs() -> None:
+    """Rebuild groups with a different nonzero line_end still bridge via line-start key."""
+    from apme_gateway.proposals.draft import upsert_live_proposal_stubs
+
+    await _seed_project_scan(scan_id="bridge-diff-end")
+    async with get_session() as db:
+        await upsert_live_proposal_stubs(
+            db,
+            scan_id="bridge-diff-end",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-span",
+                    "rule_id": "L001",
+                    "file": "tasks/main.yml",
+                    "tier": 2,
+                    "status": "approved",
+                    "source": "ai",
+                    "line_start": 10,
+                    "line_end": 14,
+                }
+            ],
+        )
+        await db.commit()
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == "bridge-diff-end"))).scalar_one()
+        prop.analytics_flushed = 1
+        await db.commit()
+
+        await replace_scan_proposals(
+            db,
+            scan_id="bridge-diff-end",
+            proposals=[
+                GroupedProposal(
+                    proposal_id="prop-ai-span",
+                    rule_id="L001",
+                    rule_ids=("L001",),
+                    violation_ids=(1,),
+                    file="tasks/main.yml",
+                    path="tasks/main.yml::t[0]",
+                    line_start=10,
+                    line_end=18,
+                    tier=2,
+                    source="ai",
+                    gate="ai",
+                    status="pending",
+                )
+            ],
+        )
+        await db.commit()
+        rebuilt = (await db.execute(select(Proposal).where(Proposal.scan_id == "bridge-diff-end"))).scalar_one()
+        assert rebuilt.engine_proposal_id == "eng-span"
+        assert rebuilt.status == "approved"
+        assert rebuilt.analytics_flushed == 1
+
+
 async def test_bridge_distinguishes_line_end() -> None:
     """Same file/rule/line_start with different line_end must not collide."""
     from apme_gateway.proposals.draft import upsert_live_proposal_stubs

--- a/tests/test_proposal_flush.py
+++ b/tests/test_proposal_flush.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from dataclasses import replace
+from typing import cast
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -432,3 +433,403 @@ async def test_ai_acceptance_prefers_analytics_after_flush() -> None:
     assert approved == 1
     assert rejected == 0
     assert pending == 0
+
+
+class TestLineEndMapping:
+    """line_end flows from engine proposals to ProposalDetail (finding #50)."""
+
+    def test_grouped_line_end_reaches_detail(self) -> None:
+        """Grouped views carry line_end into ProposalDetail construction."""
+        from apme_gateway.api.schemas import ProposalDetail
+        from apme_gateway.proposals.flush import proposal_to_detail_dict
+
+        grouped = GroupedProposal(
+            proposal_id="t1-abc",
+            rule_id="L007",
+            rule_ids=("L007",),
+            violation_ids=(),
+            file="a.yml",
+            path="",
+            line_start=10,
+            line_end=14,
+            tier=1,
+            source="deterministic",
+            gate="tier1",
+        )
+        detail = ProposalDetail.model_validate(proposal_to_detail_dict(grouped))
+        assert detail.line_start == 10
+        assert detail.line_end == 14
+
+    def test_operation_proposal_defaults_line_end_zero(self) -> None:
+        """Registry proposals default line_end to 0 when unknown."""
+        from apme_gateway.operation_types import Proposal as OperationProposal
+
+        proposal = OperationProposal(id="p-1", rule_id="L007", file="a.yml")
+        assert proposal.line_start == 0
+        assert proposal.line_end == 0
+
+    def test_orm_branch_includes_line_end(self) -> None:
+        """DB-backed rows serialize line_end like the duck-typed branch."""
+        from apme_gateway.api.schemas import ProposalDetail
+        from apme_gateway.db.models import Proposal
+        from apme_gateway.proposals.flush import proposal_to_detail_dict
+
+        row = Proposal(
+            id=1,
+            scan_id="scan-x",
+            proposal_id="prop-tier1-abc",
+            rule_id="L007",
+            file="a.yml",
+            tier=1,
+            confidence=0.9,
+            status="pending",
+            path="a.yml::t[0]",
+            source="deterministic",
+            gate="tier1",
+            rule_ids_json='["L007"]',
+            violation_ids_json="[1]",
+            line_start=10,
+            line_end=14,
+            diff_hunk="",
+            explanation="",
+            suggestion="",
+            engine_proposal_id=None,
+            draft=0,
+        )
+        payload = proposal_to_detail_dict(row)
+        assert payload["line_start"] == 10
+        assert payload["line_end"] == 14
+        detail = ProposalDetail.model_validate(payload)
+        assert detail.line_start == 10
+        assert detail.line_end == 14
+
+
+def test_proposal_detail_dict_coerces_string_lines() -> None:
+    """Duck-typed string spans coerce instead of raising."""
+    from types import SimpleNamespace
+
+    from apme_gateway.proposals.flush import proposal_to_detail_dict
+
+    good = SimpleNamespace(
+        proposal_id="p-1",
+        rule_id="L007",
+        file="a.yml",
+        tier="1",
+        confidence="0.9",
+        status="pending",
+        path="",
+        node_type="",
+        source="deterministic",
+        gate="tier1",
+        rule_ids=("L007",),
+        violation_ids=(),
+        line_start="10",
+        line_end="12.0",
+        diff_hunk="",
+        explanation="",
+        suggestion="",
+        engine_proposal_id=None,
+        draft=False,
+    )
+    payload = proposal_to_detail_dict(good)
+    assert payload["line_start"] == 10
+    assert payload["line_end"] == 12
+    assert payload["tier"] == 1
+    assert payload["confidence"] == 0.9
+
+    bad = SimpleNamespace(
+        proposal_id="p-2",
+        rule_id="L007",
+        file="a.yml",
+        tier="high",
+        confidence="high",
+        status="pending",
+        path="",
+        node_type="",
+        source="deterministic",
+        gate="tier1",
+        rule_ids=("L007",),
+        violation_ids=(),
+        line_start="high",
+        line_end="abc",
+        diff_hunk="",
+        explanation="",
+        suggestion="",
+        engine_proposal_id=None,
+        draft=False,
+    )
+    fallback = proposal_to_detail_dict(bad)
+    assert fallback["line_start"] == 0
+    assert fallback["line_end"] == 0
+    assert fallback["tier"] == 0
+    assert fallback["confidence"] == 0.0
+
+
+async def test_bridge_distinguishes_line_end() -> None:
+    """Same file/rule/line_start with different line_end must not collide."""
+    from apme_gateway.proposals.draft import upsert_live_proposal_stubs
+
+    await _seed_project_scan(scan_id="bridge-line-end")
+    async with get_session() as db:
+        await upsert_live_proposal_stubs(
+            db,
+            scan_id="bridge-line-end",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-a",
+                    "rule_id": "L001",
+                    "file": "same.yml",
+                    "tier": 2,
+                    "status": "approved",
+                    "source": "ai",
+                    "line_start": 1,
+                    "line_end": 10,
+                },
+                {
+                    "id": "eng-b",
+                    "rule_id": "L001",
+                    "file": "same.yml",
+                    "tier": 2,
+                    "status": "declined",
+                    "source": "ai",
+                    "line_start": 1,
+                    "line_end": 20,
+                },
+            ],
+        )
+        await db.commit()
+        for prop in (await db.execute(select(Proposal).where(Proposal.scan_id == "bridge-line-end"))).scalars().all():
+            prop.analytics_flushed = 1
+        await db.commit()
+
+        await replace_scan_proposals(
+            db,
+            scan_id="bridge-line-end",
+            proposals=[
+                GroupedProposal(
+                    proposal_id="prop-ai-a",
+                    rule_id="L001",
+                    rule_ids=("L001",),
+                    violation_ids=(1,),
+                    file="same.yml",
+                    path="same.yml::t[0]",
+                    line_start=1,
+                    line_end=10,
+                    tier=2,
+                    source="ai",
+                    gate="ai",
+                    status="pending",
+                ),
+                GroupedProposal(
+                    proposal_id="prop-ai-b",
+                    rule_id="L001",
+                    rule_ids=("L001",),
+                    violation_ids=(2,),
+                    file="same.yml",
+                    path="same.yml::t[1]",
+                    line_start=1,
+                    line_end=20,
+                    tier=2,
+                    source="ai",
+                    gate="ai",
+                    status="pending",
+                ),
+            ],
+        )
+        await db.commit()
+        by_end = {
+            p.line_end: p
+            for p in (await db.execute(select(Proposal).where(Proposal.scan_id == "bridge-line-end"))).scalars().all()
+        }
+        assert by_end[10].engine_proposal_id == "eng-a"
+        assert by_end[10].status == "approved"
+        assert by_end[20].engine_proposal_id == "eng-b"
+        assert by_end[20].status == "declined"
+
+
+async def test_replace_tolerates_string_line_end() -> None:
+    """Grouped string line_end coerces instead of crashing replace."""
+    from apme_gateway.db.models import Proposal as ProposalRow
+
+    await _seed_project_scan(scan_id="replace-str-line-end")
+    async with get_session() as db:
+        prop = GroupedProposal(
+            proposal_id="prop-str",
+            rule_id="L001",
+            rule_ids=("L001",),
+            violation_ids=(),
+            file="a.yml",
+            path="",
+            line_start=1,
+            tier=1,
+            source="deterministic",
+            gate="tier1",
+            status="pending",
+        )
+        # GroupedProposal is frozen — rebuild (not plain assignment) the way
+        # JSON-ish callers do.
+        prop = replace(prop, line_end=cast(int, "12.0"))
+        await replace_scan_proposals(db, scan_id="replace-str-line-end", proposals=[prop])
+        await db.commit()
+        row = (await db.execute(select(ProposalRow).where(ProposalRow.scan_id == "replace-str-line-end"))).scalar_one()
+        assert row.line_end == 12
+
+
+def test_proposal_detail_dict_filters_invalid_violation_ids() -> None:
+    """Duck-typed violation_ids with garbage filter instead of raising."""
+    from types import SimpleNamespace
+
+    from apme_gateway.proposals.flush import proposal_to_detail_dict
+
+    obj = SimpleNamespace(
+        proposal_id="p-1",
+        rule_id="L007",
+        file="a.yml",
+        tier=1,
+        confidence=0.9,
+        status="pending",
+        path="",
+        node_type="",
+        source="deterministic",
+        gate="tier1",
+        rule_ids=("L007",),
+        violation_ids=("abc", True, 12.9, 3, "4"),
+        line_start=1,
+        line_end=2,
+        diff_hunk="",
+        explanation="",
+        suggestion="",
+        engine_proposal_id=None,
+        draft=False,
+    )
+    payload = proposal_to_detail_dict(obj)
+    assert payload["violation_ids"] == [3, 4]
+
+
+def test_proposal_detail_dict_orm_branch_filters_invalid_violation_ids() -> None:
+    """ORM violation_ids_json with garbage filters instead of raising."""
+    from apme_gateway.db.models import Proposal
+    from apme_gateway.proposals.flush import proposal_to_detail_dict
+
+    row = Proposal(
+        id=1,
+        scan_id="scan-x",
+        proposal_id="prop-tier1-abc",
+        rule_id="L007",
+        file="a.yml",
+        tier=1,
+        confidence=0.9,
+        status="pending",
+        path="a.yml::t[0]",
+        source="deterministic",
+        gate="tier1",
+        rule_ids_json='["L007"]',
+        violation_ids_json='["abc", true, 12.9, 3, "4"]',
+        line_start=1,
+        line_end=2,
+        diff_hunk="",
+        explanation="",
+        suggestion="",
+        engine_proposal_id=None,
+        draft=0,
+    )
+    payload = proposal_to_detail_dict(row)
+    assert payload["violation_ids"] == [3, 4]
+
+
+def test_replace_tolerates_string_draft_flag() -> None:
+    """String draft flags coerce to bool instead of crashing detail render."""
+    from types import SimpleNamespace
+
+    from apme_gateway.proposals.flush import proposal_to_detail_dict
+
+    obj = SimpleNamespace(
+        proposal_id="p-3",
+        rule_id="L007",
+        file="a.yml",
+        tier="1",
+        confidence="0.9",
+        status="pending",
+        path="",
+        node_type="",
+        source="deterministic",
+        gate="tier1",
+        rule_ids=("L007",),
+        violation_ids=(1,),
+        line_start=1,
+        line_end=2,
+        diff_hunk="",
+        explanation="",
+        suggestion="",
+        engine_proposal_id=None,
+        draft="1",
+    )
+    payload = proposal_to_detail_dict(obj)
+    assert payload["draft"] is True
+    assert payload["violation_ids"] == [1]
+
+
+async def test_replace_tolerates_string_draft_in_store() -> None:
+    """String draft/bridge flags coerce instead of crashing replace."""
+    from apme_gateway.db.models import Proposal as ProposalRow
+
+    await _seed_project_scan(scan_id="replace-str-draft")
+    async with get_session() as db:
+        good = GroupedProposal(
+            proposal_id="prop-draft-str",
+            rule_id="L001",
+            rule_ids=("L001",),
+            violation_ids=(),
+            file="a.yml",
+            path="",
+            line_start=1,
+            tier=1,
+            source="deterministic",
+            gate="tier1",
+            status="pending",
+        )
+        # GroupedProposal is frozen and has no draft field — bypass both the
+        # way JSON-ish callers do (plain assignment raises FrozenInstanceError
+        # and replace() rejects the unknown field).
+        object.__setattr__(good, "draft", "1.0")
+        await replace_scan_proposals(db, scan_id="replace-str-draft", proposals=[good])
+        await db.commit()
+        row = (await db.execute(select(ProposalRow).where(ProposalRow.scan_id == "replace-str-draft"))).scalar_one()
+        assert row.draft == 1
+
+    async with get_session() as db:
+        from apme_gateway.db.models import Scan as ScanRow
+
+        db.add(
+            ScanRow(
+                scan_id="replace-bad-draft",
+                session_id="sess-1",
+                project_id="proj-1",
+                project_path="/proj",
+                source="cli",
+                created_at="2026-01-01T00:00:00Z",
+                scan_type="remediate",
+                total_violations=0,
+            )
+        )
+        bad = GroupedProposal(
+            proposal_id="prop-draft-bad",
+            rule_id="L001",
+            rule_ids=("L001",),
+            violation_ids=(),
+            file="a.yml",
+            path="",
+            line_start=1,
+            tier=1,
+            source="deterministic",
+            gate="tier1",
+            status="pending",
+        )
+        # Same frozen/no-field bypass as above — plain assignment cannot
+        # attach a non-field to a frozen dataclass.
+        object.__setattr__(bad, "draft", "high")
+        await replace_scan_proposals(db, scan_id="replace-bad-draft", proposals=[bad])
+        await db.commit()
+        row = (await db.execute(select(ProposalRow).where(ProposalRow.scan_id == "replace-bad-draft"))).scalar_one()
+        assert row.draft == 0

--- a/tests/test_proposal_flush.py
+++ b/tests/test_proposal_flush.py
@@ -565,6 +565,61 @@ def test_proposal_detail_dict_coerces_string_lines() -> None:
     assert fallback["confidence"] == 0.0
 
 
+async def test_bridge_matches_stub_when_rebuild_line_end_zero() -> None:
+    """Rebuild groups without line_end still bridge to live stubs with spans."""
+    from apme_gateway.proposals.draft import upsert_live_proposal_stubs
+
+    await _seed_project_scan(scan_id="bridge-zero-end")
+    async with get_session() as db:
+        await upsert_live_proposal_stubs(
+            db,
+            scan_id="bridge-zero-end",
+            project_id=None,
+            proposals=[
+                {
+                    "id": "eng-span",
+                    "rule_id": "L001",
+                    "file": "tasks/main.yml",
+                    "tier": 2,
+                    "status": "approved",
+                    "source": "ai",
+                    "line_start": 10,
+                    "line_end": 14,
+                }
+            ],
+        )
+        await db.commit()
+        prop = (await db.execute(select(Proposal).where(Proposal.scan_id == "bridge-zero-end"))).scalar_one()
+        prop.analytics_flushed = 1
+        await db.commit()
+
+        await replace_scan_proposals(
+            db,
+            scan_id="bridge-zero-end",
+            proposals=[
+                GroupedProposal(
+                    proposal_id="prop-ai-span",
+                    rule_id="L001",
+                    rule_ids=("L001",),
+                    violation_ids=(1,),
+                    file="tasks/main.yml",
+                    path="tasks/main.yml::t[0]",
+                    line_start=10,
+                    line_end=0,
+                    tier=2,
+                    source="ai",
+                    gate="ai",
+                    status="pending",
+                )
+            ],
+        )
+        await db.commit()
+        rebuilt = (await db.execute(select(Proposal).where(Proposal.scan_id == "bridge-zero-end"))).scalar_one()
+        assert rebuilt.engine_proposal_id == "eng-span"
+        assert rebuilt.status == "approved"
+        assert rebuilt.analytics_flushed == 1
+
+
 async def test_bridge_distinguishes_line_end() -> None:
     """Same file/rule/line_start with different line_end must not collide."""
     from apme_gateway.proposals.draft import upsert_live_proposal_stubs

--- a/tests/test_proposal_grouping.py
+++ b/tests/test_proposal_grouping.py
@@ -407,3 +407,344 @@ def test_group_violations_splits_mixed_rem_class_path() -> None:
     assert len(props) == 2
     sources = {p.source for p in props}
     assert sources == {"deterministic", "ai-candidate"}
+
+
+def test_group_object_input_preserves_node_line_end() -> None:
+    """Attribute objects keep the ``node_line_end`` fallback like mappings do."""
+
+    class _Violation:
+        id = 7
+        rule_id = "L013"
+        file = "tasks/main.yml"
+        path = "tasks/main.yml::task[0]"
+        line = 5
+        node_line_start = 5
+        node_line_end = 14
+        remediation_class = 1
+        fixed_yaml = "command: echo hi\n"
+        original_yaml = "shell: echo hi\n"
+
+    props = group_violations([_Violation()])
+    assert len(props) == 1
+    assert props[0].line_start == 5
+    assert props[0].line_end == 14
+
+
+def test_group_violations_selects_span_from_same_item() -> None:
+    """line_start/line_end come from the same grouped item."""
+    violations = [
+        {
+            "id": 1,
+            "rule_id": "L007",
+            "file": "a.yml",
+            "path": "a.yml::t[0]",
+            "line": 5,
+            "node_line_start": 10,
+            "node_line_end": 0,
+            "line_end": 0,
+            "remediation_class": 1,
+            "fixed_yaml": "x\n",
+        },
+        {
+            "id": 2,
+            "rule_id": "L013",
+            "file": "a.yml",
+            "path": "a.yml::t[0]",
+            "line": 99,
+            "node_line_start": 0,
+            "node_line_end": 50,
+            "line_end": 50,
+            "remediation_class": 1,
+            "fixed_yaml": "x\n",
+        },
+    ]
+    props = group_violations(violations)
+    assert len(props) == 1
+    assert props[0].line_start == 10
+    assert props[0].line_end == 0
+
+
+def test_to_int_coercion() -> None:
+    """_to_int coerces integral floats/numeric strings; bool/others map to 0."""
+    from apme_gateway.proposals.grouping import _to_int
+
+    assert _to_int(12) == 12
+    assert _to_int("12") == 12
+    assert _to_int(" 12 ") == 12
+    assert _to_int(12.0) == 12
+    assert _to_int("12.0") == 12
+    assert _to_int(12.5) == 0
+    assert _to_int("12.5") == 0
+    assert _to_int("high") == 0
+    assert _to_int(True) == 0
+    assert _to_int(False) == 0
+    assert _to_int(None) == 0
+    assert _to_int("") == 0
+
+
+def test_group_violations_coerces_numeric_string_lines() -> None:
+    """JSON-ish numeric strings do not collapse to 0."""
+    violations = [
+        {
+            "id": "7",
+            "rule_id": "L007",
+            "file": "a.yml",
+            "path": "a.yml::t[0]",
+            "line": "12",
+            "node_line_start": "12",
+            "node_line_end": "18",
+            "line_end": "18",
+            "remediation_class": 1,
+            "fixed_yaml": "x\n",
+        }
+    ]
+    props = group_violations(violations)
+    assert len(props) == 1
+    assert props[0].line_start == 12
+    assert props[0].line_end == 18
+    assert props[0].violation_ids == (7,)
+
+
+def test_group_violations_bool_lines_map_to_zero() -> None:
+    """Bool line values map to 0 instead of 1."""
+    violations = [
+        {
+            "id": 1,
+            "rule_id": "L007",
+            "file": "a.yml",
+            "path": "a.yml::t[0]",
+            "line": True,
+            "node_line_start": True,
+            "node_line_end": True,
+            "line_end": True,
+            "remediation_class": 1,
+            "fixed_yaml": "x\n",
+        }
+    ]
+    props = group_violations(violations)
+    assert props[0].line_start == 0
+    assert props[0].line_end == 0
+
+
+def test_merge_outcomes_coerces_string_payloads() -> None:
+    """String outcome fields coerce instead of crashing the merge."""
+    from types import SimpleNamespace
+
+    props = group_violations(
+        [
+            {
+                "id": 1,
+                "rule_id": "L007",
+                "file": "a.yml",
+                "path": "a.yml::t[0]",
+                "remediation_class": 2,
+            }
+        ]
+    )
+    outcome = SimpleNamespace(
+        proposal_id="",
+        rule_id="L007",
+        file="a.yml",
+        status="approved",
+        confidence="0.9",
+        tier="2",
+        line_end="12",
+    )
+    merged = merge_outcomes(props, [outcome])
+    assert merged[0].confidence == 0.9
+    assert merged[0].tier == 2
+    assert merged[0].line_end == 12
+
+
+def test_merge_outcomes_coerces_float_strings_and_falls_back() -> None:
+    """Integral float strings parse; garbage falls back to grouped values."""
+    from types import SimpleNamespace
+
+    props = group_violations(
+        [
+            {
+                "id": 1,
+                "rule_id": "L007",
+                "file": "a.yml",
+                "path": "a.yml::t[0]",
+                "remediation_class": 2,
+            }
+        ]
+    )
+    good = SimpleNamespace(
+        proposal_id="",
+        rule_id="L007",
+        file="a.yml",
+        status="approved",
+        confidence="high",
+        tier="2.0",
+        line_end="12.0",
+    )
+    merged = merge_outcomes(props, [good])
+    assert merged[0].tier == 2
+    assert merged[0].line_end == 12
+    assert merged[0].confidence == props[0].confidence
+
+    bad = SimpleNamespace(
+        proposal_id="",
+        rule_id="L007",
+        file="a.yml",
+        status="approved",
+        confidence="abc",
+        tier="abc",
+        line_end="abc",
+    )
+    merged_bad = merge_outcomes(props, [bad])
+    assert merged_bad[0].tier == props[0].tier
+    assert merged_bad[0].line_end == props[0].line_end
+    assert merged_bad[0].confidence == props[0].confidence
+
+
+def test_grouping_coercers_clamp() -> None:
+    """Negative lines/tiers clamp to 0 and confidence clamps to 0..1."""
+    from apme_gateway.proposals.grouping import _safe_float, _to_int
+
+    assert _to_int(-5) == 0
+    assert _to_int("-5") == 0
+    assert _to_int("12", 7) == 12
+    assert _to_int("abc", 7) == 7
+    assert _safe_float(1.5) == 1.0
+    assert _safe_float(-0.5) == 0.0
+    assert _safe_float("2.0") == 1.0
+    assert _safe_float("abc", 0.7) == 0.7
+
+
+def test_group_violations_tolerates_string_remediation_class() -> None:
+    """String remediation_class payloads coerce instead of raising."""
+    ai_like = group_violations(
+        [
+            {
+                "id": 1,
+                "rule_id": "L007",
+                "file": "a.yml",
+                "path": "a.yml::t[0]",
+                "remediation_class": "2.0",
+            }
+        ]
+    )
+    assert ai_like[0].source == SOURCE_AI_CANDIDATE
+    assert ai_like[0].tier == 2
+
+    garbage = group_violations(
+        [
+            {
+                "id": 2,
+                "rule_id": "L007",
+                "file": "a.yml",
+                "path": "",
+                "remediation_class": "high",
+            }
+        ]
+    )
+    assert garbage[0].source == "outcome"
+    assert garbage[0].tier == 0
+
+
+def test_as_mapping_coerces_object_remediation_class() -> None:
+    """Attribute objects with string remediation_class do not crash lanes."""
+
+    class _Violation:
+        id = 7
+        rule_id = "L007"
+        file = "a.yml"
+        path = "a.yml::t[0]"
+        line = 5
+        remediation_class = "2.0"
+        fixed_yaml = ""
+
+    props = group_violations([_Violation()])
+    assert len(props) == 1
+    assert props[0].source == SOURCE_AI_CANDIDATE
+    assert props[0].tier == 2
+
+
+def test_analytics_increments_tolerates_string_tier() -> None:
+    """String tier payloads coerce instead of raising."""
+    rows = analytics_increments(
+        {
+            "status": "approved",
+            "rule_id": "L001",
+            "rule_ids": ["L001"],
+            "source": "outcome",
+            "tier": "2.0",
+            "gate": "ai",
+            "coupled": False,
+        }
+    )
+    assert rows
+    assert rows[0]["tier"] == 2
+    assert rows[0]["source"] == "ai"
+
+    garbage = analytics_increments(
+        {
+            "status": "approved",
+            "rule_id": "L001",
+            "rule_ids": ["L001"],
+            "source": "outcome",
+            "tier": "high",
+            "gate": "",
+            "coupled": False,
+        }
+    )
+    assert garbage
+    assert garbage[0]["tier"] == 0
+    assert garbage[0]["source"] == "deterministic"
+
+
+def test_parse_violation_id_rejects_bool_and_non_integral() -> None:
+    """Violation id parsing mirrors _to_int validation without a default."""
+    from apme_gateway.proposals.grouping import _coerce_violation_ids, _parse_violation_id
+
+    assert _parse_violation_id(7) == 7
+    assert _parse_violation_id("7") == 7
+    assert _parse_violation_id(" 7 ") == 7
+    assert _parse_violation_id(12.0) == 12
+    assert _parse_violation_id("12.0") == 12
+    assert _parse_violation_id(True) is None
+    assert _parse_violation_id(False) is None
+    assert _parse_violation_id(12.9) is None
+    assert _parse_violation_id("12.5") is None
+    assert _parse_violation_id("abc") is None
+    assert _parse_violation_id(None) is None
+    assert _parse_violation_id(0) is None
+    assert _parse_violation_id(-3) is None
+    assert _coerce_violation_ids(["abc", 1, "2", True, 3.5]) == [1, 2]
+
+
+def test_group_violations_rejects_bool_and_truncated_ids() -> None:
+    """Bool and non-integral ids are skipped instead of admitted/truncated."""
+    raws = [True, 12.9, "12.5", "abc", None, -3, 0, 5, "7", 12.0]
+    violations = [
+        {
+            "id": raw,
+            "rule_id": "L007",
+            "file": "a.yml",
+            "path": "a.yml::t[0]",
+            "remediation_class": 1,
+            "fixed_yaml": "x\n",
+        }
+        for raw in raws
+    ]
+    props = group_violations(violations)
+    assert len(props) == 1
+    assert props[0].violation_ids == (5, 7, 12)
+
+
+def test_violation_accepts_review_status_tolerates_string_rem_class() -> None:
+    """String remediation_class coerces instead of raising on stamp checks."""
+    from types import SimpleNamespace
+
+    from apme_gateway.proposals.grouping import violation_accepts_review_status
+
+    ai_str = SimpleNamespace(fixed_yaml="", remediation_class="2.0")
+    assert violation_accepts_review_status("ai", ai_str) is True
+    garbage = SimpleNamespace(fixed_yaml="", remediation_class="high")
+    assert violation_accepts_review_status("ai", garbage) is False
+    assert violation_accepts_review_status("deterministic", garbage) is False
+    mapping_ai = {"fixed_yaml": "", "remediation_class": "2"}
+    assert violation_accepts_review_status("ai", mapping_ai) is True

--- a/tests/test_risk_assessment_model.py
+++ b/tests/test_risk_assessment_model.py
@@ -1557,6 +1557,17 @@ def test_search_module_fuzzy_match_via_findings(tmp_path: Path) -> None:
     assert result[0]["name"] == "ns.coll.mymod"
 
 
+def test_findings_path_parts_windows_backslashes() -> None:
+    """Backslash-separated findings paths split into usable components."""
+    from apme_engine.engine.risk_assessment_model import _findings_path_parts
+
+    parts = _findings_path_parts(r"C:\cache\collections\findings\ns.coll\1.0.0\abc123\findings.json")
+    assert len(parts) >= 6
+    assert parts[-4] == "ns.coll"
+    assert parts[-3] == "1.0.0"
+    assert parts[-2] == "abc123"
+
+
 def test_search_module_findings_cache_hit(tmp_path: Path) -> None:
     """Populated findings caches avoid Findings.load calls.
 

--- a/tests/test_risk_assessment_model.py
+++ b/tests/test_risk_assessment_model.py
@@ -1,0 +1,3580 @@
+"""Unit tests for RAMClient risk assessment model loading, search, and index persistence."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from apme_engine.engine.findings import Findings
+from apme_engine.engine.models import (
+    ActionGroupMetadata,
+    Collection,
+    ExecutableType,
+    Module,
+    ModuleMetadata,
+    ObjectList,
+    Role,
+    RoleMetadata,
+    Task,
+    TaskFile,
+    TaskFileMetadata,
+    YAMLDict,
+    YAMLList,
+)
+from apme_engine.engine.risk_assessment_model import (
+    RAMClient,
+    _collect_offspring_objects,
+    _get_modules_list,
+    _get_roles_list,
+    _get_taskfiles_list,
+    _get_tasks_list,
+    _path_to_collection_name,
+    _path_to_reversed_version_num,
+    _safe_dict,
+    _safe_list,
+    _safe_str,
+    _version_to_num,
+    action_group_index_name,
+    module_index_name,
+    role_index_name,
+    sort_by_version,
+    taskfile_index_name,
+)
+
+
+def _make_module(
+    name: str = "mymod",
+    fqcn: str = "ns.coll.mymod",
+    defined_in: str = "lib/mymod.py",
+    collection: str = "ns.coll",
+) -> Module:
+    """Build a minimal Module for registrar and search tests.
+
+    Args:
+        name: Short module name.
+        fqcn: Fully qualified module name.
+        defined_in: Path where the module is defined.
+        collection: Collection the module belongs to.
+
+    Returns:
+        Configured Module instance.
+    """
+    mod = Module(name=name, fqcn=fqcn, collection=collection, defined_in=defined_in)
+    mod.key = "module collection:" + collection + "#module:" + fqcn
+    return mod
+
+
+def _make_role(
+    name: str = "myrole",
+    fqcn: str = "ns.coll.myrole",
+    defined_in: str = "roles/myrole",
+    collection: str = "ns.coll",
+) -> Role:
+    """Build a minimal Role for registrar and search tests.
+
+    Args:
+        name: Role name.
+        fqcn: Fully qualified role name.
+        defined_in: Path where the role is defined.
+        collection: Collection the role belongs to.
+
+    Returns:
+        Configured Role instance.
+    """
+    role = Role(name=name, fqcn=fqcn, defined_in=defined_in, collection=collection)
+    role.key = "role collection:" + collection + "#role:" + fqcn
+    return role
+
+
+def _make_taskfile(taskfile_key: str = "taskfile collection:ns.coll#taskfile:tasks/main.yml") -> TaskFile:
+    """Build a minimal TaskFile with the given key.
+
+    Args:
+        taskfile_key: Full taskfile key string.
+
+    Returns:
+        Configured TaskFile instance.
+    """
+    taskfile = TaskFile(name="main.yml", defined_in="tasks/main.yml", key=taskfile_key)
+    return taskfile
+
+
+def _make_task(
+    task_key: str = "task collection:ns.coll#task:[0]",
+    task_name: str = "do thing",
+    executable: str = "ns.coll.mymod",
+    executable_type: str = "Module",
+    defined_in: str = "tasks/main.yml",
+) -> Task:
+    """Build a minimal Task for search tests.
+
+    Args:
+        task_key: Full task key string.
+        task_name: Human-readable task name.
+        executable: Executable reference (module/role/taskfile).
+        executable_type: One of Module, Role, TaskFile, or unknown.
+        defined_in: Path where the task is defined.
+
+    Returns:
+        Configured Task instance.
+    """
+    task = Task(name=task_name, executable=executable, executable_type=executable_type, defined_in=defined_in)
+    task.key = task_key
+    return task
+
+
+def _make_collection(collection_name: str = "ns.coll") -> Collection:
+    """Build a minimal Collection with the given name.
+
+    Args:
+        collection_name: Collection name.
+
+    Returns:
+        Configured Collection instance.
+    """
+    coll = Collection(name=collection_name)
+    coll.key = "collection collection:" + collection_name
+    return coll
+
+
+def _make_findings(
+    type_name: str = "collection",
+    target_name: str = "ns.coll",
+    version: str = "1.0.0",
+    hash_value: str = "abc123",
+) -> Findings:
+    """Build Findings with standard metadata and empty definitions.
+
+    Args:
+        type_name: Load type string.
+        target_name: Target name string.
+        version: Target version string.
+        hash_value: Target content hash string.
+
+    Returns:
+        Findings instance with metadata set.
+    """
+    meta: YAMLDict = {"type": type_name, "name": target_name, "version": version, "hash": hash_value}
+    return Findings(metadata=meta, root_definitions=cast(YAMLDict, {"definitions": {}, "mappings": {}}))
+
+
+def _make_client(root: Path) -> RAMClient:
+    """Build a RAMClient rooted at the given directory.
+
+    Args:
+        root: Root directory for RAM data files.
+
+    Returns:
+        RAMClient with empty indices.
+    """
+    return RAMClient(root_dir=str(root))
+
+
+def test_safe_str_none_default() -> None:
+    """None converts to the empty default string."""
+    assert _safe_str(None) == ""
+
+
+def test_safe_str_none_custom_default() -> None:
+    """None converts to a custom default string."""
+    assert _safe_str(None, "dflt") == "dflt"
+
+
+def test_safe_str_value() -> None:
+    """String values pass through unchanged."""
+    assert _safe_str("hello") == "hello"
+
+
+def test_safe_str_int_value() -> None:
+    """Integer values stringify instead of returning the default."""
+    assert _safe_str(5) == "5"
+
+
+def test_safe_dict_with_dict() -> None:
+    """Dict input returns the same dict."""
+    assert _safe_dict({"a": "b"}) == {"a": "b"}
+
+
+def test_safe_dict_with_list() -> None:
+    """List input yields an empty dict."""
+    assert _safe_dict(["x"]) == {}
+
+
+def test_safe_dict_with_none() -> None:
+    """None input yields an empty dict."""
+    assert _safe_dict(None) == {}
+
+
+def test_safe_dict_with_str() -> None:
+    """String input yields an empty dict."""
+    assert _safe_dict("nope") == {}
+
+
+def test_safe_list_with_list() -> None:
+    """List input returns an equal list."""
+    assert _safe_list(["a", "b"]) == ["a", "b"]
+
+
+def test_safe_list_with_dict() -> None:
+    """Dict input yields an empty list."""
+    assert _safe_list({"a": "b"}) == []
+
+
+def test_safe_list_with_none() -> None:
+    """None input yields an empty list."""
+    assert _safe_list(None) == []
+
+
+def test_safe_list_with_str() -> None:
+    """String input yields an empty list."""
+    assert _safe_list("nope") == []
+
+
+def test_get_modules_list_objectlist() -> None:
+    """ObjectList definitions expose their items."""
+    mod = _make_module()
+    obj_list = ObjectList(items=[mod])
+    defs = cast(YAMLDict, {"modules": obj_list})
+    assert _get_modules_list(defs) == [mod]
+
+
+def test_get_modules_list_plain_list() -> None:
+    """Plain list definitions return a copy of the list."""
+    mod = _make_module()
+    defs = cast(YAMLDict, {"modules": [mod]})
+    assert _get_modules_list(defs) == [mod]
+
+
+def test_get_modules_list_missing() -> None:
+    """Missing modules key yields an empty list."""
+    assert _get_modules_list({}) == []
+
+
+def test_get_modules_list_wrong_type() -> None:
+    """Non-list modules value yields an empty list."""
+    defs = cast(YAMLDict, {"modules": "junk"})
+    assert _get_modules_list(defs) == []
+
+
+def test_get_roles_list_objectlist() -> None:
+    """ObjectList role definitions expose their items."""
+    role = _make_role()
+    obj_list = ObjectList(items=[role])
+    defs = cast(YAMLDict, {"roles": obj_list})
+    assert _get_roles_list(defs) == [role]
+
+
+def test_get_roles_list_plain_list() -> None:
+    """Plain list role definitions return a copy."""
+    role = _make_role()
+    defs = cast(YAMLDict, {"roles": [role]})
+    assert _get_roles_list(defs) == [role]
+
+
+def test_get_roles_list_missing() -> None:
+    """Missing roles key yields an empty list."""
+    assert _get_roles_list({}) == []
+
+
+def test_get_roles_list_wrong_type() -> None:
+    """Non-list roles value yields an empty list."""
+    defs = cast(YAMLDict, {"roles": 42})
+    assert _get_roles_list(defs) == []
+
+
+def test_get_taskfiles_list_objectlist() -> None:
+    """ObjectList taskfile definitions expose their items."""
+    taskfile = _make_taskfile()
+    obj_list = ObjectList(items=[taskfile])
+    defs = cast(YAMLDict, {"taskfiles": obj_list})
+    assert _get_taskfiles_list(defs) == [taskfile]
+
+
+def test_get_taskfiles_list_plain_list() -> None:
+    """Plain list taskfile definitions return a copy."""
+    taskfile = _make_taskfile()
+    defs = cast(YAMLDict, {"taskfiles": [taskfile]})
+    assert _get_taskfiles_list(defs) == [taskfile]
+
+
+def test_get_taskfiles_list_missing() -> None:
+    """Missing taskfiles key yields an empty list."""
+    assert _get_taskfiles_list({}) == []
+
+
+def test_get_taskfiles_list_wrong_type() -> None:
+    """Non-list taskfiles value yields an empty list."""
+    defs = cast(YAMLDict, {"taskfiles": "junk"})
+    assert _get_taskfiles_list(defs) == []
+
+
+def test_get_tasks_list_objectlist() -> None:
+    """ObjectList task definitions expose their items."""
+    task = _make_task()
+    obj_list = ObjectList(items=[task])
+    defs = cast(YAMLDict, {"tasks": obj_list})
+    assert _get_tasks_list(defs) == [task]
+
+
+def test_get_tasks_list_plain_list() -> None:
+    """Plain list task definitions return a copy."""
+    task = _make_task()
+    defs = cast(YAMLDict, {"tasks": [task]})
+    assert _get_tasks_list(defs) == [task]
+
+
+def test_get_tasks_list_missing() -> None:
+    """Missing tasks key yields an empty list."""
+    assert _get_tasks_list({}) == []
+
+
+def test_get_tasks_list_wrong_type() -> None:
+    """Non-list tasks value yields an empty list."""
+    defs = cast(YAMLDict, {"tasks": 7})
+    assert _get_tasks_list(defs) == []
+
+
+def test_collect_offspring_empty_results() -> None:
+    """Empty search results append nothing."""
+    out: YAMLDict = {}
+    out_list: list[YAMLDict] = []
+    assert out == {}
+    _collect_offspring_objects([], out_list)
+    assert out_list == []
+
+
+def test_collect_offspring_non_dict_first() -> None:
+    """Non-dict first result appends nothing."""
+    out: list[YAMLDict] = []
+    _collect_offspring_objects(cast(list[YAMLDict], ["junk"]), out)
+    assert out == []
+
+
+def test_collect_offspring_missing_key() -> None:
+    """First result without offspring_objects appends nothing."""
+    out: list[YAMLDict] = []
+    _collect_offspring_objects([{"type": "task"}], out)
+    assert out == []
+
+
+def test_collect_offspring_skips_non_dict_entries() -> None:
+    """Non-dict offspring entries are skipped."""
+    out: list[YAMLDict] = []
+    first = cast(YAMLDict, {"offspring_objects": ["junk", 42]})
+    _collect_offspring_objects([first], out)
+    assert out == []
+
+
+def test_collect_offspring_skips_missing_object() -> None:
+    """Offspring entries without an object are skipped."""
+    out: list[YAMLDict] = []
+    first = cast(YAMLDict, {"offspring_objects": [{"name": "x"}]})
+    _collect_offspring_objects([first], out)
+    assert out == []
+
+
+def test_collect_offspring_skips_object_without_key() -> None:
+    """Offspring objects lacking a key attribute are skipped."""
+
+    class _NoKey:
+        """Helper without a key attribute."""
+
+    out: list[YAMLDict] = []
+    first = cast(YAMLDict, {"offspring_objects": [{"object": _NoKey()}]})
+    _collect_offspring_objects([first], out)
+    assert out == []
+
+
+def test_collect_offspring_dedups_by_key() -> None:
+    """Duplicate offspring keys appear only once."""
+    mod = _make_module()
+    entry_one = cast(YAMLDict, {"object": mod})
+    entry_two = cast(YAMLDict, {"object": mod})
+    first = cast(YAMLDict, {"offspring_objects": [entry_one, entry_two]})
+    out: list[YAMLDict] = []
+    _collect_offspring_objects([first], out)
+    assert out == [entry_one]
+
+
+def test_collect_offspring_appends_unique() -> None:
+    """Distinct offspring keys are all appended."""
+    mod_one = _make_module(name="one", fqcn="ns.coll.one")
+    mod_two = _make_module(name="two", fqcn="ns.coll.two")
+    entry_one = cast(YAMLDict, {"object": mod_one})
+    entry_two = cast(YAMLDict, {"object": mod_two})
+    first = cast(YAMLDict, {"offspring_objects": [entry_one, entry_two]})
+    out: list[YAMLDict] = []
+    _collect_offspring_objects([first], out)
+    assert out == [entry_one, entry_two]
+
+
+def test_post_init_no_indices(tmp_path: Path) -> None:
+    """Empty root leaves all indices empty.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.module_index == {}
+    assert client.role_index == {}
+    assert client.taskfile_index == {}
+    assert client.action_group_index == {}
+
+
+def test_post_init_loads_all_indices(tmp_path: Path) -> None:
+    """Present index files populate all four indices.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    indices = tmp_path / "indices"
+    indices.mkdir()
+    (indices / module_index_name).write_text(json.dumps({"m": "v"}))
+    (indices / role_index_name).write_text(json.dumps({"r": "v"}))
+    (indices / taskfile_index_name).write_text(json.dumps({"t": "v"}))
+    (indices / action_group_index_name).write_text(json.dumps({"a": "v"}))
+    client = _make_client(tmp_path)
+    assert client.module_index == {"m": "v"}
+    assert client.role_index == {"r": "v"}
+    assert client.taskfile_index == {"t": "v"}
+    assert client.action_group_index == {"a": "v"}
+
+
+def test_post_init_partial_indices(tmp_path: Path) -> None:
+    """Only existing index files are loaded.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    indices = tmp_path / "indices"
+    indices.mkdir()
+    (indices / module_index_name).write_text(json.dumps({"m": "v"}))
+    client = _make_client(tmp_path)
+    assert client.module_index == {"m": "v"}
+    assert client.role_index == {}
+    assert client.taskfile_index == {}
+    assert client.action_group_index == {}
+
+
+def test_remove_old_item_under_limit(tmp_path: Path) -> None:
+    """Cache under the limit is unchanged.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    data: YAMLDict = {"a": "1", "b": "2"}
+    client._remove_old_item(data, 5)
+    assert data == {"a": "1", "b": "2"}
+
+
+def test_remove_old_item_at_limit(tmp_path: Path) -> None:
+    """Cache exactly at the limit is unchanged.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    data: YAMLDict = {"a": "1", "b": "2"}
+    client._remove_old_item(data, 2)
+    assert data == {"a": "1", "b": "2"}
+
+
+def test_remove_old_item_evicts_oldest(tmp_path: Path) -> None:
+    """Overflow evicts the oldest inserted keys first.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    data: YAMLDict = {"a": "1", "b": "2", "c": "3", "d": "4"}
+    client._remove_old_item(data, 2)
+    assert data == {"c": "3", "d": "4"}
+
+
+def test_clear_old_cache_evicts_all(tmp_path: Path) -> None:
+    """All five caches shrink to max_cache_size.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.max_cache_size = 2
+    client.findings_cache = {"a": "1", "b": "2", "c": "3"}
+    client.module_search_cache = {"a": "1", "b": "2", "c": "3"}
+    client.role_search_cache = {"a": "1", "b": "2", "c": "3"}
+    client.taskfile_search_cache = {"a": "1", "b": "2", "c": "3"}
+    client.task_search_cache = {"a": "1", "b": "2", "c": "3"}
+    client.clear_old_cache()
+    assert len(client.findings_cache) == 2
+    assert len(client.module_search_cache) == 2
+    assert len(client.role_search_cache) == 2
+    assert len(client.taskfile_search_cache) == 2
+    assert len(client.task_search_cache) == 2
+
+
+def test_clear_old_cache_under_limit_noop(tmp_path: Path) -> None:
+    """Small caches are left untouched.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.findings_cache = {"a": "1"}
+    client.clear_old_cache()
+    assert client.findings_cache == {"a": "1"}
+
+
+def test_register_saves_and_clears(tmp_path: Path) -> None:
+    """Register writes findings to the derived directory.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    findings = _make_findings()
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.save_findings") as mock_save,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.clear_old_cache") as mock_clear,
+    ):
+        client.register(findings)
+    assert mock_save.call_count == 1
+    assert mock_clear.call_count == 1
+    out_dir = str(mock_save.call_args[0][1])
+    assert out_dir == client.make_findings_dir_path("collection", "ns.coll", "1.0.0", "abc123")
+
+
+def test_register_empty_metadata_defaults(tmp_path: Path) -> None:
+    """Missing metadata keys default to empty strings.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    findings = Findings(metadata={})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.save_findings") as mock_save,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.clear_old_cache"),
+    ):
+        client.register(findings)
+    out_dir = str(mock_save.call_args[0][1])
+    assert out_dir == client.make_findings_dir_path("", "", "", "")
+
+
+def test_register_indices_delegates(tmp_path: Path) -> None:
+    """register_indices_to_ram fans out to all four registrars.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    findings = _make_findings()
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.register_module_index_to_ram") as m_mod,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.register_role_index_to_ram") as m_role,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.register_taskfile_index_to_ram") as m_tf,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.register_action_group_index_to_ram") as m_ag,
+    ):
+        client.register_indices_to_ram(findings, include_test_contents=True)
+    assert m_mod.call_count == 1
+    assert m_role.call_count == 1
+    assert m_tf.call_count == 1
+    assert m_ag.call_count == 1
+    assert bool(m_mod.call_args[1]["include_test_contents"]) is True
+
+
+def test_register_module_index_new_module(tmp_path: Path) -> None:
+    """A new module is persisted to the module index.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    defs = cast(YAMLDict, {"modules": [mod]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_module_index_to_ram(findings)
+    loaded = client.load_module_index()
+    assert "mymod" in loaded
+
+
+def test_register_module_index_duplicate_skips_save(tmp_path: Path) -> None:
+    """Re-registering the same module performs no second save.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    defs = cast(YAMLDict, {"modules": [mod]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_module_index_to_ram(findings)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+        client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_module_index_skips_non_module(tmp_path: Path) -> None:
+    """Non-Module entries in the modules list are ignored.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    defs = cast(YAMLDict, {"modules": ["junk", 42]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+        client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_module_index_skips_test_content(tmp_path: Path) -> None:
+    """Test-path modules are skipped when the flag is set.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module(defined_in="tests/integration/foo.py")
+    defs = cast(YAMLDict, {"modules": [mod]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+        client.register_module_index_to_ram(findings, include_test_contents=True)
+    assert mock_save.call_count == 0
+
+
+def test_register_module_index_includes_test_without_flag(tmp_path: Path) -> None:
+    """Test-path modules are kept when the flag is unset.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module(defined_in="tests/integration/foo.py")
+    defs = cast(YAMLDict, {"modules": [mod]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_module_index_to_ram(findings, include_test_contents=False)
+    assert "mymod" in client.load_module_index()
+
+
+def test_register_module_index_existing_dict_duplicate(tmp_path: Path) -> None:
+    """Dict-encoded existing entries compare equal and skip saving.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    defs = cast(YAMLDict, {"modules": [mod]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_module_index_to_ram(findings)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+        client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_module_index_existing_object_duplicate(tmp_path: Path) -> None:
+    """ModuleMetadata object entries compare equal and skip saving.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    findings = _make_findings()
+    meta = ModuleMetadata.from_module(mod, findings.metadata)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_module_index") as mock_load:
+        mock_load.return_value = {"mymod": [meta]}
+        with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+            defs = cast(YAMLDict, {"modules": [mod]})
+            findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+            client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_module_index_junk_existing_entry(tmp_path: Path) -> None:
+    """Junk existing entries are skipped before appending the new module.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_module_index") as mock_load:
+        mock_load.return_value = cast(YAMLDict, {"mymod": ["junk"]})
+        defs = cast(YAMLDict, {"modules": [mod]})
+        findings = _make_findings()
+        findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+        client.register_module_index_to_ram(findings)
+    assert "mymod" in client.load_module_index()
+
+
+def test_register_module_index_routing_redirect(tmp_path: Path) -> None:
+    """Plugin routing redirects create deprecated index entries.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"plugin_routing": {"modules": {"oldmod": {"redirect": "ns.coll.newmod"}}}})
+    defs = cast(YAMLDict, {"modules": [], "collections": [coll]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_module_index_to_ram(findings)
+    assert "oldmod" in client.load_module_index()
+
+
+def test_register_module_index_routing_empty_redirect(tmp_path: Path) -> None:
+    """Routing entries without a redirect are ignored.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"plugin_routing": {"modules": {"oldmod": {"redirect": ""}}}})
+    defs = cast(YAMLDict, {"modules": [], "collections": [coll]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+        client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_module_index_routing_duplicate(tmp_path: Path) -> None:
+    """Duplicate routing redirects are not saved twice.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"plugin_routing": {"modules": {"oldmod": {"redirect": "ns.coll.newmod"}}}})
+    defs = cast(YAMLDict, {"modules": [], "collections": [coll]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_module_index_to_ram(findings)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+        client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_module_index_routing_junk_existing(tmp_path: Path) -> None:
+    """Junk routing entries are skipped before appending.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"plugin_routing": {"modules": {"oldmod": {"redirect": "ns.coll.newmod"}}}})
+    defs = cast(YAMLDict, {"modules": [], "collections": [coll]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_module_index") as mock_load:
+        mock_load.return_value = cast(YAMLDict, {"oldmod": [42]})
+        client.register_module_index_to_ram(findings)
+    assert "oldmod" in client.load_module_index()
+
+
+def test_register_module_index_skips_non_collection(tmp_path: Path) -> None:
+    """Non-Collection entries in collections are ignored.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    defs = cast(YAMLDict, {"modules": [], "collections": ["junk"]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+        client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_module_index_collection_no_runtime(tmp_path: Path) -> None:
+    """Collections without meta_runtime add no routing entries.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = {}
+    defs = cast(YAMLDict, {"modules": [], "collections": [coll]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+        client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_role_index_new_role(tmp_path: Path) -> None:
+    """A new role is persisted to the role index.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role()
+    defs = cast(YAMLDict, {"roles": [role]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_role_index_to_ram(findings)
+    assert "ns.coll.myrole" in client.load_role_index()
+
+
+def test_register_role_index_duplicate(tmp_path: Path) -> None:
+    """Re-registering the same role performs no second save.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role()
+    defs = cast(YAMLDict, {"roles": [role]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_role_index_to_ram(findings)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_role_index") as mock_save:
+        client.register_role_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_role_index_skips_non_role(tmp_path: Path) -> None:
+    """Non-Role entries are ignored.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    defs = cast(YAMLDict, {"roles": ["junk"]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_role_index") as mock_save:
+        client.register_role_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_role_index_skips_test_content(tmp_path: Path) -> None:
+    """Test-path roles are skipped when the flag is set.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role(defined_in="molecule/default")
+    defs = cast(YAMLDict, {"roles": [role]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_role_index") as mock_save:
+        client.register_role_index_to_ram(findings, include_test_contents=True)
+    assert mock_save.call_count == 0
+
+
+def test_register_role_index_object_duplicate(tmp_path: Path) -> None:
+    """RoleMetadata object entries compare equal and skip saving.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role()
+    findings = _make_findings()
+    meta = RoleMetadata.from_role(role, findings.metadata)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_role_index") as mock_load:
+        mock_load.return_value = {"ns.coll.myrole": [meta]}
+        with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_role_index") as mock_save:
+            defs = cast(YAMLDict, {"roles": [role]})
+            findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+            client.register_role_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_role_index_junk_existing(tmp_path: Path) -> None:
+    """Junk existing role entries are skipped before appending.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role()
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_role_index") as mock_load:
+        mock_load.return_value = cast(YAMLDict, {"ns.coll.myrole": [None]})
+        defs = cast(YAMLDict, {"roles": [role]})
+        findings = _make_findings()
+        findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+        client.register_role_index_to_ram(findings)
+    assert "ns.coll.myrole" in client.load_role_index()
+
+
+def test_register_taskfile_index_new(tmp_path: Path) -> None:
+    """A new taskfile is persisted to the taskfile index.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    taskfile = _make_taskfile()
+    defs = cast(YAMLDict, {"taskfiles": [taskfile]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_taskfile_index_to_ram(findings)
+    assert taskfile.key in client.load_taskfile_index()
+
+
+def test_register_taskfile_index_duplicate(tmp_path: Path) -> None:
+    """Re-registering the same taskfile performs no second save.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    taskfile = _make_taskfile()
+    defs = cast(YAMLDict, {"taskfiles": [taskfile]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_taskfile_index_to_ram(findings)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_taskfile_index") as mock_save:
+        client.register_taskfile_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_taskfile_index_skips_non_taskfile(tmp_path: Path) -> None:
+    """Non-TaskFile entries are ignored.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    defs = cast(YAMLDict, {"taskfiles": ["junk"]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_taskfile_index") as mock_save:
+        client.register_taskfile_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_taskfile_index_skips_test_content(tmp_path: Path) -> None:
+    """Test-path taskfiles are skipped when the flag is set.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    taskfile = _make_taskfile()
+    taskfile.defined_in = "tests/integration/tasks.yml"
+    defs = cast(YAMLDict, {"taskfiles": [taskfile]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_taskfile_index") as mock_save:
+        client.register_taskfile_index_to_ram(findings, include_test_contents=True)
+    assert mock_save.call_count == 0
+
+
+def test_register_taskfile_index_object_duplicate(tmp_path: Path) -> None:
+    """TaskFileMetadata object entries compare equal and skip saving.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    taskfile = _make_taskfile()
+    findings = _make_findings()
+    meta = TaskFileMetadata.from_taskfile(taskfile, findings.metadata)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_taskfile_index") as mock_load:
+        mock_load.return_value = {taskfile.key: [meta]}
+        with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_taskfile_index") as mock_save:
+            defs = cast(YAMLDict, {"taskfiles": [taskfile]})
+            findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+            client.register_taskfile_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_taskfile_index_junk_existing(tmp_path: Path) -> None:
+    """Junk existing taskfile entries are skipped before appending.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    taskfile = _make_taskfile()
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_taskfile_index") as mock_load:
+        mock_load.return_value = cast(YAMLDict, {taskfile.key: [None]})
+        defs = cast(YAMLDict, {"taskfiles": [taskfile]})
+        findings = _make_findings()
+        findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+        client.register_taskfile_index_to_ram(findings)
+    assert taskfile.key in client.load_taskfile_index()
+
+
+def test_register_action_group_new(tmp_path: Path) -> None:
+    """Action groups register both short and fully qualified names.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"action_groups": {"aws": ["ns.coll.mod1", "ns.coll.mod2"]}})
+    defs = cast(YAMLDict, {"collections": [coll]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_action_group_index_to_ram(findings)
+    loaded = client.load_action_group_index()
+    assert "group/aws" in loaded
+    assert "group/ns.coll.aws" in loaded
+
+
+def test_register_action_group_duplicate(tmp_path: Path) -> None:
+    """Re-registering the same action group performs no second save.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"action_groups": {"aws": ["ns.coll.mod1"]}})
+    defs = cast(YAMLDict, {"collections": [coll]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    client.register_action_group_index_to_ram(findings)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_action_group_index") as mock_save:
+        client.register_action_group_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_action_group_skips_non_collection(tmp_path: Path) -> None:
+    """Non-Collection entries are ignored.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    defs = cast(YAMLDict, {"collections": ["junk"]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_action_group_index") as mock_save:
+        client.register_action_group_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_action_group_no_runtime(tmp_path: Path) -> None:
+    """Collections without meta_runtime add no groups.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = {}
+    defs = cast(YAMLDict, {"collections": [coll]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_action_group_index") as mock_save:
+        client.register_action_group_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_action_group_empty_modules(tmp_path: Path) -> None:
+    """Empty group module lists yield no crash and no duplicate crash.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"action_groups": {"aws": []}})
+    defs = cast(YAMLDict, {"collections": [coll]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    agm_none = ActionGroupMetadata.from_action_group("group/aws", [], findings.metadata)
+    assert agm_none is None
+    client.register_action_group_index_to_ram(findings)
+    loaded = client.load_action_group_index()
+    assert "group/aws" in loaded
+
+
+def test_register_action_group_junk_existing(tmp_path: Path) -> None:
+    """Junk existing action group entries are skipped before appending.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"action_groups": {"aws": ["ns.coll.mod1"]}})
+    defs = cast(YAMLDict, {"collections": [coll]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_action_group_index") as mock_load:
+        mock_load.return_value = cast(YAMLDict, {"group/aws": [None], "group/ns.coll.aws": ["junk"]})
+        client.register_action_group_index_to_ram(findings)
+    loaded = client.load_action_group_index()
+    assert "group/aws" in loaded
+
+
+def test_register_action_group_object_duplicate(tmp_path: Path) -> None:
+    """ActionGroupMetadata object entries compare equal and skip saving.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    modules_list = [_make_module()]
+    coll.meta_runtime = cast(YAMLDict, {"action_groups": {"aws": modules_list}})
+    findings = _make_findings()
+    agm1 = ActionGroupMetadata.from_action_group("group/aws", modules_list, findings.metadata)
+    agm2 = ActionGroupMetadata.from_action_group("group/ns.coll.aws", modules_list, findings.metadata)
+    assert agm1 is not None
+    assert agm2 is not None
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_action_group_index") as mock_load:
+        mock_load.return_value = cast(YAMLDict, {"group/aws": [agm1], "group/ns.coll.aws": [agm2]})
+        with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_action_group_index") as mock_save:
+            defs = cast(YAMLDict, {"collections": [coll]})
+            findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+            client.register_action_group_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_make_findings_dir_path_collection(tmp_path: Path) -> None:
+    """Collection paths use the plain name without escaping.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    out = client.make_findings_dir_path("collection", "ns.coll", "1.0", "abc")
+    assert out == os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "abc")
+
+
+def test_make_findings_dir_path_project_escapes(tmp_path: Path) -> None:
+    """Project paths escape URL characters.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    out = client.make_findings_dir_path("project", "https://example.com/a/b", "1.0", "abc")
+    assert "https__example.com_a_b" in out
+    assert out.startswith(os.path.join(str(tmp_path), "projects"))
+
+
+def test_make_findings_dir_path_playbook_escapes(tmp_path: Path) -> None:
+    """Playbook paths escape URL characters.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    out = client.make_findings_dir_path("playbook", "https://example.com/p.yml", "2.0", "h")
+    assert out.startswith(os.path.join(str(tmp_path), "playbooks"))
+
+
+def test_make_findings_dir_path_taskfile_escapes(tmp_path: Path) -> None:
+    """Taskfile paths escape URL characters.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    out = client.make_findings_dir_path("taskfile", "https://example.com/t.yml", "2.0", "h")
+    assert out.startswith(os.path.join(str(tmp_path), "taskfiles"))
+
+
+def test_make_findings_dir_path_unknown_version_hash(tmp_path: Path) -> None:
+    """Empty version and hash become unknown placeholders.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    out = client.make_findings_dir_path("role", "myrole", "", "")
+    assert out == os.path.join(str(tmp_path), "roles", "findings", "myrole", "unknown", "unknown")
+
+
+def test_load_metadata_not_found(tmp_path: Path) -> None:
+    """Missing findings return a not-loaded tuple.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient._search_findings") as mock_search:
+        mock_search.return_value = None
+        loaded, meta, deps = client.load_metadata_from_findings("collection", "ns.coll", "1.0")
+    assert loaded is False
+    assert meta is None
+    assert deps is None
+
+
+def test_load_metadata_non_findings(tmp_path: Path) -> None:
+    """Non-Findings search results return a not-loaded tuple.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient._search_findings") as mock_search:
+        mock_search.return_value = cast(Findings | None, cast(object, "junk"))
+        loaded, meta, deps = client.load_metadata_from_findings("collection", "ns.coll", "1.0")
+    assert loaded is False
+    assert meta is None
+    assert deps is None
+
+
+def test_load_metadata_success(tmp_path: Path) -> None:
+    """Matching findings return metadata and dependencies.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    findings = _make_findings()
+    findings.dependencies = cast(YAMLList, ["dep"])
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient._search_findings") as mock_search:
+        mock_search.return_value = findings
+        loaded, meta, deps = client.load_metadata_from_findings("collection", "ns.coll", "1.0")
+    assert loaded is True
+    assert meta == findings.metadata
+    assert deps == findings.dependencies
+
+
+def test_load_definitions_missing_file(tmp_path: Path) -> None:
+    """Absent findings.json yields empty definitions and mappings.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    with patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists:
+        mock_exists.return_value = False
+        loaded, defs, maps = client.load_definitions_from_findings("collection", "ns.coll", "1.0", "abc")
+    assert loaded is False
+    assert defs == {}
+    assert maps == {}
+
+
+def test_load_definitions_none_findings(tmp_path: Path) -> None:
+    """Findings.load returning None yields empty results.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = None
+        loaded, defs, maps = client.load_definitions_from_findings("collection", "ns.coll", "1.0", "abc")
+    assert loaded is False
+    assert defs == {}
+    assert maps == {}
+
+
+def test_load_definitions_unresolved_blocked(tmp_path: Path) -> None:
+    """Extra requirements block loading unless allowed.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    findings = _make_findings()
+    findings.extra_requirements = cast(YAMLList, ["req"])
+    findings.root_definitions = cast(YAMLDict, {"definitions": {"modules": []}, "mappings": {"a": "b"}})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        loaded, _defs, _maps = client.load_definitions_from_findings(
+            "collection", "ns.coll", "1.0", "abc", allow_unresolved=False
+        )
+    assert loaded is False
+
+
+def test_load_definitions_unresolved_allowed(tmp_path: Path) -> None:
+    """Allow-unresolved loads definitions despite extra requirements.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    findings = _make_findings()
+    findings.extra_requirements = cast(YAMLList, ["req"])
+    findings.root_definitions = cast(YAMLDict, {"definitions": {"modules": []}, "mappings": {"a": "b"}})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        loaded, defs, maps = client.load_definitions_from_findings(
+            "collection", "ns.coll", "1.0", "abc", allow_unresolved=True
+        )
+    assert loaded is True
+    assert defs == {"modules": []}
+    assert maps == {"a": "b"}
+
+
+def test_load_definitions_empty_mappings(tmp_path: Path) -> None:
+    """Empty mappings leave the loaded flag false.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": {"modules": []}, "mappings": {}})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        loaded, _defs, _maps = client.load_definitions_from_findings("collection", "ns.coll", "1.0", "abc")
+    assert loaded is False
+
+
+def test_search_builtin_module_cache_hit(tmp_path: Path) -> None:
+    """Cached builtin modules avoid the loader call.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module(name="ping", fqcn="ansible.builtin.ping", collection="ansible.builtin")
+    client.builtin_modules_cache = cast(YAMLDict, {"ping": mod})
+    with patch("apme_engine.engine.risk_assessment_model.load_builtin_modules") as mock_loader:
+        result = client.search_builtin_module("ping", used_in="/x.yml")
+    assert mock_loader.call_count == 0
+    assert len(result) == 1
+    assert result[0]["name"] == "ansible.builtin.ping"
+    assert result[0]["used_in"] == "/x.yml"
+
+
+def test_search_builtin_module_loads_and_strips_fqcn(tmp_path: Path) -> None:
+    """FQCN input strips to the short name before lookup.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module(name="ping", fqcn="ansible.builtin.ping", collection="ansible.builtin")
+    with patch("apme_engine.engine.risk_assessment_model.load_builtin_modules") as mock_loader:
+        mock_loader.return_value = {"ping": mod}
+        result = client.search_builtin_module("ansible.builtin.ping")
+    assert len(result) == 1
+    assert client.builtin_modules_cache != {}
+
+
+def test_search_builtin_module_miss(tmp_path: Path) -> None:
+    """Unknown builtin names return no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    with patch("apme_engine.engine.risk_assessment_model.load_builtin_modules") as mock_loader:
+        mock_loader.return_value = {}
+        result = client.search_builtin_module("nosuchmod")
+    assert result == []
+
+
+def test_load_from_indice_collection(tmp_path: Path) -> None:
+    """Collection-typed metadata builds a module wrapper.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    meta = cast(
+        YAMLDict, {"type": "collection", "name": "ns.coll", "fqcn": "ns.coll.mymod", "version": "1.0", "hash": "h"}
+    )
+    wrapper = client.load_from_indice("mymod", meta, used_in="/u.yml")
+    assert wrapper["type"] == "module"
+    assert wrapper["name"] == "ns.coll.mymod"
+    assert wrapper["used_in"] == "/u.yml"
+    assert cast(Module, cast(object, wrapper["object"])).collection == "ns.coll"
+    assert cast(YAMLDict, cast(object, wrapper["defined_in"]))["name"] == "ns.coll"
+
+
+def test_load_from_indice_role(tmp_path: Path) -> None:
+    """Role-typed metadata records the role name.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    meta = cast(YAMLDict, {"type": "role", "name": "myrole", "fqcn": "ns.coll.mymod", "version": "1.0", "hash": "h"})
+    wrapper = client.load_from_indice("mymod", meta)
+    assert cast(Module, cast(object, wrapper["object"])).role == "myrole"
+    assert cast(YAMLDict, cast(object, wrapper["defined_in"]))["name"] == "myrole"
+
+
+def test_load_from_indice_other_type(tmp_path: Path) -> None:
+    """Unknown index types leave collection and role empty.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    meta = cast(YAMLDict, {"type": "", "name": "n", "fqcn": "f.q.m", "version": "", "hash": ""})
+    wrapper = client.load_from_indice("m", meta)
+    assert wrapper["type"] == "module"
+    assert cast(YAMLDict, cast(object, wrapper["defined_in"]))["type"] == "module"
+
+
+def test_search_module_max_match_zero(tmp_path: Path) -> None:
+    """max_match zero short-circuits to an empty list.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_module("anything", max_match=0) == []
+
+
+def test_search_module_cache_hit(tmp_path: Path) -> None:
+    """Cached module searches return without index work.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    import json as _json
+
+    client = _make_client(tmp_path)
+    args_str = _json.dumps(["mymod", False, -1, "", ""])
+    cached = cast(YAMLDict, {"type": "module"})
+    client.module_search_cache[args_str] = cast(object, [cached])  # type: ignore[assignment]
+    assert client.search_module("mymod") == [cached]
+
+
+def test_search_module_builtin_hit(tmp_path: Path) -> None:
+    """Builtin matches are cached and returned directly.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    sentinel = cast(YAMLDict, {"type": "module"})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b:
+        mock_b.return_value = [sentinel]
+        result = client.search_module("ping")
+    assert result == [sentinel]
+    assert len(client.module_search_cache) == 1
+
+
+def test_search_module_index_miss(tmp_path: Path) -> None:
+    """Names absent from the index return no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b:
+        mock_b.return_value = []
+        result = client.search_module("nosuchmod_xyz")
+    assert result == []
+
+
+def test_search_module_index_empty_list(tmp_path: Path) -> None:
+    """Empty index lists behave like a missing index.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.module_index = cast(YAMLDict, {"mymod": []})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b:
+        mock_b.return_value = []
+        result = client.search_module("mymod")
+    assert result == []
+
+
+def test_search_module_index_path_missing(tmp_path: Path) -> None:
+    """Indexed entries without findings files return no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.module_index = cast(
+        YAMLDict,
+        {"mymod": [{"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]},
+    )
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = False
+        result = client.search_module("mymod")
+    assert result == []
+
+
+def test_search_module_fuzzy_match_via_findings(tmp_path: Path) -> None:
+    """Fuzzy short-name matches resolve through the findings cache.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    client.module_index = cast(
+        YAMLDict,
+        {"mymod": [{"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]},
+    )
+    defs = cast(YAMLDict, {"modules": [mod]})
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_module("mymod")
+    assert len(result) == 1
+    assert result[0]["name"] == "ns.coll.mymod"
+
+
+def test_search_module_findings_cache_hit(tmp_path: Path) -> None:
+    """Populated findings caches avoid Findings.load calls.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    findings_path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1", "h", "findings.json")
+    client.module_index = cast(
+        YAMLDict,
+        {"mymod": [{"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]},
+    )
+    client.findings_cache[findings_path] = cast(object, {"modules": [mod]})  # type: ignore[assignment]
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        result = client.search_module("mymod")
+    assert mock_load.call_count == 0
+    assert len(result) == 1
+
+
+def test_search_module_load_not_findings(tmp_path: Path) -> None:
+    """Non-Findings loads are skipped gracefully.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.module_index = cast(
+        YAMLDict,
+        {"mymod": [{"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]},
+    )
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = None
+        result = client.search_module("mymod")
+    assert result == []
+
+
+def test_search_module_skips_non_module(tmp_path: Path) -> None:
+    """Non-Module definitions never match.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.module_index = cast(
+        YAMLDict,
+        {"mymod": [{"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]},
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"modules": ["junk"]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_module("mymod")
+    assert result == []
+
+
+def test_search_module_exact_match(tmp_path: Path) -> None:
+    """Exact matching requires full FQCN equality.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    client.module_index = cast(
+        YAMLDict,
+        {"mymod": [{"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]},
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"modules": [mod]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        matched = client.search_module("ns.coll.mymod", exact_match=True)
+    assert len(matched) == 1
+    client2 = _make_client(tmp_path)
+    client2.module_index = client.module_index
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b2,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists2,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load2,
+    ):
+        mock_b2.return_value = []
+        mock_exists2.return_value = True
+        mock_load2.return_value = findings
+        missed = client2.search_module("ns.coll.other", exact_match=True)
+    assert missed == []
+
+
+def test_search_module_fqcn_suffix_match(tmp_path: Path) -> None:
+    """Short names match the trailing FQCN component.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module(fqcn="other.coll.mymod")
+    client.module_index = cast(
+        YAMLDict,
+        {
+            "mymod": [
+                {"fqcn": "other.coll.mymod", "type": "collection", "name": "other.coll", "version": "1", "hash": "h"}
+            ]
+        },
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"modules": [mod]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_module("mymod")
+    assert len(result) == 1
+
+
+def test_search_module_fqcn_name_match(tmp_path: Path) -> None:
+    """FQCN queries match findings entries by full name.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    client.module_index = cast(
+        YAMLDict,
+        {"mymod": [{"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]},
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"modules": [mod]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_module("ns.coll.mymod")
+    assert len(result) == 1
+
+
+def test_search_module_max_match_limits(tmp_path: Path) -> None:
+    """max_match stops the scan after enough matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod_one = _make_module(name="mymod", fqcn="ns.coll.mymod")
+    mod_two = _make_module(name="mymod", fqcn="other.mymod")
+    mod_two.fqcn = "ns.coll.mymod"
+    client.module_index = cast(
+        YAMLDict,
+        {"mymod": [{"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]},
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"modules": [mod_one, mod_two]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_module("mymod", max_match=1)
+    assert len(result) == 1
+
+
+def test_search_module_deprecated_preference(tmp_path: Path) -> None:
+    """FQCN lookups prefer non-deprecated index entries.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    client.module_index = cast(
+        YAMLDict,
+        {
+            "mymod": [
+                {"fqcn": "ns.coll.mymod", "deprecated": True, "type": "c", "name": "old", "version": "1", "hash": "h"},
+                {"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "2", "hash": "h2"},
+                "junk-entry",
+            ]
+        },
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"modules": [mod]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_module("ns.coll.mymod")
+    assert len(result) == 1
+    assert cast(YAMLDict, cast(object, result[0]["defined_in"]))["version"] == "2"
+
+
+def test_search_module_all_deprecated_fallback(tmp_path: Path) -> None:
+    """All-deprecated lists fall back to the first index entry.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    client.module_index = cast(
+        YAMLDict,
+        {
+            "mymod": [
+                {"fqcn": "ns.coll.mymod", "deprecated": True, "type": "c", "name": "old", "version": "9", "hash": "h"},
+            ]
+        },
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"modules": [mod]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_module("mymod")
+    assert len(result) == 1
+
+
+def test_search_module_nondict_first_index(tmp_path: Path) -> None:
+    """Non-dict first entries resolve to no index and miss.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.module_index = cast(YAMLDict, {"mymod": ["junk"]})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b:
+        mock_b.return_value = []
+        result = client.search_module("mymod")
+    assert result == []
+
+
+def test_search_role_max_match_zero(tmp_path: Path) -> None:
+    """max_match zero short-circuits role search.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_role("r", max_match=0) == []
+
+
+def test_search_role_cache_hit(tmp_path: Path) -> None:
+    """Cached role searches return directly.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    import json as _json
+
+    client = _make_client(tmp_path)
+    args_str = _json.dumps(["myrole", False, -1])
+    cached = cast(YAMLDict, {"type": "role"})
+    client.role_search_cache[args_str] = cast(object, [cached])  # type: ignore[assignment]
+    assert client.search_role("myrole") == [cached]
+
+
+def test_search_role_index_miss(tmp_path: Path) -> None:
+    """Roles absent from the index return no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_role("nosuchrole") == []
+
+
+def test_search_role_index_empty_list(tmp_path: Path) -> None:
+    """Empty role index lists behave like a miss.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.role_index = cast(YAMLDict, {"myrole": []})
+    assert client.search_role("myrole") == []
+
+
+def test_search_role_nondict_index(tmp_path: Path) -> None:
+    """Non-dict role index entries resolve to no findings.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.role_index = cast(YAMLDict, {"myrole": ["junk"]})
+    assert client.search_role("myrole") == []
+
+
+def test_search_role_path_missing(tmp_path: Path) -> None:
+    """Indexed roles without findings files return no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.role_index = cast(
+        YAMLDict, {"myrole": [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    with patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists:
+        mock_exists.return_value = False
+        assert client.search_role("myrole") == []
+
+
+def test_search_role_match_with_offspring(tmp_path: Path) -> None:
+    """Role matches collect taskfile offspring recursively.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role()
+    taskfile = _make_taskfile()
+    role.taskfiles = [taskfile]
+    client.role_index = cast(
+        YAMLDict, {"ns.coll.myrole": [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"roles": [role]})})
+    child = cast(YAMLDict, {"object": taskfile, "offspring_objects": []})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_taskfile") as mock_tf,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_tf.return_value = [child]
+        result = client.search_role("ns.coll.myrole")
+    assert len(result) == 1
+    assert result[0]["name"] == "ns.coll.myrole"
+    assert len(cast(list[YAMLDict], cast(object, result[0]["offspring_objects"]))) >= 1
+
+
+def test_search_role_string_taskfile_key(tmp_path: Path) -> None:
+    """String taskfile references are resolved via search_taskfile.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role()
+    role.taskfiles = ["some-string-key"]
+    client.role_index = cast(
+        YAMLDict, {"myrole": [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"roles": [role]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_taskfile") as mock_tf,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_tf.return_value = []
+        result = client.search_role("myrole")
+    assert len(result) == 1
+    assert cast(list[YAMLDict], cast(object, result[0]["offspring_objects"])) == []
+
+
+def test_search_role_exact_and_fuzzy(tmp_path: Path) -> None:
+    """Exact matching rejects suffixes that fuzzy matching accepts.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role(fqcn="ns.coll.myrole")
+    client.role_index = cast(
+        YAMLDict, {"myrole": [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"roles": [role]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_taskfile") as mock_tf,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_tf.return_value = []
+        fuzzy = client.search_role("myrole")
+    assert len(fuzzy) == 1
+    client2 = _make_client(tmp_path)
+    client2.role_index = client.role_index
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists2,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load2,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_taskfile") as mock_tf2,
+    ):
+        mock_exists2.return_value = True
+        mock_load2.return_value = findings
+        mock_tf2.return_value = []
+        exact_miss = client2.search_role("myrole", exact_match=True)
+    assert exact_miss == []
+
+
+def test_search_role_findings_cache_and_non_findings(tmp_path: Path) -> None:
+    """Findings cache hits avoid loads; non-Findings loads are skipped.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role(fqcn="ns.coll.myrole")
+    findings_path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1", "h", "findings.json")
+    client.role_index = cast(
+        YAMLDict, {"ns.coll.myrole": [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    client.findings_cache[findings_path] = cast(object, {"roles": [role]})  # type: ignore[assignment]
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_taskfile") as mock_tf,
+    ):
+        mock_exists.return_value = True
+        mock_tf.return_value = []
+        result = client.search_role("ns.coll.myrole")
+    assert mock_load.call_count == 0
+    assert len(result) == 1
+    client2 = _make_client(tmp_path)
+    client2.role_index = client.role_index
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists2,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load2,
+    ):
+        mock_exists2.return_value = True
+        mock_load2.return_value = None
+        assert client2.search_role("ns.coll.myrole") == []
+
+
+def test_search_role_skips_non_role_and_max_match(tmp_path: Path) -> None:
+    """Non-Role definitions are skipped and max_match limits output.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role(fqcn="ns.coll.myrole")
+    client.role_index = cast(
+        YAMLDict, {"ns.coll.myrole": [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"roles": ["junk", role, role]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_taskfile") as mock_tf,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_tf.return_value = []
+        result = client.search_role("ns.coll.myrole", max_match=1)
+    assert len(result) == 1
+
+
+def test_search_role_falsy_child_offspring(tmp_path: Path) -> None:
+    """Falsy taskfile children skip the direct append but still collect.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role(fqcn="ns.coll.myrole")
+    role.taskfiles = [_make_taskfile()]
+    client.role_index = cast(
+        YAMLDict, {"ns.coll.myrole": [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"roles": [role]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_taskfile") as mock_tf,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_tf.return_value = cast(list[YAMLDict], [{}])
+        result = client.search_role("ns.coll.myrole")
+    assert len(result) == 1
+
+
+def test_make_taskfile_key_candidates_empty(tmp_path: Path) -> None:
+    """Empty from_path yields no candidates.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.make_taskfile_key_candidates("tasks/a.yml", "", "k") == []
+
+
+def test_make_taskfile_key_candidates_simple(tmp_path: Path) -> None:
+    """Sibling references yield a single candidate key.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    cands = client.make_taskfile_key_candidates("other.yml", "/repo/tasks/main.yml", "taskfile k")
+    assert len(cands) == 1
+    assert "other.yml" in cands[0]
+
+
+def test_make_taskfile_key_candidates_roles(tmp_path: Path) -> None:
+    """Role-relative references yield two candidate keys.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    cands = client.make_taskfile_key_candidates(
+        "roles/other/tasks/x.yml", "/repo/roles/myrole/tasks/main.yml", "taskfile k"
+    )
+    assert len(cands) == 2
+
+
+def test_search_taskfile_max_match_zero(tmp_path: Path) -> None:
+    """max_match zero short-circuits taskfile search.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_taskfile("x", is_key=True, max_match=0) == []
+
+
+def test_search_taskfile_requires_from_path(tmp_path: Path) -> None:
+    """Non-key lookups without from_path return nothing.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_taskfile("tasks/a.yml") == []
+
+
+def test_search_taskfile_cache_hit(tmp_path: Path) -> None:
+    """Cached taskfile searches return directly.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    import json as _json
+
+    client = _make_client(tmp_path)
+    args_str = _json.dumps(["k", "", "", -1, True])
+    cached = cast(YAMLDict, {"type": "taskfile"})
+    client.taskfile_search_cache[args_str] = cast(object, [cached])  # type: ignore[assignment]
+    assert client.search_taskfile("k", is_key=True) == [cached]
+
+
+def test_search_taskfile_index_miss(tmp_path: Path) -> None:
+    """Unknown taskfile keys return no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_taskfile("unknown-key", is_key=True) == []
+
+
+def test_search_taskfile_nondict_index(tmp_path: Path) -> None:
+    """Non-dict taskfile index entries resolve to no findings.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.taskfile_index = cast(YAMLDict, {"mykey": ["junk"]})
+    assert client.search_taskfile("mykey", is_key=True) == []
+
+
+def test_search_taskfile_path_missing(tmp_path: Path) -> None:
+    """Indexed taskfiles without findings files return nothing.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    tkey = "taskfile collection:ns.coll#taskfile:tasks/main.yml"
+    client.taskfile_index = cast(
+        YAMLDict, {tkey: [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    with patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists:
+        mock_exists.return_value = False
+        assert client.search_taskfile(tkey, is_key=True) == []
+
+
+def test_search_taskfile_match_with_offspring(tmp_path: Path) -> None:
+    """Taskfile matches collect task offspring recursively.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    tkey = "taskfile collection:ns.coll#taskfile:tasks/main.yml"
+    task = _make_task()
+    taskfile = _make_taskfile(tkey)
+    taskfile.tasks = [task]
+    client.taskfile_index = cast(
+        YAMLDict, {tkey: [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"taskfiles": [taskfile]})})
+    child = cast(YAMLDict, {"object": task, "offspring_objects": []})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_task") as mock_task,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_task.return_value = [child]
+        result = client.search_taskfile(tkey, is_key=True)
+    assert len(result) == 1
+    assert result[0]["name"] == tkey
+
+
+def test_search_taskfile_string_task_key(tmp_path: Path) -> None:
+    """String task references resolve through search_task.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    tkey = "taskfile collection:ns.coll#taskfile:tasks/main.yml"
+    taskfile = _make_taskfile(tkey)
+    taskfile.tasks = ["task-string-key"]
+    client.taskfile_index = cast(
+        YAMLDict, {tkey: [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"taskfiles": [taskfile]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_task") as mock_task,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_task.return_value = []
+        result = client.search_taskfile(tkey, is_key=True)
+    assert len(result) == 1
+
+
+def test_search_taskfile_findings_cache_and_non_findings(tmp_path: Path) -> None:
+    """Findings cache hits avoid loads; bad loads are skipped.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    tkey = "taskfile collection:ns.coll#taskfile:tasks/main.yml"
+    taskfile = _make_taskfile(tkey)
+    taskfile.tasks = []
+    findings_path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1", "h", "findings.json")
+    client.taskfile_index = cast(
+        YAMLDict, {tkey: [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    client.findings_cache[findings_path] = cast(object, {"taskfiles": [taskfile]})  # type: ignore[assignment]
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_task") as mock_task,
+    ):
+        mock_exists.return_value = True
+        mock_task.return_value = []
+        result = client.search_taskfile(tkey, is_key=True)
+    assert mock_load.call_count == 0
+    assert len(result) == 1
+    client2 = _make_client(tmp_path)
+    client2.taskfile_index = client.taskfile_index
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists2,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load2,
+    ):
+        mock_exists2.return_value = True
+        mock_load2.return_value = None
+        assert client2.search_taskfile(tkey, is_key=True) == []
+
+
+def test_search_taskfile_skips_non_taskfile_and_max_match(tmp_path: Path) -> None:
+    """Non-TaskFile entries are skipped and max_match limits output.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    tkey = "taskfile collection:ns.coll#taskfile:tasks/main.yml"
+    taskfile = _make_taskfile(tkey)
+    taskfile.tasks = []
+    client.taskfile_index = cast(
+        YAMLDict, {tkey: [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(
+        YAMLDict, {"definitions": cast(YAMLDict, {"taskfiles": ["junk", taskfile, taskfile]})}
+    )
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_task") as mock_task,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_task.return_value = []
+        result = client.search_taskfile(tkey, is_key=True, max_match=1)
+    assert len(result) == 1
+
+
+def test_search_taskfile_via_reference_path(tmp_path: Path) -> None:
+    """Non-key references build candidate keys from the call site.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    from apme_engine.engine.keyutil import make_imported_taskfile_key
+
+    from_key = "taskfile collection:ns.coll#taskfile:tasks/main.yml"
+    cand = make_imported_taskfile_key(from_key, os.path.normpath("/repo/tasks/other.yml"))
+    taskfile = TaskFile(name="other.yml", defined_in="/repo/tasks/other.yml", key=cand)
+    client.taskfile_index = cast(
+        YAMLDict, {cand: [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"taskfiles": [taskfile]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_task") as mock_task,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_task.return_value = []
+        result = client.search_taskfile("other.yml", from_path="/repo/tasks/main.yml", from_key=from_key)
+    assert len(result) == 1
+
+
+def test_search_taskfile_falsy_child(tmp_path: Path) -> None:
+    """Falsy task children skip the direct append but still collect.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    tkey = "taskfile collection:ns.coll#taskfile:tasks/main.yml"
+    taskfile = _make_taskfile(tkey)
+    taskfile.tasks = [_make_task()]
+    client.taskfile_index = cast(
+        YAMLDict, {tkey: [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"taskfiles": [taskfile]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_task") as mock_task,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_task.return_value = cast(list[YAMLDict], [{}])
+        result = client.search_taskfile(tkey, is_key=True)
+    assert len(result) == 1
+
+
+def test_search_task_max_match_zero(tmp_path: Path) -> None:
+    """max_match zero short-circuits task search.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_task("x", content_info=cast(YAMLDict, {"type": "c"}), max_match=0) == []
+
+
+def test_search_task_no_content_info(tmp_path: Path) -> None:
+    """Missing content info returns no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_task("x") == []
+    assert client.search_task("x", content_info=None) == []
+
+
+def test_search_task_non_dict_content_info(tmp_path: Path) -> None:
+    """Non-dict content info returns no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_task("x", content_info=cast(YAMLDict, cast(object, "junk"))) == []
+
+
+def test_search_task_empty_content_info(tmp_path: Path) -> None:
+    """Empty content info returns no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_task("x", content_info={}) == []
+
+
+def test_search_task_cache_hit(tmp_path: Path) -> None:
+    """Cached task searches return directly.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    import json as _json
+
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    args_str = _json.dumps(["k", False, -1, True, info])
+    cached = cast(YAMLDict, {"type": "task"})
+    client.task_search_cache[args_str] = cast(object, [cached])  # type: ignore[assignment]
+    assert client.search_task("k", is_key=True, content_info=info) == [cached]
+
+
+def test_search_task_path_missing(tmp_path: Path) -> None:
+    """Missing findings files return no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    with patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists:
+        mock_exists.return_value = False
+        assert client.search_task("k", is_key=True, content_info=info) == []
+
+
+def test_search_task_empty_type_content(tmp_path: Path) -> None:
+    """Content info without a type still builds a findings path.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "", "name": "n", "version": "1", "hash": "h"})
+    task = _make_task(task_key="k", task_name="hello")
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"tasks": [task]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_task("k", is_key=True, content_info=info)
+    assert len(result) == 1
+
+
+def test_search_task_by_key_module_offspring(tmp_path: Path) -> None:
+    """Key matches with module executables collect module offspring.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    task = _make_task(task_key="mykey", executable="ns.coll.mymod", executable_type=ExecutableType.MODULE_TYPE)
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"tasks": [task]})})
+    child = cast(YAMLDict, {"object": _make_module(), "offspring_objects": []})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_module") as mock_mod,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_mod.return_value = [child]
+        result = client.search_task("mykey", is_key=True, content_info=info)
+    assert len(result) == 1
+    assert len(cast(list[YAMLDict], cast(object, result[0]["offspring_objects"]))) == 1
+
+
+def test_search_task_role_offspring(tmp_path: Path) -> None:
+    """Role executables resolve through role search.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    task = _make_task(task_key="k2", executable="ns.coll.myrole", executable_type=ExecutableType.ROLE_TYPE)
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"tasks": [task]})})
+    child = cast(YAMLDict, {"object": _make_role(), "offspring_objects": []})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_role") as mock_role,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_role.return_value = [child]
+        result = client.search_task("k2", is_key=True, content_info=info)
+    assert len(result) == 1
+
+
+def test_search_task_taskfile_offspring(tmp_path: Path) -> None:
+    """Taskfile executables resolve through taskfile search.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    task = _make_task(task_key="k3", executable="other.yml", executable_type=ExecutableType.TASKFILE_TYPE)
+    task.defined_in = "/repo/tasks/main.yml"
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"tasks": [task]})})
+    child = cast(YAMLDict, {"object": _make_taskfile(), "offspring_objects": []})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_taskfile") as mock_tf,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_tf.return_value = [child]
+        result = client.search_task("k3", is_key=True, content_info=info)
+    assert len(result) == 1
+
+
+def test_unknown_executable_type_yields_no_offspring(tmp_path: Path) -> None:
+    """Matched unknown-type tasks return one result with empty offspring.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    task = _make_task(task_key="mystery", executable="whatever", executable_type="UnknownType")
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"tasks": [task]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_task("mystery", is_key=True, content_info=info)
+    assert len(result) == 1
+    assert result[0]["offspring_objects"] == []
+
+
+def test_search_task_empty_executable_type_no_offspring(tmp_path: Path) -> None:
+    """Empty executable types also yield empty offspring.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    task = _make_task(task_key="k4", executable="x", executable_type="")
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"tasks": [task]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_task("k4", is_key=True, content_info=info)
+    assert len(result) == 1
+    assert result[0]["offspring_objects"] == []
+
+
+def test_search_task_name_exact_and_fuzzy(tmp_path: Path) -> None:
+    """Exact name search rejects partial names that fuzzy accepts.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    task = _make_task(task_key="k5", task_name="install nginx server", executable_type="")
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"tasks": [task]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        fuzzy = client.search_task("nginx", content_info=info)
+    assert len(fuzzy) == 1
+    client2 = _make_client(tmp_path)
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists2,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load2,
+    ):
+        mock_exists2.return_value = True
+        mock_load2.return_value = findings
+        exact_miss = client2.search_task("nginx", exact_match=True, content_info=info)
+    assert exact_miss == []
+    client3 = _make_client(tmp_path)
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists3,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load3,
+    ):
+        mock_exists3.return_value = True
+        mock_load3.return_value = findings
+        exact_hit = client3.search_task("install nginx server", exact_match=True, content_info=info)
+    assert len(exact_hit) == 1
+
+
+def test_search_task_empty_name_never_fuzzy_matches(tmp_path: Path) -> None:
+    """Tasks with empty names never match fuzzy queries.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    task = _make_task(task_key="k6", task_name="", executable_type="")
+    task.name = ""
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"tasks": [task]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_task("anything", content_info=info)
+    assert result == []
+
+
+def test_search_task_findings_cache_and_skips(tmp_path: Path) -> None:
+    """Findings cache hits avoid loads; bad entries are skipped.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    task = _make_task(task_key="k7", executable_type="")
+    findings_path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1", "h", "findings.json")
+    client.findings_cache[findings_path] = cast(object, {"tasks": ["junk", task]})  # type: ignore[assignment]
+    with patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists:
+        mock_exists.return_value = True
+        with patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load:
+            result = client.search_task("k7", is_key=True, content_info=info)
+    assert mock_load.call_count == 0
+    assert len(result) == 1
+    client2 = _make_client(tmp_path)
+    client2.findings_cache[findings_path] = client.findings_cache[findings_path]
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists2,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load2,
+    ):
+        mock_exists2.return_value = True
+        mock_load2.return_value = None
+        assert client2.search_task("other", is_key=True, content_info=info) == []
+
+
+def test_search_task_max_match_and_falsy_child(tmp_path: Path) -> None:
+    """max_match limits tasks and falsy children skip direct appends.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    task_one = _make_task(task_key="dup", task_name="n", executable_type="")
+    task_two = _make_task(task_key="dup", task_name="n", executable_type="")
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"tasks": [task_one, task_two]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client.search_task("dup", is_key=True, content_info=info, max_match=1)
+    assert len(result) == 1
+    client2 = _make_client(tmp_path)
+    task_three = _make_task(task_key="k8", executable="m", executable_type=ExecutableType.MODULE_TYPE)
+    findings2 = _make_findings()
+    findings2.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"tasks": [task_three]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists2,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load2,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_module") as mock_mod,
+    ):
+        mock_exists2.return_value = True
+        mock_load2.return_value = findings2
+        mock_mod.return_value = cast(list[YAMLDict], [{}])
+        result2 = client2.search_task("k8", is_key=True, content_info=info)
+    assert len(result2) == 1
+    assert result2[0]["offspring_objects"] == []
+
+
+def test_search_action_group_max_zero(tmp_path: Path) -> None:
+    """max_match zero short-circuits action group search.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_action_group("group/aws", max_match=0) == []
+
+
+def test_search_action_group_miss(tmp_path: Path) -> None:
+    """Unknown groups return no matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.search_action_group("group/missing") == []
+
+
+def test_search_action_group_hit(tmp_path: Path) -> None:
+    """Known groups return their indexed entries.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    entry = cast(YAMLDict, {"group_name": "group/aws"})
+    client.action_group_index = cast(YAMLDict, {"group/aws": [entry]})
+    assert client.search_action_group("group/aws") == [entry]
+
+
+def test_search_action_group_max_match_slice(tmp_path: Path) -> None:
+    """max_match truncates long group lists.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    one = cast(YAMLDict, {"group_name": "a"})
+    two = cast(YAMLDict, {"group_name": "b"})
+    three = cast(YAMLDict, {"group_name": "c"})
+    client.action_group_index = cast(YAMLDict, {"group/aws": [one, two, three]})
+    assert client.search_action_group("group/aws", max_match=2) == [one, two]
+    assert client.search_action_group("group/aws", max_match=10) == [one, two, three]
+
+
+def test_get_object_by_key_hit(tmp_path: Path) -> None:
+    """Matching keys return the object plus defined-in metadata.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    obj_list = ObjectList(items=[mod])
+    obj_list.update_dict()
+    coll_path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h", "root", "modules.json")
+    with (
+        patch("apme_engine.engine.risk_assessment_model.safe_glob") as mock_glob,
+        patch("apme_engine.engine.risk_assessment_model.ObjectList.from_json") as mock_from,
+    ):
+        mock_glob.side_effect = lambda pattern: [coll_path] if "collections" in str(pattern) else []
+        mock_from.return_value = obj_list
+        result = client.get_object_by_key(mod.key)
+    assert result is not None
+    assert cast(Module, cast(object, result["object"])) is mod
+    assert "defined_in" in result
+
+
+def test_get_object_by_key_miss(tmp_path: Path) -> None:
+    """Unknown keys return None.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    with (
+        patch("apme_engine.engine.risk_assessment_model.safe_glob") as mock_glob,
+        patch("apme_engine.engine.risk_assessment_model.ObjectList.from_json") as mock_from,
+    ):
+        mock_glob.return_value = []
+        mock_from.return_value = ObjectList(items=[mod])
+        assert client.get_object_by_key(mod.key) is None
+
+
+def test_get_object_by_key_role_path(tmp_path: Path) -> None:
+    """Role-side findings files are also searched.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    obj_list = ObjectList(items=[mod])
+    obj_list.update_dict()
+    role_path = os.path.join(str(tmp_path), "roles", "findings", "myrole", "1.0", "h", "root", "modules.json")
+    with (
+        patch("apme_engine.engine.risk_assessment_model.safe_glob") as mock_glob,
+        patch("apme_engine.engine.risk_assessment_model.ObjectList.from_json") as mock_from,
+    ):
+        mock_glob.side_effect = lambda pattern: [] if "collections" in str(pattern) else [role_path]
+        mock_from.return_value = obj_list
+        result = client.get_object_by_key(mod.key)
+    assert result is not None
+
+
+def test_get_object_by_key_find_miss_in_file(tmp_path: Path) -> None:
+    """Files without the key yield None.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    other = _make_module(name="other", fqcn="ns.coll.other")
+    obj_list = ObjectList(items=[other])
+    obj_list.update_dict()
+    coll_path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h", "root", "modules.json")
+    with (
+        patch("apme_engine.engine.risk_assessment_model.safe_glob") as mock_glob,
+        patch("apme_engine.engine.risk_assessment_model.ObjectList.from_json") as mock_from,
+    ):
+        mock_glob.side_effect = lambda pattern: [coll_path] if "collections" in str(pattern) else []
+        mock_from.return_value = obj_list
+        assert client.get_object_by_key(mod.key) is None
+
+
+def test_init_findings_json_list_cache(tmp_path: Path) -> None:
+    """Cache combines collection and role findings paths.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = os.path.join(str(tmp_path), "collections", "findings", "a", "1", "h", "findings.json")
+    role = os.path.join(str(tmp_path), "roles", "findings", "b", "1", "h", "findings.json")
+    with patch("apme_engine.engine.risk_assessment_model.safe_glob") as mock_glob:
+        mock_glob.side_effect = lambda pattern: [coll] if "collections" in str(pattern) else [role]
+        client._init_findings_json_list_cache()
+    assert client._findings_json_list_cache == [coll, role]
+
+
+def test_search_findings_empty_name_raises(tmp_path: Path) -> None:
+    """Empty target names raise ValueError.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client._findings_json_list_cache = ["x"]
+    with pytest.raises(ValueError):
+        client._search_findings("", "1.0")
+
+
+def test_search_findings_cache_hit(tmp_path: Path) -> None:
+    """Cached findings searches return without scanning.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    import json as _json
+
+    findings = _make_findings()
+    args_str = _json.dumps(["ns.coll", "1.0", None])
+    client._findings_json_list_cache = ["x"]
+    client._findings_search_cache[args_str] = cast(object, findings)  # type: ignore[assignment]
+    assert client._search_findings("ns.coll", "1.0") is findings
+
+
+def test_search_findings_single_match(tmp_path: Path) -> None:
+    """A single matching path loads and caches its findings.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h", "findings.json")
+    other = os.path.join(str(tmp_path), "collections", "findings", "other", "2.0", "h", "findings.json")
+    client._findings_json_list_cache = [path, other]
+    findings = _make_findings()
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient._load_findings") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client._search_findings("ns.coll", "*")
+    assert result is findings
+
+
+def test_search_findings_version_filter_skips(tmp_path: Path) -> None:
+    """Version-filtered searches skip non-matching versions.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "9.9", "h", "findings.json")
+    client._findings_json_list_cache = [path]
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient._load_findings") as mock_load,
+    ):
+        mock_exists.return_value = False
+        mock_load.return_value = None
+        result = client._search_findings("ns.coll", "1.0")
+    assert result is None
+
+
+def test_search_findings_type_filter(tmp_path: Path) -> None:
+    """Type filters skip non-matching entries.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h", "findings.json")
+    client._findings_json_list_cache = [path]
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient._load_findings") as mock_load,
+    ):
+        mock_exists.return_value = False
+        mock_load.return_value = None
+        result = client._search_findings("ns.coll", "*", target_type="collection")
+    assert result is None
+
+
+def test_search_findings_empty_version_defaults_star(tmp_path: Path) -> None:
+    """Empty versions behave like wildcard searches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h", "findings.json")
+    client._findings_json_list_cache = [path]
+    findings = _make_findings()
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient._load_findings") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        assert client._search_findings("ns.coll", "") is findings
+
+
+def test_search_findings_multiple_picks_newest(tmp_path: Path) -> None:
+    """Multiple matches select the newest mtime path.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    old = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h", "findings.json")
+    new = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h2", "findings.json")
+    client._findings_json_list_cache = [old, new]
+    findings = _make_findings()
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.getmtime") as mock_mtime,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient._load_findings") as mock_load,
+    ):
+        mock_mtime.side_effect = lambda p: 200.0 if str(p) == new else 100.0
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client._search_findings("ns.coll", "*")
+        assert mock_load.call_args[0][0] == new
+    assert result is findings
+
+
+def test_search_findings_multiple_first_newest(tmp_path: Path) -> None:
+    """The first path wins when it already has the newest mtime.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    first = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h", "findings.json")
+    second = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h2", "findings.json")
+    client._findings_json_list_cache = [first, second]
+    findings = _make_findings()
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.getmtime") as mock_mtime,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient._load_findings") as mock_load,
+    ):
+        mock_mtime.side_effect = lambda p: 300.0 if str(p) == first else 100.0
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        result = client._search_findings("ns.coll", "*")
+        assert mock_load.call_args[0][0] == first
+    assert result is findings
+
+
+def test_search_findings_inits_cache_when_empty(tmp_path: Path) -> None:
+    """Empty list caches trigger a glob-backed initialization.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client._findings_json_list_cache == []
+    path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h", "findings.json")
+    findings = _make_findings()
+    with (
+        patch("apme_engine.engine.risk_assessment_model.safe_glob") as mock_glob,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient._load_findings") as mock_load,
+    ):
+        mock_glob.side_effect = lambda pattern: [path] if "collections" in str(pattern) else []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        assert client._search_findings("ns.coll", "*") is findings
+    assert client._findings_json_list_cache == [path]
+
+
+def test_load_findings_from_file(tmp_path: Path) -> None:
+    """File paths load findings.json from their directory.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    findings = _make_findings()
+    target = tmp_path / "out" / "findings.json"
+    with patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load:
+        mock_load.return_value = findings
+        assert client._load_findings(str(target)) is findings
+        assert mock_load.call_args[1]["fpath"] == os.path.join(str(tmp_path / "out"), "findings.json")
+
+
+def test_load_findings_from_dir(tmp_path: Path) -> None:
+    """Directory paths append findings.json before loading.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    findings = _make_findings()
+    target = tmp_path / "outdir"
+    with patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load:
+        mock_load.return_value = findings
+        assert client._load_findings(str(target)) is findings
+        assert mock_load.call_args[1]["fpath"] == os.path.join(str(target), "findings.json")
+
+
+def test_save_findings_empty_dir_raises(tmp_path: Path) -> None:
+    """Empty output directories raise ValueError.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    with pytest.raises(ValueError):
+        client.save_findings(_make_findings(), "")
+
+
+def test_save_findings_creates_dir(tmp_path: Path) -> None:
+    """Missing directories are created and findings.json is written.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    out_dir = str(tmp_path / "newdir" / "nested")
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": {}, "mappings": {}})
+    client.save_findings(findings, out_dir)
+    assert os.path.exists(os.path.join(out_dir, "findings.json"))
+
+
+def test_save_findings_existing_dir(tmp_path: Path) -> None:
+    """Existing directories are reused without recreation errors.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    out_dir = str(tmp_path / "exists")
+    os.makedirs(out_dir)
+    client.save_findings(_make_findings(), out_dir)
+    assert os.path.exists(os.path.join(out_dir, "findings.json"))
+
+
+def test_save_index_roundtrip(tmp_path: Path) -> None:
+    """Saved indices load back the same content.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client.save_index(cast(YAMLDict, {"k": "v"}), module_index_name)
+    assert client.load_index(module_index_name) == {"k": "v"}
+    client.save_index(cast(YAMLDict, {"k2": "v2"}), module_index_name)
+    assert client.load_index(module_index_name) == {"k2": "v2"}
+
+
+def test_load_index_missing_returns_empty(tmp_path: Path) -> None:
+    """Missing index files load as empty dicts.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    assert client.load_index("does-not-exist.json") == {}
+
+
+def test_index_wrapper_delegation(tmp_path: Path) -> None:
+    """Typed wrappers delegate to save_index and load_index.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    payload = cast(YAMLDict, {"x": "y"})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_index") as mock_save:
+        client.save_module_index(payload)
+        assert mock_save.call_args[0][1] == module_index_name
+        client.save_role_index(payload)
+        assert mock_save.call_args[0][1] == role_index_name
+        client.save_taskfile_index(payload)
+        assert mock_save.call_args[0][1] == taskfile_index_name
+        client.save_action_group_index(payload)
+        assert mock_save.call_args[0][1] == action_group_index_name
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_index") as mock_load:
+        mock_load.return_value = payload
+        assert client.load_module_index() == payload
+        assert mock_load.call_args[0][0] == module_index_name
+        assert client.load_role_index() == payload
+        assert client.load_taskfile_index() == payload
+        assert client.load_action_group_index() == payload
+
+
+def test_save_error_empty_dir_raises(tmp_path: Path) -> None:
+    """Empty output directories raise ValueError for errors.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    with pytest.raises(ValueError):
+        client.save_error("boom", "")
+
+
+def test_save_error_writes_file(tmp_path: Path) -> None:
+    """Error text lands in error.log inside new directories.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    out_dir = str(tmp_path / "errdir")
+    client.save_error("boom", out_dir)
+    assert (Path(out_dir) / "error.log").read_text() == "boom"
+
+
+def test_save_error_existing_dir(tmp_path: Path) -> None:
+    """Existing directories accept additional error writes.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    out_dir = str(tmp_path / "errexists")
+    os.makedirs(out_dir)
+    client.save_error("again", out_dir)
+    assert (Path(out_dir) / "error.log").read_text() == "again"
+
+
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
+    "case",
+    [
+        ("unknown", 0.0),
+        ("1", 1.0),
+        ("1.2", 1.002),
+        ("2.0.1", 2.000001),
+        ("1.2.3-suffix", 1.002003),
+        ("abc", 0.0),
+        ("1.x.3", 1.000003),
+        ("", 0.0),
+    ],
+)
+def test_version_to_num_cases(case: tuple[str, float]) -> None:
+    """Version strings convert to comparable numbers.
+
+    Args:
+        case: Version string paired with its expected numeric value.
+    """
+    ver, expected = case
+    assert _version_to_num(ver) == pytest.approx(expected)
+
+
+def test_version_to_num_two_parts_nonnumeric_minor() -> None:
+    """Non-numeric minor versions contribute only the major part."""
+    assert _version_to_num("3.x") == 3.0
+
+
+def test_version_to_num_nonnumeric_patch() -> None:
+    """Non-numeric patch versions keep major and minor parts."""
+    assert _version_to_num("1.2.x") == pytest.approx(1.002)
+
+
+def test_path_to_reversed_version_num() -> None:
+    """Higher versions sort first via negated numbers."""
+    path = "/r/collections/findings/ns.coll/2.0.0/hash/findings.json"
+    assert _path_to_reversed_version_num(path) == pytest.approx(-2.0)
+
+
+def test_path_to_collection_name() -> None:
+    """Collection names extract from findings paths."""
+    path = "/r/collections/findings/ns.coll/1.0/hash/findings.json"
+    assert _path_to_collection_name(path) == "ns.coll"
+
+
+def test_sort_by_version_groups_and_orders() -> None:
+    """Paths group by collection with newest versions first."""
+    base = "/r/collections/findings"
+    paths = [
+        base + "/b/1.0.0/h/findings.json",
+        base + "/a/2.0.0/h/findings.json",
+        base + "/a/1.0.0/h/findings.json",
+        base + "/b/2.0.0/h/findings.json",
+    ]
+    ordered = sort_by_version(paths)
+    assert ordered[0] == base + "/a/2.0.0/h/findings.json"
+    assert ordered[1] == base + "/a/1.0.0/h/findings.json"
+    assert ordered[2] == base + "/b/2.0.0/h/findings.json"
+    assert ordered[3] == base + "/b/1.0.0/h/findings.json"
+
+
+def test_sort_by_version_empty() -> None:
+    """Empty path lists sort to empty lists."""
+    assert sort_by_version([]) == []
+
+
+def test_register_module_index_mismatch_appends(tmp_path: Path) -> None:
+    """Differing existing module entries append the new metadata.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    findings = _make_findings()
+    other_meta = ModuleMetadata.from_module(
+        mod, cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "9.9", "hash": "h"})
+    )
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_module_index") as mock_load:
+        mock_load.return_value = {"mymod": [other_meta]}
+        with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+            defs = cast(YAMLDict, {"modules": [mod]})
+            findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+            client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 1
+
+
+def test_register_module_index_routing_mismatch_appends(tmp_path: Path) -> None:
+    """Differing routing entries append the new redirect metadata.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"plugin_routing": {"modules": {"oldmod": {"redirect": "ns.coll.newmod"}}}})
+    findings = _make_findings()
+    existing = cast(YAMLDict, {"fqcn": "other.mod", "type": "c", "name": "x", "version": "1", "hash": "h"})
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_module_index") as mock_load:
+        mock_load.return_value = cast(YAMLDict, {"oldmod": [existing]})
+        with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+            defs = cast(YAMLDict, {"modules": [], "collections": [coll]})
+            findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+            client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 1
+
+
+def test_register_module_index_routing_object_duplicate(tmp_path: Path) -> None:
+    """Routing ModuleMetadata objects compare equal and skip saving.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"plugin_routing": {"modules": {"oldmod": {"redirect": "ns.coll.newmod"}}}})
+    findings = _make_findings()
+    existing = ModuleMetadata.from_routing("ns.coll.newmod", findings.metadata)
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_module_index") as mock_load:
+        mock_load.return_value = {"oldmod": [existing]}
+        with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_module_index") as mock_save:
+            defs = cast(YAMLDict, {"modules": [], "collections": [coll]})
+            findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+            client.register_module_index_to_ram(findings)
+    assert mock_save.call_count == 0
+
+
+def test_register_role_index_mismatch_appends(tmp_path: Path) -> None:
+    """Differing existing role entries append the new metadata.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role()
+    findings = _make_findings()
+    other_meta = RoleMetadata.from_role(
+        role, cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "9.9", "hash": "h"})
+    )
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_role_index") as mock_load:
+        mock_load.return_value = {"ns.coll.myrole": [other_meta]}
+        with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_role_index") as mock_save:
+            defs = cast(YAMLDict, {"roles": [role]})
+            findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+            client.register_role_index_to_ram(findings)
+    assert mock_save.call_count == 1
+
+
+def test_register_taskfile_index_mismatch_appends(tmp_path: Path) -> None:
+    """Differing existing taskfile entries append the new metadata.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    taskfile = _make_taskfile()
+    findings = _make_findings()
+    other_meta = TaskFileMetadata.from_taskfile(taskfile, findings.metadata)
+    other_meta.version = "9.9"
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_taskfile_index") as mock_load:
+        mock_load.return_value = {taskfile.key: [other_meta]}
+        with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_taskfile_index") as mock_save:
+            defs = cast(YAMLDict, {"taskfiles": [taskfile]})
+            findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+            client.register_taskfile_index_to_ram(findings)
+    assert mock_save.call_count == 1
+
+
+def test_register_action_group_mismatch_appends(tmp_path: Path) -> None:
+    """Differing action group entries append new metadata for both names.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    coll = _make_collection()
+    coll.meta_runtime = cast(YAMLDict, {"action_groups": {"aws": [_make_module()]}})
+    findings = _make_findings()
+    short_meta = ActionGroupMetadata()
+    short_meta.group_name = "group/aws"
+    short_meta.type = "collection"
+    short_meta.name = "ns.coll"
+    short_meta.version = "9.9"
+    short_meta.hash = "h"
+    fq_meta = ActionGroupMetadata()
+    fq_meta.group_name = "group/ns.coll.aws"
+    fq_meta.type = "collection"
+    fq_meta.name = "ns.coll"
+    fq_meta.version = "9.9"
+    fq_meta.hash = "h"
+    with patch("apme_engine.engine.risk_assessment_model.RAMClient.load_action_group_index") as mock_load:
+        mock_load.return_value = cast(YAMLDict, {"group/aws": [short_meta], "group/ns.coll.aws": [fq_meta]})
+        with patch("apme_engine.engine.risk_assessment_model.RAMClient.save_action_group_index") as mock_save:
+            defs = cast(YAMLDict, {"collections": [coll]})
+            findings.root_definitions = cast(YAMLDict, {"definitions": defs})
+            client.register_action_group_index_to_ram(findings)
+    assert mock_save.call_count == 1
+
+
+def test_search_module_exact_miss_with_findings(tmp_path: Path) -> None:
+    """Exact searches miss when findings hold a different FQCN.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module(name="different", fqcn="ns.coll.different")
+    client.module_index = cast(
+        YAMLDict,
+        {"mymod": [{"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]},
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"modules": [mod]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        assert client.search_module("ns.coll.mymod", exact_match=True) == []
+
+
+def test_search_module_fuzzy_miss_with_findings(tmp_path: Path) -> None:
+    """Fuzzy searches miss when no FQCN component matches.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module(name="different", fqcn="ns.coll.different")
+    client.module_index = cast(
+        YAMLDict,
+        {"mymod": [{"fqcn": "ns.coll.mymod", "type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]},
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"modules": [mod]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_builtin_module") as mock_b,
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_b.return_value = []
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        assert client.search_module("mymod") == []
+
+
+def test_search_role_exact_hit(tmp_path: Path) -> None:
+    """Exact role searches hit on full FQCN equality.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role(fqcn="ns.coll.myrole")
+    client.role_index = cast(
+        YAMLDict, {"ns.coll.myrole": [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"roles": [role]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_taskfile") as mock_tf,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_tf.return_value = []
+        result = client.search_role("ns.coll.myrole", exact_match=True)
+    assert len(result) == 1
+
+
+def test_search_role_fuzzy_miss_with_findings(tmp_path: Path) -> None:
+    """Fuzzy role searches miss when findings hold another role.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    role = _make_role(name="other", fqcn="ns.coll.other")
+    client.role_index = cast(
+        YAMLDict, {"myrole": [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"roles": [role]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_taskfile") as mock_tf,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_tf.return_value = []
+        assert client.search_role("myrole") == []
+
+
+def test_search_taskfile_key_mismatch(tmp_path: Path) -> None:
+    """Taskfile searches miss when findings hold another key.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    wanted = "taskfile collection:ns.coll#taskfile:tasks/main.yml"
+    other = "taskfile collection:ns.coll#taskfile:tasks/other.yml"
+    taskfile = _make_taskfile(other)
+    client.taskfile_index = cast(
+        YAMLDict, {wanted: [{"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"}]}
+    )
+    findings = _make_findings()
+    findings.root_definitions = cast(YAMLDict, {"definitions": cast(YAMLDict, {"taskfiles": [taskfile]})})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient.search_task") as mock_task,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = findings
+        mock_task.return_value = []
+        assert client.search_taskfile(wanted, is_key=True) == []
+
+
+def test_search_task_load_not_findings(tmp_path: Path) -> None:
+    """Task searches skip non-Findings loads gracefully.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    info = cast(YAMLDict, {"type": "collection", "name": "ns.coll", "version": "1", "hash": "h"})
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.Findings.load") as mock_load,
+    ):
+        mock_exists.return_value = True
+        mock_load.return_value = None
+        assert client.search_task("whatever", is_key=True, content_info=info) == []
+
+
+def test_search_findings_version_filter_returns_match(tmp_path: Path) -> None:
+    """Version-filtered searches return the row with the matching version.
+
+    Guards the ``target_version`` comparison: the path version must be
+    compared against the requested version, not the target name, so a
+    filtered search finds its row while other versions are skipped.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    path = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "1.0", "h", "findings.json")
+    other = os.path.join(str(tmp_path), "collections", "findings", "ns.coll", "2.0", "h2", "findings.json")
+    client._findings_json_list_cache = [path, other]
+    findings = _make_findings(version="1.0")
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient._load_findings") as mock_load,
+    ):
+        mock_exists.side_effect = lambda p: bool(p)
+        mock_load.return_value = findings
+        result = client._search_findings("ns.coll", "1.0")
+    assert result is findings
+    assert mock_load.call_args[0][0] == path
+
+
+def test_search_findings_skips_short_path(tmp_path: Path) -> None:
+    """Findings paths too short to index into are skipped, not crashed on.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    client._findings_json_list_cache = ["short.json"]
+    with (
+        patch("apme_engine.engine.risk_assessment_model.os.path.exists") as mock_exists,
+        patch("apme_engine.engine.risk_assessment_model.RAMClient._load_findings") as mock_load,
+    ):
+        mock_exists.side_effect = lambda p: bool(p)
+        mock_load.return_value = None
+        assert client._search_findings("ns.coll", "*") is None
+    assert mock_load.call_count == 0
+
+
+def test_get_object_by_key_skips_short_path(tmp_path: Path) -> None:
+    """Object JSON paths too short to index into are skipped, not crashed on.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    client = _make_client(tmp_path)
+    mod = _make_module()
+    obj_list = ObjectList(items=[mod])
+    obj_list.update_dict()
+    with (
+        patch("apme_engine.engine.risk_assessment_model.safe_glob") as mock_glob,
+        patch("apme_engine.engine.risk_assessment_model.ObjectList.from_json") as mock_from,
+    ):
+        # Short enough (< 6 segments) to hit the guard, but shaped so the
+        # version sort key derivation does not crash first.
+        mock_glob.side_effect = lambda pattern: ["findings/n/1"] if "collections" in str(pattern) else []
+        mock_from.return_value = obj_list
+        assert client.get_object_by_key(mod.key) is None

--- a/tests/test_scan_driver.py
+++ b/tests/test_scan_driver.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 import os
+import subprocess
 import tempfile
 from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,8 +14,11 @@ import pytest
 from apme.v1 import engine_pb2
 from apme_gateway.scan.driver import (
     _REMOTE_HEAD_CACHE,
+    _REMOTE_HEAD_NEG_CACHE,
+    _git_auth_env,
     _git_subprocess_env,
     _inject_token_in_url,
+    _merge_git_config_env,
     clone_repo,
     coerce_option_bool,
     derive_session_id,
@@ -22,6 +27,21 @@ from apme_gateway.scan.driver import (
     run_project_scan,
 )
 from apme_gateway.scm.redaction import redact_credentials
+
+
+def _decode_auth_env(env: dict[str, str]) -> str:
+    """Decode the ``http.extraHeader`` basic credentials from a git env mapping.
+
+    Args:
+        env: Git subprocess environment containing ``GIT_CONFIG_VALUE_0``.
+
+    Returns:
+        Decoded ``username:password`` credential string.
+    """
+    value = env["GIT_CONFIG_VALUE_0"]
+    scheme, _, encoded = value.partition("Basic ")
+    assert scheme.strip().rstrip(":").upper() == "AUTHORIZATION"
+    return base64.b64decode(encoded.strip()).decode("utf-8")
 
 
 @pytest.mark.parametrize(  # type: ignore[untyped-decorator]
@@ -128,6 +148,7 @@ async def test_fetch_remote_head_uses_git_ca_env() -> None:
     """Remote head lookups pass the derived CA env through to git."""
     fake_sha = "b" * 40
     _REMOTE_HEAD_CACHE.clear()
+    _REMOTE_HEAD_NEG_CACHE.clear()
     with (
         patch.dict(os.environ, {"SSL_CERT_FILE": "/etc/ssl/certs/custom-ca.pem"}, clear=True),
         patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
@@ -222,6 +243,7 @@ async def test_fetch_remote_head_success() -> None:
     """Verify fetch_remote_head returns SHA from ls-remote output."""
     fake_sha = "a" * 40
     _REMOTE_HEAD_CACHE.clear()
+    _REMOTE_HEAD_NEG_CACHE.clear()
     with patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop:
         result = MagicMock()
         result.returncode = 0
@@ -379,10 +401,35 @@ class TestRedactCredentials:
         result = redact_credentials(text)
         assert result == text
 
+    def test_redacts_basic_auth_header(self) -> None:
+        """AUTHORIZATION Basic header tokens are masked."""
+        token = base64.b64encode(b"x-access-token:ghp_secret123").decode("ascii")
+        text = f"http.https://github.com.extraHeader: AUTHORIZATION: Basic {token}"
+        result = redact_credentials(text)
+        assert token not in result
+        assert "Basic [REDACTED]" in result
+
+    def test_redacts_curl_verbose_authorization(self) -> None:
+        """Curl-verbose Authorization headers are masked case-insensitively."""
+        token = base64.b64encode(b"oauth2:glpat-secret").decode("ascii")
+        text = f"> Authorization: Basic {token}\r\n< HTTP/1.1 401"
+        result = redact_credentials(text)
+        assert token not in result
+        assert "[REDACTED]" in result
+
+    def test_redacts_url_and_basic_header_together(self) -> None:
+        """URL credentials and header tokens are both masked."""
+        token = base64.b64encode(b"git:s3cret-token").decode("ascii")
+        text = f"fatal: https://x-access-token:s3cret-token@github.com/repo not found (AUTHORIZATION: Basic {token})"
+        result = redact_credentials(text)
+        assert "s3cret-token" not in result
+        assert token not in result
+        assert result.count("[REDACTED]") >= 2
+
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_clone_repo_with_scm_token() -> None:
-    """Verify clone_repo injects token into URL when provided."""
+    """Verify clone_repo passes the token via env, never in argv."""
     with patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop:
         result = MagicMock()
         result.returncode = 0
@@ -400,7 +447,10 @@ async def test_clone_repo_with_scm_token() -> None:
             await clone_repo("https://github.com/owner/repo.git", "main", dest, scm_token="ghp_test")
 
         call_args = mock_run.call_args[0][0]
-        assert "x-access-token:ghp_test@github.com" in call_args[-2]
+        assert call_args[-2] == "https://github.com/owner/repo.git"
+        assert "ghp_test" not in " ".join(call_args)
+        env = mock_run.call_args.kwargs["env"]
+        assert _decode_auth_env(env) == "x-access-token:ghp_test"
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
@@ -427,10 +477,36 @@ async def test_clone_repo_redacts_error_messages() -> None:
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_clone_repo_redacts_basic_header_in_error() -> None:
+    """Verify clone_repo masks AUTHORIZATION Basic material from git stderr."""
+    token = base64.b64encode(b"x-access-token:ghp_secret123").decode("ascii")
+    with patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop:
+        result = MagicMock()
+        result.returncode = 128
+        result.stderr = f"trace: http.extraHeader: AUTHORIZATION: Basic {token}\nfatal: auth failed"
+        mock_loop.return_value.run_in_executor = AsyncMock(return_value=result)
+
+        with tempfile.TemporaryDirectory() as td:
+            dest = os.path.join(td, "repo")
+            with pytest.raises(RuntimeError) as exc_info:
+                await clone_repo(
+                    "https://github.com/bad/repo.git",
+                    "main",
+                    dest,
+                    scm_token="ghp_secret123",
+                )
+
+        assert token not in str(exc_info.value)
+        assert "ghp_secret123" not in str(exc_info.value)
+        assert "[REDACTED]" in str(exc_info.value)
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_fetch_remote_head_with_scm_token() -> None:
-    """Verify fetch_remote_head injects token when provided."""
+    """Verify fetch_remote_head passes the token via env, never in argv."""
     fake_sha = "c" * 40
     _REMOTE_HEAD_CACHE.clear()
+    _REMOTE_HEAD_NEG_CACHE.clear()
     with (
         patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
         patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
@@ -449,7 +525,77 @@ async def test_fetch_remote_head_with_scm_token() -> None:
 
     assert sha == fake_sha
     call_args = mock_run.call_args[0][0]
-    assert "oauth2:glpat-test@gitlab.com" in call_args[3]
+    assert call_args[3] == "https://gitlab.com/owner/repo.git"
+    assert "glpat-test" not in " ".join(call_args)
+    env = mock_run.call_args.kwargs["env"]
+    assert _decode_auth_env(env) == "oauth2:glpat-test"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_fetch_remote_head_negative_cache_throttles_retries() -> None:
+    """Failed ls-remote lookups are cached with a short TTL, not forever."""
+    _REMOTE_HEAD_CACHE.clear()
+    _REMOTE_HEAD_NEG_CACHE.clear()
+    with (
+        patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
+        patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 128
+        result.stdout = ""
+        mock_run.return_value = result
+        mock_loop.return_value.run_in_executor = AsyncMock(side_effect=lambda _exec, func: func())
+
+        assert await fetch_remote_head("https://github.com/owner/repo.git", "main") is None
+        assert await fetch_remote_head("https://github.com/owner/repo.git", "main") is None
+
+    assert _REMOTE_HEAD_CACHE == {}
+    assert len(_REMOTE_HEAD_NEG_CACHE) == 1
+    # Second lookup served from the short-TTL negative cache: no new subprocess.
+    assert mock_run.call_count == 1
+
+
+class TestGitAuthEnv:
+    """Tests for _git_auth_env token transport via git config env."""
+
+    def test_github_credentials(self) -> None:
+        """GitHub tokens map to x-access-token basic credentials."""
+        env = _git_auth_env("https://github.com/owner/repo.git", "ghp_test123")
+        assert env["GIT_CONFIG_COUNT"] == "1"
+        assert env["GIT_CONFIG_KEY_0"] == "http.https://github.com.extraHeader"
+        assert _decode_auth_env(env) == "x-access-token:ghp_test123"
+
+    def test_auth_header_scoped_to_repo_origin(self) -> None:
+        """The extraHeader key is scoped per origin, including ports."""
+        env = _git_auth_env("https://git.example.com:8443/org/repo.git", "token123")
+        assert env["GIT_CONFIG_KEY_0"] == "http.https://git.example.com:8443.extraHeader"
+        assert _decode_auth_env(env) == "git:token123"
+
+    def test_merge_preserves_existing_git_config(self) -> None:
+        """Merging appends pairs instead of clobbering existing entries."""
+        base = {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "http.sslVerify",
+            "GIT_CONFIG_VALUE_0": "false",
+        }
+        merged = _merge_git_config_env(base, [("http.https://a.example.extraHeader", "AUTHORIZATION: Basic eA==")])
+        assert merged["GIT_CONFIG_COUNT"] == "2"
+        assert merged["GIT_CONFIG_KEY_0"] == "http.sslVerify"
+        assert merged["GIT_CONFIG_KEY_1"] == "http.https://a.example.extraHeader"
+        assert merged["GIT_CONFIG_VALUE_1"] == "AUTHORIZATION: Basic eA=="
+
+    def test_gitlab_user_pass_credentials(self) -> None:
+        """GitLab deploy tokens keep username:password credentials."""
+        env = _git_auth_env(
+            "https://gitlab.com/group/repo.git",
+            "gitlab+deploy-token-1:secret",
+        )
+        assert _decode_auth_env(env) == "gitlab+deploy-token-1:secret"
+
+    def test_unknown_provider_git_fallback(self) -> None:
+        """Unknown providers fall back to the git username."""
+        env = _git_auth_env("https://custom-git.example.com/repo.git", "token123")
+        assert _decode_auth_env(env) == "git:token123"
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
@@ -458,6 +604,7 @@ async def test_fetch_remote_head_cache_separates_auth_and_unauth() -> None:
     fake_sha_unauth = "a" * 40
     fake_sha_auth = "b" * 40
     _REMOTE_HEAD_CACHE.clear()
+    _REMOTE_HEAD_NEG_CACHE.clear()
 
     with (
         patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
@@ -487,3 +634,229 @@ async def test_fetch_remote_head_cache_separates_auth_and_unauth() -> None:
         # Should make a new request, not return cached unauthenticated result
         assert sha2 == fake_sha_auth
         assert mock_run.call_count == 2
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_fetch_remote_head_separates_distinct_tokens() -> None:
+    """Two different tokens on the same repo+branch do not share a cache entry."""
+    _REMOTE_HEAD_CACHE.clear()
+    _REMOTE_HEAD_NEG_CACHE.clear()
+    with (
+        patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
+        patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
+    ):
+        mock_loop.return_value.run_in_executor = AsyncMock(side_effect=lambda _exec, func: func())
+
+        first = MagicMock()
+        first.returncode = 0
+        first.stdout = f"{'a' * 40}\trefs/heads/main\n"
+        mock_run.return_value = first
+        assert await fetch_remote_head("https://github.com/o/r.git", "main", scm_token="tok-one") == "a" * 40
+
+        second = MagicMock()
+        second.returncode = 0
+        second.stdout = f"{'b' * 40}\trefs/heads/main\n"
+        mock_run.return_value = second
+        assert await fetch_remote_head("https://github.com/o/r.git", "main", scm_token="tok-two") == "b" * 40
+
+        assert mock_run.call_count == 2
+    """clone_repo TimeoutExpired surfaces as RuntimeError, never raw."""
+    with patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop:
+        mock_loop.return_value.run_in_executor = AsyncMock(
+            side_effect=subprocess.TimeoutExpired(cmd=["git"], timeout=120)
+        )
+        with tempfile.TemporaryDirectory() as td, pytest.raises(RuntimeError, match="timed out"):
+            await clone_repo("https://github.com/o/r.git", "main", td + "/repo", scm_token="s3cret")
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_clone_repo_strips_embedded_userinfo(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Userinfo in the stored URL never reaches git argv; host is warned, secret is not.
+
+    Args:
+        caplog: Pytest log capture fixture.
+    """
+    secret_url = "https://deployer:s3cret-token@github.com/owner/repo.git"
+    with (
+        caplog.at_level("WARNING", logger="apme_gateway.scan.driver"),
+        patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
+        patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        mock_run.return_value = result
+        mock_loop.return_value.run_in_executor = AsyncMock(side_effect=lambda _exec, func: func())
+
+        with tempfile.TemporaryDirectory() as td:
+            await clone_repo(secret_url, "main", os.path.join(td, "repo"))
+
+    call_args = mock_run.call_args[0][0]
+    assert call_args[-2] == "https://github.com/owner/repo.git"
+    assert "s3cret-token" not in " ".join(call_args)
+    assert "github.com" in caplog.text
+    assert "s3cret-token" not in caplog.text
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_clone_repo_userinfo_with_token_keeps_header_auth() -> None:
+    """Stripped userinfo URLs still authenticate via header env when scm_token is set."""
+    secret_url = "https://deployer:old-credential@github.com/owner/repo.git"
+    with patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop:
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        mock_loop.return_value.run_in_executor = AsyncMock(return_value=result)
+
+        with (
+            tempfile.TemporaryDirectory() as td,
+            patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = result
+            mock_loop.return_value.run_in_executor = AsyncMock(side_effect=lambda _exec, func: func())
+
+            dest = os.path.join(td, "repo")
+            await clone_repo(secret_url, "main", dest, scm_token="ghp_test")
+
+        call_args = mock_run.call_args[0][0]
+        assert call_args[-2] == "https://github.com/owner/repo.git"
+        assert "old-credential" not in " ".join(call_args)
+        assert "ghp_test" not in " ".join(call_args)
+        env = mock_run.call_args.kwargs["env"]
+        assert _decode_auth_env(env) == "x-access-token:ghp_test"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_fetch_remote_head_strips_embedded_userinfo(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """ls-remote receives the stripped URL; header auth still sent when scm_token is set.
+
+    Args:
+        caplog: Pytest log capture fixture.
+    """
+    fake_sha = "f" * 40
+    _REMOTE_HEAD_CACHE.clear()
+    _REMOTE_HEAD_NEG_CACHE.clear()
+    secret_url = "https://deployer:s3cret-token@github.com/owner/repo.git"
+    with (
+        caplog.at_level("WARNING", logger="apme_gateway.scan.driver"),
+        patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
+        patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = f"{fake_sha}\trefs/heads/main\n"
+        mock_run.return_value = result
+        mock_loop.return_value.run_in_executor = AsyncMock(side_effect=lambda _exec, func: func())
+
+        sha = await fetch_remote_head(secret_url, "main", scm_token="ghp_test")
+
+    assert sha == fake_sha
+    call_args = mock_run.call_args[0][0]
+    assert call_args[3] == "https://github.com/owner/repo.git"
+    assert "s3cret-token" not in " ".join(call_args)
+    assert "ghp_test" not in " ".join(call_args)
+    env = mock_run.call_args.kwargs["env"]
+    assert _decode_auth_env(env) == "x-access-token:ghp_test"
+    assert "github.com" in caplog.text
+    assert "s3cret-token" not in caplog.text
+
+
+class TestRedactTightenedPatterns:
+    """Tightened Basic/Bearer patterns avoid prose while covering headers."""
+
+    def test_bearer_token_masked(self) -> None:
+        """Bearer tokens are masked."""
+        token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.c29tZXBheWxvYWQ.c2lnbmF0dXJl"
+        text = f"Authorization: Bearer {token}"
+        result = redact_credentials(text)
+        assert token not in result
+        assert "[REDACTED]" in result
+
+    def test_plain_english_untouched(self) -> None:
+        """Plain English mentioning bearer/basic is left alone."""
+        text = "The bearer of bad news arrived yesterday with a Basic understanding of the system"
+        assert redact_credentials(text) == text
+
+    def test_bare_basic_prose_untouched(self) -> None:
+        """Bare Basic prose without an Authorization prefix is not redacted."""
+        text = "This is a Basic understanding of the configuration format"
+        assert redact_credentials(text) == text
+
+    def test_short_bearer_fragment_untouched(self) -> None:
+        """Short Bearer fragments below the token floor are not redacted."""
+        text = "Bearer of light"
+        assert redact_credentials(text) == text
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_fetch_remote_head_cache_normalizes_repo_url() -> None:
+    """Variant URL spellings share one cache entry; raw URL still goes to git."""
+    fake_sha = "e" * 40
+    _REMOTE_HEAD_CACHE.clear()
+    _REMOTE_HEAD_NEG_CACHE.clear()
+    with (
+        patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
+        patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = f"{fake_sha}\trefs/heads/main\n"
+        mock_run.return_value = result
+        mock_loop.return_value.run_in_executor = AsyncMock(side_effect=lambda _exec, func: func())
+
+        sha1 = await fetch_remote_head("https://github.com/org/repo.git", "main")
+        assert sha1 == fake_sha
+        assert mock_run.call_count == 1
+        raw_argv = mock_run.call_args[0][0]
+        assert raw_argv[3] == "https://github.com/org/repo.git"
+
+        sha2 = await fetch_remote_head("https://GitHub.com/org/repo", "main")
+        assert sha2 == fake_sha
+        assert mock_run.call_count == 1
+    """Tokens straddling the 500-char cut are masked (redact before truncate)."""
+    secret = "ghp_straddlingsecret123456"
+    filler = "E" * 470
+    stderr = f"{filler} https://x-access-token:{secret}@github.com/org/repo not found"
+    assert "@" not in stderr[:500]
+    with patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop:
+        result = MagicMock()
+        result.returncode = 128
+        result.stderr = stderr
+        mock_loop.return_value.run_in_executor = AsyncMock(return_value=result)
+
+        with tempfile.TemporaryDirectory() as td:
+            dest = os.path.join(td, "repo")
+            with pytest.raises(RuntimeError) as exc_info:
+                await clone_repo("https://github.com/bad/repo.git", "main", dest)
+
+        assert secret not in str(exc_info.value)
+        assert "[REDACTED]" in str(exc_info.value)
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_fetch_remote_head_stores_fresh_timestamp() -> None:
+    """Cache entries use the post-subprocess clock reading, not the stale one."""
+    fake_sha = "d" * 40
+    _REMOTE_HEAD_CACHE.clear()
+    _REMOTE_HEAD_NEG_CACHE.clear()
+    with (
+        patch("apme_gateway.scan.driver.time.monotonic", side_effect=[100.0, 200.0]),
+        patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop,
+        patch("apme_gateway.scan.driver.subprocess.run") as mock_run,
+    ):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = f"{fake_sha}\trefs/heads/main\n"
+        mock_run.return_value = result
+        mock_loop.return_value.run_in_executor = AsyncMock(side_effect=lambda _exec, func: func())
+
+        sha = await fetch_remote_head("https://github.com/org/fresh.git", "main")
+        assert sha == fake_sha
+
+    assert len(_REMOTE_HEAD_CACHE) == 1
+    stored_ts = next(iter(_REMOTE_HEAD_CACHE.values()))[0]
+    assert stored_ts == 200.0

--- a/tests/test_scan_driver.py
+++ b/tests/test_scan_driver.py
@@ -660,6 +660,10 @@ async def test_fetch_remote_head_separates_distinct_tokens() -> None:
         assert await fetch_remote_head("https://github.com/o/r.git", "main", scm_token="tok-two") == "b" * 40
 
         assert mock_run.call_count == 2
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_clone_repo_timeout_expired_surfaces_runtime_error() -> None:
     """clone_repo TimeoutExpired surfaces as RuntimeError, never raw."""
     with patch("apme_gateway.scan.driver.asyncio.get_running_loop") as mock_loop:
         mock_loop.return_value.run_in_executor = AsyncMock(

--- a/tests/test_scan_driver.py
+++ b/tests/test_scan_driver.py
@@ -847,6 +847,10 @@ async def test_fetch_remote_head_cache_normalizes_repo_url() -> None:
         sha2 = await fetch_remote_head("https://GitHub.com/org/repo", "main")
         assert sha2 == fake_sha
         assert mock_run.call_count == 1
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_clone_repo_redacts_tokens_straddling_stderr_truncation() -> None:
     """Tokens straddling the 500-char cut are masked (redact before truncate)."""
     secret = "ghp_straddlingsecret123456"
     filler = "E" * 470

--- a/tests/test_scan_driver.py
+++ b/tests/test_scan_driver.py
@@ -33,12 +33,17 @@ def _decode_auth_env(env: dict[str, str]) -> str:
     """Decode the ``http.extraHeader`` basic credentials from a git env mapping.
 
     Args:
-        env: Git subprocess environment containing ``GIT_CONFIG_VALUE_0``.
+        env: Git subprocess environment containing ``GIT_CONFIG_*`` entries.
 
     Returns:
         Decoded ``username:password`` credential string.
     """
-    value = env["GIT_CONFIG_VALUE_0"]
+    count = int(env["GIT_CONFIG_COUNT"])
+    value = next(
+        env[f"GIT_CONFIG_VALUE_{i}"]
+        for i in range(count - 1, -1, -1)
+        if env.get(f"GIT_CONFIG_KEY_{i}", "").endswith(".extraHeader")
+    )
     scheme, _, encoded = value.partition("Basic ")
     assert scheme.strip().rstrip(":").upper() == "AUTHORIZATION"
     return base64.b64decode(encoded.strip()).decode("utf-8")

--- a/tests/test_scan_driver.py
+++ b/tests/test_scan_driver.py
@@ -696,6 +696,8 @@ async def test_clone_repo_strips_embedded_userinfo(
     call_args = mock_run.call_args[0][0]
     assert call_args[-2] == "https://github.com/owner/repo.git"
     assert "s3cret-token" not in " ".join(call_args)
+    env = mock_run.call_args.kwargs["env"]
+    assert _decode_auth_env(env) == "deployer:s3cret-token"
     assert "github.com" in caplog.text
     assert "s3cret-token" not in caplog.text
 
@@ -726,6 +728,16 @@ async def test_clone_repo_userinfo_with_token_keeps_header_auth() -> None:
         assert "ghp_test" not in " ".join(call_args)
         env = mock_run.call_args.kwargs["env"]
         assert _decode_auth_env(env) == "x-access-token:ghp_test"
+
+
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
+async def test_fetch_remote_head_malformed_port_returns_none() -> None:
+    """Malformed ports in authenticated URLs return None instead of raising."""
+    _REMOTE_HEAD_CACHE.clear()
+    _REMOTE_HEAD_NEG_CACHE.clear()
+    bad_url = "https://host:badport/repo.git"
+    sha = await fetch_remote_head(bad_url, "main", scm_token="tok")
+    assert sha is None
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]
@@ -790,6 +802,20 @@ class TestRedactTightenedPatterns:
         """Short Bearer fragments below the token floor are not redacted."""
         text = "Bearer of light"
         assert redact_credentials(text) == text
+
+    def test_short_basic_auth_header_masked(self) -> None:
+        """Short Basic auth values are redacted when prefixed by Authorization."""
+        text = "AUTHORIZATION: Basic YTpi"
+        result = redact_credentials(text)
+        assert "YTpi" not in result
+        assert "Basic [REDACTED]" in result
+
+    def test_short_bearer_token_masked(self) -> None:
+        """Short bearer access tokens are redacted."""
+        text = "Authorization: Bearer ghp_ab"
+        result = redact_credentials(text)
+        assert "ghp_ab" not in result
+        assert "[REDACTED]" in result
 
 
 @pytest.mark.asyncio  # type: ignore[untyped-decorator]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2222,3 +2222,49 @@ class TestFixSessionRPC:
                 pass
 
         assert store.count == before
+
+    async def test_cancel_after_upload_then_resume_removes_upload_session(self) -> None:
+        """Cancellation removes the upload-created session, not a later resume target."""
+        from apme_engine.daemon.engine_server import EngineServicer
+
+        servicer = EngineServicer()
+        store = servicer._get_session_store()
+        resume_session = store.create()
+        resume_session.report = FixReport(passes=1, fixed=0)
+
+        upload_created_id: str | None = None
+
+        class _UploadThenResumeCancelStream:
+            """Upload into one session, resume another, then cancel."""
+
+            def __init__(self) -> None:
+                self._step = 0
+
+            def __aiter__(self) -> _UploadThenResumeCancelStream:
+                return self
+
+            async def __anext__(self) -> SessionCommand:
+                if self._step == 0:
+                    self._step = 1
+                    return SessionCommand(
+                        upload=ScanChunk(scan_id="upload-then-resume", last=False),
+                    )
+                if self._step == 1:
+                    self._step = 2
+                    return SessionCommand(
+                        resume=ResumeRequest(session_id=resume_session.session_id),
+                    )
+                raise asyncio.CancelledError
+
+        ctx = FakeGrpcContext()
+        with pytest.raises(asyncio.CancelledError):
+            async for event in servicer.FixSession(
+                _UploadThenResumeCancelStream(),
+                ctx,  # type: ignore[arg-type]
+            ):
+                if event.WhichOneof("event") == "created" and upload_created_id is None:
+                    upload_created_id = event.created.session_id
+
+        assert upload_created_id is not None
+        assert store.get(upload_created_id) is None
+        assert store.get(resume_session.session_id) is resume_session

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2102,12 +2102,75 @@ class TestFixSessionRPC:
             async for _event in servicer.FixSession(stream, ctx):  # type: ignore[arg-type]
                 pass
 
-    async def test_client_cancel_removes_session(self) -> None:
-        """Client cancellation does not leak the session until TTL.
+    async def test_resume_stream_end_preserves_session(self) -> None:
+        """Disconnecting a resumed stream without close keeps the session alive."""
+        from apme_engine.daemon.engine_server import EngineServicer
+
+        servicer = EngineServicer()
+        store = servicer._get_session_store()
+
+        session = store.create()
+        session.report = FixReport(passes=1, fixed=0)
+        session.status = 1
+        session.proposals = {
+            "t2-0000": Proposal(id="t2-0000", file="test.yml", rule_id="L001"),
+        }
+
+        stream = AsyncCommandStream()
+        ctx = FakeGrpcContext()
+        stream.send(
+            SessionCommand(
+                resume=ResumeRequest(session_id=session.session_id),
+            )
+        )
+
+        async for event in servicer.FixSession(stream, ctx):  # type: ignore[arg-type]
+            if event.WhichOneof("event") == "proposals":
+                stream.close()
+                break
+
+        assert store.get(session.session_id) is session
+
+    async def test_upload_stream_end_preserves_session(self) -> None:
+        """Disconnecting an upload stream without close keeps the session for resume."""
+        from apme_engine.daemon.engine_server import EngineServicer
+
+        servicer = EngineServicer()
+        store = servicer._get_session_store()
+        before = store.count
+
+        stream = AsyncCommandStream()
+        ctx = FakeGrpcContext()
+        stream.send(
+            SessionCommand(
+                upload=ScanChunk(scan_id="test-persist", last=True),
+            )
+        )
+
+        session_id = None
+        with patch.object(
+            EngineServicer,
+            "_session_process",
+            _mock_session_process_with_proposals,
+        ):
+            async for event in servicer.FixSession(stream, ctx):  # type: ignore[arg-type]
+                oneof = event.WhichOneof("event")
+                if oneof == "created" and session_id is None:
+                    session_id = event.created.session_id
+                elif oneof == "proposals":
+                    stream.close()
+                    break
+
+        assert session_id is not None
+        assert store.count == before + 1
+        assert store.get(session_id) is not None
+
+    async def test_client_cancel_removes_created_session(self) -> None:
+        """Client cancellation removes only sessions created by this stream.
 
         A CancelledError from the request stream bypasses the explicit
-        close path; the FixSession finally must still remove the session
-        so repeated client retries cannot exhaust _MAX_SESSIONS.
+        close path; created sessions must still be removed so repeated
+        client retries cannot exhaust _MAX_SESSIONS.
         """
         from apme_engine.daemon.engine_server import EngineServicer
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2101,3 +2101,61 @@ class TestFixSessionRPC:
         with pytest.raises(_AbortSignal):
             async for _event in servicer.FixSession(stream, ctx):  # type: ignore[arg-type]
                 pass
+
+    async def test_client_cancel_removes_session(self) -> None:
+        """Client cancellation does not leak the session until TTL.
+
+        A CancelledError from the request stream bypasses the explicit
+        close path; the FixSession finally must still remove the session
+        so repeated client retries cannot exhaust _MAX_SESSIONS.
+        """
+        from apme_engine.daemon.engine_server import EngineServicer
+
+        servicer = EngineServicer()
+        store = servicer._get_session_store()
+        before = store.count
+
+        class _CancellingStream:
+            """Yield one upload, then raise CancelledError like a dead client."""
+
+            def __init__(self) -> None:
+                """Initialize with the first command not yet delivered."""
+                self._sent_first = False
+
+            def __aiter__(self) -> _CancellingStream:
+                """Return self as async iterator.
+
+                Returns:
+                    Self.
+                """
+                return self
+
+            async def __anext__(self) -> SessionCommand:
+                """Deliver the upload once, then simulate client cancel.
+
+                Returns:
+                    The initial upload command.
+
+                Raises:
+                    asyncio.CancelledError: On every call after the first.
+                """
+                if not self._sent_first:
+                    self._sent_first = True
+                    return SessionCommand(
+                        upload=ScanChunk(scan_id="test-cancel", last=False),
+                    )
+                raise asyncio.CancelledError
+
+        ctx = FakeGrpcContext()
+        with (
+            patch.object(
+                EngineServicer,
+                "_session_process",
+                _mock_session_process_complete,
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            async for _event in servicer.FixSession(_CancellingStream(), ctx):  # type: ignore[arg-type]
+                pass
+
+        assert store.count == before

--- a/tests/test_venv_session.py
+++ b/tests/test_venv_session.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import subprocess
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1050,3 +1051,71 @@ class TestListInstalledCollections:
 
         fqcns = [c[0] for c in colls]
         assert fqcns == ["ansible.posix", "community.general"]
+
+
+class TestCreateBaseVenvTimeout:
+    """Bounded venv creation maps stalls to PipInstallTimeout."""
+
+    def test_venv_creation_timeout_raises(self, tmp_path: Path) -> None:
+        """TimeoutExpired during venv creation raises PipInstallTimeout.
+
+        Args:
+            tmp_path: Pytest-provided temporary directory.
+        """
+        from apme_engine.venv_manager.session import (
+            _PIP_INSTALL_TIMEOUT_S,
+            PipInstallTimeout,
+            create_base_venv,
+        )
+
+        venv_dir = tmp_path / "venv"
+        with (
+            patch(
+                "apme_engine.venv_manager.session.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="uv venv", timeout=_PIP_INSTALL_TIMEOUT_S),
+            ) as mock_run,
+            pytest.raises(PipInstallTimeout),
+        ):
+            create_base_venv(venv_dir, "2.17.0")
+
+        assert mock_run.call_args is not None
+        assert mock_run.call_args[1].get("timeout") == _PIP_INSTALL_TIMEOUT_S
+
+    def test_ansible_core_install_timeout_raises(self, tmp_path: Path) -> None:
+        """TimeoutExpired during ansible-core install raises PipInstallTimeout.
+
+        Args:
+            tmp_path: Pytest-provided temporary directory.
+        """
+        from apme_engine.venv_manager.session import (
+            _PIP_INSTALL_TIMEOUT_S,
+            PipInstallTimeout,
+            create_base_venv,
+        )
+
+        venv_dir = tmp_path / "venv"
+        ok_result = MagicMock()
+        ok_result.returncode = 0
+        with (
+            patch(
+                "apme_engine.venv_manager.session._uv_available",
+                return_value=False,
+            ),
+            patch(
+                "apme_engine.venv_manager.session.subprocess.run",
+                side_effect=[
+                    ok_result,
+                    subprocess.TimeoutExpired(cmd="pip install", timeout=_PIP_INSTALL_TIMEOUT_S),
+                ],
+            ) as mock_run,
+            patch(
+                "apme_engine.venv_manager.session.get_venv_python",
+                return_value=tmp_path / "venv" / "bin" / "python",
+            ),
+            pytest.raises(PipInstallTimeout),
+        ):
+            create_base_venv(venv_dir, "2.17.0")
+
+        assert mock_run.call_count == 2
+        for call in mock_run.call_args_list:
+            assert call[1].get("timeout") == _PIP_INSTALL_TIMEOUT_S

--- a/tests/test_venv_session.py
+++ b/tests/test_venv_session.py
@@ -587,7 +587,7 @@ class TestRunPipInstallIndexStrategy:
 
         with (
             patch.dict(os.environ, {}, clear=False),
-            patch("apme_engine.venv_manager.session.subprocess.run", return_value=mock_result) as mock_run,
+            patch("apme_engine.venv_manager.session._run_subprocess_timed", return_value=mock_result) as mock_run,
         ):
             os.environ.pop("APME_UV_INDEX_STRATEGY", None)
             _run_pip_install(Path("/venv/bin/python"), ["pkg"], "http://proxy", use_uv=True)
@@ -607,7 +607,7 @@ class TestRunPipInstallIndexStrategy:
 
         with (
             patch.dict(os.environ, {"APME_UV_INDEX_STRATEGY": "first-match"}),
-            patch("apme_engine.venv_manager.session.subprocess.run", return_value=mock_result) as mock_run,
+            patch("apme_engine.venv_manager.session._run_subprocess_timed", return_value=mock_result) as mock_run,
         ):
             _run_pip_install(Path("/venv/bin/python"), ["pkg"], "http://proxy", use_uv=True)
 
@@ -626,7 +626,7 @@ class TestRunPipInstallIndexStrategy:
 
         with (
             patch.dict(os.environ, {"APME_UV_INDEX_STRATEGY": "  "}),
-            patch("apme_engine.venv_manager.session.subprocess.run", return_value=mock_result) as mock_run,
+            patch("apme_engine.venv_manager.session._run_subprocess_timed", return_value=mock_result) as mock_run,
         ):
             _run_pip_install(Path("/venv/bin/python"), ["pkg"], "http://proxy", use_uv=True)
 
@@ -1071,14 +1071,14 @@ class TestCreateBaseVenvTimeout:
         venv_dir = tmp_path / "venv"
         with (
             patch(
-                "apme_engine.venv_manager.session.subprocess.run",
+                "apme_engine.venv_manager.session._run_subprocess_timed",
                 side_effect=subprocess.TimeoutExpired(cmd="uv venv", timeout=_PIP_INSTALL_TIMEOUT_S),
             ) as mock_run,
             pytest.raises(PipInstallTimeout),
         ):
             create_base_venv(venv_dir, "2.17.0")
 
-        assert mock_run.call_args is not None
+        assert mock_run.call_count == 1
         assert mock_run.call_args[1].get("timeout") == _PIP_INSTALL_TIMEOUT_S
 
     def test_ansible_core_install_timeout_raises(self, tmp_path: Path) -> None:
@@ -1102,7 +1102,7 @@ class TestCreateBaseVenvTimeout:
                 return_value=False,
             ),
             patch(
-                "apme_engine.venv_manager.session.subprocess.run",
+                "apme_engine.venv_manager.session._run_subprocess_timed",
                 side_effect=[
                     ok_result,
                     subprocess.TimeoutExpired(cmd="pip install", timeout=_PIP_INSTALL_TIMEOUT_S),
@@ -1119,3 +1119,40 @@ class TestCreateBaseVenvTimeout:
         assert mock_run.call_count == 2
         for call in mock_run.call_args_list:
             assert call[1].get("timeout") == _PIP_INSTALL_TIMEOUT_S
+
+
+class TestRunSubprocessTimed:
+    """Process-group isolation and teardown for bounded subprocess runs."""
+
+    def test_run_subprocess_timed_uses_isolated_process_group(self) -> None:
+        """Pip/uv installs start in a new session so timeouts can kill the group."""
+        from apme_engine.venv_manager.session import _run_subprocess_timed
+
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = ("ok", "")
+        mock_proc.returncode = 0
+
+        with patch("apme_engine.venv_manager.session.subprocess.Popen", return_value=mock_proc) as mock_popen:
+            result = _run_subprocess_timed(["uv", "pip", "install", "pkg"], timeout=30)
+
+        assert result.returncode == 0
+        assert mock_popen.call_args[1]["start_new_session"] is True
+
+    def test_run_subprocess_timed_terminates_process_group_on_timeout(self) -> None:
+        """TimeoutExpired triggers process-group termination before re-raising."""
+        from apme_engine.venv_manager.session import _run_subprocess_timed
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 4242
+        mock_proc.communicate.side_effect = subprocess.TimeoutExpired(cmd=["uv"], timeout=30)
+
+        with (
+            patch("apme_engine.venv_manager.session.subprocess.Popen", return_value=mock_proc),
+            patch("apme_engine.venv_manager.session._terminate_process_group") as mock_term,
+            patch("apme_engine.venv_manager.session._kill_process_group") as mock_kill,
+            pytest.raises(subprocess.TimeoutExpired),
+        ):
+            _run_subprocess_timed(["uv", "pip", "install", "pkg"], timeout=30)
+
+        mock_term.assert_called_once_with(mock_proc)
+        mock_kill.assert_called_once_with(mock_proc)


### PR DESCRIPTION
## Summary

Security, reliability, and correctness hardening across gateway, engine, Galaxy proxy, and the workflow UI, driven by review cycles (10-persona review + Rule-of-Five cold reviews to convergence). Split out of #646 for independent review. Excludes branch-name validation (#647) and the secrets-deny (#648), which are separate PRs.

## Changes

- remediate CLI: FixSession stream stays open past uploads; reconnect retry with per-attempt state reset, fresh scan_id, attributable logging; producer errors fail loudly; accurate written-file counts; upload worker teardown on retry; EXIT_ERROR on patch write failures
- Gateway SSE: `is_must_deliver` vs `is_terminal` split; snapshot drain forwards result/completed in order; non-terminal-first broadcast eviction
- SCM auth: tokens via git `extraHeader` env (never argv); embedded URL userinfo preserved as header when no explicit token; remote-head cache correctness; malformed-port URLs handled gracefully; short-token redaction
- Project lookup: indexed `normalized_repo_url` with startup backfill, stale-index verification, isolated legacy heal writes, keyset fallback pagination, deterministic ordering
- Proposals: end-to-end `line_end` (grouping/flush/SSE/REST/SPA); flush bridge preserves approvals across rebuilds; duplicate-row reconciliation; non-finite confidence rejected
- Galaxy: pagination bound with failover; truncation returns None (not empty catalog); metadata cached only on success
- Abbenay chat: retry on transient gRPC codes only, fail fast on permanent; bounded venv/health timeouts
- Engine: FixSession preserves resumable sessions on stream end; removes upload-created sessions only on explicit close or CancelledError; unknown task types yield empty offspring; Windows path findings via PureWindowsPath
- Frontend: WS payload validators tolerate mixed-version skew; malformed non-terminal frames preserve resume; taint cleared on resume; stale socket handler guards; `line_end` forwarded
- Venv: pip/uv installs use isolated process groups with group-wide timeout termination
- Includes regression tests pinning each fix above (pure-coverage expansion ships separately in #649)

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e unit` passes
- [x] Frontend `vitest` + `tsc --noEmit` clean
- [x] CodeRabbit + Qodo review feedback addressed (d85fe4cd)
- [ ] ADR added (not applicable)

## Follow-ups (tracked separately)

- Server-side FixSession supersession/GC; approval replay on retry
- Violation-storage `line_end` backfill; `merge_outcomes` by-ID claim check
- Gateway/Galaxy coverage gates (current gate measures `src/apme_engine` only — follow-up tests PR #651)
- `line_end` span rendering in ProposalReviewPanel; per-field branch error names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Proposal details now include end-line information and support additional statuses.
  - Repository matching works consistently across URL variants and embedded credentials.
  - AI triage results include remediation and source details.
  - Operation streams better preserve terminal results and event order.

- **Bug Fixes**
  - Improved handling of malformed or incomplete streamed data.
  - Added retry and recovery for transient service interruptions.
  - Galaxy discovery and downloads handle invalid responses more safely.
  - Installations and health checks now terminate predictably on timeouts.

- **Security**
  - Repository credentials are transmitted and redacted more securely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->